### PR TITLE
Fix group id for ml-commons dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ def knnJarDirectory = "$buildDir/dependencies/opensearch-knn"
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
-    zipArchive group: 'org.opensearch', name:'opensearch-ml-plugin', version: "${opensearch_build}"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
     compileOnly fileTree(dir: knnJarDirectory, include: '*.jar')
     api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'


### PR DESCRIPTION
### Description
Appends plugin to group ID for ml-commons dependency. Recently, ml-commons added this for their publishing zip task.

To confirm this is correct, we see that:
https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-ml-plugin/
is more up to date than 
https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/opensearch-ml-plugin/ 

### Issues Resolved
Related:
1. https://github.com/opensearch-project/ml-commons/pull/468
2. https://github.com/opensearch-project/ml-commons/issues/412


### Check List
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
