### PR TITLE
Adding weights param for combination technique

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
@@ -5,16 +5,34 @@
 
 package org.opensearch.neuralsearch.processor.combination;
 
-import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.opensearch.OpenSearchParseException;
 
 /**
  * Abstracts combination of scores based on arithmetic mean method
  */
-@NoArgsConstructor
 public class ArithmeticMeanScoreCombinationTechnique implements ScoreCombinationTechnique {
 
     public static final String TECHNIQUE_NAME = "arithmetic_mean";
+    public static final String PARAM_NAME_WEIGHTS = "weights";
     private static final Float ZERO_SCORE = 0.0f;
+    private final List<Double> weights;
+
+    public ArithmeticMeanScoreCombinationTechnique(final Map<String, Object> params) {
+        validateParams(params);
+        if (Objects.isNull(params) || params.isEmpty()) {
+            weights = List.of();
+            return;
+        }
+        // get weights, we don't need to check for instance as it's done during validation
+        weights = (List<Double>) params.getOrDefault(PARAM_NAME_WEIGHTS, new ArrayList<>());
+    }
 
     /**
      * Arithmetic mean method for combining scores.
@@ -26,8 +44,13 @@ public class ArithmeticMeanScoreCombinationTechnique implements ScoreCombination
     public float combine(final float[] scores) {
         float combinedScore = 0.0f;
         int count = 0;
-        for (float score : scores) {
+        for (int i = 0; i < scores.length; i++) {
+            float score = scores[i];
             if (score >= 0.0) {
+                // apply weight for this sub-query if it's set for particular sub-query
+                if (i < weights.size()) {
+                    score = (float) (score * weights.get(i));
+                }
                 combinedScore += score;
                 count++;
             }
@@ -36,5 +59,27 @@ public class ArithmeticMeanScoreCombinationTechnique implements ScoreCombination
             return ZERO_SCORE;
         }
         return combinedScore / count;
+    }
+
+    private void validateParams(final Map<String, Object> params) {
+        if (Objects.isNull(params) || params.isEmpty()) {
+            return;
+        }
+        // check if only supported params are passed
+        Set<String> supportedParams = Set.of(PARAM_NAME_WEIGHTS);
+        Optional<String> optionalNotSupportedParam = params.keySet()
+            .stream()
+            .filter(paramName -> !supportedParams.contains(paramName))
+            .findFirst();
+        if (optionalNotSupportedParam.isPresent()) {
+            throw new OpenSearchParseException("provided parameter for combination technique is not supported");
+        }
+
+        // check param types
+        if (params.keySet().stream().anyMatch(PARAM_NAME_WEIGHTS::equalsIgnoreCase)) {
+            if (!(params.get(PARAM_NAME_WEIGHTS) instanceof List)) {
+                throw new OpenSearchParseException("parameter {} must be a collection of numbers", PARAM_NAME_WEIGHTS);
+            }
+        }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
@@ -99,6 +99,6 @@ public class ArithmeticMeanScoreCombinationTechnique implements ScoreCombination
      * @return weight for sub-query, use one that is set in processor/pipeline definition or 1.0 as default
      */
     private float getWeightForSubQuery(int indexOfSubQuery) {
-        return indexOfSubQuery < weights.size() ? weights.get(indexOfSubQuery).floatValue() : 1.0f;
+        return indexOfSubQuery < weights.size() ? weights.get(indexOfSubQuery) : 1.0f;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
@@ -41,27 +41,27 @@ public class ArithmeticMeanScoreCombinationTechnique implements ScoreCombination
 
     /**
      * Arithmetic mean method for combining scores.
-     * cscore = (score1 + score2 +...+ scoreN)/N
+     * score = (weight1*score1 + weight2*score2 +...+ weightN*scoreN)/(weight1 + weight2 + ... + weightN)
      *
      * Zero (0.0) scores are excluded from number of scores N
      */
     @Override
     public float combine(final float[] scores) {
         float combinedScore = 0.0f;
-        int count = 0;
+        float weights = 0;
         for (int indexOfSubQuery = 0; indexOfSubQuery < scores.length; indexOfSubQuery++) {
             float score = scores[indexOfSubQuery];
             if (score >= 0.0) {
                 float weight = getWeightForSubQuery(indexOfSubQuery);
                 score = score * weight;
                 combinedScore += score;
-                count++;
+                weights += weight;
             }
         }
-        if (count == 0) {
+        if (weights == 0.0f) {
             return ZERO_SCORE;
         }
-        return combinedScore / count;
+        return combinedScore / weights;
     }
 
     private void validateParams(final Map<String, Object> params) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactory.java
@@ -7,6 +7,7 @@ package org.opensearch.neuralsearch.processor.combination;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.opensearch.OpenSearchParseException;
 
@@ -15,11 +16,11 @@ import org.opensearch.OpenSearchParseException;
  */
 public class ScoreCombinationFactory {
 
-    public static final ScoreCombinationTechnique DEFAULT_METHOD = new ArithmeticMeanScoreCombinationTechnique();
+    public static final ScoreCombinationTechnique DEFAULT_METHOD = new ArithmeticMeanScoreCombinationTechnique(Map.of());
 
-    private final Map<String, ScoreCombinationTechnique> scoreCombinationMethodsMap = Map.of(
+    private final Map<String, Function<Map<String, Object>, ScoreCombinationTechnique>> scoreCombinationMethodsMap = Map.of(
         ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME,
-        new ArithmeticMeanScoreCombinationTechnique()
+        ArithmeticMeanScoreCombinationTechnique::new
     );
 
     /**
@@ -28,7 +29,17 @@ public class ScoreCombinationFactory {
      * @return instance of ScoreCombinationTechnique for technique name
      */
     public ScoreCombinationTechnique createCombination(final String technique) {
+        return createCombination(technique, Map.of());
+    }
+
+    /**
+     * Get score combination method by technique name
+     * @param technique name of technique
+     * @return instance of ScoreCombinationTechnique for technique name
+     */
+    public ScoreCombinationTechnique createCombination(final String technique, final Map<String, Object> params) {
         return Optional.ofNullable(scoreCombinationMethodsMap.get(technique))
-            .orElseThrow(() -> new OpenSearchParseException("provided combination technique is not supported"));
+            .orElseThrow(() -> new OpenSearchParseException("provided combination technique is not supported"))
+            .apply(params);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactory.java
@@ -9,8 +9,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.opensearch.OpenSearchParseException;
-
 /**
  * Abstracts creation of exact score combination method based on technique name
  */
@@ -35,11 +33,12 @@ public class ScoreCombinationFactory {
     /**
      * Get score combination method by technique name
      * @param technique name of technique
+     * @param params parameters that combination technique may use
      * @return instance of ScoreCombinationTechnique for technique name
      */
     public ScoreCombinationTechnique createCombination(final String technique, final Map<String, Object> params) {
         return Optional.ofNullable(scoreCombinationMethodsMap.get(technique))
-            .orElseThrow(() -> new OpenSearchParseException("provided combination technique is not supported"))
+            .orElseThrow(() -> new IllegalArgumentException("provided combination technique is not supported"))
             .apply(params);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
@@ -6,6 +6,7 @@
 package org.opensearch.neuralsearch.processor.factory;
 
 import static org.opensearch.ingest.ConfigurationUtils.readOptionalMap;
+import static org.opensearch.ingest.ConfigurationUtils.readOptionalStringProperty;
 
 import java.util.Map;
 import java.util.Objects;
@@ -29,6 +30,7 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
     public static final String NORMALIZATION_CLAUSE = "normalization";
     public static final String COMBINATION_CLAUSE = "combination";
     public static final String TECHNIQUE = "technique";
+    public static final String PARAMETERS = "parameters";
 
     private final NormalizationProcessorWorkflow normalizationProcessorWorkflow;
     private ScoreNormalizationFactory scoreNormalizationFactory;
@@ -53,9 +55,12 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
         Map<String, Object> combinationClause = readOptionalMap(NormalizationProcessor.TYPE, tag, config, COMBINATION_CLAUSE);
 
         ScoreCombinationTechnique scoreCombinationTechnique = ScoreCombinationFactory.DEFAULT_METHOD;
+        Map<String, Object> combinationParams;
         if (Objects.nonNull(combinationClause)) {
-            String combinationTechnique = (String) combinationClause.getOrDefault(TECHNIQUE, "");
-            scoreCombinationTechnique = scoreCombinationFactory.createCombination(combinationTechnique);
+            String combinationTechnique = readOptionalStringProperty(NormalizationProcessor.TYPE, tag, combinationClause, TECHNIQUE);
+            // check for optional combination params
+            combinationParams = readOptionalMap(NormalizationProcessor.TYPE, tag, combinationClause, PARAMETERS);
+            scoreCombinationTechnique = scoreCombinationFactory.createCombination(combinationTechnique, combinationParams);
         }
 
         return new NormalizationProcessor(

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
@@ -20,7 +20,7 @@ import com.google.common.primitives.Floats;
  */
 public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTechnique {
 
-    protected static final String TECHNIQUE_NAME = "min_max";
+    public static final String TECHNIQUE_NAME = "min_max";
     private static final float MIN_SCORE = 0.001f;
     private static final float SINGLE_RESULT_SCORE = 1.0f;
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
@@ -8,8 +8,6 @@ package org.opensearch.neuralsearch.processor.normalization;
 import java.util.Map;
 import java.util.Optional;
 
-import org.opensearch.OpenSearchParseException;
-
 /**
  * Abstracts creation of exact score normalization method based on technique name
  */
@@ -29,6 +27,6 @@ public class ScoreNormalizationFactory {
      */
     public ScoreNormalizationTechnique createNormalization(final String technique) {
         return Optional.ofNullable(scoreNormalizationMethodsMap.get(technique))
-            .orElseThrow(() -> new OpenSearchParseException("provided normalization technique is not supported"));
+            .orElseThrow(() -> new IllegalArgumentException("provided normalization technique is not supported"));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationCombinationIT.java
@@ -252,7 +252,7 @@ public class ScoreNormalizationCombinationIT extends BaseNeuralSearchIT {
     }
 
     @SneakyThrows
-    public void testCombinationParams_whenWeightsParamSet_thenSuccessful() {
+    public void testArithmeticWeightedMean_whenWeightsPassed_thenSuccessful() {
         initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME);
         // check case when number of weights and sub-queries are same
         createSearchPipeline(
@@ -275,7 +275,7 @@ public class ScoreNormalizationCombinationIT extends BaseNeuralSearchIT {
             Map.of("search_pipeline", SEARCH_PIPELINE)
         );
 
-        assertWeightedScores(searchResponseWithWeights1AsMap, 0.6, 0.5, 0.001);
+        assertWeightedScores(searchResponseWithWeights1AsMap, 1.0, 1.0, 0.001);
 
         // delete existing pipeline and create a new one with another set of weights
         deleteSearchPipeline(SEARCH_PIPELINE);
@@ -294,7 +294,7 @@ public class ScoreNormalizationCombinationIT extends BaseNeuralSearchIT {
             Map.of("search_pipeline", SEARCH_PIPELINE)
         );
 
-        assertWeightedScores(searchResponseWithWeights2AsMap, 2.0, 0.8, 0.001);
+        assertWeightedScores(searchResponseWithWeights2AsMap, 1.0, 1.0, 0.001);
 
         // check case when number of weights is less than number of sub-queries
         // delete existing pipeline and create a new one with another set of weights
@@ -314,7 +314,7 @@ public class ScoreNormalizationCombinationIT extends BaseNeuralSearchIT {
             Map.of("search_pipeline", SEARCH_PIPELINE)
         );
 
-        assertWeightedScores(searchResponseWithWeights3AsMap, 1.0, 0.8, 0.001);
+        assertWeightedScores(searchResponseWithWeights3AsMap, 1.0, 1.0, 0.001);
 
         // check case when number of weights is more than number of sub-queries
         // delete existing pipeline and create a new one with another set of weights
@@ -334,7 +334,7 @@ public class ScoreNormalizationCombinationIT extends BaseNeuralSearchIT {
             Map.of("search_pipeline", SEARCH_PIPELINE)
         );
 
-        assertWeightedScores(searchResponseWithWeights4AsMap, 0.6, 0.5, 0.001);
+        assertWeightedScores(searchResponseWithWeights4AsMap, 1.0, 1.0, 0.001);
     }
 
     private void initializeIndexIfNotExist(String indexName) throws IOException {

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechniqueTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.processor.combination;
+
+import static org.opensearch.neuralsearch.processor.combination.ArithmeticMeanScoreCombinationTechnique.PARAM_NAME_WEIGHTS;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ArithmeticMeanScoreCombinationTechniqueTests extends OpenSearchTestCase {
+
+    private static final float DELTA_FOR_ASSERTION = 0.0001f;
+
+    public void testLogic_whenAllScoresPresentAndNoWeights_thenCorrectScores() {
+        ArithmeticMeanScoreCombinationTechnique combinationTechnique = new ArithmeticMeanScoreCombinationTechnique(Map.of());
+        float[] scores = { 1.0f, 0.5f, 0.3f };
+        float actualScore = combinationTechnique.combine(scores);
+        assertEquals(0.6f, actualScore, DELTA_FOR_ASSERTION);
+    }
+
+    public void testLogic_whenNotAllScoresPresentAndNoWeights_thenCorrectScores() {
+        ArithmeticMeanScoreCombinationTechnique combinationTechnique = new ArithmeticMeanScoreCombinationTechnique(Map.of());
+        float[] scores = { 1.0f, -1.0f, 0.6f };
+        float actualScore = combinationTechnique.combine(scores);
+        assertEquals(0.8f, actualScore, DELTA_FOR_ASSERTION);
+    }
+
+    public void testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores() {
+        ArithmeticMeanScoreCombinationTechnique combinationTechnique = new ArithmeticMeanScoreCombinationTechnique(
+            Map.of(PARAM_NAME_WEIGHTS, List.of(0.9, 0.2, 0.7))
+        );
+        float[] scores = { 1.0f, 0.5f, 0.3f };
+        float actualScore = combinationTechnique.combine(scores);
+        assertEquals(0.6722f, actualScore, DELTA_FOR_ASSERTION);
+    }
+
+    public void testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
+        ArithmeticMeanScoreCombinationTechnique combinationTechnique = new ArithmeticMeanScoreCombinationTechnique(
+            Map.of(PARAM_NAME_WEIGHTS, List.of(0.9, 0.15, 0.7))
+        );
+        float[] scores = { 1.0f, -1.0f, 0.6f };
+        float actualScore = combinationTechnique.combine(scores);
+        assertEquals(0.825f, actualScore, DELTA_FOR_ASSERTION);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactoryTests.java
@@ -6,7 +6,12 @@
 package org.opensearch.neuralsearch.processor.factory;
 
 import static org.mockito.Mockito.mock;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.COMBINATION_CLAUSE;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.NORMALIZATION_CLAUSE;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.PARAMETERS;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.TECHNIQUE;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,6 +28,8 @@ import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
 import org.opensearch.test.OpenSearchTestCase;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 public class NormalizationProcessorFactoryTests extends OpenSearchTestCase {
 
@@ -68,8 +75,8 @@ public class NormalizationProcessorFactoryTests extends OpenSearchTestCase {
         String description = "description";
         boolean ignoreFailure = false;
         Map<String, Object> config = new HashMap<>();
-        config.put("normalization", Map.of("technique", "min_max"));
-        config.put("combination", Map.of("technique", "arithmetic_mean"));
+        config.put("normalization", new HashMap<>(Map.of("technique", "min_max")));
+        config.put("combination", new HashMap<>(Map.of("technique", "arithmetic_mean")));
         Processor.PipelineContext pipelineContext = mock(Processor.PipelineContext.class);
         SearchPhaseResultsProcessor searchPhaseResultsProcessor = normalizationProcessorFactory.create(
             processorFactories,
@@ -85,7 +92,46 @@ public class NormalizationProcessorFactoryTests extends OpenSearchTestCase {
         assertEquals("normalization-processor", normalizationProcessor.getType());
     }
 
-    public void testInputValidation_whenInvalidParameters_thenFail() {
+    @SneakyThrows
+    public void testNormalizationProcessor_whenWithCombinationParams_thenSuccessful() {
+        NormalizationProcessorFactory normalizationProcessorFactory = new NormalizationProcessorFactory(
+            new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
+            new ScoreNormalizationFactory(),
+            new ScoreCombinationFactory()
+        );
+        final Map<String, Processor.Factory<SearchPhaseResultsProcessor>> processorFactories = new HashMap<>();
+        String tag = "tag";
+        String description = "description";
+        boolean ignoreFailure = false;
+        Map<String, Object> config = new HashMap<>();
+        config.put(NORMALIZATION_CLAUSE, new HashMap<>(Map.of("technique", "min_max")));
+        config.put(
+            COMBINATION_CLAUSE,
+            new HashMap<>(
+                Map.of(
+                    TECHNIQUE,
+                    "arithmetic_mean",
+                    PARAMETERS,
+                    new HashMap<>(Map.of("weights", Arrays.asList(RandomizedTest.randomFloat(), RandomizedTest.randomFloat())))
+                )
+            )
+        );
+        Processor.PipelineContext pipelineContext = mock(Processor.PipelineContext.class);
+        SearchPhaseResultsProcessor searchPhaseResultsProcessor = normalizationProcessorFactory.create(
+            processorFactories,
+            tag,
+            description,
+            ignoreFailure,
+            config,
+            pipelineContext
+        );
+        assertNotNull(searchPhaseResultsProcessor);
+        assertTrue(searchPhaseResultsProcessor instanceof NormalizationProcessor);
+        NormalizationProcessor normalizationProcessor = (NormalizationProcessor) searchPhaseResultsProcessor;
+        assertEquals("normalization-processor", normalizationProcessor.getType());
+    }
+
+    public void testInputValidation_whenInvalidNormalizationClause_thenFail() {
         NormalizationProcessorFactory normalizationProcessorFactory = new NormalizationProcessorFactory(
             new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
             new ScoreNormalizationFactory(),
@@ -107,9 +153,9 @@ public class NormalizationProcessorFactoryTests extends OpenSearchTestCase {
                 new HashMap<>(
                     Map.of(
                         NormalizationProcessorFactory.NORMALIZATION_CLAUSE,
-                        Map.of(NormalizationProcessorFactory.TECHNIQUE, ""),
+                        Map.of(TECHNIQUE, ""),
                         NormalizationProcessorFactory.COMBINATION_CLAUSE,
-                        Map.of(NormalizationProcessorFactory.TECHNIQUE, ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME)
+                        Map.of(TECHNIQUE, ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME)
                     )
                 ),
                 pipelineContext
@@ -126,9 +172,41 @@ public class NormalizationProcessorFactoryTests extends OpenSearchTestCase {
                 new HashMap<>(
                     Map.of(
                         NormalizationProcessorFactory.NORMALIZATION_CLAUSE,
-                        Map.of(NormalizationProcessorFactory.TECHNIQUE, NORMALIZATION_METHOD),
+                        new HashMap(Map.of(TECHNIQUE, "random_name_for_normalization")),
                         NormalizationProcessorFactory.COMBINATION_CLAUSE,
-                        Map.of(NormalizationProcessorFactory.TECHNIQUE, "")
+                        new HashMap(Map.of(TECHNIQUE, ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME))
+                    )
+                ),
+                pipelineContext
+            )
+        );
+    }
+
+    public void testInputValidation_whenInvalidCombinationClause_thenFail() {
+        NormalizationProcessorFactory normalizationProcessorFactory = new NormalizationProcessorFactory(
+            new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
+            new ScoreNormalizationFactory(),
+            new ScoreCombinationFactory()
+        );
+        Map<String, Processor.Factory<SearchPhaseResultsProcessor>> processorFactories = new HashMap<>();
+        String tag = "tag";
+        String description = "description";
+        boolean ignoreFailure = false;
+        Processor.PipelineContext pipelineContext = mock(Processor.PipelineContext.class);
+
+        expectThrows(
+            OpenSearchParseException.class,
+            () -> normalizationProcessorFactory.create(
+                processorFactories,
+                tag,
+                description,
+                ignoreFailure,
+                new HashMap<>(
+                    Map.of(
+                        NormalizationProcessorFactory.NORMALIZATION_CLAUSE,
+                        new HashMap(Map.of(TECHNIQUE, NORMALIZATION_METHOD)),
+                        NormalizationProcessorFactory.COMBINATION_CLAUSE,
+                        new HashMap(Map.of(TECHNIQUE, ""))
                     )
                 ),
                 pipelineContext
@@ -145,9 +223,48 @@ public class NormalizationProcessorFactoryTests extends OpenSearchTestCase {
                 new HashMap<>(
                     Map.of(
                         NormalizationProcessorFactory.NORMALIZATION_CLAUSE,
-                        Map.of(NormalizationProcessorFactory.TECHNIQUE, "random_name_for_normalization"),
+                        new HashMap(Map.of(TECHNIQUE, NORMALIZATION_METHOD)),
                         NormalizationProcessorFactory.COMBINATION_CLAUSE,
-                        Map.of(NormalizationProcessorFactory.TECHNIQUE, ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME)
+                        new HashMap(Map.of(TECHNIQUE, "random_name_for_combination"))
+                    )
+                ),
+                pipelineContext
+            )
+        );
+    }
+
+    public void testInputValidation_whenInvalidCombinationParams_thenFail() {
+        NormalizationProcessorFactory normalizationProcessorFactory = new NormalizationProcessorFactory(
+            new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
+            new ScoreNormalizationFactory(),
+            new ScoreCombinationFactory()
+        );
+        Map<String, Processor.Factory<SearchPhaseResultsProcessor>> processorFactories = new HashMap<>();
+        String tag = "tag";
+        String description = "description";
+        boolean ignoreFailure = false;
+        Processor.PipelineContext pipelineContext = mock(Processor.PipelineContext.class);
+
+        expectThrows(
+            OpenSearchParseException.class,
+            () -> normalizationProcessorFactory.create(
+                processorFactories,
+                tag,
+                description,
+                ignoreFailure,
+                new HashMap<>(
+                    Map.of(
+                        NormalizationProcessorFactory.NORMALIZATION_CLAUSE,
+                        new HashMap(Map.of(TECHNIQUE, NORMALIZATION_METHOD)),
+                        NormalizationProcessorFactory.COMBINATION_CLAUSE,
+                        new HashMap(
+                            Map.of(
+                                TECHNIQUE,
+                                "",
+                                NormalizationProcessorFactory.PARAMETERS,
+                                new HashMap<>(Map.of("weights", "random_string"))
+                            )
+                        )
                     )
                 ),
                 pipelineContext
@@ -164,9 +281,56 @@ public class NormalizationProcessorFactoryTests extends OpenSearchTestCase {
                 new HashMap<>(
                     Map.of(
                         NormalizationProcessorFactory.NORMALIZATION_CLAUSE,
-                        Map.of(NormalizationProcessorFactory.TECHNIQUE, NORMALIZATION_METHOD),
+                        new HashMap(Map.of(TECHNIQUE, NORMALIZATION_METHOD)),
                         NormalizationProcessorFactory.COMBINATION_CLAUSE,
-                        Map.of(NormalizationProcessorFactory.TECHNIQUE, "random_name_for_combination")
+                        new HashMap(Map.of(TECHNIQUE, "", NormalizationProcessorFactory.PARAMETERS, new HashMap<>(Map.of("weights", 5.0))))
+                    )
+                ),
+                pipelineContext
+            )
+        );
+
+        expectThrows(
+            OpenSearchParseException.class,
+            () -> normalizationProcessorFactory.create(
+                processorFactories,
+                tag,
+                description,
+                ignoreFailure,
+                new HashMap<>(
+                    Map.of(
+                        NormalizationProcessorFactory.NORMALIZATION_CLAUSE,
+                        new HashMap(Map.of(TECHNIQUE, NORMALIZATION_METHOD)),
+                        NormalizationProcessorFactory.COMBINATION_CLAUSE,
+                        new HashMap(
+                            Map.of(
+                                TECHNIQUE,
+                                "",
+                                NormalizationProcessorFactory.PARAMETERS,
+                                new HashMap<>(Map.of("weights", new Boolean[] { true, false }))
+                            )
+                        )
+                    )
+                ),
+                pipelineContext
+            )
+        );
+
+        expectThrows(
+            OpenSearchParseException.class,
+            () -> normalizationProcessorFactory.create(
+                processorFactories,
+                tag,
+                description,
+                ignoreFailure,
+                new HashMap<>(
+                    Map.of(
+                        NormalizationProcessorFactory.NORMALIZATION_CLAUSE,
+                        new HashMap(Map.of(TECHNIQUE, NORMALIZATION_METHOD)),
+                        NormalizationProcessorFactory.COMBINATION_CLAUSE,
+                        new HashMap(
+                            Map.of(TECHNIQUE, "", NormalizationProcessorFactory.PARAMETERS, new HashMap<>(Map.of("random_param", "value")))
+                        )
                     )
                 ),
                 pipelineContext

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.processor.normalization;
+
+import java.util.List;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+import org.opensearch.neuralsearch.search.CompoundTopDocs;
+
+/**
+ * Abstracts normalization of scores based on min-max method
+ */
+public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase {
+    private static final float DELTA_FOR_ASSERTION = 0.0001f;
+
+    public void testNormalization_whenResultFromOneShardOneSubQuery_thenSuccessful() {
+        MinMaxScoreNormalizationTechnique normalizationTechnique = new MinMaxScoreNormalizationTechnique();
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    )
+                )
+            )
+        );
+        normalizationTechnique.normalize(compoundTopDocs);
+
+        CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, 0.001f) }
+                )
+            )
+        );
+        assertNotNull(compoundTopDocs);
+        assertEquals(1, compoundTopDocs.size());
+        assertNotNull(compoundTopDocs.get(0).getCompoundTopDocs());
+        assertCompoundTopDocs(expectedCompoundDocs, compoundTopDocs.get(0).getCompoundTopDocs().get(0));
+    }
+
+    public void testNormalization_whenResultFromOneShardMultipleSubQueries_thenSuccessful() {
+        MinMaxScoreNormalizationTechnique normalizationTechnique = new MinMaxScoreNormalizationTechnique();
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    ),
+                    new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
+                    new TopDocs(
+                        new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(3, 0.9f), new ScoreDoc(4, 0.7f), new ScoreDoc(2, 0.1f) }
+                    )
+                )
+            )
+        );
+        normalizationTechnique.normalize(compoundTopDocs);
+
+        CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
+            new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, 0.001f) }
+                ),
+                new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
+                new TopDocs(
+                    new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(3, 1.0f), new ScoreDoc(4, 0.75f), new ScoreDoc(2, 0.001f) }
+                )
+            )
+        );
+        assertNotNull(compoundTopDocs);
+        assertEquals(1, compoundTopDocs.size());
+        assertNotNull(compoundTopDocs.get(0).getCompoundTopDocs());
+        for (int i = 0; i < expectedCompoundDocs.getCompoundTopDocs().size(); i++) {
+            assertCompoundTopDocs(expectedCompoundDocs.getCompoundTopDocs().get(i), compoundTopDocs.get(0).getCompoundTopDocs().get(i));
+        }
+    }
+
+    public void testNormalization_whenResultFromMultipleShardsMultipleSubQueries_thenSuccessful() {
+        MinMaxScoreNormalizationTechnique normalizationTechnique = new MinMaxScoreNormalizationTechnique();
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    ),
+                    new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
+                    new TopDocs(
+                        new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(3, 0.9f), new ScoreDoc(4, 0.7f), new ScoreDoc(2, 0.1f) }
+                    )
+                )
+            ),
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(7, 2.9f), new ScoreDoc(9, 0.7f) }
+                    )
+                )
+            )
+        );
+        normalizationTechnique.normalize(compoundTopDocs);
+
+        CompoundTopDocs expectedCompoundDocsShard1 = new CompoundTopDocs(
+            new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, 0.001f) }
+                ),
+                new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
+                new TopDocs(
+                    new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(3, 1.0f), new ScoreDoc(4, 0.75f), new ScoreDoc(2, 0.001f) }
+                )
+            )
+        );
+
+        CompoundTopDocs expectedCompoundDocsShard2 = new CompoundTopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(7, 1.0f), new ScoreDoc(9, 0.001f) }
+                )
+            )
+        );
+
+        assertNotNull(compoundTopDocs);
+        assertEquals(2, compoundTopDocs.size());
+        assertNotNull(compoundTopDocs.get(0).getCompoundTopDocs());
+        for (int i = 0; i < expectedCompoundDocsShard1.getCompoundTopDocs().size(); i++) {
+            assertCompoundTopDocs(
+                expectedCompoundDocsShard1.getCompoundTopDocs().get(i),
+                compoundTopDocs.get(0).getCompoundTopDocs().get(i)
+            );
+        }
+        assertNotNull(compoundTopDocs.get(1).getCompoundTopDocs());
+        for (int i = 0; i < expectedCompoundDocsShard2.getCompoundTopDocs().size(); i++) {
+            assertCompoundTopDocs(
+                expectedCompoundDocsShard2.getCompoundTopDocs().get(i),
+                compoundTopDocs.get(1).getCompoundTopDocs().get(i)
+            );
+        }
+    }
+
+    private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {
+        assertEquals(expected.totalHits.value, actual.totalHits.value);
+        assertEquals(expected.totalHits.relation, actual.totalHits.relation);
+        assertEquals(expected.scoreDocs.length, actual.scoreDocs.length);
+        for (int i = 0; i < expected.scoreDocs.length; i++) {
+            assertEquals(expected.scoreDocs[i].score, actual.scoreDocs[i].score, DELTA_FOR_ASSERTION);
+            assertEquals(expected.scoreDocs[i].doc, actual.scoreDocs[i].doc);
+            assertEquals(expected.scoreDocs[i].shardIndex, actual.scoreDocs[i].shardIndex);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Adding parameter "weights" for combination technique in normalization processor. Weights are use to multiply scores for each sub-query from the Hybrid search query. Weights are mapped to sub-query based on position (index), if there are less weights provided we use "1.0" for the rest of sub-query scores. If there are more weights provided we take first N and ignore the rest. 

Parameter is set as part of the search pipeline, example of such request:

```
{
    "description": "Post processor for hybrid search",
    "phase_results_processors": [
        {
            "normalization-processor": {
                "normalization": {
                    "technique": "min_max"
                },
                "combination": {
                    "technique": "arithmetic_mean",
                    "parameters": {
                        "weights": [
                            0.4, 0.7
                        ]
                    }
                }
            }
        }
    ]
}
```

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/228, part of solution for https://github.com/opensearch-project/neural-search/issues/126

### Check List
- [X] All tests pass
- [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
skip