### PR TITLE
Add parsing logic for neural query

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,7 @@ allprojects {
 }
 
 repositories {
+    mavenLocal()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -13,7 +13,6 @@ import java.util.function.Supplier;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.client.Client;
-import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
@@ -52,9 +51,7 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin {
         final IndexNameExpressionResolver indexNameExpressionResolver,
         final Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        final MachineLearningNodeClient machineLearningNodeClient = new MachineLearningNodeClient(
-            new NodeClient(environment.settings(), threadPool)
-        );
+        final MachineLearningNodeClient machineLearningNodeClient = new MachineLearningNodeClient(client);
         final MLCommonsClientAccessor clientAccessor = new MLCommonsClientAccessor(machineLearningNodeClient);
         return List.of(clientAccessor);
     }

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -6,12 +6,14 @@
 package org.opensearch.neuralsearch.plugin;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
@@ -20,10 +22,12 @@ import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.plugin.query.NeuralQueryBuilder;
 import org.opensearch.neuralsearch.transport.MLPredictAction;
 import org.opensearch.neuralsearch.transport.MLPredictTransportAction;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.SearchPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
@@ -32,7 +36,7 @@ import org.opensearch.watcher.ResourceWatcherService;
 /**
  * Neural Search plugin class
  */
-public class NeuralSearch extends Plugin implements ActionPlugin {
+public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin {
 
     @Override
     public Collection<Object> createComponents(
@@ -48,7 +52,9 @@ public class NeuralSearch extends Plugin implements ActionPlugin {
         final IndexNameExpressionResolver indexNameExpressionResolver,
         final Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        final MachineLearningNodeClient machineLearningNodeClient = new MachineLearningNodeClient(client);
+        final MachineLearningNodeClient machineLearningNodeClient = new MachineLearningNodeClient(
+            new NodeClient(environment.settings(), threadPool)
+        );
         final MLCommonsClientAccessor clientAccessor = new MLCommonsClientAccessor(machineLearningNodeClient);
         return List.of(clientAccessor);
     }
@@ -61,5 +67,11 @@ public class NeuralSearch extends Plugin implements ActionPlugin {
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return List.of(new ActionHandler<>(MLPredictAction.INSTANCE, MLPredictTransportAction.class));
+    }
+
+    public List<QuerySpec<?>> getQueries() {
+        return Collections.singletonList(
+            new QuerySpec<>(NeuralQueryBuilder.NAME, NeuralQueryBuilder::new, NeuralQueryBuilder::fromXContent)
+        );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilder.java
@@ -124,12 +124,13 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
         if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
             throw new ParsingException(
                 parser.getTokenLocation(),
-                String.format(
-                    "[%s] query doesn't support multiple fields, found [%s] and [%s]",
-                    NAME,
-                    neuralQueryBuilder.fieldName(),
-                    parser.currentName()
-                )
+                "["
+                    + NAME
+                    + "] query doesn't support multiple fields, found ["
+                    + neuralQueryBuilder.fieldName()
+                    + "] and ["
+                    + parser.currentName()
+                    + "]"
             );
         }
         requireValue(neuralQueryBuilder.queryText(), "Query text must be provided for neural query");

--- a/src/main/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilder.java
@@ -52,7 +52,7 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
     @VisibleForTesting
     static final ParseField K_FIELD = new ParseField("k");
 
-    private static int DEFAULT_K = 10;
+    private static final int DEFAULT_K = 10;
 
     private String fieldName;
     private String queryText;

--- a/src/main/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilder.java
@@ -122,7 +122,15 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
         parseQueryParams(parser, neuralQueryBuilder);
         parser.nextToken();
         if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
-            throw new ParsingException(parser.getTokenLocation(), "Token must be END_OBJECT");
+            throw new ParsingException(
+                parser.getTokenLocation(),
+                String.format(
+                    "[%s] query doesn't support multiple fields, found [%s] and [%s]",
+                    NAME,
+                    neuralQueryBuilder.fieldName(),
+                    parser.currentName()
+                )
+            );
         }
         requireValue(neuralQueryBuilder.queryText(), "Query text must be provided for neural query");
         requireValue(neuralQueryBuilder.fieldName(), "Field name must be provided for neural query");

--- a/src/main/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilder.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.plugin.query;
+
+import java.io.IOException;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.lucene.search.Query;
+import org.opensearch.common.ParseField;
+import org.opensearch.common.ParsingException;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+
+/**
+ * NeuralQueryBuilder is responsible for producing "neural" query types. A "neural" query type is a wrapper around a
+ * k-NN vector query. It uses a ML language model to produce a dense vector from a query string that is then used as
+ * the query vector for the k-NN search.
+ */
+
+@Log4j2
+@Getter
+@NoArgsConstructor
+public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder> {
+
+    public static final String NAME = "neural";
+
+    static final ParseField QUERY_TEXT_FIELD = new ParseField("query_text");
+
+    static final ParseField MODEL_ID_FIELD = new ParseField("model_id");
+
+    static final ParseField K_FIELD = new ParseField("k");
+
+    private String fieldName;
+    private String queryText;
+    private String modelId;
+    private int k;
+
+    /**
+     * Set the fieldName this query will be executed against
+     *
+     * @param fieldName name of k-NN vector field that query will be executed against
+     * @return this
+     */
+    public NeuralQueryBuilder fieldName(String fieldName) {
+        this.fieldName = fieldName;
+        return this;
+    }
+
+    /**
+     * Set the queryText that will be translated into the dense query vector used for k-NN search.
+     *
+     * @param queryText Text of a query that should be translated to a dense vector
+     * @return this
+     */
+    public NeuralQueryBuilder queryText(String queryText) {
+        this.queryText = queryText;
+        return this;
+    }
+
+    /**
+     * Set the modelId that should produce the dense query vector
+     *
+     * @param modelId ID of model to produce query vector
+     * @return this
+     */
+    public NeuralQueryBuilder modelId(String modelId) {
+        this.modelId = modelId;
+        return this;
+    }
+
+    /**
+     * Set the number of neighbors that should be retrieved during k-NN search
+     *
+     * @param k number of neighbors to be retrieved in k-NN query
+     * @return this
+     */
+    public NeuralQueryBuilder k(int k) {
+        this.k = k;
+        return this;
+    }
+
+    /**
+     * Constructor from stream input
+     *
+     * @param in StreamInput to initialize object from
+     * @throws IOException thrown if unable to read from input stream
+     */
+    public NeuralQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.fieldName = in.readString();
+        this.queryText = in.readString();
+        this.modelId = in.readString();
+        this.k = in.readInt();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(this.fieldName);
+        out.writeString(this.queryText);
+        out.writeString(this.modelId);
+        out.writeInt(this.k);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+        xContentBuilder.startObject(NAME);
+        xContentBuilder.startObject(fieldName);
+        xContentBuilder.field(QUERY_TEXT_FIELD.getPreferredName(), queryText);
+        xContentBuilder.field(MODEL_ID_FIELD.getPreferredName(), modelId);
+        xContentBuilder.field(K_FIELD.getPreferredName(), k);
+        printBoostAndQueryName(xContentBuilder);
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+    }
+
+    /**
+     * Creates NeuralQueryBuilder from xContent.
+     *
+     * The expected parsing form looks like:
+     * {
+     *  "VECTOR_FIELD": {
+     *    "query_text": "string",
+     *    "model_id": "string",
+     *    "k": int,
+     *    "name": "string", (optional)
+     *    "boost": float (optional)
+     *  }
+     * }
+     *
+     * @param parser XContentParser
+     * @return NeuralQueryBuilder
+     * @throws IOException can be thrown by parser
+     */
+    public static NeuralQueryBuilder fromXContent(XContentParser parser) throws IOException {
+        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
+        if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+            throw new ParsingException(parser.getTokenLocation(), "Token must be START_OBJECT");
+        }
+        parser.nextToken();
+        neuralQueryBuilder.fieldName(parser.currentName());
+        parser.nextToken();
+        parseQueryParams(parser, neuralQueryBuilder);
+        parser.nextToken();
+        if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
+            throw new ParsingException(parser.getTokenLocation(), "Token must be END_OBJECT");
+        }
+
+        requireValue(neuralQueryBuilder.getQueryText(), "Query text must be provided for neural query");
+        requireValue(neuralQueryBuilder.getFieldName(), "Field name must be provided for neural query");
+        requireValue(neuralQueryBuilder.getModelId(), "Model ID must be provided for neural query");
+        requireValue(neuralQueryBuilder.getK(), "K must be provided for neural query");
+
+        return neuralQueryBuilder;
+    }
+
+    private static void parseQueryParams(XContentParser parser, NeuralQueryBuilder neuralQueryBuilder) throws IOException {
+        XContentParser.Token token;
+        String currentFieldName = "";
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (QUERY_TEXT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    neuralQueryBuilder.queryText(parser.text());
+                } else if (MODEL_ID_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    neuralQueryBuilder.modelId(parser.text());
+                } else if (K_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    neuralQueryBuilder.k((Integer) NumberFieldMapper.NumberType.INTEGER.parse(parser.objectBytes(), false));
+                } else if (NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    neuralQueryBuilder.queryName(parser.text());
+                } else if (BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    neuralQueryBuilder.boost(parser.floatValue());
+                } else {
+                    throw new ParsingException(
+                        parser.getTokenLocation(),
+                        "[" + NAME + "] query does not support [" + currentFieldName + "]"
+                    );
+                }
+            } else {
+                throw new ParsingException(
+                    parser.getTokenLocation(),
+                    "[" + NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]"
+                );
+            }
+        }
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext queryShardContext) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected boolean doEquals(NeuralQueryBuilder obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        EqualsBuilder equalsBuilder = new EqualsBuilder();
+        equalsBuilder.append(fieldName, obj.fieldName);
+        equalsBuilder.append(queryText, obj.queryText);
+        equalsBuilder.append(modelId, obj.modelId);
+        equalsBuilder.append(k, obj.k);
+        return equalsBuilder.isEquals();
+    }
+
+    @Override
+    protected int doHashCode() {
+        return new HashCodeBuilder().append(fieldName).append(queryText).append(modelId).append(k).toHashCode();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/plugin/TestUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/TestUtils.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.plugin;
+
+import java.util.Map;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentHelper;
+
+public class TestUtils {
+
+    /**
+     * Convert an xContentBuilder to a map
+     * @param xContentBuilder to produce map from
+     * @return Map from xContentBuilder
+     */
+    public static Map<String, Object> xContentBuilderToMap(XContentBuilder xContentBuilder) {
+        return XContentHelper.convertToMap(BytesReference.bytes(xContentBuilder), true, xContentBuilder.contentType()).v2();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilderTests.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.plugin.query;
+
+import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
+import static org.opensearch.index.query.AbstractQueryBuilder.NAME_FIELD;
+import static org.opensearch.neuralsearch.plugin.TestUtils.xContentBuilderToMap;
+import static org.opensearch.neuralsearch.plugin.query.NeuralQueryBuilder.K_FIELD;
+import static org.opensearch.neuralsearch.plugin.query.NeuralQueryBuilder.MODEL_ID_FIELD;
+import static org.opensearch.neuralsearch.plugin.query.NeuralQueryBuilder.NAME;
+import static org.opensearch.neuralsearch.plugin.query.NeuralQueryBuilder.QUERY_TEXT_FIELD;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.opensearch.common.ParsingException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class NeuralQueryBuilderTests extends OpenSearchTestCase {
+
+    private static final String FIELD_NAME = "testField";
+    private static final String QUERY_TEXT = "Hello world!";
+    private static final String MODEL_ID = "mfgfgdsfgfdgsde";
+    private static final int K = 10;
+    private static final float BOOST = 1.8f;
+    private static final String QUERY_NAME = "queryName";
+
+    public void testFromXContent_valid_withDefaults() throws IOException {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "model_id": "string",
+                "k": int
+              }
+          }
+        */
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(FIELD_NAME)
+            .field(QUERY_TEXT_FIELD.getPreferredName(), QUERY_TEXT)
+            .field(MODEL_ID_FIELD.getPreferredName(), MODEL_ID)
+            .field(K_FIELD.getPreferredName(), K)
+            .endObject()
+            .endObject();
+
+        XContentParser contentParser = createParser(xContentBuilder);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.fromXContent(contentParser);
+
+        assertEquals(FIELD_NAME, neuralQueryBuilder.getFieldName());
+        assertEquals(QUERY_TEXT, neuralQueryBuilder.getQueryText());
+        assertEquals(MODEL_ID, neuralQueryBuilder.getModelId());
+        assertEquals(K, neuralQueryBuilder.getK());
+    }
+
+    public void testFromXContent_valid_withOptionals() throws IOException {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "model_id": "string",
+                "k": int,
+                "boost": 10.0,
+                "_name": "something",
+              }
+          }
+        */
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(FIELD_NAME)
+            .field(QUERY_TEXT_FIELD.getPreferredName(), QUERY_TEXT)
+            .field(MODEL_ID_FIELD.getPreferredName(), MODEL_ID)
+            .field(K_FIELD.getPreferredName(), K)
+            .field(BOOST_FIELD.getPreferredName(), BOOST)
+            .field(NAME_FIELD.getPreferredName(), QUERY_NAME)
+            .endObject()
+            .endObject();
+
+        XContentParser contentParser = createParser(xContentBuilder);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.fromXContent(contentParser);
+
+        assertEquals(FIELD_NAME, neuralQueryBuilder.getFieldName());
+        assertEquals(QUERY_TEXT, neuralQueryBuilder.getQueryText());
+        assertEquals(MODEL_ID, neuralQueryBuilder.getModelId());
+        assertEquals(K, neuralQueryBuilder.getK());
+        assertEquals(BOOST, neuralQueryBuilder.boost(), 0.0);
+        assertEquals(QUERY_NAME, neuralQueryBuilder.queryName());
+    }
+
+    public void testFromXContent_invalid_multipleRootFields() throws IOException {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "model_id": "string",
+                "k": int,
+                "boost": 10.0,
+                "_name": "something",
+              },
+              "invalid": 10
+          }
+        */
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(FIELD_NAME)
+            .field(QUERY_TEXT_FIELD.getPreferredName(), QUERY_TEXT)
+            .field(MODEL_ID_FIELD.getPreferredName(), MODEL_ID)
+            .field(K_FIELD.getPreferredName(), K)
+            .field(BOOST_FIELD.getPreferredName(), BOOST)
+            .field(NAME_FIELD.getPreferredName(), QUERY_NAME)
+            .endObject()
+            .field("invalid", 10)
+            .endObject();
+
+        XContentParser contentParser = createParser(xContentBuilder);
+        expectThrows(ParsingException.class, () -> NeuralQueryBuilder.fromXContent(contentParser));
+    }
+
+    public void testFromXContent_invalid_missingParameters() throws IOException {
+        /*
+          {
+              "VECTOR_FIELD": {
+
+              }
+          }
+        */
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject(FIELD_NAME).endObject().endObject();
+
+        XContentParser contentParser = createParser(xContentBuilder);
+        expectThrows(IllegalArgumentException.class, () -> NeuralQueryBuilder.fromXContent(contentParser));
+    }
+
+    public void testFromXContent_invalid_duplicateParameters() throws IOException {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "query_text": "string",
+                "model_id": "string",
+                "model_id": "string",
+                "k": int,
+                "k": int
+              }
+          }
+        */
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(FIELD_NAME)
+            .field(QUERY_TEXT_FIELD.getPreferredName(), QUERY_TEXT)
+            .field(MODEL_ID_FIELD.getPreferredName(), MODEL_ID)
+            .field(K_FIELD.getPreferredName(), K)
+            .field(QUERY_TEXT_FIELD.getPreferredName(), QUERY_TEXT)
+            .field(MODEL_ID_FIELD.getPreferredName(), MODEL_ID)
+            .field(K_FIELD.getPreferredName(), K)
+            .endObject()
+            .endObject();
+
+        XContentParser contentParser = createParser(xContentBuilder);
+        expectThrows(IOException.class, () -> NeuralQueryBuilder.fromXContent(contentParser));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testToXContent() throws IOException {
+        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME).modelId(MODEL_ID).queryText(QUERY_TEXT).k(K);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder = neuralQueryBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        Map<String, Object> out = xContentBuilderToMap(builder);
+
+        Object outer = out.get(NAME);
+        if (!(outer instanceof Map)) {
+            fail("neural does not map to nested object");
+        }
+
+        Map<String, Object> outerMap = (Map<String, Object>) outer;
+
+        assertEquals(1, outerMap.size());
+        assertTrue(outerMap.containsKey(FIELD_NAME));
+
+        Object secondInner = outerMap.get(FIELD_NAME);
+        if (!(secondInner instanceof Map)) {
+            fail("field name does not map to nested object");
+        }
+
+        Map<String, Object> secondInnerMap = (Map<String, Object>) secondInner;
+
+        assertEquals(MODEL_ID, secondInnerMap.get(MODEL_ID_FIELD.getPreferredName()));
+        assertEquals(QUERY_TEXT, secondInnerMap.get(QUERY_TEXT_FIELD.getPreferredName()));
+        assertEquals(K, secondInnerMap.get(K_FIELD.getPreferredName()));
+    }
+
+    public void testStreams() throws IOException {
+        NeuralQueryBuilder original = new NeuralQueryBuilder();
+        original.fieldName(FIELD_NAME);
+        original.queryText(QUERY_TEXT);
+        original.modelId(MODEL_ID);
+        original.k(K);
+        original.boost(BOOST);
+        original.queryName(QUERY_NAME);
+
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        original.writeTo(streamOutput);
+
+        NeuralQueryBuilder copy = new NeuralQueryBuilder(streamOutput.bytes().streamInput());
+        assertEquals(original, copy);
+    }
+
+    public void testHashAndEquals() {
+        String fieldName1 = "field 1";
+        String fieldName2 = "field 2";
+        String queryText1 = "query text 1";
+        String queryText2 = "query text 2";
+        String modelId1 = "model-1";
+        String modelId2 = "model-2";
+        float boost1 = 1.8f;
+        float boost2 = 3.8f;
+        String queryName1 = "query-1";
+        String queryName2 = "query-2";
+        int k1 = 1;
+        int k2 = 2;
+
+        NeuralQueryBuilder neuralQueryBuilder1 = new NeuralQueryBuilder().fieldName(fieldName1)
+            .queryText(queryText1)
+            .modelId(modelId1)
+            .k(k1)
+            .boost(boost1)
+            .queryName(queryName1);
+
+        // Identical to neuralQueryBuilder1
+        NeuralQueryBuilder neuralQueryBuilder2 = new NeuralQueryBuilder().fieldName(fieldName1)
+            .queryText(queryText1)
+            .modelId(modelId1)
+            .k(k1)
+            .boost(boost1)
+            .queryName(queryName1);
+
+        // Identical to neuralQueryBuilder1 except default boost and query name
+        NeuralQueryBuilder neuralQueryBuilder3 = new NeuralQueryBuilder().fieldName(fieldName1)
+            .queryText(queryText1)
+            .modelId(modelId1)
+            .k(k1);
+
+        // Identical to neuralQueryBuilder1 except diff field name
+        NeuralQueryBuilder neuralQueryBuilder4 = new NeuralQueryBuilder().fieldName(fieldName2)
+            .queryText(queryText1)
+            .modelId(modelId1)
+            .k(k1)
+            .boost(boost1)
+            .queryName(queryName1);
+
+        // Identical to neuralQueryBuilder1 except diff query text
+        NeuralQueryBuilder neuralQueryBuilder5 = new NeuralQueryBuilder().fieldName(fieldName1)
+            .queryText(queryText2)
+            .modelId(modelId1)
+            .k(k1)
+            .boost(boost1)
+            .queryName(queryName1);
+
+        // Identical to neuralQueryBuilder1 except diff model ID
+        NeuralQueryBuilder neuralQueryBuilder6 = new NeuralQueryBuilder().fieldName(fieldName1)
+            .queryText(queryText1)
+            .modelId(modelId2)
+            .k(k1)
+            .boost(boost1)
+            .queryName(queryName1);
+
+        // Identical to neuralQueryBuilder1 except diff k
+        NeuralQueryBuilder neuralQueryBuilder7 = new NeuralQueryBuilder().fieldName(fieldName1)
+            .queryText(queryText1)
+            .modelId(modelId1)
+            .k(k2)
+            .boost(boost1)
+            .queryName(queryName1);
+
+        // Identical to neuralQueryBuilder1 except diff boost
+        NeuralQueryBuilder neuralQueryBuilder8 = new NeuralQueryBuilder().fieldName(fieldName1)
+            .queryText(queryText1)
+            .modelId(modelId1)
+            .k(k1)
+            .boost(boost2)
+            .queryName(queryName1);
+
+        // Identical to neuralQueryBuilder1 except diff query name
+        NeuralQueryBuilder neuralQueryBuilder9 = new NeuralQueryBuilder().fieldName(fieldName1)
+            .queryText(queryText1)
+            .modelId(modelId1)
+            .k(k1)
+            .boost(boost1)
+            .queryName(queryName2);
+
+        assertEquals(neuralQueryBuilder1, neuralQueryBuilder1);
+        assertEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder1.hashCode());
+
+        assertEquals(neuralQueryBuilder1, neuralQueryBuilder2);
+        assertEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder2.hashCode());
+
+        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder3);
+        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder3.hashCode());
+
+        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder4);
+        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder4.hashCode());
+
+        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder5);
+        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder5.hashCode());
+
+        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder6);
+        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder6.hashCode());
+
+        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder7);
+        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder7.hashCode());
+
+        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder8);
+        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder8.hashCode());
+
+        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder9);
+        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder9.hashCode());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/query/NeuralQueryBuilderTests.java
@@ -16,6 +16,8 @@ import static org.opensearch.neuralsearch.plugin.query.NeuralQueryBuilder.QUERY_
 import java.io.IOException;
 import java.util.Map;
 
+import lombok.SneakyThrows;
+
 import org.opensearch.common.ParsingException;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.ToXContent;
@@ -33,7 +35,8 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
     private static final float BOOST = 1.8f;
     private static final String QUERY_NAME = "queryName";
 
-    public void testFromXContent_valid_withDefaults() throws IOException {
+    @SneakyThrows
+    public void testFromXContent_whenBuiltWithDefaults_thenBuildSuccessfully() {
         /*
           {
               "VECTOR_FIELD": {
@@ -55,13 +58,14 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         XContentParser contentParser = createParser(xContentBuilder);
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.fromXContent(contentParser);
 
-        assertEquals(FIELD_NAME, neuralQueryBuilder.getFieldName());
-        assertEquals(QUERY_TEXT, neuralQueryBuilder.getQueryText());
-        assertEquals(MODEL_ID, neuralQueryBuilder.getModelId());
-        assertEquals(K, neuralQueryBuilder.getK());
+        assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
+        assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
+        assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
+        assertEquals(K, neuralQueryBuilder.k());
     }
 
-    public void testFromXContent_valid_withOptionals() throws IOException {
+    @SneakyThrows
+    public void testFromXContent_whenBuiltWithOptionals_thenBuildSuccessfully() {
         /*
           {
               "VECTOR_FIELD": {
@@ -87,15 +91,16 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         XContentParser contentParser = createParser(xContentBuilder);
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.fromXContent(contentParser);
 
-        assertEquals(FIELD_NAME, neuralQueryBuilder.getFieldName());
-        assertEquals(QUERY_TEXT, neuralQueryBuilder.getQueryText());
-        assertEquals(MODEL_ID, neuralQueryBuilder.getModelId());
-        assertEquals(K, neuralQueryBuilder.getK());
+        assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
+        assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
+        assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
+        assertEquals(K, neuralQueryBuilder.k());
         assertEquals(BOOST, neuralQueryBuilder.boost(), 0.0);
         assertEquals(QUERY_NAME, neuralQueryBuilder.queryName());
     }
 
-    public void testFromXContent_invalid_multipleRootFields() throws IOException {
+    @SneakyThrows
+    public void testFromXContent_whenBuildWithMultipleRootFields_thenFail() {
         /*
           {
               "VECTOR_FIELD": {
@@ -124,7 +129,8 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         expectThrows(ParsingException.class, () -> NeuralQueryBuilder.fromXContent(contentParser));
     }
 
-    public void testFromXContent_invalid_missingParameters() throws IOException {
+    @SneakyThrows
+    public void testFromXContent_whenBuildWithMissingParameters_thenFail() {
         /*
           {
               "VECTOR_FIELD": {
@@ -138,7 +144,8 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         expectThrows(IllegalArgumentException.class, () -> NeuralQueryBuilder.fromXContent(contentParser));
     }
 
-    public void testFromXContent_invalid_duplicateParameters() throws IOException {
+    @SneakyThrows
+    public void testFromXContent_whenBuildWithDuplicateParameters_thenFail() {
         /*
           {
               "VECTOR_FIELD": {
@@ -168,7 +175,8 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testToXContent() throws IOException {
+    @SneakyThrows
+    public void testToXContent() {
         NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME).modelId(MODEL_ID).queryText(QUERY_TEXT).k(K);
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
@@ -197,7 +205,8 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         assertEquals(K, secondInnerMap.get(K_FIELD.getPreferredName()));
     }
 
-    public void testStreams() throws IOException {
+    @SneakyThrows
+    public void testStreams() {
         NeuralQueryBuilder original = new NeuralQueryBuilder();
         original.fieldName(FIELD_NAME);
         original.queryText(QUERY_TEXT);
@@ -227,100 +236,100 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         int k1 = 1;
         int k2 = 2;
 
-        NeuralQueryBuilder neuralQueryBuilder1 = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_baseline = new NeuralQueryBuilder().fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1);
 
-        // Identical to neuralQueryBuilder1
-        NeuralQueryBuilder neuralQueryBuilder2 = new NeuralQueryBuilder().fieldName(fieldName1)
+        // Identical to neuralQueryBuilder_baseline
+        NeuralQueryBuilder neuralQueryBuilder_baselineCopy = new NeuralQueryBuilder().fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1);
 
-        // Identical to neuralQueryBuilder1 except default boost and query name
-        NeuralQueryBuilder neuralQueryBuilder3 = new NeuralQueryBuilder().fieldName(fieldName1)
+        // Identical to neuralQueryBuilder_baseline except default boost and query name
+        NeuralQueryBuilder neuralQueryBuilder_defaultBoostAndQueryName = new NeuralQueryBuilder().fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1);
 
-        // Identical to neuralQueryBuilder1 except diff field name
-        NeuralQueryBuilder neuralQueryBuilder4 = new NeuralQueryBuilder().fieldName(fieldName2)
+        // Identical to neuralQueryBuilder_baseline except diff field name
+        NeuralQueryBuilder neuralQueryBuilder_diffFieldName = new NeuralQueryBuilder().fieldName(fieldName2)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1);
 
-        // Identical to neuralQueryBuilder1 except diff query text
-        NeuralQueryBuilder neuralQueryBuilder5 = new NeuralQueryBuilder().fieldName(fieldName1)
+        // Identical to neuralQueryBuilder_baseline except diff query text
+        NeuralQueryBuilder neuralQueryBuilder_diffQueryText = new NeuralQueryBuilder().fieldName(fieldName1)
             .queryText(queryText2)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1);
 
-        // Identical to neuralQueryBuilder1 except diff model ID
-        NeuralQueryBuilder neuralQueryBuilder6 = new NeuralQueryBuilder().fieldName(fieldName1)
+        // Identical to neuralQueryBuilder_baseline except diff model ID
+        NeuralQueryBuilder neuralQueryBuilder_diffModelId = new NeuralQueryBuilder().fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId2)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1);
 
-        // Identical to neuralQueryBuilder1 except diff k
-        NeuralQueryBuilder neuralQueryBuilder7 = new NeuralQueryBuilder().fieldName(fieldName1)
+        // Identical to neuralQueryBuilder_baseline except diff k
+        NeuralQueryBuilder neuralQueryBuilder_diffK = new NeuralQueryBuilder().fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k2)
             .boost(boost1)
             .queryName(queryName1);
 
-        // Identical to neuralQueryBuilder1 except diff boost
-        NeuralQueryBuilder neuralQueryBuilder8 = new NeuralQueryBuilder().fieldName(fieldName1)
+        // Identical to neuralQueryBuilder_baseline except diff boost
+        NeuralQueryBuilder neuralQueryBuilder_diffBoost = new NeuralQueryBuilder().fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost2)
             .queryName(queryName1);
 
-        // Identical to neuralQueryBuilder1 except diff query name
-        NeuralQueryBuilder neuralQueryBuilder9 = new NeuralQueryBuilder().fieldName(fieldName1)
+        // Identical to neuralQueryBuilder_baseline except diff query name
+        NeuralQueryBuilder neuralQueryBuilder_diffQueryName = new NeuralQueryBuilder().fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName2);
 
-        assertEquals(neuralQueryBuilder1, neuralQueryBuilder1);
-        assertEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder1.hashCode());
+        assertEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_baseline);
+        assertEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_baseline.hashCode());
 
-        assertEquals(neuralQueryBuilder1, neuralQueryBuilder2);
-        assertEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder2.hashCode());
+        assertEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_baselineCopy);
+        assertEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_baselineCopy.hashCode());
 
-        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder3);
-        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder3.hashCode());
+        assertNotEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_defaultBoostAndQueryName);
+        assertNotEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_defaultBoostAndQueryName.hashCode());
 
-        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder4);
-        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder4.hashCode());
+        assertNotEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_diffFieldName);
+        assertNotEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_diffFieldName.hashCode());
 
-        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder5);
-        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder5.hashCode());
+        assertNotEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_diffQueryText);
+        assertNotEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_diffQueryText.hashCode());
 
-        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder6);
-        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder6.hashCode());
+        assertNotEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_diffModelId);
+        assertNotEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_diffModelId.hashCode());
 
-        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder7);
-        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder7.hashCode());
+        assertNotEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_diffK);
+        assertNotEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_diffK.hashCode());
 
-        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder8);
-        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder8.hashCode());
+        assertNotEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_diffBoost);
+        assertNotEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_diffBoost.hashCode());
 
-        assertNotEquals(neuralQueryBuilder1, neuralQueryBuilder9);
-        assertNotEquals(neuralQueryBuilder1.hashCode(), neuralQueryBuilder9.hashCode());
+        assertNotEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_diffQueryName);
+        assertNotEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_diffQueryName.hashCode());
     }
 }


### PR DESCRIPTION
### Description
Adds new query builder to plugin: NeuralQueryBuilder. Adds logic to parse the user provided parameters for the NeuralQueryBuilder as well as a few other smaller methods. Query text to dense vector logic will be added in a future PR

The query has the following structure:
```
{
  "neural": {
    "<VECTOR_FIELD>": {
    "query_text": "string",
    "model_id": "string",
    "k": int,
    "boost": float, (optional - comes with default query builder)
    "_name": "string", (optional - comes with default query builder)
  }
}
```

Adds unit tests as well as test utility class

### Issues Resolved
#14  (partially resolved)

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] New functionality has been documented.
    - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
