### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,11 @@
-## Maintainers
+## Overview
+
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
 
 | Maintainer             | GitHub ID                                                 | Affiliation |
-|------------------------|-----------------------------------------------------------|-------------|
+| ---------------------- | --------------------------------------------------------- | ----------- |
 | Vamshi Vijay Nakkirtha | [vamshin](https://github.com/vamshin)                     | Amazon      |
 | Sean Zheng             | [sean-zheng-amazon](https://github.com/sean-zheng-amazon) | Amazon      |
 | Jack Mazanec           | [jmazanec15](https://github.com/jmazanec15)               | Amazon      |
@@ -11,5 +15,3 @@
 | Zan Niu                | [zane-neo](https://github.com/zane-neo)                   | Amazon      |
 | Yaliang Wu             | [ylwu-amzn](https://github.com/ylwu-amzn)                 | Amazon      |
 | Jing Zhang             | [jngz-es](https://github.com/jngz-es)                     | Amazon      |
-
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.