### PR TITLE
Added MLCommonsClientAcessor and MLPredict TransportAction for accessing the MLClient APIs predict API.

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,3 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true
+lombok.nonNull.exceptionType = JDK

--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.ml;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.MLInputDataset;
+import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLModelTaskType;
+import org.opensearch.ml.common.output.model.ModelResultFilter;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+
+/**
+ * This class will act as an abstraction on the MLCommons client for accessing the ML Capabilities
+ */
+@RequiredArgsConstructor
+@Log4j2
+public class MLCommonsClientAccessor {
+    private static final List<String> TARGET_RESPONSE_FILTERS = List.of("sentence_embedding");
+    private final MachineLearningNodeClient mlClient;
+
+    /**
+     * Abstraction to call predict function of api of MLClient with default targetResponse filters. It uses the
+     * custom model provided as modelId and run the {@link MLModelTaskType#TEXT_EMBEDDING}. The return will be sent
+     * using the actionListener which will have a {@link List} of {@link List} of {@link Float} in the order of
+     * inputText. We are not making this function generic enough to take any function or TaskType as currently we
+     * need to run only TextEmbedding tasks only.
+     *
+     * @param modelId {@link String}
+     * @param inputText {@link List} of {@link String} on which inference needs to happen
+     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out
+     */
+    public void inferenceSentences(
+        @NonNull final String modelId,
+        @NonNull final List<String> inputText,
+        @NonNull final ActionListener<List<List<Float>>> listener
+    ) {
+        inferenceSentences(TARGET_RESPONSE_FILTERS, modelId, inputText, listener);
+    }
+
+    /**
+     * Abstraction to call predict function of api of MLClient with provided targetResponse filters. It uses the
+     * custom model provided as modelId and run the {@link MLModelTaskType#TEXT_EMBEDDING}. The return will be sent
+     * using the actionListener which will have a {@link List} of {@link List} of {@link Float} in the order of
+     * inputText. We are not making this function generic enough to take any function or TaskType as currently we
+     * need to run only TextEmbedding tasks only.
+     *
+     * @param targetResponseFilters {@link List} of {@link String} which filters out the responses
+     * @param modelId {@link String}
+     * @param inputText {@link List} of {@link String} on which inference needs to happen
+     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out.
+     */
+    public void inferenceSentences(
+        @NonNull final List<String> targetResponseFilters,
+        @NonNull final String modelId,
+        @NonNull final List<String> inputText,
+        @NonNull final ActionListener<List<List<Float>>> listener
+    ) {
+        final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
+        final MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
+        final MLInput mlInput = new MLInput(FunctionName.CUSTOM, null, inputDataset, MLModelTaskType.TEXT_EMBEDDING);
+        final List<List<Float>> vector = new ArrayList<>();
+
+        mlClient.predict(modelId, mlInput, ActionListener.wrap(mlOutput -> {
+            final ModelTensorOutput modelTensorOutput = (ModelTensorOutput) mlOutput;
+            final List<ModelTensors> tensorOutputList = modelTensorOutput.getMlModelOutputs();
+            for (final ModelTensors tensors : tensorOutputList) {
+                final List<ModelTensor> tensorsList = tensors.getMlModelTensors();
+                for (final ModelTensor tensor : tensorsList) {
+                    vector.add(Arrays.stream(tensor.getData()).map(value -> (Float) value).collect(Collectors.toList()));
+                }
+            }
+            log.debug("Inference Response for input sentence {} is : {} ", inputText, vector);
+            listener.onResponse(vector);
+        }, listener::onFailure));
+    }
+
+}

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -5,9 +5,61 @@
 
 package org.opensearch.neuralsearch.plugin;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.transport.MLPredictAction;
+import org.opensearch.neuralsearch.transport.MLPredictTransportAction;
+import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.script.ScriptService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.watcher.ResourceWatcherService;
 
 /**
  * Neural Search plugin class
  */
-public class NeuralSearch extends Plugin {}
+public class NeuralSearch extends Plugin implements ActionPlugin {
+
+    @Override
+    public Collection<Object> createComponents(
+        final Client client,
+        final ClusterService clusterService,
+        final ThreadPool threadPool,
+        final ResourceWatcherService resourceWatcherService,
+        final ScriptService scriptService,
+        final NamedXContentRegistry xContentRegistry,
+        final Environment environment,
+        final NodeEnvironment nodeEnvironment,
+        final NamedWriteableRegistry namedWriteableRegistry,
+        final IndexNameExpressionResolver indexNameExpressionResolver,
+        final Supplier<RepositoriesService> repositoriesServiceSupplier
+    ) {
+        final MachineLearningNodeClient machineLearningNodeClient = new MachineLearningNodeClient(client);
+        final MLCommonsClientAccessor clientAccessor = new MLCommonsClientAccessor(machineLearningNodeClient);
+        return List.of(clientAccessor);
+    }
+
+    /**
+     * Registering the Action Handlers
+     *
+     * @return A {@link List} of {@link ActionHandler}
+     */
+    @Override
+    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return List.of(new ActionHandler<>(MLPredictAction.INSTANCE, MLPredictTransportAction.class));
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/transport/MLPredictAction.java
+++ b/src/main/java/org/opensearch/neuralsearch/transport/MLPredictAction.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.io.stream.Writeable;
+
+public class MLPredictAction extends ActionType<MLPredictActionResponse> {
+
+    public static final MLPredictAction INSTANCE = new MLPredictAction();
+    public static final String NAME = "cluster:admin/opensearch/neural-search/ml_predict_action";
+
+    private MLPredictAction() {
+        super(NAME, MLPredictActionResponse::new);
+    }
+
+    @Override
+    public Writeable.Reader<MLPredictActionResponse> getResponseReader() {
+        return MLPredictActionResponse::new;
+    }
+
+}

--- a/src/main/java/org/opensearch/neuralsearch/transport/MLPredictActionRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/transport/MLPredictActionRequest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.transport;
+
+import java.io.IOException;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.ValidateActions;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class MLPredictActionRequest extends ActionRequest {
+    @Getter
+    private final String modelId;
+    @Getter
+    private final List<String> inputSentencesList;
+
+    public MLPredictActionRequest(final StreamInput in) throws IOException {
+        super(in);
+        this.modelId = in.readString();
+        this.inputSentencesList = in.readStringList();
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(modelId);
+        out.writeStringCollection(inputSentencesList);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        if (!Strings.hasText(modelId)) {
+            return ValidateActions.addValidationError("Model id cannot be empty ", null);
+        }
+        if (inputSentencesList.size() == 0) {
+            return ValidateActions.addValidationError("Input Sentences List cannot be empty ", null);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/transport/MLPredictActionResponse.java
+++ b/src/main/java/org/opensearch/neuralsearch/transport/MLPredictActionResponse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.transport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.log4j.Log4j2;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@Log4j2
+public class MLPredictActionResponse extends ActionResponse implements ToXContentObject {
+
+    private static final String INFERENCE_VECTORS = "inference_vectors";
+
+    private List<List<Float>> inferenceVectorsList;
+
+    public MLPredictActionResponse(StreamInput streamInput) throws IOException {
+        super(streamInput);
+        final int inferenceVectorsListSize = streamInput.readVInt();
+        inferenceVectorsList = new ArrayList<>(inferenceVectorsListSize);
+        for (int i = 0; i < inferenceVectorsListSize; i++) {
+            final int vectorSize = streamInput.readVInt();
+            final List<Float> vector = new ArrayList<>();
+            for (int j = 0; j < vectorSize; j++) {
+                vector.add(streamInput.readFloat());
+            }
+            inferenceVectorsList.add(vector);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        streamOutput.writeVInt(inferenceVectorsList.size());
+        for (final List<Float> vector : inferenceVectorsList) {
+            streamOutput.writeCollection(vector, StreamOutput::writeFloat);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+        xContentBuilder.startObject().startArray(INFERENCE_VECTORS);
+        for (final List<Float> floats : inferenceVectorsList) {
+            xContentBuilder.startArray();
+            for (final Float value : floats) {
+                xContentBuilder.value(value);
+            }
+            xContentBuilder.endArray();
+        }
+        return xContentBuilder.endArray().endObject();
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/transport/MLPredictTransportAction.java
+++ b/src/main/java/org/opensearch/neuralsearch/transport/MLPredictTransportAction.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.transport;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Transport action to do call inference/predict api of ML Client.
+ */
+public class MLPredictTransportAction extends HandledTransportAction<MLPredictActionRequest, MLPredictActionResponse> {
+
+    private final MLCommonsClientAccessor clientAccessor;
+
+    @Inject
+    public MLPredictTransportAction(
+        final TransportService transportService,
+        final ActionFilters filters,
+        final MLCommonsClientAccessor clientAccessor
+    ) {
+        super(MLPredictAction.NAME, transportService, filters, MLPredictActionRequest::new);
+        this.clientAccessor = clientAccessor;
+    }
+
+    @Override
+    protected void doExecute(
+        final Task task,
+        final MLPredictActionRequest request,
+        final ActionListener<MLPredictActionResponse> actionListener
+    ) {
+        clientAccessor.inferenceSentences(
+            request.getModelId(),
+            request.getInputSentencesList(),
+            ActionListener.wrap(
+                inferenceResponse -> actionListener.onResponse(new MLPredictActionResponse(inferenceResponse)),
+                actionListener::onFailure
+            )
+        );
+    }
+}

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -1,0 +1,7 @@
+grant {
+    //ml-commons client
+    permission java.lang.RuntimePermission "getClassLoader";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+    permission java.lang.RuntimePermission "setContextClassLoader";
+};

--- a/src/test/java/org/opensearch/neuralsearch/constants/TestCommonConstants.java
+++ b/src/test/java/org/opensearch/neuralsearch/constants/TestCommonConstants.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.constants;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TestCommonConstants {
+    public static final String MODEL_ID = "modeId";
+    public static final List<String> TARGET_RESPONSE_FILTERS = List.of("sentence_embedding");
+    public static final Float[] PREDICT_VECTOR_ARRAY = new Float[] { 2.0f, 3.0f };
+    public static final List<List<Float>> PREDICTIONS_LIST = List.of(Arrays.asList(PREDICT_VECTOR_ARRAY));
+    public static final List<String> SENTENCES_LIST = List.of("TEXT");
+}

--- a/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.ml;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.ActionListener;
+import org.opensearch.ml.client.MachineLearningNodeClient;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.model.MLResultDataType;
+import org.opensearch.ml.common.output.MLOutput;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+import org.opensearch.neuralsearch.constants.TestCommonConstants;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
+
+    @Mock
+    private ActionListener<List<List<Float>>> resultListener;
+
+    @Mock
+    private MachineLearningNodeClient client;
+
+    @InjectMocks
+    private MLCommonsClientAccessor accessor;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void testInferenceSentences_whenValidInputThenSuccess() {
+        final List<List<Float>> vectorList = new ArrayList<>();
+        vectorList.add(Arrays.asList(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+            return null;
+        }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        accessor.inferenceSentences(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+
+        Mockito.verify(client)
+            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        Mockito.verify(resultListener).onResponse(vectorList);
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    public void testInferenceSentences_whenResultFromClient_thenEmptyVectorList() {
+        final List<List<Float>> vectorList = new ArrayList<>();
+        vectorList.add(Collections.emptyList());
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createModelTensorOutput(new Float[] {}));
+            return null;
+        }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        accessor.inferenceSentences(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+
+        Mockito.verify(client)
+            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        Mockito.verify(resultListener).onResponse(vectorList);
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    public void testInferenceSentences_whenExceptionFromMLClient_thenFailure() {
+        final RuntimeException exception = new RuntimeException();
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onFailure(exception);
+            return null;
+        }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        accessor.inferenceSentences(
+            TestCommonConstants.TARGET_RESPONSE_FILTERS,
+            TestCommonConstants.MODEL_ID,
+            TestCommonConstants.SENTENCES_LIST,
+            resultListener
+        );
+
+        Mockito.verify(client)
+            .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        Mockito.verify(resultListener).onFailure(exception);
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    private ModelTensorOutput createModelTensorOutput(final Float[] output) {
+        final List<ModelTensors> tensorsList = new ArrayList<>();
+        final List<ModelTensor> mlModelTensorList = new ArrayList<>();
+        final ModelTensor tensor = new ModelTensor(
+            "someValue",
+            output,
+            new long[] { 1, 2 },
+            MLResultDataType.FLOAT64,
+            ByteBuffer.wrap(new byte[12])
+        );
+        mlModelTensorList.add(tensor);
+        final ModelTensors modelTensors = new ModelTensors(mlModelTensorList);
+        tensorsList.add(modelTensors);
+        return new ModelTensorOutput(tensorsList);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchIT.java
@@ -5,15 +5,25 @@
 
 package org.opensearch.neuralsearch.plugin;
 
+import java.io.IOException;
+
+import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.neuralsearch.OpenSearchSecureRestTestCase;
+import org.opensearch.rest.RestRequest;
 
 public class NeuralSearchIT extends OpenSearchSecureRestTestCase {
+    private static final String NEURAL_SEARCH_PLUGIN_NAME = "neural-search";
 
-    /**
-     * Dummy test case for passing the build.
-     */
-    public void testDemo() {
-        Assert.assertTrue(true);
+    public void testNeuralSearchPluginInstalled() throws IOException {
+        final Request request = new Request(RestRequest.Method.GET.name(), String.join("/", "_cat", "plugins"));
+        final Response response = client().performRequest(request);
+        assertOK(response);
+
+        final String responseBody = EntityUtils.toString(response.getEntity());
+        Assert.assertNotNull(responseBody);
+        Assert.assertTrue(responseBody.contains(NEURAL_SEARCH_PLUGIN_NAME));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/transport/MLPredictActionRequestTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/transport/MLPredictActionRequestTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.transport;
+
+import java.util.Collections;
+
+import lombok.SneakyThrows;
+
+import org.junit.Assert;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.neuralsearch.constants.TestCommonConstants;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MLPredictActionRequestTests extends OpenSearchTestCase {
+
+    @SneakyThrows
+    public void testStreams_whenValidInput_thenSuccess() {
+        final MLPredictActionRequest request = new MLPredictActionRequest(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST);
+        final MLPredictActionRequest differentObject = new MLPredictActionRequest(TestCommonConstants.MODEL_ID, Collections.emptyList());
+        final BytesStreamOutput streamOutput = new BytesStreamOutput();
+        request.writeTo(streamOutput);
+        final MLPredictActionRequest mlPredictActionRequestDuplicate = new MLPredictActionRequest(streamOutput.bytes().streamInput());
+        Assert.assertEquals(request, mlPredictActionRequestDuplicate);
+        Assert.assertNotEquals(differentObject, mlPredictActionRequestDuplicate);
+    }
+
+    public void testValidateForAllCases() {
+        final MLPredictActionRequest validRequest = new MLPredictActionRequest(
+            TestCommonConstants.MODEL_ID,
+            TestCommonConstants.SENTENCES_LIST
+        );
+        Assert.assertNull(validRequest.validate());
+        final MLPredictActionRequest inValidRequest = new MLPredictActionRequest(null, TestCommonConstants.SENTENCES_LIST);
+        Assert.assertNotNull(inValidRequest.validate());
+
+        final MLPredictActionRequest inValidRequestWithEmptySentenceList = new MLPredictActionRequest(
+            TestCommonConstants.MODEL_ID,
+            Collections.emptyList()
+        );
+        Assert.assertNotNull(inValidRequestWithEmptySentenceList.validate());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/transport/MLPredictActionResponseTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/transport/MLPredictActionResponseTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.transport;
+
+import java.util.Collections;
+
+import lombok.SneakyThrows;
+
+import org.junit.Assert;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.neuralsearch.constants.TestCommonConstants;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MLPredictActionResponseTests extends OpenSearchTestCase {
+
+    @SneakyThrows
+    public void testStreams_whenValidInput_thenSuccess() {
+        final MLPredictActionResponse response = new MLPredictActionResponse(TestCommonConstants.PREDICTIONS_LIST);
+        final BytesStreamOutput streamOutput = new BytesStreamOutput();
+        response.writeTo(streamOutput);
+        final MLPredictActionResponse duplicateResponse = new MLPredictActionResponse(streamOutput.bytes().streamInput());
+        Assert.assertEquals(response, duplicateResponse);
+    }
+
+    @SneakyThrows
+    public void testStreams_whenPredictionListEmpty_thenSuccess() {
+        final MLPredictActionResponse response = new MLPredictActionResponse(Collections.emptyList());
+        final BytesStreamOutput streamOutput = new BytesStreamOutput();
+        response.writeTo(streamOutput);
+        final MLPredictActionResponse duplicateResponse = new MLPredictActionResponse(streamOutput.bytes().streamInput());
+        Assert.assertEquals(response, duplicateResponse);
+    }
+
+    @SneakyThrows
+    public void testToXContent_whenValidInput_thenSuccess() {
+        final MLPredictActionResponse response = new MLPredictActionResponse(TestCommonConstants.PREDICTIONS_LIST);
+        final String xContentString = "{\"inference_vectors\":[[2.0,3.0]]}";
+        final XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        Assert.assertEquals(xContentString, Strings.toString(response.toXContent(xContentBuilder, null)));
+    }
+
+}

--- a/src/test/java/org/opensearch/neuralsearch/transport/MLPredictTransportActionTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/transport/MLPredictTransportActionTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.transport;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.neuralsearch.constants.TestCommonConstants;
+import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+
+public class MLPredictTransportActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private MLCommonsClientAccessor mlCommonsClientAccessor;
+    @Mock
+    private ActionListener<MLPredictActionResponse> mlPredictActionResponseActionListener;
+    @Mock
+    private Task task;
+    // This variable is required for construction of TransportAction
+    @Mock
+    private TransportService transportService;
+    // This variable is required for construction of TransportAction
+    @Mock
+    private ActionFilters actionFilters;
+    @InjectMocks
+    private MLPredictTransportAction transportAction;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void testDoExecute_whenValidInput_thenSuccess() {
+        final MLPredictActionRequest request = new MLPredictActionRequest(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST);
+
+        final List<List<Float>> vectorList = new ArrayList<>();
+        vectorList.add(Arrays.asList(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+
+        final MLPredictActionResponse response = new MLPredictActionResponse(vectorList);
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<List<List<Float>>> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(vectorList);
+            return null;
+        })
+            .when(mlCommonsClientAccessor)
+            .inferenceSentences(
+                Mockito.eq(TestCommonConstants.MODEL_ID),
+                Mockito.eq(TestCommonConstants.SENTENCES_LIST),
+                Mockito.isA(ActionListener.class)
+            );
+
+        transportAction.doExecute(task, request, mlPredictActionResponseActionListener);
+
+        Mockito.verify(mlCommonsClientAccessor)
+            .inferenceSentences(
+                Mockito.eq(TestCommonConstants.MODEL_ID),
+                Mockito.eq(TestCommonConstants.SENTENCES_LIST),
+                Mockito.isA(ActionListener.class)
+            );
+
+        Mockito.verify(mlPredictActionResponseActionListener).onResponse(response);
+    }
+}


### PR DESCRIPTION
### Description
Added MLCommonsClientAcessor and MLPredict TransportAction for accessing the MLClient APIs predict API.

Changes:
1. Added Accessor Class to invoke the MLClient predict API.
2. Added Transport Action for calling the MLCommonsClientAccessor predict API.
3. Added Unit test.

Signed-off-by: Navneet Verma <navneev@amazon.com>

### Testing
Tested locally by adding the 2.4 zips for K-NN and MLCommons. The MLCommons client which has the API changes is not present in repo hence used the Maven Local for testing.

### Issues Resolved
#7 

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] New functionality has been documented.
    - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
