### PR TITLE
Switch processor IT to use Lucene

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -32,6 +32,7 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
         createPipelineProcessor(modelId, PIPELINE_NAME);
         createTextEmbeddingIndex();
         ingestDocument();
+        assertEquals(1, getDocCount(INDEX_NAME));
     }
 
     private String uploadTextEmbeddingModel() throws Exception {
@@ -64,7 +65,7 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
         Response response = makeRequest(
             client(),
             "POST",
-            INDEX_NAME + "/_doc",
+            INDEX_NAME + "/_doc?refresh",
             null,
             toHttpEntity(ingestDocument),
             ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))

--- a/src/test/resources/processor/IndexMappings.json
+++ b/src/test/resources/processor/IndexMappings.json
@@ -17,7 +17,7 @@
         "method": {
           "name": "hnsw",
           "space_type": "l2",
-          "engine": "nmslib",
+          "engine": "lucene",
           "parameters": {
             "ef_construction": 128,
             "m": 24
@@ -30,7 +30,7 @@
         "method": {
           "name": "hnsw",
           "space_type": "l2",
-          "engine": "nmslib",
+          "engine": "lucene",
           "parameters": {
             "ef_construction": 128,
             "m": 24
@@ -43,7 +43,7 @@
         "method": {
           "name": "hnsw",
           "space_type": "l2",
-          "engine": "nmslib",
+          "engine": "lucene",
           "parameters": {
             "ef_construction": 128,
             "m": 24
@@ -59,7 +59,7 @@
             "method": {
               "name": "hnsw",
               "space_type": "l2",
-              "engine": "nmslib",
+              "engine": "lucene",
               "parameters": {
                 "ef_construction": 128,
                 "m": 24


### PR DESCRIPTION
### Description
Currently, Processor IT silently fails because it relies on k-NN plugin's nmslib jni library which is not shipped with the zip at the moment. It fails silently because on ingest, the index is not refreshed.

Updated processor test to use Lucene engine to avoid dependency issue. Refactored ingest document to refresh after ingestion and confirm doc gets indexed.

### Check List
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
