### PR TITLE
Dont wipe cluster settings after rest tests

### DIFF
--- a/release-notes/opensearch-neural-search.release-notes-2.7.0.0.md
+++ b/release-notes/opensearch-neural-search.release-notes-2.7.0.0.md
@@ -4,6 +4,7 @@ Compatible with OpenSearch 2.7.0
 
 ### Infrastructure
 
+* Avoid clearing settings after each test ([#135](https://github.com/opensearch-project/neural-search/pull/159))
 * Add GHA to publish to maven repository ([#237](https://github.com/opensearch-project/neural-search/pull/130))
 * Add reflection dependency ([#136](https://github.com/opensearch-project/neural-search/pull/136))
 * Add CHANGELOG ([#135](https://github.com/opensearch-project/neural-search/pull/135))

--- a/src/test/java/org/opensearch/neuralsearch/OpenSearchSecureRestTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/OpenSearchSecureRestTestCase.java
@@ -159,4 +159,9 @@ public abstract class OpenSearchSecureRestTestCase extends OpenSearchRestTestCas
             }
         }
     }
+
+    @Override
+    protected boolean preserveClusterSettings() {
+        return true;
+    }
 }


### PR DESCRIPTION
### Description
Fixes failure in #158

Change prevents cluster settings from being wiped clean after each rest test case. With
https://github.com/opensearch-project/ml-commons/commit/c25d116bae1df7636ea9817a7f22f4c550eca8d7, ml-commons now auto redeploy models on ml-nodes. As part of this, they added a setting consumer that will watch for model deployed on node and will undeploy if changed ([ref](https://github.com/opensearch-project/ml-commons/commit/c25d116bae1df7636ea9817a7f22f4c550eca8d7#diff-a81f529712d8f8f4b41ad5f5a2e7c7cbf8712211f26d04c91a4b208c1c1436b3R95)). Because we were setting the runs only on ml-node setting from true to false for each test and it was getting unset after each test, this was causing the model to get removed.

### Issues Resolved
#158 

### Check List
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
