### PR TITLE
Add opensearch prefix to plugin name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'jacoco'
 apply plugin: "com.diffplug.spotless"
 apply plugin: 'io.freefair.lombok'
 
-def pluginName = 'neural-search'
+def pluginName = 'opensearch-neural-search'
 def pluginDescription = 'A plugin that adds dense neural retrieval into the OpenSearch ecosytem'
 def projectPath = 'org.opensearch'
 def pathToPlugin = 'neuralsearch.plugin'


### PR DESCRIPTION
### Description
Adds prefix "opensearch" to plugin name to conform with OpenSearch plugin standards.

A few other plugin examples:
1. https://github.com/opensearch-project/k-NN/blob/main/build.gradle#L135
2. https://github.com/opensearch-project/anomaly-detection/blob/main/build.gradle#L131
3. https://github.com/opensearch-project/alerting/blob/01a28e97de45b99dea88e84eed577222bdbc457e/alerting/build.gradle#L27

### Check List
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
