### PR TITLE
Change the behavior when embedding fields not present

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -102,12 +102,13 @@ public class TextEmbeddingProcessor extends AbstractProcessor {
             Map<String, Object> knnMap = buildMapWithKnnKeyAndOriginalValue(ingestDocument);
             List<String> inferenceList = createInferenceList(knnMap);
             if (inferenceList.size() == 0) {
-                throw new IllegalArgumentException("Unable to process embedding since no text found from corresponding source fields");
-            }
-            mlCommonsClientAccessor.inferenceSentences(this.modelId, inferenceList, ActionListener.wrap(vectors -> {
-                appendVectorFieldsToDocument(ingestDocument, knnMap, vectors);
                 handler.accept(ingestDocument, null);
-            }, e -> { handler.accept(null, e); }));
+            } else {
+                mlCommonsClientAccessor.inferenceSentences(this.modelId, inferenceList, ActionListener.wrap(vectors -> {
+                    appendVectorFieldsToDocument(ingestDocument, knnMap, vectors);
+                    handler.accept(ingestDocument, null);
+                }, e -> { handler.accept(null, e); }));
+            }
         } catch (Exception e) {
             handler.accept(null, e);
         }

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -100,7 +100,11 @@ public class TextEmbeddingProcessor extends AbstractProcessor {
         try {
             validateEmbeddingFieldsValue(ingestDocument);
             Map<String, Object> knnMap = buildMapWithKnnKeyAndOriginalValue(ingestDocument);
-            mlCommonsClientAccessor.inferenceSentences(this.modelId, createInferenceList(knnMap), ActionListener.wrap(vectors -> {
+            List<String> inferenceList = createInferenceList(knnMap);
+            if (inferenceList.size() == 0) {
+                throw new IllegalArgumentException("Unable to process embedding since no text found from corresponding source fields");
+            }
+            mlCommonsClientAccessor.inferenceSentences(this.modelId, inferenceList, ActionListener.wrap(vectors -> {
                 appendVectorFieldsToDocument(ingestDocument, knnMap, vectors);
                 handler.accept(ingestDocument, null);
             }, e -> { handler.accept(null, e); }));

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -127,10 +127,8 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(RuntimeException.class));
     }
 
-    public void testExecute_whenInferenceTextListEmpty_throwIllegalArgumentsException() throws Exception {
+    public void testExecute_whenInferenceTextListEmpty_SuccessWithoutEmbedding() throws Exception {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
-        sourceAndMetadata.put("key1", null);
-        sourceAndMetadata.put("key2", null);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
         Map<String, Processor.Factory> registry = new HashMap<>();
         MLCommonsClientAccessor accessor = mock(MLCommonsClientAccessor.class);
@@ -143,7 +141,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         doThrow(new RuntimeException()).when(accessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
-        verify(handler).accept(isNull(), any(IllegalArgumentException.class));
+        verify(handler).accept(any(IngestDocument.class), isNull());
     }
 
     public void testExecute_withListTypeInput_successful() throws Exception {

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -127,6 +127,25 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(RuntimeException.class));
     }
 
+    public void testExecute_whenInferenceTextListEmpty_throwIllegalArgumentsException() throws Exception {
+        Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put("key1", null);
+        sourceAndMetadata.put("key2", null);
+        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        MLCommonsClientAccessor accessor = mock(MLCommonsClientAccessor.class);
+        TextEmbeddingProcessorFactory textEmbeddingProcessorFactory = new TextEmbeddingProcessorFactory(accessor, env);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1Mapped", "key2", "key2Mapped"));
+        TextEmbeddingProcessor processor = textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
+        doThrow(new RuntimeException()).when(accessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        verify(handler).accept(isNull(), any(IllegalArgumentException.class));
+    }
+
     public void testExecute_withListTypeInput_successful() throws Exception {
         List<String> list1 = ImmutableList.of("test1", "test2", "test3");
         List<String> list2 = ImmutableList.of("test4", "test5", "test6");


### PR DESCRIPTION
Signed-off-by: Zan Niu <zaniu@amazon.com>

### Description
This PR is to optimize the error prompt message when inference list is empty, which is caused by user configuration error or expected fields empty. Previously the error message is too general for user to understand what's the root cause.

### Issues Resolved
#71 & #73 

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
