### PR TITLE
Add Query phase searcher

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.opensearch.client.Client;
@@ -26,6 +27,7 @@ import org.opensearch.neuralsearch.processor.TextEmbeddingProcessor;
 import org.opensearch.neuralsearch.processor.factory.TextEmbeddingProcessorFactory;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+import org.opensearch.neuralsearch.search.query.HybridQueryPhaseSearcher;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.IngestPlugin;
@@ -33,6 +35,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.SearchPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
+import org.opensearch.search.query.QueryPhaseSearcher;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -73,5 +76,10 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
         clientAccessor = new MLCommonsClientAccessor(new MachineLearningNodeClient(parameters.client));
         return Collections.singletonMap(TextEmbeddingProcessor.TYPE, new TextEmbeddingProcessorFactory(clientAccessor, parameters.env));
+    }
+
+    @Override
+    public Optional<QueryPhaseSearcher> getQueryPhaseSearcher() {
+        return Optional.of(new HybridQueryPhaseSearcher());
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -191,9 +191,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                     boost = parser.floatValue();
                     // regular boost functionality is not supported, user should use score normalization methods to manipulate with scores
                     if (boost != DEFAULT_BOOST) {
-                        log.error(
-                            String.format(Locale.ROOT, "[%s] query does not support provided value %.4f for [%s]", NAME, boost, BOOST_FIELD)
-                        );
+                        log.error("[{}] query does not support provided value {} for [{}]", NAME, boost, BOOST_FIELD);
                         throw new ParsingException(parser.getTokenLocation(), "[{}] query does not support [{}]", NAME, BOOST_FIELD);
                     }
                 } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -191,11 +191,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                     boost = parser.floatValue();
                     // regular boost functionality is not supported, user should use score normalization methods to manipulate with scores
                     if (boost != DEFAULT_BOOST) {
-                        log.error(String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, BOOST_FIELD));
-                        throw new ParsingException(
-                            parser.getTokenLocation(),
-                            String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, BOOST_FIELD)
+                        log.error(
+                            String.format(Locale.ROOT, "[%s] query does not support provided value %.4f for [%s]", NAME, boost, BOOST_FIELD)
                         );
+                        throw new ParsingException(parser.getTokenLocation(), "[{}] query does not support [{}]", NAME, BOOST_FIELD);
                     }
                 } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     queryName = parser.text();

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -189,6 +189,14 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             } else {
                 if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     boost = parser.floatValue();
+                    // regular boost functionality is not supported, user should use score normalization methods to manipulate with scores
+                    if (boost != DEFAULT_BOOST) {
+                        log.error(String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, BOOST_FIELD));
+                        throw new ParsingException(
+                            parser.getTokenLocation(),
+                            String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, BOOST_FIELD)
+                        );
+                    }
                 } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     queryName = parser.text();
                 } else {

--- a/src/main/java/org/opensearch/neuralsearch/search/CompoundTopDocs.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/CompoundTopDocs.java
@@ -6,6 +6,7 @@
 package org.opensearch.neuralsearch.search;
 
 import java.util.Arrays;
+import java.util.List;
 
 import lombok.Getter;
 import lombok.ToString;
@@ -21,23 +22,23 @@ import org.apache.lucene.search.TotalHits;
 public class CompoundTopDocs extends TopDocs {
 
     @Getter
-    private TopDocs[] compoundTopDocs;
+    private List<TopDocs> compoundTopDocs;
 
     public CompoundTopDocs(TotalHits totalHits, ScoreDoc[] scoreDocs) {
         super(totalHits, scoreDocs);
     }
 
-    public CompoundTopDocs(TotalHits totalHits, TopDocs[] docs) {
+    public CompoundTopDocs(TotalHits totalHits, List<TopDocs> docs) {
         // we pass clone of score docs from the sub-query that has most hits
         super(totalHits, cloneLargestScoreDocs(docs));
         this.compoundTopDocs = docs;
     }
 
-    private static ScoreDoc[] cloneLargestScoreDocs(TopDocs[] docs) {
+    private static ScoreDoc[] cloneLargestScoreDocs(List<TopDocs> docs) {
         if (docs == null) {
             return null;
         }
-        ScoreDoc[] maxScoreDocs = null;
+        ScoreDoc[] maxScoreDocs = new ScoreDoc[0];
         int maxLength = -1;
         for (TopDocs topDoc : docs) {
             if (topDoc == null || topDoc.scoreDocs == null) {
@@ -47,9 +48,6 @@ public class CompoundTopDocs extends TopDocs {
                 maxLength = topDoc.scoreDocs.length;
                 maxScoreDocs = topDoc.scoreDocs;
             }
-        }
-        if (maxScoreDocs == null) {
-            return null;
         }
         // do deep copy
         return Arrays.stream(maxScoreDocs).map(doc -> new ScoreDoc(doc.doc, doc.score, doc.shardIndex)).toArray(ScoreDoc[]::new);

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollector.java
@@ -6,6 +6,8 @@
 package org.opensearch.neuralsearch.search;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import lombok.Getter;
@@ -31,9 +33,7 @@ import org.opensearch.neuralsearch.query.HybridQueryScorer;
 public class HybridTopScoreDocCollector implements Collector {
     private static final TopDocs EMPTY_TOPDOCS = new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
     private int docBase;
-    private float minCompetitiveScore;
     private final HitsThresholdChecker hitsThresholdChecker;
-    private ScoreDoc pqTop;
     private TotalHits.Relation totalHitsRelation = TotalHits.Relation.EQUAL_TO;
     private int[] totalHits;
     private final int numOfHits;
@@ -48,7 +48,6 @@ public class HybridTopScoreDocCollector implements Collector {
     @Override
     public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
         docBase = context.docBase;
-        minCompetitiveScore = 0f;
 
         return new TopScoreDocCollector.ScorerLeafCollector() {
             HybridQueryScorer compoundQueryScorer;
@@ -56,7 +55,6 @@ public class HybridTopScoreDocCollector implements Collector {
             @Override
             public void setScorer(Scorable scorer) throws IOException {
                 super.setScorer(scorer);
-                updateMinCompetitiveScore(scorer);
                 compoundQueryScorer = (HybridQueryScorer) scorer;
             }
 
@@ -93,29 +91,19 @@ public class HybridTopScoreDocCollector implements Collector {
         return hitsThresholdChecker.scoreMode();
     }
 
-    protected void updateMinCompetitiveScore(Scorable scorer) throws IOException {
-        if (hitsThresholdChecker.isThresholdReached() && pqTop != null && pqTop.score != Float.NEGATIVE_INFINITY) { // -Infinity is the
-                                                                                                                    // boundary score
-            // we have multiple identical doc id and collect in doc id order, we need next float
-            float localMinScore = Math.nextUp(pqTop.score);
-            if (localMinScore > minCompetitiveScore) {
-                scorer.setMinCompetitiveScore(localMinScore);
-                totalHitsRelation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
-                minCompetitiveScore = localMinScore;
-            }
-        }
-    }
-
     /**
      * Get resulting collection of TopDocs for hybrid query after we ran search for each of its sub query
      * @return
      */
-    public TopDocs[] topDocs() {
-        TopDocs[] topDocs = new TopDocs[compoundScores.length];
+    public List<TopDocs> topDocs() {
+        List<TopDocs> topDocs;
+        if (compoundScores == null) {
+            return new ArrayList<>();
+        }
+        topDocs = new ArrayList(compoundScores.length);
         for (int i = 0; i < compoundScores.length; i++) {
             int qTopSize = totalHits[i];
-            TopDocs topDocsPerQuery = topDocsPerQuery(0, Math.min(qTopSize, compoundScores[i].size()), compoundScores[i], qTopSize);
-            topDocs[i] = topDocsPerQuery;
+            topDocs.add(topDocsPerQuery(0, Math.min(qTopSize, compoundScores[i].size()), compoundScores[i], qTopSize));
         }
         return topDocs;
     }

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollector.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -96,15 +98,12 @@ public class HybridTopScoreDocCollector implements Collector {
      * @return
      */
     public List<TopDocs> topDocs() {
-        List<TopDocs> topDocs;
         if (compoundScores == null) {
             return new ArrayList<>();
         }
-        topDocs = new ArrayList(compoundScores.length);
-        for (int i = 0; i < compoundScores.length; i++) {
-            int qTopSize = totalHits[i];
-            topDocs.add(topDocsPerQuery(0, Math.min(qTopSize, compoundScores[i].size()), compoundScores[i], qTopSize));
-        }
+        final List<TopDocs> topDocs = IntStream.range(0, compoundScores.length)
+            .mapToObj(i -> topDocsPerQuery(0, Math.min(totalHits[i], compoundScores[i].size()), compoundScores[i], totalHits[i]))
+            .collect(Collectors.toList());
         return topDocs;
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.search.query;
+
+import static org.opensearch.search.query.TopDocsCollectorContext.createTopDocsCollectorContext;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHitCountCollector;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+import org.opensearch.neuralsearch.query.HybridQuery;
+import org.opensearch.neuralsearch.search.CompoundTopDocs;
+import org.opensearch.neuralsearch.search.HitsThresholdChecker;
+import org.opensearch.neuralsearch.search.HybridTopScoreDocCollector;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.internal.ContextIndexSearcher;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.query.QueryCollectorContext;
+import org.opensearch.search.query.QueryPhase;
+import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.search.query.TopDocsCollectorContext;
+import org.opensearch.search.rescore.RescoreContext;
+import org.opensearch.search.sort.SortAndFormats;
+
+/**
+ * Custom search implementation to be used at {@link QueryPhase} for Hybrid Query search. For queries other than Hybrid the
+ * upstream standard implementation of searcher is called.
+ */
+@Log4j2
+public class HybridQueryPhaseSearcher extends QueryPhase.DefaultQueryPhaseSearcher {
+
+    private Function<List<TopDocs>, TotalHits> totalHitsSupplier;
+    private Function<List<TopDocs>, Float> maxScoreSupplier;
+    protected SortAndFormats sortAndFormats;
+
+    public boolean searchWith(
+        SearchContext searchContext,
+        ContextIndexSearcher searcher,
+        Query query,
+        LinkedList<QueryCollectorContext> collectors,
+        boolean hasFilterCollector,
+        boolean hasTimeout
+    ) throws IOException {
+        if (query instanceof HybridQuery) {
+            return searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
+        }
+        return super.searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
+    }
+
+    protected boolean searchWithCollector(
+        SearchContext searchContext,
+        ContextIndexSearcher searcher,
+        Query query,
+        LinkedList<QueryCollectorContext> collectors,
+        boolean hasFilterCollector,
+        boolean hasTimeout
+    ) throws IOException {
+        log.debug(String.format(Locale.ROOT, "searching with custom doc collector, shard %s", searchContext.shardTarget().getShardId()));
+
+        final TopDocsCollectorContext topDocsFactory = createTopDocsCollectorContext(searchContext, hasFilterCollector);
+        collectors.addFirst(topDocsFactory);
+
+        final IndexReader reader = searchContext.searcher().getIndexReader();
+        int totalNumDocs = Math.max(0, reader.numDocs());
+        if (searchContext.size() == 0) {
+            final TotalHitCountCollector collector = new TotalHitCountCollector();
+            searcher.search(query, collector);
+            return false;
+        }
+        int numDocs = Math.min(searchContext.from() + searchContext.size(), totalNumDocs);
+        final boolean rescore = !searchContext.rescore().isEmpty();
+        if (rescore) {
+            assert searchContext.sort() == null;
+            for (RescoreContext rescoreContext : searchContext.rescore()) {
+                numDocs = Math.max(numDocs, rescoreContext.getWindowSize());
+            }
+        }
+
+        final QuerySearchResult queryResult = searchContext.queryResult();
+
+        final HybridTopScoreDocCollector collector = new HybridTopScoreDocCollector(
+            numDocs,
+            new HitsThresholdChecker(Math.max(numDocs, searchContext.trackTotalHitsUpTo()))
+        );
+        totalHitsSupplier = topDocs -> {
+            int trackTotalHitsUpTo = searchContext.trackTotalHitsUpTo();
+            final TotalHits.Relation relation = trackTotalHitsUpTo == SearchContext.TRACK_TOTAL_HITS_DISABLED
+                ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+                : TotalHits.Relation.EQUAL_TO;
+            if (topDocs == null || topDocs.size() == 0) {
+                return new TotalHits(0, relation);
+            }
+            long maxTotalHits = topDocs.get(0).totalHits.value;
+            for (TopDocs topDoc : topDocs) {
+                maxTotalHits = Math.max(maxTotalHits, topDoc.totalHits.value);
+            }
+            return new TotalHits(maxTotalHits, relation);
+        };
+        maxScoreSupplier = topDocs -> {
+            if (topDocs.size() == 0) {
+                return Float.NaN;
+            } else {
+                return topDocs.stream()
+                    .map(docs -> docs.scoreDocs.length == 0 ? new ScoreDoc(-1, 0.0f) : docs.scoreDocs[0])
+                    .map(scoreDoc -> scoreDoc.score)
+                    .max(Float::compare)
+                    .get();
+            }
+        };
+        sortAndFormats = searchContext.sort();
+
+        searcher.search(query, collector);
+
+        if (searchContext.terminateAfter() != SearchContext.DEFAULT_TERMINATE_AFTER && queryResult.terminatedEarly() == null) {
+            queryResult.terminatedEarly(false);
+        }
+
+        setTopDocsInQueryResult(queryResult, collector);
+
+        return rescore;
+    }
+
+    void setTopDocsInQueryResult(final QuerySearchResult queryResult, final HybridTopScoreDocCollector collector) {
+        final List<TopDocs> topDocs = collector.topDocs();
+        float maxScore = maxScoreSupplier.apply(topDocs);
+        final TopDocs newTopDocs = new CompoundTopDocs(totalHitsSupplier.apply(topDocs), topDocs);
+        final TopDocsAndMaxScore topDocsAndMaxScore = new TopDocsAndMaxScore(newTopDocs, maxScore);
+        queryResult.topDocs(topDocsAndMaxScore, getSortValueFormats());
+    }
+
+    private DocValueFormat[] getSortValueFormats() {
+        return sortAndFormats == null ? null : sortAndFormats.formats;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -130,7 +130,7 @@ public class HybridQueryPhaseSearcher extends QueryPhase.DefaultQueryPhaseSearch
         return new TotalHits(maxTotalHits, relation);
     }
 
-    private float getMaxScore(List<TopDocs> topDocs) {
+    private float getMaxScore(final List<TopDocs> topDocs) {
         if (topDocs.size() == 0) {
             return Float.NaN;
         } else {

--- a/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
@@ -62,6 +62,12 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
     @Before
     public void setupSettings() {
+        if (isUpdateClusterSettings()) {
+            updateClusterSettings();
+        }
+    }
+
+    protected void updateClusterSettings() {
         updateClusterSettings("plugins.ml_commons.only_run_on_ml_node", false);
         // default threshold for native circuit breaker is 90, it may be not enough on test runner machine
         updateClusterSettings("plugins.ml_commons.native_memory_threshold", 100);
@@ -513,5 +519,9 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             toHttpEntity(""),
             ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
+    }
+
+    public boolean isUpdateClusterSettings() {
+        return true;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.neuralsearch.plugin;
 
+import static org.mockito.Mockito.mock;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -17,8 +19,6 @@ import org.opensearch.neuralsearch.search.query.HybridQueryPhaseSearcher;
 import org.opensearch.plugins.SearchPlugin;
 import org.opensearch.search.query.QueryPhaseSearcher;
 import org.opensearch.test.OpenSearchTestCase;
-
-import static org.mockito.Mockito.mock;
 
 public class NeuralSearchTests extends OpenSearchTestCase {
 

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -6,11 +6,19 @@
 package org.opensearch.neuralsearch.plugin;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
+import org.opensearch.ingest.Processor;
+import org.opensearch.neuralsearch.processor.TextEmbeddingProcessor;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+import org.opensearch.neuralsearch.search.query.HybridQueryPhaseSearcher;
 import org.opensearch.plugins.SearchPlugin;
+import org.opensearch.search.query.QueryPhaseSearcher;
 import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
 
 public class NeuralSearchTests extends OpenSearchTestCase {
 
@@ -22,5 +30,22 @@ public class NeuralSearchTests extends OpenSearchTestCase {
         assertFalse(querySpecs.isEmpty());
         assertTrue(querySpecs.stream().anyMatch(spec -> NeuralQueryBuilder.NAME.equals(spec.getName().getPreferredName())));
         assertTrue(querySpecs.stream().anyMatch(spec -> HybridQueryBuilder.NAME.equals(spec.getName().getPreferredName())));
+    }
+
+    public void testQueryPhaseSearcher() {
+        NeuralSearch plugin = new NeuralSearch();
+        Optional<QueryPhaseSearcher> queryPhaseSearcher = plugin.getQueryPhaseSearcher();
+
+        assertNotNull(queryPhaseSearcher);
+        assertFalse(queryPhaseSearcher.isEmpty());
+        assertTrue(queryPhaseSearcher.get() instanceof HybridQueryPhaseSearcher);
+    }
+
+    public void testProcessors() {
+        NeuralSearch plugin = new NeuralSearch();
+        Processor.Parameters processorParams = mock(Processor.Parameters.class);
+        Map<String, Processor.Factory> processors = plugin.getProcessors(processorParams);
+        assertNotNull(processors);
+        assertNotNull(processors.get(TextEmbeddingProcessor.TYPE));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -597,9 +597,30 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertEquals(termSubQuery.value(), termQueryBuilder.value());
     }
 
+    /**
+     * Tests query with boost:
+     * {
+     *     "query": {
+     *         "hybrid": {
+     *              "queries": [
+     *                  {
+     *                      "term": {
+     *                          "text": "keyword"
+     *                      }
+     *                  },
+     *                  {
+     *                      "term": {
+     *                          "text": "keyword"
+     *                       }
+     *                  }
+     *              ],
+     *              "boost" : 2.0
+     *          }
+     *      }
+     * }
+     */
     @SneakyThrows
     public void testBoost_whenNonDefaultBoostSet_thenFail() {
-        // create query with 6 sub-queries, which is more than current max allowed
         XContentBuilder xContentBuilderWithNonDefaultBoost = XContentFactory.jsonBuilder()
             .startObject()
             .startArray("queries")

--- a/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
@@ -11,15 +11,10 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -46,14 +41,11 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.indices.mapper.MapperRegistry;
-import org.opensearch.knn.index.VectorField;
 import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.script.ScriptModule;
 import org.opensearch.script.ScriptService;
 import org.opensearch.test.OpenSearchTestCase;
-
-import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
 
@@ -139,41 +131,6 @@ public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
         doc.add(new TextField("id", Integer.toString(docId), Field.Store.YES));
         doc.add(new Field(fieldName, fieldValue, ft));
         return doc;
-    }
-
-    protected static Document getTextAndVectorDocument(
-        String fieldName,
-        int docId,
-        String fieldValue,
-        FieldType ft,
-        String vectorName,
-        float[] vector,
-        FieldType vt
-    ) {
-        Document doc = new Document();
-        doc.add(new TextField("id", Integer.toString(docId), Field.Store.YES));
-        doc.add(new Field(fieldName, fieldValue, ft));
-        doc.add(new BinaryDocValuesField(vectorName, new VectorField(vectorName, vector, new FieldType()).binaryValue()));
-        return doc;
-    }
-
-    private Pair<int[], float[]> generateDocuments(int maxDocId) {
-        final int numDocs = RandomizedTest.randomIntBetween(1, maxDocId / 2);
-        final int[] docs = new int[numDocs];
-        final Set<Integer> uniqueDocs = new HashSet<>();
-        while (uniqueDocs.size() < numDocs) {
-            uniqueDocs.add(random().nextInt(maxDocId));
-        }
-        int i = 0;
-        for (int doc : uniqueDocs) {
-            docs[i++] = doc;
-        }
-        Arrays.sort(docs);
-        final float[] scores = new float[numDocs];
-        for (int j = 0; j < numDocs; ++j) {
-            scores[j] = random().nextFloat();
-        }
-        return new ImmutablePair<>(docs, scores);
     }
 
     protected static Weight fakeWeight(Query query) {

--- a/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -45,6 +46,7 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.indices.mapper.MapperRegistry;
+import org.opensearch.knn.index.VectorField;
 import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.plugins.ScriptPlugin;
 import org.opensearch.script.ScriptModule;
@@ -136,6 +138,22 @@ public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
         Document doc = new Document();
         doc.add(new TextField("id", Integer.toString(docId), Field.Store.YES));
         doc.add(new Field(fieldName, fieldValue, ft));
+        return doc;
+    }
+
+    protected static Document getTextAndVectorDocument(
+        String fieldName,
+        int docId,
+        String fieldValue,
+        FieldType ft,
+        String vectorName,
+        float[] vector,
+        FieldType vt
+    ) {
+        Document doc = new Document();
+        doc.add(new TextField("id", Integer.toString(docId), Field.Store.YES));
+        doc.add(new Field(fieldName, fieldValue, ft));
+        doc.add(new BinaryDocValuesField(vectorName, new VectorField(vectorName, vector, new FieldType()).binaryValue()));
         return doc;
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/search/CompoundTopDocsTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/CompoundTopDocsTests.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.neuralsearch.search;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -25,7 +28,7 @@ public class CompoundTopDocsTests extends OpenSearchQueryTestCase {
                 new ScoreDoc(4, RandomUtils.nextFloat()),
                 new ScoreDoc(5, RandomUtils.nextFloat()) }
         );
-        TopDocs[] topDocs = new TopDocs[] { topDocs1, topDocs2 };
+        List<TopDocs> topDocs = List.of(topDocs1, topDocs2);
         CompoundTopDocs compoundTopDocs = new CompoundTopDocs(new TotalHits(3, TotalHits.Relation.EQUAL_TO), topDocs);
         assertNotNull(compoundTopDocs);
         assertEquals(topDocs, compoundTopDocs.getCompoundTopDocs());
@@ -49,7 +52,7 @@ public class CompoundTopDocsTests extends OpenSearchQueryTestCase {
             new TotalHits(2, TotalHits.Relation.EQUAL_TO),
             new ScoreDoc[] { new ScoreDoc(2, RandomUtils.nextFloat()), new ScoreDoc(4, RandomUtils.nextFloat()) }
         );
-        TopDocs[] topDocs = new TopDocs[] { topDocs1, topDocs2 };
+        List<TopDocs> topDocs = List.of(topDocs1, topDocs2);
         CompoundTopDocs compoundTopDocs = new CompoundTopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), topDocs);
         assertNotNull(compoundTopDocs);
         assertNotNull(compoundTopDocs.scoreDocs);
@@ -57,15 +60,16 @@ public class CompoundTopDocsTests extends OpenSearchQueryTestCase {
     }
 
     public void testBasics_whenMultipleTopDocsIsNull_thenScoreDocsIsNull() {
-        CompoundTopDocs compoundTopDocs = new CompoundTopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), (TopDocs[]) null);
+        CompoundTopDocs compoundTopDocs = new CompoundTopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), (List<TopDocs>) null);
         assertNotNull(compoundTopDocs);
         assertNull(compoundTopDocs.scoreDocs);
 
         CompoundTopDocs compoundTopDocsWithNullArray = new CompoundTopDocs(
             new TotalHits(0, TotalHits.Relation.EQUAL_TO),
-            new TopDocs[] { null, null }
+            Arrays.asList(null, null)
         );
         assertNotNull(compoundTopDocsWithNullArray);
-        assertNull(compoundTopDocsWithNullArray.scoreDocs);
+        assertNotNull(compoundTopDocsWithNullArray.scoreDocs);
+        assertEquals(0, compoundTopDocsWithNullArray.scoreDocs.length);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollectorTests.java
@@ -204,10 +204,10 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
             doc = iterator.nextDoc();
         }
 
-        TopDocs[] topDocs = hybridTopScoreDocCollector.topDocs();
+        List<TopDocs> topDocs = hybridTopScoreDocCollector.topDocs();
 
         assertNotNull(topDocs);
-        assertEquals(2, topDocs.length);
+        assertEquals(2, topDocs.size());
 
         for (TopDocs topDoc : topDocs) {
             // assert results for each sub-query, there must be correct number of matches, all doc id are correct and scores must be desc
@@ -296,14 +296,14 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
             doc = iterator.nextDoc();
         }
 
-        TopDocs[] topDocs = hybridTopScoreDocCollector.topDocs();
+        List<TopDocs> topDocs = hybridTopScoreDocCollector.topDocs();
 
         assertNotNull(topDocs);
-        assertEquals(4, topDocs.length);
+        assertEquals(4, topDocs.size());
 
         // assert result for each sub query
         // term query 1
-        TopDocs topDocQuery1 = topDocs[0];
+        TopDocs topDocQuery1 = topDocs.get(0);
         assertEquals(docIdsQuery1.length, topDocQuery1.totalHits.value);
         ScoreDoc[] scoreDocsQuery1 = topDocQuery1.scoreDocs;
         assertNotNull(scoreDocsQuery1);
@@ -314,7 +314,7 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         List<Integer> resultDocIdsQuery1 = Arrays.stream(scoreDocsQuery1).map(scoreDoc -> scoreDoc.doc).collect(Collectors.toList());
         assertTrue(Arrays.stream(docIdsQuery1).allMatch(resultDocIdsQuery1::contains));
         // term query 2
-        TopDocs topDocQuery2 = topDocs[1];
+        TopDocs topDocQuery2 = topDocs.get(1);
         assertEquals(docIdsQuery2.length, topDocQuery2.totalHits.value);
         ScoreDoc[] scoreDocsQuery2 = topDocQuery2.scoreDocs;
         assertNotNull(scoreDocsQuery2);
@@ -325,13 +325,13 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         List<Integer> resultDocIdsQuery2 = Arrays.stream(scoreDocsQuery2).map(scoreDoc -> scoreDoc.doc).collect(Collectors.toList());
         assertTrue(Arrays.stream(docIdsQuery2).allMatch(resultDocIdsQuery2::contains));
         // no match query
-        TopDocs topDocQuery3 = topDocs[2];
+        TopDocs topDocQuery3 = topDocs.get(2);
         assertEquals(0, topDocQuery3.totalHits.value);
         ScoreDoc[] scoreDocsQuery3 = topDocQuery3.scoreDocs;
         assertNotNull(scoreDocsQuery3);
         assertEquals(0, scoreDocsQuery3.length);
         // all match query
-        TopDocs topDocQueryMatchAll = topDocs[3];
+        TopDocs topDocQueryMatchAll = topDocs.get(3);
         assertEquals(docIdsQueryMatchAll.length, topDocQueryMatchAll.totalHits.value);
         ScoreDoc[] scoreDocsQueryMatchAll = topDocQueryMatchAll.scoreDocs;
         assertNotNull(scoreDocsQueryMatchAll);

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.search.query;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import lombok.SneakyThrows;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.opensearch.action.OriginalIndices;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+import org.opensearch.index.Index;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+import org.opensearch.neuralsearch.search.CompoundTopDocs;
+import org.opensearch.search.SearchShardTarget;
+import org.opensearch.search.internal.ContextIndexSearcher;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.query.QueryCollectorContext;
+import org.opensearch.search.query.QuerySearchResult;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+
+public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
+    private static final String VECTOR_FIELD_NAME = "vectorField";
+    private static final String TEXT_FIELD_NAME = "field";
+    private static final String TEST_DOC_TEXT1 = "Hello world";
+    private static final String TEST_DOC_TEXT2 = "Hi to this place";
+    private static final String TEST_DOC_TEXT3 = "We would like to welcome everyone";
+    private static final String TEST_DOC_TEXT4 = "This is really nice place to be";
+    private static final String QUERY_TEXT1 = "hello";
+    private static final String QUERY_TEXT2 = "randomkeyword";
+    private static final String QUERY_TEXT3 = "place";
+    private static final Index dummyIndex = new Index("dummy", "dummy");
+    private static final String MODEL_ID = "mfgfgdsfgfdgsde";
+    private static final int K = 10;
+    private static final QueryBuilder TEST_FILTER = new MatchAllQueryBuilder();
+
+    @SneakyThrows
+    public void testQueryType_whenQueryIsHybrid_thenCallHybridDocCollector() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = spy(new HybridQueryPhaseSearcher());
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        Directory directory = newDirectory();
+        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+
+        w.addDocument(getDocument(TEXT_FIELD_NAME, RandomizedTest.randomInt(), TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, RandomizedTest.randomInt(), TEST_DOC_TEXT2, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, RandomizedTest.randomInt(), TEST_DOC_TEXT3, ft));
+        w.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+
+        ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null
+        );
+
+        SearchContext searchContext = mock(SearchContext.class);
+        ShardId shardId = new ShardId(dummyIndex, 1);
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            randomAlphaOfLength(10),
+            shardId,
+            randomAlphaOfLength(10),
+            OriginalIndices.NONE
+        );
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+
+        LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
+        boolean hasFilterCollector = randomBoolean();
+        boolean hasTimeout = randomBoolean();
+
+        HybridQueryBuilder queryBuilder = new HybridQueryBuilder();
+
+        TermQueryBuilder termSubQuery = QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1);
+        queryBuilder.add(termSubQuery);
+
+        Query query = queryBuilder.toQuery(mockQueryShardContext);
+        when(searchContext.query()).thenReturn(query);
+
+        hybridQueryPhaseSearcher.searchWith(searchContext, contextIndexSearcher, query, collectors, hasFilterCollector, hasTimeout);
+
+        releaseResources(directory, w, reader);
+
+        verify(hybridQueryPhaseSearcher, atLeastOnce()).searchWithCollector(any(), any(), any(), any(), anyBoolean(), anyBoolean());
+    }
+
+    @SneakyThrows
+    public void testQueryType_whenQueryIsNotHybrid_thenDoNotCallHybridDocCollector() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = spy(new HybridQueryPhaseSearcher());
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        Directory directory = newDirectory();
+        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+
+        w.addDocument(getDocument(TEXT_FIELD_NAME, RandomizedTest.randomInt(), TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, RandomizedTest.randomInt(), TEST_DOC_TEXT2, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, RandomizedTest.randomInt(), TEST_DOC_TEXT3, ft));
+        w.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+
+        ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null
+        );
+
+        SearchContext searchContext = mock(SearchContext.class);
+        ShardId shardId = new ShardId(dummyIndex, 1);
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            randomAlphaOfLength(10),
+            shardId,
+            randomAlphaOfLength(10),
+            OriginalIndices.NONE
+        );
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        when(searchContext.queryResult()).thenReturn(new QuerySearchResult());
+
+        LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
+        boolean hasFilterCollector = randomBoolean();
+        boolean hasTimeout = randomBoolean();
+
+        TermQueryBuilder termSubQuery = QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1);
+
+        Query query = termSubQuery.toQuery(mockQueryShardContext);
+        when(searchContext.query()).thenReturn(query);
+
+        hybridQueryPhaseSearcher.searchWith(searchContext, contextIndexSearcher, query, collectors, hasFilterCollector, hasTimeout);
+
+        releaseResources(directory, w, reader);
+
+        verify(hybridQueryPhaseSearcher, never()).searchWithCollector(any(), any(), any(), any(), anyBoolean(), anyBoolean());
+    }
+
+    @SneakyThrows
+    public void testQueryResult_whenOneSubQueryWithHits_thenHybridResultsAreSet() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = spy(new HybridQueryPhaseSearcher());
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        Directory directory = newDirectory();
+        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+        int docId1 = RandomizedTest.randomInt();
+        int docId2 = RandomizedTest.randomInt();
+        int docId3 = RandomizedTest.randomInt();
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId1, TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId2, TEST_DOC_TEXT2, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
+        w.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+
+        ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null
+        );
+
+        SearchContext searchContext = mock(SearchContext.class);
+        ShardId shardId = new ShardId(dummyIndex, 1);
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            randomAlphaOfLength(10),
+            shardId,
+            randomAlphaOfLength(10),
+            OriginalIndices.NONE
+        );
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        when(searchContext.size()).thenReturn(3);
+        final QuerySearchResult querySearchResult = new QuerySearchResult();
+        when(searchContext.queryResult()).thenReturn(querySearchResult);
+
+        LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
+        boolean hasFilterCollector = randomBoolean();
+        boolean hasTimeout = randomBoolean();
+
+        HybridQueryBuilder queryBuilder = new HybridQueryBuilder();
+
+        TermQueryBuilder termSubQuery = QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1);
+        queryBuilder.add(termSubQuery);
+
+        Query query = queryBuilder.toQuery(mockQueryShardContext);
+        when(searchContext.query()).thenReturn(query);
+
+        hybridQueryPhaseSearcher.searchWith(searchContext, contextIndexSearcher, query, collectors, hasFilterCollector, hasTimeout);
+
+        assertNotNull(querySearchResult.topDocs());
+        TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
+        TopDocs topDocs = topDocsAndMaxScore.topDocs;
+        assertEquals(1, topDocs.totalHits.value);
+        assertTrue(topDocs instanceof CompoundTopDocs);
+        List<TopDocs> compoundTopDocs = ((CompoundTopDocs) topDocs).getCompoundTopDocs();
+        assertNotNull(compoundTopDocs);
+        assertEquals(1, compoundTopDocs.size());
+        TopDocs subQueryTopDocs = compoundTopDocs.get(0);
+        assertEquals(1, subQueryTopDocs.totalHits.value);
+        assertNotNull(subQueryTopDocs.scoreDocs);
+        assertEquals(1, subQueryTopDocs.scoreDocs.length);
+        ScoreDoc scoreDoc = subQueryTopDocs.scoreDocs[0];
+        assertNotNull(scoreDoc);
+        int actualDocId = Integer.parseInt(reader.document(scoreDoc.doc).getField("id").stringValue());
+        assertEquals(docId1, actualDocId);
+        assertTrue(scoreDoc.score > 0.0f);
+
+        releaseResources(directory, w, reader);
+    }
+
+    @SneakyThrows
+    public void testQueryResult_whenMultipleTextSubQueriesWithSomeHits_thenHybridResultsAreSet() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = new HybridQueryPhaseSearcher();
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        Directory directory = newDirectory();
+        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+        int docId1 = RandomizedTest.randomInt();
+        int docId2 = RandomizedTest.randomInt();
+        int docId3 = RandomizedTest.randomInt();
+        int docId4 = RandomizedTest.randomInt();
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId1, TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId2, TEST_DOC_TEXT2, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId4, TEST_DOC_TEXT4, ft));
+        w.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+
+        ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null
+        );
+
+        SearchContext searchContext = mock(SearchContext.class);
+        ShardId shardId = new ShardId(dummyIndex, 1);
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            randomAlphaOfLength(10),
+            shardId,
+            randomAlphaOfLength(10),
+            OriginalIndices.NONE
+        );
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        when(searchContext.size()).thenReturn(4);
+        final QuerySearchResult querySearchResult = new QuerySearchResult();
+        when(searchContext.queryResult()).thenReturn(querySearchResult);
+
+        LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
+        boolean hasFilterCollector = randomBoolean();
+        boolean hasTimeout = randomBoolean();
+
+        HybridQueryBuilder queryBuilder = new HybridQueryBuilder();
+
+        queryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1));
+        queryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT2));
+        queryBuilder.add(QueryBuilders.matchAllQuery());
+
+        Query query = queryBuilder.toQuery(mockQueryShardContext);
+        when(searchContext.query()).thenReturn(query);
+
+        hybridQueryPhaseSearcher.searchWith(searchContext, contextIndexSearcher, query, collectors, hasFilterCollector, hasTimeout);
+
+        assertNotNull(querySearchResult.topDocs());
+        TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
+        TopDocs topDocs = topDocsAndMaxScore.topDocs;
+        assertEquals(4, topDocs.totalHits.value);
+        assertTrue(topDocs instanceof CompoundTopDocs);
+        List<TopDocs> compoundTopDocs = ((CompoundTopDocs) topDocs).getCompoundTopDocs();
+        assertNotNull(compoundTopDocs);
+        assertEquals(3, compoundTopDocs.size());
+
+        TopDocs subQueryTopDocs1 = compoundTopDocs.get(0);
+        List<Integer> expectedIds1 = List.of(docId1);
+        assertQueryResults(subQueryTopDocs1, expectedIds1, reader);
+
+        TopDocs subQueryTopDocs2 = compoundTopDocs.get(1);
+        List<Integer> expectedIds2 = List.of();
+        assertQueryResults(subQueryTopDocs2, expectedIds2, reader);
+
+        TopDocs subQueryTopDocs3 = compoundTopDocs.get(2);
+        List<Integer> expectedIds3 = List.of(docId1, docId2, docId3, docId4);
+        assertQueryResults(subQueryTopDocs3, expectedIds3, reader);
+
+        releaseResources(directory, w, reader);
+    }
+
+    @SneakyThrows
+    private void assertQueryResults(TopDocs subQueryTopDocs, List<Integer> expectedDocIds, IndexReader reader) {
+        assertEquals(expectedDocIds.size(), subQueryTopDocs.totalHits.value);
+        assertNotNull(subQueryTopDocs.scoreDocs);
+        assertEquals(expectedDocIds.size(), subQueryTopDocs.scoreDocs.length);
+        assertEquals(TotalHits.Relation.EQUAL_TO, subQueryTopDocs.totalHits.relation);
+        for (int i = 0; i < expectedDocIds.size(); i++) {
+            int expectedDocId = expectedDocIds.get(i);
+            ScoreDoc scoreDoc = subQueryTopDocs.scoreDocs[i];
+            assertNotNull(scoreDoc);
+            int actualDocId = Integer.parseInt(reader.document(scoreDoc.doc).getField("id").stringValue());
+            assertEquals(expectedDocId, actualDocId);
+            assertTrue(scoreDoc.score > 0.0f);
+        }
+    }
+
+    private void releaseResources(Directory directory, IndexWriter w, IndexReader reader) throws IOException {
+        w.close();
+        reader.close();
+        directory.close();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -83,7 +83,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
 
         Directory directory = newDirectory();
-        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
         ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
         ft.setOmitNorms(random().nextBoolean());
@@ -143,7 +143,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
 
         Directory directory = newDirectory();
-        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
         ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
         ft.setOmitNorms(random().nextBoolean());
@@ -202,7 +202,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
 
         Directory directory = newDirectory();
-        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
         ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
         ft.setOmitNorms(random().nextBoolean());
@@ -237,7 +237,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.shardTarget()).thenReturn(shardTarget);
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         when(searchContext.size()).thenReturn(3);
-        final QuerySearchResult querySearchResult = new QuerySearchResult();
+        QuerySearchResult querySearchResult = new QuerySearchResult();
         when(searchContext.queryResult()).thenReturn(querySearchResult);
 
         LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
@@ -284,7 +284,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
 
         Directory directory = newDirectory();
-        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
         ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
         ft.setOmitNorms(random().nextBoolean());
@@ -321,7 +321,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.shardTarget()).thenReturn(shardTarget);
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         when(searchContext.size()).thenReturn(4);
-        final QuerySearchResult querySearchResult = new QuerySearchResult();
+        QuerySearchResult querySearchResult = new QuerySearchResult();
         when(searchContext.queryResult()).thenReturn(querySearchResult);
 
         LinkedList<QueryCollectorContext> collectors = new LinkedList<>();


### PR DESCRIPTION
### Description
Adding Query Phase Searcher required for Normalization and Score Combination feature. 
Searcher is registered on plugin level, it calls previously created doc collector and collect docs and scores and updated Query Result in SearchContext. This allows search results to be visible in later phases for post processors.

Adding integ tests, it's not complete end to end as post processor is coming later, but it allows to execute Hybrid Query on cluster with data.

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/194

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] New functionality has been documented.
    - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
