### PR TITLE
Switch pull_request_target to pull_request in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,8 +4,7 @@ on:
     branches:
       - "*"
       - "feature/**"
-  pull_request_target:
-    types: [ opened, synchronize, reopened ]
+  pull_request:
     branches:
       - "*"
       - "feature/**"


### PR DESCRIPTION
### Description
Right now, our CI checks out the base branch instead of merge branch (see https://github.com/opensearch-project/neural-search/pull/25#issuecomment-1284576387)

Switch pull_request_target to pull_request in CI.

pull_request_target uses base as a context, while pull_request will use merge context. More info can be found: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
