### PR TITLE
Add retry mechanism for neural search inference.

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -5,9 +5,15 @@
 
 package org.opensearch.neuralsearch.ml;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+
 import org.opensearch.action.ActionListener;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
@@ -20,11 +26,6 @@ import org.opensearch.ml.common.output.model.ModelTensor;
 import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.neuralsearch.util.RetryUtil;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class will act as an abstraction on the MLCommons client for accessing the ML Capabilities
@@ -123,7 +124,6 @@ public class MLCommonsClientAccessor {
             }
         }));
     }
-
 
     private MLInput createMLInput(final List<String> targetResponseFilters, List<String> inputText) {
         final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);

--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -5,11 +5,16 @@
 
 package org.opensearch.neuralsearch.ml;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.opensearch.action.ActionFuture;
 import org.opensearch.action.ActionListener;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
@@ -24,12 +29,6 @@ import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.transport.NodeDisconnectedException;
 import org.opensearch.transport.NodeNotConnectedException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-
 /**
  * This class will act as an abstraction on the MLCommons client for accessing the ML Capabilities
  */
@@ -40,6 +39,7 @@ public class MLCommonsClientAccessor {
     private final MachineLearningNodeClient mlClient;
 
     private static final int MAX_RETRY = 3;
+
     /**
      * Wrapper around {@link #inferenceSentences} that expected a single input text and produces a single floating
      * point vector as a response.

--- a/src/main/java/org/opensearch/neuralsearch/util/RetryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/RetryUtil.java
@@ -19,6 +19,12 @@ public class RetryUtil {
     private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS = ImmutableList.of(NodeNotConnectedException.class,
         NodeDisconnectedException.class);
 
+    /**
+     *
+     * @param e {@link Exception} which is the exception received to check if retryable.
+     * @param retryTime {@link int} which is the current retried times.
+     * @return {@link boolean} which is the result of if current exception needs retry or not.
+     */
     public static boolean shouldRetry(final Exception e, int retryTime) {
         boolean hasRetryException = RETRYABLE_EXCEPTIONS.stream().anyMatch(x -> ExceptionUtils.indexOfThrowable(e, x) != -1);
         return hasRetryException && retryTime < MAX_RETRY;

--- a/src/main/java/org/opensearch/neuralsearch/util/RetryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/RetryUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.util;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.opensearch.transport.NodeDisconnectedException;
+import org.opensearch.transport.NodeNotConnectedException;
+
+import java.util.List;
+
+public class RetryUtil {
+
+    private static final int MAX_RETRY = 3;
+
+    private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS = ImmutableList.of(NodeNotConnectedException.class,
+        NodeDisconnectedException.class);
+
+    public static boolean shouldRetry(final Exception e, int retryTime) {
+        boolean hasRetryException = RETRYABLE_EXCEPTIONS.stream().anyMatch(x -> ExceptionUtils.indexOfThrowable(e, x) != -1);
+        return hasRetryException && retryTime < MAX_RETRY;
+    }
+
+}

--- a/src/main/java/org/opensearch/neuralsearch/util/RetryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/RetryUtil.java
@@ -5,19 +5,22 @@
 
 package org.opensearch.neuralsearch.util;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.opensearch.transport.NodeDisconnectedException;
 import org.opensearch.transport.NodeNotConnectedException;
 
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 
 public class RetryUtil {
 
     private static final int MAX_RETRY = 3;
 
-    private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS = ImmutableList.of(NodeNotConnectedException.class,
-        NodeDisconnectedException.class);
+    private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS = ImmutableList.of(
+        NodeNotConnectedException.class,
+        NodeDisconnectedException.class
+    );
 
     /**
      *

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import lombok.SneakyThrows;
+
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -54,16 +56,17 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         when(env.settings()).thenReturn(settings);
     }
 
-    private TextEmbeddingProcessor createInstance(List<List<Float>> vector) throws Exception {
+    @SneakyThrows
+    private TextEmbeddingProcessor createInstance(List<List<Float>> vector) {
         Map<String, Processor.Factory> registry = new HashMap<>();
         Map<String, Object> config = new HashMap<>();
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
         config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1Mapped", "key2", "key2Mapped"));
-        TextEmbeddingProcessor processor = textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
-        return processor;
+        return textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
     }
 
-    public void testTextEmbeddingProcessConstructor_whenConfigMapError_throwIllegalArgumentException() throws Exception {
+    @SneakyThrows
+    public void testTextEmbeddingProcessConstructor_whenConfigMapError_throwIllegalArgumentException() {
         Map<String, Processor.Factory> registry = new HashMap<>();
         Map<String, Object> config = new HashMap<>();
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
@@ -78,7 +81,8 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         }
     }
 
-    public void testTextEmbeddingProcessConstructor_whenConfigMapEmpty_throwIllegalArgumentException() throws Exception {
+    @SneakyThrows
+    public void testTextEmbeddingProcessConstructor_whenConfigMapEmpty_throwIllegalArgumentException() {
         Map<String, Processor.Factory> registry = new HashMap<>();
         Map<String, Object> config = new HashMap<>();
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
@@ -89,7 +93,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         }
     }
 
-    public void testExecute_successful() throws Exception {
+    public void testExecute_successful() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
@@ -108,7 +112,8 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(any(IngestDocument.class), isNull());
     }
 
-    public void testExecute_whenInferenceThrowInterruptedException_throwRuntimeException() throws Exception {
+    @SneakyThrows
+    public void testExecute_whenInferenceThrowInterruptedException_throwRuntimeException() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
@@ -127,7 +132,8 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(RuntimeException.class));
     }
 
-    public void testExecute_whenInferenceTextListEmpty_SuccessWithoutEmbedding() throws Exception {
+    @SneakyThrows
+    public void testExecute_whenInferenceTextListEmpty_SuccessWithoutEmbedding() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
         Map<String, Processor.Factory> registry = new HashMap<>();
@@ -144,7 +150,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(any(IngestDocument.class), isNull());
     }
 
-    public void testExecute_withListTypeInput_successful() throws Exception {
+    public void testExecute_withListTypeInput_successful() {
         List<String> list1 = ImmutableList.of("test1", "test2", "test3");
         List<String> list2 = ImmutableList.of("test4", "test5", "test6");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
@@ -165,7 +171,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(any(IngestDocument.class), isNull());
     }
 
-    public void testExecute_SimpleTypeWithEmptyStringValue_throwIllegalArgumentException() throws Exception {
+    public void testExecute_SimpleTypeWithEmptyStringValue_throwIllegalArgumentException() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key1", "    ");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
@@ -176,7 +182,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testExecute_listHasEmptyStringValue_throwIllegalArgumentException() throws Exception {
+    public void testExecute_listHasEmptyStringValue_throwIllegalArgumentException() {
         List<String> list1 = ImmutableList.of("", "test2", "test3");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key1", list1);
@@ -188,7 +194,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testExecute_listHasNonStringValue_throwIllegalArgumentException() throws Exception {
+    public void testExecute_listHasNonStringValue_throwIllegalArgumentException() {
         List<Integer> list2 = ImmutableList.of(1, 2, 3);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key2", list2);
@@ -199,7 +205,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testExecute_listHasNull_throwIllegalArgumentException() throws Exception {
+    public void testExecute_listHasNull_throwIllegalArgumentException() {
         List<String> list = new ArrayList<>();
         list.add("hello");
         list.add(null);
@@ -213,7 +219,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testExecute_withMapTypeInput_successful() throws Exception {
+    public void testExecute_withMapTypeInput_successful() {
         Map<String, String> map1 = ImmutableMap.of("test1", "test2");
         Map<String, String> map2 = ImmutableMap.of("test4", "test5");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
@@ -235,7 +241,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
 
     }
 
-    public void testExecute_mapHasNonStringValue_throwIllegalArgumentException() throws Exception {
+    public void testExecute_mapHasNonStringValue_throwIllegalArgumentException() {
         Map<String, String> map1 = ImmutableMap.of("test1", "test2");
         Map<String, Double> map2 = ImmutableMap.of("test3", 209.3D);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
@@ -248,7 +254,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testExecute_mapHasEmptyStringValue_throwIllegalArgumentException() throws Exception {
+    public void testExecute_mapHasEmptyStringValue_throwIllegalArgumentException() {
         Map<String, String> map1 = ImmutableMap.of("test1", "test2");
         Map<String, String> map2 = ImmutableMap.of("test3", "   ");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
@@ -261,7 +267,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testExecute_mapDepthReachLimit_throwIllegalArgumentException() throws Exception {
+    public void testExecute_mapDepthReachLimit_throwIllegalArgumentException() {
         Map<String, Object> ret = createMaxDepthLimitExceedMap(() -> 1);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key1", "hello world");
@@ -273,7 +279,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testExecute_MLClientAccessorThrowFail_handlerFailure() throws Exception {
+    public void testExecute_MLClientAccessorThrowFail_handlerFailure() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
@@ -303,7 +309,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         return innerMap;
     }
 
-    public void testExecute_hybridTypeInput_successful() throws Exception {
+    public void testExecute_hybridTypeInput_successful() {
         List<String> list1 = ImmutableList.of("test1", "test2");
         Map<String, List<String>> map1 = ImmutableMap.of("test3", list1);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
@@ -314,7 +320,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         assert document.getSourceAndMetadata().containsKey("key2");
     }
 
-    public void testExecute_simpleTypeInputWithNonStringValue_handleIllegalArgumentException() throws Exception {
+    public void testExecute_simpleTypeInputWithNonStringValue_handleIllegalArgumentException() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key1", 100);
         sourceAndMetadata.put("key2", 100.232D);
@@ -331,7 +337,7 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testGetType_successful() throws Exception {
+    public void testGetType_successful() {
         TextEmbeddingProcessor processor = createInstance(createMockVectorWithLength(2));
         assert processor.getType().equals(TextEmbeddingProcessor.TYPE);
     }
@@ -348,7 +354,8 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         assertEquals(12, ingestDocument.getSourceAndMetadata().size());
     }
 
-    public void testBuildVectorOutput_withPlainStringValue_successful() throws Exception {
+    @SneakyThrows
+    public void testBuildVectorOutput_withPlainStringValue_successful() {
         Map<String, Object> config = createPlainStringConfiguration();
         IngestDocument ingestDocument = createPlainIngestDocument();
         TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
@@ -373,8 +380,9 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         assertTrue(result.containsKey("oriKey6_knn"));
     }
 
+    @SneakyThrows
     @SuppressWarnings("unchecked")
-    public void testBuildVectorOutput_withNestedMap_successful() throws Exception {
+    public void testBuildVectorOutput_withNestedMap_successful() {
         Map<String, Object> config = createNestedMapConfiguration();
         IngestDocument ingestDocument = createNestedMapIngestDocument();
         TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
@@ -421,7 +429,8 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         return result;
     }
 
-    private TextEmbeddingProcessor createInstanceWithNestedMapConfiguration(Map<String, Object> fieldMap) throws Exception {
+    @SneakyThrows
+    private TextEmbeddingProcessor createInstanceWithNestedMapConfiguration(Map<String, Object> fieldMap) {
         Map<String, Processor.Factory> registry = new HashMap<>();
         Map<String, Object> config = new HashMap<>();
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");


### PR DESCRIPTION
### Description
This feature is an enhancement to neural-search and the purpose is to improve the availability of the opensearch ml cluster. The core idea is add retry for inference operation, once a request is been sending or have sent to a ml instance which is not available now, rather than simply fail this request we use retry to improve the success rate of requests.

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/92

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
