### PR TITLE
Remove direct dependency on ml-commons related jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add GHA to publish to maven repository ([#237](https://github.com/opensearch-project/neural-search/pull/130))
 * Add reflection dependency ([#136](https://github.com/opensearch-project/neural-search/pull/136))
 * Add CHANGELOG ([#135](https://github.com/opensearch-project/neural-search/pull/135))
+* Remove direct dependency on ml-commons related jars ([#xxx](url))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -145,9 +145,6 @@ dependencies {
     compileOnly fileTree(dir: knnJarDirectory, include: '*.jar')
     api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
-    // ml-common excluded reflection for runtime so we need to add it by ourselves.
-    // https://github.com/opensearch-project/ml-commons/commit/464bfe34c66d7a729a00dd457f03587ea4e504d9
-    // TODO: Remove following three lines of dependencies if ml-common include them in their jar
     runtimeOnly group: 'org.reflections', name: 'reflections', version: '0.9.12'
     runtimeOnly group: 'org.javassist', name: 'javassist', version: '3.29.2-GA'
     runtimeOnly group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"


### PR DESCRIPTION
### Description
Following dependencies are coming from ml-commons and need to be removed from build.gradle, otherwise it causes jarhell errors:
- reflections
- javassist
- common-utils

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/148

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
