### PR TITLE
Fix flaky integ tests

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
@@ -56,6 +56,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     private static final int MAX_TASK_RESULT_QUERY_TIME_IN_SECOND = 60 * 5;
 
     private static final int DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND = 1000;
+    private static final String DEFAULT_USER_AGENT = "Kibana";
 
     protected final ClassLoader classLoader = this.getClass().getClassLoader();
 
@@ -93,7 +94,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             "/_plugins/_ml/models/_upload",
             null,
             toHttpEntity(requestBody),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
         Map<String, Object> uploadResJson = XContentHelper.convertToMap(
             XContentFactory.xContent(XContentType.JSON),
@@ -122,7 +123,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             String.format(LOCALE, "/_plugins/_ml/models/%s/_load", modelId),
             null,
             toHttpEntity(""),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
         Map<String, Object> uploadResJson = XContentHelper.convertToMap(
             XContentFactory.xContent(XContentType.JSON),
@@ -170,7 +171,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             String.format(LOCALE, "/_plugins/_ml/_predict/text_embedding/%s", modelId),
             null,
             toHttpEntity(String.format(LOCALE, "{\"text_docs\": [\"%s\"],\"target_response\": [\"sentence_embedding\"]}", queryText)),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
 
         Map<String, Object> inferenceResJson = XContentHelper.convertToMap(
@@ -201,7 +202,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             indexName,
             null,
             toHttpEntity(indexConfiguration),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
         Map<String, Object> node = XContentHelper.convertToMap(
             XContentFactory.xContent(XContentType.JSON),
@@ -225,7 +226,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
                     modelId
                 )
             ),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
         Map<String, Object> node = XContentHelper.convertToMap(
             XContentFactory.xContent(XContentType.JSON),
@@ -403,7 +404,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             String.format(LOCALE, "_plugins/_ml/tasks/%s", taskId),
             null,
             toHttpEntity(""),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
         return XContentHelper.convertToMap(
             XContentFactory.xContent(XContentType.JSON),
@@ -490,5 +491,27 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         private final String name;
         private final Integer dimension;
         private final SpaceType spaceType;
+    }
+
+    @SneakyThrows
+    protected void deleteModel(String modelId) {
+        // need to undeploy first as model can be in use
+        makeRequest(
+            client(),
+            "POST",
+            String.format(LOCALE, "/_plugins/_ml/models/%s/_undeploy", modelId),
+            null,
+            toHttpEntity(""),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        makeRequest(
+            client(),
+            "DELETE",
+            String.format(LOCALE, "/_plugins/_ml/models/%s", modelId),
+            null,
+            toHttpEntity(""),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
@@ -8,7 +8,6 @@ package org.opensearch.neuralsearch.query;
 import static org.opensearch.neuralsearch.TestUtils.createRandomVector;
 import static org.opensearch.neuralsearch.TestUtils.objectToFloat;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.SneakyThrows;
 
+import org.junit.After;
 import org.junit.Before;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
@@ -46,6 +46,17 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
     public void setUp() throws Exception {
         super.setUp();
         modelId.compareAndSet(modelId.get(), prepareModel());
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        /* this is required to minimize chance of model not being deployed due to open memory CB,
+         * this happens in case we leave model from previous test case. We use new model for every test, and old model
+         * can be undeployed and deleted to free resources after each test case execution.
+         */
+        deleteModel(modelId.get());
     }
 
     /**
@@ -344,7 +355,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), 0.0);
     }
 
-    private void initializeIndexIfNotExist(String indexName) throws IOException {
+    @SneakyThrows
+    private void initializeIndexIfNotExist(String indexName) {
         if (TEST_BASIC_INDEX_NAME.equals(indexName) && !indexExists(TEST_BASIC_INDEX_NAME)) {
             prepareKnnIndex(
                 TEST_BASIC_INDEX_NAME,


### PR DESCRIPTION
### Description
Integ tests are failing sporadically with below exception:

```
  2> REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.neuralsearch.query.NeuralQueryIT.testNestedQuery" -Dtests.seed=812CC39392B5DA6A -Dtests.security.manager=false -Dtests.locale=tr -Dtests.timezone=America/Blanc-Sablon -Druntime.java=17

  2> java.lang.AssertionError
        at __randomizedtesting.SeedInfo.seed([812CC39392B5DA6A:E154D04423875F60]:0)
        at org.junit.Assert.fail(Assert.java:87)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.junit.Assert.assertNotNull(Assert.java:713)
        at org.junit.Assert.assertNotNull(Assert.java:723)
        at org.opensearch.neuralsearch.common.BaseNeuralSearchIT.uploadModel(BaseNeuralSearchIT.java:119)
        at org.opensearch.neuralsearch.common.BaseNeuralSearchIT.prepareModel(BaseNeuralSearchIT.java:157)
        at org.opensearch.neuralsearch.query.NeuralQueryIT.setUp(NeuralQueryIT.java:48)
```

We upload new model before each of multiple test cases, this causes exception from ml-commons if server is lacking memory for next model. We should delete model after the test is done to free memory.

Similar fix has been done for hybrid search in a feature branch https://github.com/opensearch-project/neural-search/pull/192

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/195

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
