### PR TITLE
Add github action for secure integ tests

### DIFF
--- a/.github/workflows/run-secure-cluster-tests.yml
+++ b/.github/workflows/run-secure-cluster-tests.yml
@@ -1,0 +1,91 @@
+name: Test neural-search on Secure Cluster
+on:
+  schedule:
+    - cron: '0 0 * * *'  # every night
+  push:
+    branches:
+      - "*"
+      - "feature/**"
+  pull_request:
+    branches:
+      - "*"
+      - "feature/**"
+
+jobs:
+  Build-ad:
+    strategy:
+      matrix:
+        java: [ 11,17 ]
+        os: [ubuntu-latest]
+      fail-fast: true
+
+    name: Test neural-search on Secure Cluster
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout neural-search
+        uses: actions/checkout@v1
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Install dependencies on ubuntu
+        if: startsWith(matrix.os,'ubuntu')
+        run: |
+          sudo apt-get install libopenblas-dev gfortran -y
+
+      - name: Assemble neural-search
+        run: |
+          ./gradlew assemble
+      # example of variables:
+      # plugin = opensearch-neural-search-2.7.0.0-SNAPSHOT.zip
+      # version = 2.7.0
+      # plugin_version = 2.7.0.0
+      # qualifier = `SNAPSHOT`
+      - name: Pull and Run Docker
+        run: |
+          plugin=`basename $(ls build/distributions/*.zip)`
+          version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
+          qualifier=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`  
+          if [ $qualifier != `SNAPSHOT` ];
+           then
+            docker_version=$version-$qualifier
+          else
+            docker_version=$version
+          fi
+          echo plugin version plugin_version qualifier docker_version
+          echo "($plugin) ($version) ($plugin_version) ($qualifier) ($docker_version)"
+          
+          cd ..
+          if docker pull opensearchstaging/opensearch:$docker_version
+          then
+            echo "FROM opensearchstaging/opensearch:$docker_version" >> Dockerfile
+            # neural-search plugin cannot be deleted until there are plugin that has dependency on it
+            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-performance-analyzer ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-analyzer; fi" >> Dockerfile
+            echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/$plugin" >> Dockerfile
+            docker build -t opensearch-neural-search:test .
+            echo "imagePresent=true" >> $GITHUB_ENV          
+          else
+            echo "imagePresent=false" >> $GITHUB_ENV
+          fi
+
+      - name: Run Docker Image
+        if: env.imagePresent == 'true'
+        run: |
+          cd ..
+          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opensearch-neural-search:test
+          sleep 90
+      - name: Run neural-search Integ Test
+        if: env.imagePresent == 'true'
+        run: |
+          security=`curl -XGET https://localhost:9200/_cat/plugins?v -u admin:admin --insecure |grep opensearch-security|wc -l`
+          if [ $security -gt 0 ]
+          then
+            echo "Security plugin is available"
+            ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=admin
+          else
+            echo "Security plugin is NOT available, skipping integration tests"
+          fi


### PR DESCRIPTION
### Description
Adding github action to run integ tests against cluster with security plugin. Approach is taken from [k-NN plugin](https://github.com/martin-gaievski/k-NN/blob/main/.github/workflows/test_security.yml), that in turn taken mainly taken from [AD plugin](https://github.com/opensearch-project/anomaly-detection/blob/main/.github/workflows/test_security.yml). 

This is initial minimal version as team researching other options that do not include docker usage.

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
