### PR TITLE
Switch from XContentType to MediaType to fix compilation errors

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/OpenSearchSecureRestTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/OpenSearchSecureRestTestCase.java
@@ -36,8 +36,8 @@ import org.opensearch.client.RestClientBuilder;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
@@ -150,7 +150,7 @@ public abstract class OpenSearchSecureRestTestCase extends OpenSearchRestTestCas
     @After
     public void deleteExternalIndices() throws IOException {
         final Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json" + "&expand_wildcards=all"));
-        final XContentType xContentType = XContentType.fromMediaType(response.getEntity().getContentType());
+        final MediaType xContentType = MediaType.fromMediaType(response.getEntity().getContentType());
         try (
             final XContentParser parser = xContentType.xContent()
                 .createParser(


### PR DESCRIPTION
### Description
Fix compilation errors after merge of https://github.com/opensearch-project/OpenSearch/pull/8636 in core OpenSearch, switched from XContentType to MediaType

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
