### PR TITLE
Add filter option for query type

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
@@ -339,8 +339,8 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     @SuppressWarnings("unchecked")
     protected int getHitCount(Map<String, Object> searchResponseAsMap) {
         Map<String, Object> hits1map = (Map<String, Object>) searchResponseAsMap.get("hits");
-        List<Object> hits2List = (List<Object>) hits1map.get("hits");
-        return hits2List.size();
+        List<Object> hits1List = (List<Object>) hits1map.get("hits");
+        return hits1List.size();
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
@@ -331,6 +331,19 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     }
 
     /**
+     * Parse the total number of hits from the search
+     *
+     * @param searchResponseAsMap Complete search response as a map
+     * @return number of hits from the search
+     */
+    @SuppressWarnings("unchecked")
+    protected int getHitCount(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hits1map = (Map<String, Object>) searchResponseAsMap.get("hits");
+        List<Object> hits2List = (List<Object>) hits1map.get("hits");
+        return hits2List.size();
+    }
+
+    /**
      * Create a k-NN index from a list of KNNFieldConfigs
      *
      * @param indexName of index to be created


### PR DESCRIPTION
### Description
Adds filter option for query type. Filtering support was introduced in the k-NN plugin in 2.4. This change breaks backwards compatibility with OpenSearch 2.4, however, given that 2.4 is experimental, this is okay. Backwards
  compatibility issues will only arise during mixed cluster upgrade.

Query will look like:

```
     * {
     *  "VECTOR_FIELD": {
     *    "query_text": "string",
     *    "model_id": "string",
     *    "k": int,
     *    "name": "string", (optional)
     *    "boost": float (optional),
     *    "filter": map (optional)
     *  }
     * }
```

### Issues Resolved
#86 

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] New functionality has been documented.
    - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
