### PR TITLE
Change text embedding processor to async mode for better isolation

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -8,14 +8,12 @@ package org.opensearch.neuralsearch.ml;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
-import org.opensearch.action.ActionFuture;
 import org.opensearch.action.ActionListener;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
@@ -107,29 +105,6 @@ public class MLCommonsClientAccessor {
             log.debug("Inference Response for input sentence {} is : {} ", inputText, vector);
             listener.onResponse(vector);
         }, listener::onFailure));
-    }
-
-    /**
-     * Abstraction to call predict function of api of MLClient with provided targetResponseFilters. It uses the
-     * custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}. The return will be sent
-     * using the actionListener which will have a {@link List} of {@link List} of {@link Float} in the order of
-     * inputText. We are not making this function generic enough to take any function or TaskType as currently we need
-     * to run only TextEmbedding tasks only. Please note this method is a blocking method, use this only when the processing
-     * needs block waiting for response, otherwise please use {@link #inferenceSentences(String, List, ActionListener)}
-     * instead.
-     * @param modelId {@link String}
-     * @param inputText {@link List} of {@link String} on which inference needs to happen.
-     * @return {@link List} of {@link List} of {@link String} represents the text embedding vector result.
-     * @throws ExecutionException If the underlying task failed, this exception will be thrown in the future.get().
-     * @throws InterruptedException If the thread is interrupted, this will be thrown.
-     */
-    public List<List<Float>> inferenceSentences(@NonNull final String modelId, @NonNull final List<String> inputText)
-        throws ExecutionException, InterruptedException {
-        final MLInput mlInput = createMLInput(TARGET_RESPONSE_FILTERS, inputText);
-        final ActionFuture<MLOutput> outputActionFuture = mlClient.predict(modelId, mlInput);
-        final List<List<Float>> vector = buildVectorFromResponse(outputActionFuture.get());
-        log.debug("Inference Response for input sentence {} is : {} ", inputText, vector);
-        return vector;
     }
 
     private MLInput createMLInput(final List<String> targetResponseFilters, List<String> inputText) {

--- a/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
@@ -5,25 +5,17 @@
 
 package org.opensearch.neuralsearch.ml;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import lombok.SneakyThrows;
-
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.action.ActionFuture;
 import org.opensearch.action.ActionListener;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.input.MLInput;
@@ -34,8 +26,6 @@ import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.neuralsearch.constants.TestCommonConstants;
 import org.opensearch.test.OpenSearchTestCase;
-
-import com.google.common.collect.ImmutableList;
 
 public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
@@ -122,26 +112,6 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         Mockito.verify(resultListener).onFailure(exception);
         Mockito.verifyNoMoreInteractions(resultListener);
-    }
-
-    @SneakyThrows
-    public void test_blockingInferenceSentences() {
-        ActionFuture actionFuture = mock(ActionFuture.class);
-        when(client.predict(anyString(), any(MLInput.class))).thenReturn(actionFuture);
-        List<ModelTensors> tensorsList = new ArrayList<>();
-
-        List<ModelTensor> tensors = new ArrayList<>();
-        ModelTensor tensor = mock(ModelTensor.class);
-        when(tensor.getData()).thenReturn(TestCommonConstants.PREDICT_VECTOR_ARRAY);
-        tensors.add(tensor);
-
-        ModelTensors modelTensors = new ModelTensors(tensors);
-        tensorsList.add(modelTensors);
-
-        ModelTensorOutput mlOutput = new ModelTensorOutput(tensorsList);
-        when(actionFuture.get()).thenReturn(mlOutput);
-        List<List<Float>> result = accessor.inferenceSentences("modelId", ImmutableList.of("mock"));
-        assertEquals(TestCommonConstants.PREDICT_VECTOR_ARRAY[0], result.get(0).get(0));
     }
 
     private ModelTensorOutput createModelTensorOutput(final Float[] output) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -7,7 +7,6 @@ package org.opensearch.neuralsearch.processor;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Locale;
 import java.util.Map;
 
 import org.apache.http.HttpHeaders;
@@ -36,13 +35,8 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
     }
 
     private String uploadTextEmbeddingModel() throws Exception {
-        String currentPath = System.getProperty("user.dir");
-        Path testClusterPath = Path.of(currentPath).getParent().resolveSibling("testclusters/integTest-0/data");
-        Path path = Path.of(testClusterPath + "/all-MiniLM-L6-v2.zip");
-        Files.copy(Path.of(classLoader.getResource("model/all-MiniLM-L6-v2.zip").toURI()), path);
         String requestBody = Files.readString(Path.of(classLoader.getResource("processor/UploadModelRequestBody.json").toURI()));
-        String request = String.format(Locale.getDefault(), requestBody, path);
-        return uploadModel(request);
+        return uploadModel(requestBody);
     }
 
     private void createTextEmbeddingIndex() throws Exception {

--- a/src/test/resources/processor/UploadModelRequestBody.json
+++ b/src/test/resources/processor/UploadModelRequestBody.json
@@ -9,5 +9,5 @@
     "framework_type": "sentence_transformers",
     "all_config": "{\"architectures\":[\"BertModel\"],\"max_position_embeddings\":512,\"model_type\":\"bert\",\"num_attention_heads\":12,\"num_hidden_layers\":6}"
   },
-  "url": "file://%s"
+  "url": "https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/all-MiniLM-L6-v2_torchscript_sentence-transformer.zip?raw=true"
 }


### PR DESCRIPTION
### Description
Changed text embedding processor to async mode when handling user input. 
Previously since inferencing runs in async mode, and overriding only the `execute(IngestDocument)` method TextEmbeddingProcessor needs a blocking approach to make sure the document enrichment is complete and then the indexing happens. This has a drawback that the blocking happens in the `write` thread pool, this thread pool has only `availableProcessors + 1` threads, and this could have impact on non text embedding indexing.
Changing this to async mode by overriding `execute(IngestDocument, BiConsumer)` method, thus threads in `write` thread pool will not be blocked and this has better isolation for non text embedding indexing.

### Issues Resolved
An enhancement without issue resolve.

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
