### PR TITLE
Update version to 2.8-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.7.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.8.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
### Description
Version 2.8 has been skipped from build.gradle, need to update now in order for infra automation to pick up next version (2.9-SNAPSHOT) correctly. Also need to backport to 2.8 as currently 2.8 branch has 2.7-SNAPSHOT


### Check List
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
