### PR TITLE
Add geometric mean normalization for scores

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechnique.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.processor.combination;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Abstracts combination of scores based on geometrical mean method
+ */
+public class GeometricMeanScoreCombinationTechnique implements ScoreCombinationTechnique {
+
+    public static final String TECHNIQUE_NAME = "geometric_mean";
+    public static final String PARAM_NAME_WEIGHTS = "weights";
+    private static final Set<String> SUPPORTED_PARAMS = Set.of(PARAM_NAME_WEIGHTS);
+    private static final Float ZERO_SCORE = 0.0f;
+    private final List<Float> weights;
+    private final ScoreCombinationUtil scoreCombinationUtil;
+
+    public GeometricMeanScoreCombinationTechnique(final Map<String, Object> params, final ScoreCombinationUtil combinationUtil) {
+        scoreCombinationUtil = combinationUtil;
+        scoreCombinationUtil.validateParams(params, SUPPORTED_PARAMS);
+        weights = scoreCombinationUtil.getWeights(params);
+    }
+
+    /**
+     * Weighted geometric mean method for combining scores.
+     *
+     * We use formula below to calculate mean. It's based on fact that logarithm of geometric mean is the
+     * weighted arithmetic mean of the logarithms of individual scores.
+     *
+     * geometric_mean = exp(sum(weight_1*ln(score_1) + .... + weight_n*ln(score_n))/sum(weight_1 + ... + weight_n))
+     */
+    @Override
+    public float combine(final float[] scores) {
+        float weightedLnSum = 0;
+        float sumOfWeights = 0;
+        for (int indexOfSubQuery = 0; indexOfSubQuery < scores.length; indexOfSubQuery++) {
+            float score = scores[indexOfSubQuery];
+            if (score <= 0) {
+                // scores 0.0 need to be skipped, ln() of 0 is not defined
+                continue;
+            }
+            float weight = scoreCombinationUtil.getWeightForSubQuery(weights, indexOfSubQuery);
+            sumOfWeights += weight;
+            weightedLnSum += weight * Math.log(score);
+        }
+        return sumOfWeights == 0 ? ZERO_SCORE : (float) Math.exp(weightedLnSum / sumOfWeights);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactory.java
@@ -24,7 +24,9 @@ public class ScoreCombinationFactory {
         ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME,
         params -> new ArithmeticMeanScoreCombinationTechnique(params, scoreCombinationUtil),
         HarmonicMeanScoreCombinationTechnique.TECHNIQUE_NAME,
-        params -> new HarmonicMeanScoreCombinationTechnique(params, scoreCombinationUtil)
+        params -> new HarmonicMeanScoreCombinationTechnique(params, scoreCombinationUtil),
+        GeometricMeanScoreCombinationTechnique.TECHNIQUE_NAME,
+        params -> new GeometricMeanScoreCombinationTechnique(params, scoreCombinationUtil)
     );
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/TestUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/TestUtils.java
@@ -7,18 +7,26 @@ package org.opensearch.neuralsearch;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.opensearch.test.OpenSearchTestCase.randomFloat;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
 
+import org.apache.commons.lang3.Range;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.search.query.QuerySearchResult;
 
 public class TestUtils {
+
+    private final static String RELATION_EQUAL_TO = "eq";
 
     /**
      * Convert an xContentBuilder to a map
@@ -58,7 +66,7 @@ public class TestUtils {
     }
 
     /**
-     * Assert results of hyrdir query after score normalization and combination
+     * Assert results of hyrdid query after score normalization and combination
      * @param querySearchResults collection of query search results after they processed by normalization processor
      */
     public static void assertQueryResultScores(List<QuerySearchResult> querySearchResults) {
@@ -93,5 +101,93 @@ public class TestUtils {
             .min(Float::compare)
             .orElse(Float.MAX_VALUE);
         assertEquals(0.001f, minScoreScoreFromScoreDocs, 0.0f);
+    }
+
+    /**
+     * Assert results of hybrid query after score normalization and combination
+     * @param searchResponseWithWeightsAsMap collection of query search results after they processed by normalization processor
+     * @param expectedMaxScore expected maximum score
+     * @param expectedMaxMinusOneScore second highest expected score
+     * @param expectedMinScore expected minimal score
+     */
+    public static void assertWeightedScores(
+        Map<String, Object> searchResponseWithWeightsAsMap,
+        double expectedMaxScore,
+        double expectedMaxMinusOneScore,
+        double expectedMinScore
+    ) {
+        assertNotNull(searchResponseWithWeightsAsMap);
+        Map<String, Object> totalWeights = getTotalHits(searchResponseWithWeightsAsMap);
+        assertNotNull(totalWeights.get("value"));
+        assertEquals(4, totalWeights.get("value"));
+        assertNotNull(totalWeights.get("relation"));
+        assertEquals(RELATION_EQUAL_TO, totalWeights.get("relation"));
+        assertTrue(getMaxScore(searchResponseWithWeightsAsMap).isPresent());
+        assertEquals(expectedMaxScore, getMaxScore(searchResponseWithWeightsAsMap).get(), 0.001f);
+
+        List<Double> scoresWeights = new ArrayList<>();
+        for (Map<String, Object> oneHit : getNestedHits(searchResponseWithWeightsAsMap)) {
+            scoresWeights.add((Double) oneHit.get("_score"));
+        }
+        // verify scores order
+        assertTrue(IntStream.range(0, scoresWeights.size() - 1).noneMatch(idx -> scoresWeights.get(idx) < scoresWeights.get(idx + 1)));
+        // verify the scores are normalized with inclusion of weights
+        assertEquals(expectedMaxScore, scoresWeights.get(0), 0.001);
+        assertEquals(expectedMaxMinusOneScore, scoresWeights.get(1), 0.001);
+        assertEquals(expectedMinScore, scoresWeights.get(scoresWeights.size() - 1), 0.001);
+    }
+
+    /**
+     * Assert results of hybrid query after score normalization and combination
+     * @param searchResponseAsMap collection of query search results after they processed by normalization processor
+     * @param totalExpectedDocQty expected total document quantity
+     * @param minMaxScoreRange range of scores from min to max inclusive
+     */
+    public static void assertHybridSearchResults(
+        Map<String, Object> searchResponseAsMap,
+        int totalExpectedDocQty,
+        float[] minMaxScoreRange
+    ) {
+        assertNotNull(searchResponseAsMap);
+        Map<String, Object> total = getTotalHits(searchResponseAsMap);
+        assertNotNull(total.get("value"));
+        assertEquals(totalExpectedDocQty, total.get("value"));
+        assertNotNull(total.get("relation"));
+        assertEquals(RELATION_EQUAL_TO, total.get("relation"));
+        assertTrue(getMaxScore(searchResponseAsMap).isPresent());
+        assertTrue(Range.between(minMaxScoreRange[0], minMaxScoreRange[1]).contains(getMaxScore(searchResponseAsMap).get()));
+
+        List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
+        List<String> ids = new ArrayList<>();
+        List<Double> scores = new ArrayList<>();
+        for (Map<String, Object> oneHit : hitsNestedList) {
+            ids.add((String) oneHit.get("_id"));
+            scores.add((Double) oneHit.get("_score"));
+        }
+        // verify scores order
+        assertTrue(IntStream.range(0, scores.size() - 1).noneMatch(idx -> scores.get(idx) < scores.get(idx + 1)));
+        // verify the scores are normalized. for l2 scores max score will not be 1.0 so we're checking on a range
+        assertTrue(
+            Range.between(minMaxScoreRange[0], minMaxScoreRange[1])
+                .contains(scores.stream().map(Double::floatValue).max(Double::compare).get())
+        );
+
+        // verify that all ids are unique
+        assertEquals(Set.copyOf(ids).size(), ids.size());
+    }
+
+    private static List<Map<String, Object>> getNestedHits(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
+        return (List<Map<String, Object>>) hitsMap.get("hits");
+    }
+
+    private static Map<String, Object> getTotalHits(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
+        return (Map<String, Object>) hitsMap.get("total");
+    }
+
+    private static Optional<Float> getMaxScore(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
+        return hitsMap.get("max_score") == null ? Optional.empty() : Optional.of(((Double) hitsMap.get("max_score")).floatValue());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
@@ -11,11 +11,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -623,4 +625,57 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
     }
+
+    /**
+     * Find all modesl that are currently deployed in the cluster
+     * @return set of model ids
+     */
+    @SneakyThrows
+    protected Set<String> findDeployedModels() {
+
+        StringBuilder stringBuilderForContentBody = new StringBuilder();
+        stringBuilderForContentBody.append("{")
+            .append("\"query\": { \"match_all\": {} },")
+            .append("  \"_source\": {")
+            .append("    \"includes\": [\"model_id\"],")
+            .append("    \"excludes\": [\"content\", \"model_content\"]")
+            .append("}}");
+
+        Response response = makeRequest(
+            client(),
+            "POST",
+            "/_plugins/_ml/models/_search",
+            null,
+            toHttpEntity(stringBuilderForContentBody.toString()),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+
+        Map<String, Object> models = XContentHelper.convertToMap(XContentType.JSON.xContent(), responseBody, false);
+        Set<String> modelIds = new HashSet<>();
+        if (Objects.isNull(models) || models.isEmpty()) {
+            return modelIds;
+        }
+
+        Map<String, Object> hits = (Map<String, Object>) models.get("hits");
+        List<Map<String, Object>> innerHitsMap = (List<Map<String, Object>>) hits.get("hits");
+        return innerHitsMap.stream()
+            .map(hit -> (Map<String, Object>) hit.get("_source"))
+            .filter(hitsMap -> !Objects.isNull(hitsMap) && hitsMap.containsKey("model_id"))
+            .map(hitsMap -> (String) hitsMap.get("model_id"))
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Get the id for model currently deployed in the cluster. If there are no models deployed or it's more than 1 model
+     * fail on assertion
+     * @return id of deployed model
+     */
+    protected String getDeployedModelId() {
+        Set<String> modelIds = findDeployedModels();
+        assertEquals(1, modelIds.size());
+        return modelIds.iterator().next();
+    }
+
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.processor;
+
+import static org.opensearch.neuralsearch.TestUtils.assertHybridSearchResults;
+import static org.opensearch.neuralsearch.TestUtils.assertWeightedScores;
+import static org.opensearch.neuralsearch.TestUtils.createRandomVector;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import lombok.SneakyThrows;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.neuralsearch.common.BaseNeuralSearchIT;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+
+import com.google.common.primitives.Floats;
+
+public class ScoreCombinationIT extends BaseNeuralSearchIT {
+    private static final String TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME = "test-neural-multi-doc-one-shard-index";
+    private static final String TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME = "test-neural-multi-doc-three-shards-index";
+    private static final String TEST_QUERY_TEXT3 = "hello";
+    private static final String TEST_QUERY_TEXT4 = "place";
+    private static final String TEST_QUERY_TEXT7 = "notexistingwordtwo";
+    private static final String TEST_DOC_TEXT1 = "Hello world";
+    private static final String TEST_DOC_TEXT2 = "Hi to this place";
+    private static final String TEST_DOC_TEXT3 = "We would like to welcome everyone";
+    private static final String TEST_DOC_TEXT4 = "Hello, I'm glad to you see you pal";
+    private static final String TEST_DOC_TEXT5 = "Say hello and enter my friend";
+    private static final String TEST_KNN_VECTOR_FIELD_NAME_1 = "test-knn-vector-1";
+    private static final String TEST_TEXT_FIELD_NAME_1 = "test-text-field-1";
+    private static final int TEST_DIMENSION = 768;
+    private static final SpaceType TEST_SPACE_TYPE = SpaceType.L2;
+    private static final String SEARCH_PIPELINE = "phase-results-pipeline";
+    private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector4 = createRandomVector(TEST_DIMENSION);
+
+    private static final String L2_NORMALIZATION_METHOD = "l2";
+    private static final String HARMONIC_MEAN_COMBINATION_METHOD = "harmonic_mean";
+    private static final String GEOMETRIC_MEAN_COMBINATION_METHOD = "geometric_mean";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        prepareModel();
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        deleteSearchPipeline(SEARCH_PIPELINE);
+        findDeployedModels().forEach(this::deleteModel);
+    }
+
+    /**
+     * Using search pipelines with result processor configs like below:
+     * {
+     *     "description": "Post processor for hybrid search",
+     *     "phase_results_processors": [
+     *         {
+     *             "normalization-processor": {
+     *                 "normalization": {
+     *                     "technique": "min-max"
+     *                 },
+     *                 "combination": {
+     *                     "technique": "arithmetic_mean",
+     *                     "parameters": {
+     *                         "weights": [
+     *                             0.4, 0.7
+     *                         ]
+     *                     }
+     *                 }
+     *             }
+     *         }
+     *     ]
+     * }
+     */
+    @SneakyThrows
+    public void testArithmeticWeightedMean_whenWeightsPassed_thenSuccessful() {
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME);
+        // check case when number of weights and sub-queries are same
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.6f, 0.5f, 0.5f }))
+        );
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+        hybridQueryBuilder.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4));
+        hybridQueryBuilder.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT7));
+
+        Map<String, Object> searchResponseWithWeights1AsMap = search(
+            TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+            hybridQueryBuilder,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+
+        assertWeightedScores(searchResponseWithWeights1AsMap, 1.0, 1.0, 0.001);
+
+        // delete existing pipeline and create a new one with another set of weights
+        deleteSearchPipeline(SEARCH_PIPELINE);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 2.0f, 0.5f }))
+        );
+
+        Map<String, Object> searchResponseWithWeights2AsMap = search(
+            TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+            hybridQueryBuilder,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+
+        assertWeightedScores(searchResponseWithWeights2AsMap, 1.0, 1.0, 0.001);
+
+        // check case when number of weights is less than number of sub-queries
+        // delete existing pipeline and create a new one with another set of weights
+        deleteSearchPipeline(SEARCH_PIPELINE);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f }))
+        );
+
+        Map<String, Object> searchResponseWithWeights3AsMap = search(
+            TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+            hybridQueryBuilder,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+
+        assertWeightedScores(searchResponseWithWeights3AsMap, 1.0, 1.0, 0.001);
+
+        // check case when number of weights is more than number of sub-queries
+        // delete existing pipeline and create a new one with another set of weights
+        deleteSearchPipeline(SEARCH_PIPELINE);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.6f, 0.5f, 0.5f, 1.5f }))
+        );
+
+        Map<String, Object> searchResponseWithWeights4AsMap = search(
+            TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+            hybridQueryBuilder,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+
+        assertWeightedScores(searchResponseWithWeights4AsMap, 1.0, 1.0, 0.001);
+    }
+
+    /**
+     * Using search pipelines with config for harmonic mean:
+     * {
+     *     "description": "Post processor for hybrid search",
+     *     "phase_results_processors": [
+     *         {
+     *             "normalization-processor": {
+     *                 "normalization": {
+     *                     "technique": "l2"
+     *                 },
+     *                 "combination": {
+     *                     "technique": "harmonic_mean"
+     *                 }
+     *             }
+     *         }
+     *     ]
+     * }
+     */
+    @SneakyThrows
+    public void testHarmonicMeanCombination_whenOneShardAndQueryMatches_thenSuccessful() {
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            HARMONIC_MEAN_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+        String modelId = getDeployedModelId();
+
+        HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
+        hybridQueryBuilderDefaultNorm.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapDefaultNorm = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderDefaultNorm,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+
+        assertHybridSearchResults(searchResponseAsMapDefaultNorm, 5, new float[] { 0.5f, 1.0f });
+
+        deleteSearchPipeline(SEARCH_PIPELINE);
+
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            L2_NORMALIZATION_METHOD,
+            HARMONIC_MEAN_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+
+        HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
+        hybridQueryBuilderL2Norm.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapL2Norm = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderL2Norm,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertHybridSearchResults(searchResponseAsMapL2Norm, 5, new float[] { 0.5f, 1.0f });
+    }
+
+    /**
+     * Using search pipelines with config for geometric mean:
+     * {
+     *     "description": "Post processor for hybrid search",
+     *     "phase_results_processors": [
+     *         {
+     *             "normalization-processor": {
+     *                 "normalization": {
+     *                     "technique": "l2"
+     *                 },
+     *                 "combination": {
+     *                     "technique": "geometric_mean"
+     *                 }
+     *             }
+     *         }
+     *     ]
+     * }
+     */
+    @SneakyThrows
+    public void testGeometricMeanCombination_whenOneShardAndQueryMatches_thenSuccessful() {
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            GEOMETRIC_MEAN_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+        String modelId = getDeployedModelId();
+
+        HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
+        hybridQueryBuilderDefaultNorm.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapDefaultNorm = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderDefaultNorm,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+
+        assertHybridSearchResults(searchResponseAsMapDefaultNorm, 5, new float[] { 0.5f, 1.0f });
+
+        deleteSearchPipeline(SEARCH_PIPELINE);
+
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            L2_NORMALIZATION_METHOD,
+            GEOMETRIC_MEAN_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+
+        HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
+        hybridQueryBuilderL2Norm.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapL2Norm = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderL2Norm,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertHybridSearchResults(searchResponseAsMapL2Norm, 5, new float[] { 0.5f, 1.0f });
+    }
+
+    private void initializeIndexIfNotExist(String indexName) throws IOException {
+        if (TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME.equalsIgnoreCase(indexName) && !indexExists(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME)) {
+            prepareKnnIndex(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                Collections.singletonList(new KNNFieldConfig(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DIMENSION, TEST_SPACE_TYPE)),
+                1
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "1",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector1).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT1)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "2",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector2).toArray())
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "3",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector3).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT2)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "4",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT3)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "5",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT4)
+            );
+            assertEquals(5, getDocCount(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME));
+        }
+
+        if (TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME.equalsIgnoreCase(indexName) && !indexExists(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME)) {
+            prepareKnnIndex(
+                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+                Collections.singletonList(new KNNFieldConfig(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DIMENSION, TEST_SPACE_TYPE)),
+                3
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+                "1",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector1).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT1)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+                "2",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector2).toArray())
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+                "3",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector3).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT2)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+                "4",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT3)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+                "5",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT4)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+                "6",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT5)
+            );
+            assertEquals(6, getDocCount(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.processor;
+
+import static org.opensearch.neuralsearch.TestUtils.assertHybridSearchResults;
+import static org.opensearch.neuralsearch.TestUtils.createRandomVector;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import lombok.SneakyThrows;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.neuralsearch.common.BaseNeuralSearchIT;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+
+import com.google.common.primitives.Floats;
+
+public class ScoreNormalizationIT extends BaseNeuralSearchIT {
+    private static final String TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME = "test-neural-multi-doc-one-shard-index";
+    private static final String TEST_QUERY_TEXT3 = "hello";
+    private static final String TEST_DOC_TEXT1 = "Hello world";
+    private static final String TEST_DOC_TEXT2 = "Hi to this place";
+    private static final String TEST_DOC_TEXT3 = "We would like to welcome everyone";
+    private static final String TEST_DOC_TEXT4 = "Hello, I'm glad to you see you pal";
+    private static final String TEST_KNN_VECTOR_FIELD_NAME_1 = "test-knn-vector-1";
+    private static final String TEST_TEXT_FIELD_NAME_1 = "test-text-field-1";
+    private static final int TEST_DIMENSION = 768;
+    private static final SpaceType TEST_SPACE_TYPE = SpaceType.L2;
+    private static final String SEARCH_PIPELINE = "phase-results-pipeline";
+    private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector4 = createRandomVector(TEST_DIMENSION);
+
+    private static final String L2_NORMALIZATION_METHOD = "l2";
+    private static final String HARMONIC_MEAN_COMBINATION_METHOD = "harmonic_mean";
+    private static final String GEOMETRIC_MEAN_COMBINATION_METHOD = "geometric_mean";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        updateClusterSettings();
+        prepareModel();
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        deleteSearchPipeline(SEARCH_PIPELINE);
+        findDeployedModels().forEach(this::deleteModel);
+    }
+
+    @Override
+    public boolean isUpdateClusterSettings() {
+        return false;
+    }
+
+    /**
+     * Using search pipelines with config for l2 norm:
+     * {
+     *     "description": "Post processor for hybrid search",
+     *     "phase_results_processors": [
+     *         {
+     *             "normalization-processor": {
+     *                 "normalization": {
+     *                     "technique": "l2"
+     *                 },
+     *                 "combination": {
+     *                     "technique": "arithmetic_mean"
+     *                 }
+     *             }
+     *         }
+     *     ]
+     * }
+     */
+    @SneakyThrows
+    public void testL2Norm_whenOneShardAndQueryMatches_thenSuccessful() {
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            L2_NORMALIZATION_METHOD,
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+        String modelId = getDeployedModelId();
+
+        HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
+        hybridQueryBuilderArithmeticMean.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapArithmeticMean = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderArithmeticMean,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertHybridSearchResults(searchResponseAsMapArithmeticMean, 5, new float[] { 0.6f, 1.0f });
+
+        deleteSearchPipeline(SEARCH_PIPELINE);
+
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            L2_NORMALIZATION_METHOD,
+            HARMONIC_MEAN_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+
+        HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
+        hybridQueryBuilderHarmonicMean.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapHarmonicMean = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderHarmonicMean,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertHybridSearchResults(searchResponseAsMapHarmonicMean, 5, new float[] { 0.5f, 1.0f });
+
+        deleteSearchPipeline(SEARCH_PIPELINE);
+
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            L2_NORMALIZATION_METHOD,
+            GEOMETRIC_MEAN_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+
+        HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
+        hybridQueryBuilderGeometricMean.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapGeometricMean = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderGeometricMean,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertHybridSearchResults(searchResponseAsMapGeometricMean, 5, new float[] { 0.5f, 1.0f });
+    }
+
+    /**
+     * Using search pipelines with config for min-max norm:
+     * {
+     *     "description": "Post processor for hybrid search",
+     *     "phase_results_processors": [
+     *         {
+     *             "normalization-processor": {
+     *                 "normalization": {
+     *                     "technique": "l2"
+     *                 },
+     *                 "combination": {
+     *                     "technique": "arithmetic_mean"
+     *                 }
+     *             }
+     *         }
+     *     ]
+     * }
+     */
+    @SneakyThrows
+    public void testMinMaxNorm_whenOneShardAndQueryMatches_thenSuccessful() {
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+        String modelId = getDeployedModelId();
+
+        HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
+        hybridQueryBuilderArithmeticMean.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapArithmeticMean = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderArithmeticMean,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertHybridSearchResults(searchResponseAsMapArithmeticMean, 5, new float[] { 1.0f, 1.0f });
+
+        deleteSearchPipeline(SEARCH_PIPELINE);
+
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            HARMONIC_MEAN_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+
+        HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
+        hybridQueryBuilderHarmonicMean.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapHarmonicMean = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderHarmonicMean,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertHybridSearchResults(searchResponseAsMapHarmonicMean, 5, new float[] { 0.6f, 1.0f });
+
+        deleteSearchPipeline(SEARCH_PIPELINE);
+
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        createSearchPipeline(
+            SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            GEOMETRIC_MEAN_COMBINATION_METHOD,
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.8f, 0.7f }))
+        );
+
+        HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
+        hybridQueryBuilderGeometricMean.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, "", modelId, 5, null, null));
+        hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+
+        Map<String, Object> searchResponseAsMapGeometricMean = search(
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderGeometricMean,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertHybridSearchResults(searchResponseAsMapGeometricMean, 5, new float[] { 0.6f, 1.0f });
+    }
+
+    private void initializeIndexIfNotExist(String indexName) throws IOException {
+        if (TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME.equalsIgnoreCase(indexName) && !indexExists(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME)) {
+            prepareKnnIndex(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                Collections.singletonList(new KNNFieldConfig(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DIMENSION, TEST_SPACE_TYPE)),
+                1
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "1",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector1).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT1)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "2",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector2).toArray())
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "3",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector3).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT2)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "4",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT3)
+            );
+            addKnnDoc(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                "5",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT4)
+            );
+            assertEquals(5, getDocCount(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -9,9 +9,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
+import lombok.SneakyThrows;
+
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.After;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
@@ -24,6 +27,17 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
     private static final String INDEX_NAME = "text_embedding_index";
 
     private static final String PIPELINE_NAME = "pipeline-hybrid";
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+        /* this is required to minimize chance of model not being deployed due to open memory CB,
+         * this happens in case we leave model from previous test case. We use new model for every test, and old model
+         * can be undeployed and deleted to free resources after each test case execution.
+         */
+        findDeployedModels().forEach(this::deleteModel);
+    }
 
     public void testTextEmbeddingProcessor() throws Exception {
         String modelId = uploadTextEmbeddingModel();

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechniqueTests.java
@@ -12,17 +12,19 @@ import java.util.Map;
 
 public class ArithmeticMeanScoreCombinationTechniqueTests extends BaseScoreCombinationTechniqueTests {
 
+    private ScoreCombinationUtil scoreCombinationUtil = new ScoreCombinationUtil();
+
     public ArithmeticMeanScoreCombinationTechniqueTests() {
         this.expectedScoreFunction = this::arithmeticMean;
     }
 
     public void testLogic_whenAllScoresPresentAndNoWeights_thenCorrectScores() {
-        ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(Map.of(), new ScoreCombinationUtil());
+        ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(Map.of(), scoreCombinationUtil);
         testLogic_whenAllScoresPresentAndNoWeights_thenCorrectScores(technique);
     }
 
     public void testLogic_whenNotAllScoresPresentAndNoWeights_thenCorrectScores() {
-        ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(Map.of(), new ScoreCombinationUtil());
+        ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(Map.of(), scoreCombinationUtil);
         testLogic_whenNotAllScoresPresentAndNoWeights_thenCorrectScores(technique);
     }
 
@@ -30,7 +32,7 @@ public class ArithmeticMeanScoreCombinationTechniqueTests extends BaseScoreCombi
         List<Double> weights = List.of(0.9, 0.2, 0.7);
         ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
-            new ScoreCombinationUtil()
+            scoreCombinationUtil
         );
         testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
@@ -39,7 +41,7 @@ public class ArithmeticMeanScoreCombinationTechniqueTests extends BaseScoreCombi
         List<Double> weights = List.of(0.9, 0.2, 0.7);
         ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
-            new ScoreCombinationUtil()
+            scoreCombinationUtil
         );
         testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechniqueTests.java
@@ -32,17 +32,6 @@ public class ArithmeticMeanScoreCombinationTechniqueTests extends BaseScoreCombi
         testLogic_whenNotAllScoresPresentAndNoWeights_thenCorrectScores(technique);
     }
 
-    public void testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores() {
-        List<Float> scores = List.of(1.0f, 0.5f, 0.3f);
-        List<Double> weights = List.of(0.9, 0.2, 0.7);
-        ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(
-            Map.of(PARAM_NAME_WEIGHTS, weights),
-            scoreCombinationUtil
-        );
-        float expectedScore = 0.6722f;
-        testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, scores, expectedScore);
-    }
-
     public void testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores() {
         List<Double> weights = IntStream.range(0, RANDOM_SCORES_SIZE)
             .mapToObj(i -> RandomizedTest.randomDouble())

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechniqueTests.java
@@ -9,6 +9,10 @@ import static org.opensearch.neuralsearch.processor.combination.ArithmeticMeanSc
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 public class ArithmeticMeanScoreCombinationTechniqueTests extends BaseScoreCombinationTechniqueTests {
 
@@ -29,21 +33,47 @@ public class ArithmeticMeanScoreCombinationTechniqueTests extends BaseScoreCombi
     }
 
     public void testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Float> scores = List.of(1.0f, 0.5f, 0.3f);
         List<Double> weights = List.of(0.9, 0.2, 0.7);
         ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
             scoreCombinationUtil
         );
-        testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
+        float expectedScore = 0.6722f;
+        testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, scores, expectedScore);
+    }
+
+    public void testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Double> weights = IntStream.range(0, RANDOM_SCORES_SIZE)
+            .mapToObj(i -> RandomizedTest.randomDouble())
+            .collect(Collectors.toList());
+        ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(
+            Map.of(PARAM_NAME_WEIGHTS, weights),
+            scoreCombinationUtil
+        );
+        testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
 
     public void testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Float> scores = List.of(1.0f, -1.0f, 0.6f);
         List<Double> weights = List.of(0.9, 0.2, 0.7);
         ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
             scoreCombinationUtil
         );
-        testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
+        float expectedScore = 0.825f;
+        testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, scores, expectedScore);
+    }
+
+    public void testRandomValues_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Double> weights = IntStream.range(0, RANDOM_SCORES_SIZE)
+            .mapToObj(i -> RandomizedTest.randomDouble())
+            .collect(Collectors.toList());
+        ScoreCombinationTechnique technique = new ArithmeticMeanScoreCombinationTechnique(
+            Map.of(PARAM_NAME_WEIGHTS, weights),
+            scoreCombinationUtil
+        );
+        testRandomValues_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
 
     private float arithmeticMean(List<Float> scores, List<Double> weights) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/BaseScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/BaseScoreCombinationTechniqueTests.java
@@ -14,10 +14,13 @@ import lombok.NoArgsConstructor;
 import org.apache.commons.lang.ArrayUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+
 @NoArgsConstructor
 public class BaseScoreCombinationTechniqueTests extends OpenSearchTestCase {
 
     protected BiFunction<List<Float>, List<Double>, Float> expectedScoreFunction;
+    protected static final int RANDOM_SCORES_SIZE = 100;
 
     private static final float DELTA_FOR_ASSERTION = 0.0001f;
 
@@ -37,9 +40,25 @@ public class BaseScoreCombinationTechniqueTests extends OpenSearchTestCase {
 
     public void testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(
         final ScoreCombinationTechnique technique,
-        List<Double> weights
+        List<Float> scores,
+        float expectedScore
     ) {
-        float[] scores = { 1.0f, 0.5f, 0.3f };
+        float[] scoresArray = new float[scores.size()];
+        for (int i = 0; i < scoresArray.length; i++) {
+            scoresArray[i] = scores.get(i);
+        }
+        float actualScore = technique.combine(scoresArray);
+        assertEquals(expectedScore, actualScore, DELTA_FOR_ASSERTION);
+    }
+
+    public void testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores(
+        final ScoreCombinationTechnique technique,
+        final List<Double> weights
+    ) {
+        float[] scores = new float[weights.size()];
+        for (int i = 0; i < RANDOM_SCORES_SIZE; i++) {
+            scores[i] = randomScore();
+        }
         float actualScore = technique.combine(scores);
         float expectedScore = expectedScoreFunction.apply(Arrays.asList(ArrayUtils.toObject(scores)), weights);
         assertEquals(expectedScore, actualScore, DELTA_FOR_ASSERTION);
@@ -47,11 +66,31 @@ public class BaseScoreCombinationTechniqueTests extends OpenSearchTestCase {
 
     public void testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(
         final ScoreCombinationTechnique technique,
-        List<Double> weights
+        List<Float> scores,
+        float expectedScore
     ) {
-        float[] scores = { 1.0f, -1.0f, 0.6f };
+        float[] scoresArray = new float[scores.size()];
+        for (int i = 0; i < scoresArray.length; i++) {
+            scoresArray[i] = scores.get(i);
+        }
+        float actualScore = technique.combine(scoresArray);
+        assertEquals(expectedScore, actualScore, DELTA_FOR_ASSERTION);
+    }
+
+    public void testRandomValues_whenNotAllScoresAndWeightsPresent_thenCorrectScores(
+        final ScoreCombinationTechnique technique,
+        final List<Double> weights
+    ) {
+        float[] scores = new float[weights.size()];
+        for (int i = 0; i < RANDOM_SCORES_SIZE; i++) {
+            scores[i] = randomScore();
+        }
         float actualScore = technique.combine(scores);
         float expectedScore = expectedScoreFunction.apply(Arrays.asList(ArrayUtils.toObject(scores)), weights);
         assertEquals(expectedScore, actualScore, DELTA_FOR_ASSERTION);
+    }
+
+    private float randomScore() {
+        return RandomizedTest.randomBoolean() ? -1.0f : RandomizedTest.randomFloat();
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechniqueTests.java
@@ -10,27 +10,27 @@ import static org.opensearch.neuralsearch.processor.combination.ArithmeticMeanSc
 import java.util.List;
 import java.util.Map;
 
-public class HarmonicMeanScoreCombinationTechniqueTests extends BaseScoreCombinationTechniqueTests {
+public class GeometricMeanScoreCombinationTechniqueTests extends BaseScoreCombinationTechniqueTests {
 
     private ScoreCombinationUtil scoreCombinationUtil = new ScoreCombinationUtil();
 
-    public HarmonicMeanScoreCombinationTechniqueTests() {
-        this.expectedScoreFunction = (scores, weights) -> harmonicMean(scores, weights);
+    public GeometricMeanScoreCombinationTechniqueTests() {
+        this.expectedScoreFunction = this::geometricMean;
     }
 
     public void testLogic_whenAllScoresPresentAndNoWeights_thenCorrectScores() {
-        ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(Map.of(), scoreCombinationUtil);
+        ScoreCombinationTechnique technique = new GeometricMeanScoreCombinationTechnique(Map.of(), scoreCombinationUtil);
         testLogic_whenAllScoresPresentAndNoWeights_thenCorrectScores(technique);
     }
 
     public void testLogic_whenNotAllScoresPresentAndNoWeights_thenCorrectScores() {
-        ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(Map.of(), scoreCombinationUtil);
+        ScoreCombinationTechnique technique = new GeometricMeanScoreCombinationTechnique(Map.of(), scoreCombinationUtil);
         testLogic_whenNotAllScoresPresentAndNoWeights_thenCorrectScores(technique);
     }
 
     public void testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores() {
         List<Double> weights = List.of(0.9, 0.2, 0.7);
-        ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(
+        ScoreCombinationTechnique technique = new GeometricMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
             scoreCombinationUtil
         );
@@ -39,23 +39,24 @@ public class HarmonicMeanScoreCombinationTechniqueTests extends BaseScoreCombina
 
     public void testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
         List<Double> weights = List.of(0.9, 0.2, 0.7);
-        ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(
+        ScoreCombinationTechnique technique = new GeometricMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
             scoreCombinationUtil
         );
         testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
 
-    private float harmonicMean(List<Float> scores, List<Double> weights) {
+    private float geometricMean(List<Float> scores, List<Double> weights) {
         assertEquals(scores.size(), weights.size());
-        float w = 0, h = 0;
+        float sumOfWeights = 0;
+        float weightedSumOfLn = 0;
         for (int i = 0; i < scores.size(); i++) {
             float score = scores.get(i), weight = weights.get(i).floatValue();
             if (score > 0) {
-                w += weight;
-                h += weight / score;
+                sumOfWeights += weight;
+                weightedSumOfLn += weight * Math.log(score);
             }
         }
-        return h == 0 ? 0f : w / h;
+        return sumOfWeights == 0 ? 0f : (float) Math.exp(weightedSumOfLn / sumOfWeights);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechniqueTests.java
@@ -76,17 +76,23 @@ public class GeometricMeanScoreCombinationTechniqueTests extends BaseScoreCombin
         testRandomValues_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
 
+    /**
+     * Verify score correctness by using alternative formula for geometric mean as n-th root of product of weighted scores,
+     * more details in here https://en.wikipedia.org/wiki/Weighted_geometric_mean
+     */
     private float geometricMean(List<Float> scores, List<Double> weights) {
-        assertEquals(scores.size(), weights.size());
-        float sumOfWeights = 0;
-        float weightedSumOfLn = 0;
-        for (int i = 0; i < scores.size(); i++) {
-            float score = scores.get(i), weight = weights.get(i).floatValue();
-            if (score > 0) {
-                sumOfWeights += weight;
-                weightedSumOfLn += weight * Math.log(score);
+        float product = 1.0f;
+        float sumOfWeights = 0.0f;
+        for (int indexOfSubQuery = 0; indexOfSubQuery < scores.size(); indexOfSubQuery++) {
+            float score = scores.get(indexOfSubQuery);
+            if (score <= 0) {
+                // scores 0.0 need to be skipped, ln() of 0 is not defined
+                continue;
             }
+            float weight = weights.get(indexOfSubQuery).floatValue();
+            product *= Math.pow(score, weight);
+            sumOfWeights += weight;
         }
-        return sumOfWeights == 0 ? 0f : (float) Math.exp(weightedSumOfLn / sumOfWeights);
+        return sumOfWeights == 0 ? 0f : (float) Math.pow(product, (float) 1 / sumOfWeights);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechniqueTests.java
@@ -9,6 +9,10 @@ import static org.opensearch.neuralsearch.processor.combination.ArithmeticMeanSc
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 public class GeometricMeanScoreCombinationTechniqueTests extends BaseScoreCombinationTechniqueTests {
 
@@ -29,21 +33,47 @@ public class GeometricMeanScoreCombinationTechniqueTests extends BaseScoreCombin
     }
 
     public void testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Float> scores = List.of(1.0f, 0.5f, 0.3f);
         List<Double> weights = List.of(0.9, 0.2, 0.7);
         ScoreCombinationTechnique technique = new GeometricMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
             scoreCombinationUtil
         );
-        testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
+        float expectedScore = 0.5797f;
+        testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, scores, expectedScore);
+    }
+
+    public void testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Double> weights = IntStream.range(0, RANDOM_SCORES_SIZE)
+            .mapToObj(i -> RandomizedTest.randomDouble())
+            .collect(Collectors.toList());
+        ScoreCombinationTechnique technique = new GeometricMeanScoreCombinationTechnique(
+            Map.of(PARAM_NAME_WEIGHTS, weights),
+            scoreCombinationUtil
+        );
+        testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
 
     public void testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Float> scores = List.of(1.0f, -1.0f, 0.6f);
         List<Double> weights = List.of(0.9, 0.2, 0.7);
         ScoreCombinationTechnique technique = new GeometricMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
             scoreCombinationUtil
         );
-        testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
+        float expectedScore = 0.7997f;
+        testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, scores, expectedScore);
+    }
+
+    public void testRandomValues_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Double> weights = IntStream.range(0, RANDOM_SCORES_SIZE)
+            .mapToObj(i -> RandomizedTest.randomDouble())
+            .collect(Collectors.toList());
+        ScoreCombinationTechnique technique = new GeometricMeanScoreCombinationTechnique(
+            Map.of(PARAM_NAME_WEIGHTS, weights),
+            scoreCombinationUtil
+        );
+        testRandomValues_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
 
     private float geometricMean(List<Float> scores, List<Double> weights) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/HarmonicMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/HarmonicMeanScoreCombinationTechniqueTests.java
@@ -43,17 +43,6 @@ public class HarmonicMeanScoreCombinationTechniqueTests extends BaseScoreCombina
         testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, scores, expecteScore);
     }
 
-    public void testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores() {
-        List<Double> weights = IntStream.range(0, RANDOM_SCORES_SIZE)
-            .mapToObj(i -> RandomizedTest.randomDouble())
-            .collect(Collectors.toList());
-        ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(
-            Map.of(PARAM_NAME_WEIGHTS, weights),
-            scoreCombinationUtil
-        );
-        testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
-    }
-
     public void testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
         List<Float> scores = List.of(1.0f, -1.0f, 0.6f);
         List<Double> weights = List.of(0.9, 0.2, 0.7);

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/HarmonicMeanScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/HarmonicMeanScoreCombinationTechniqueTests.java
@@ -9,6 +9,10 @@ import static org.opensearch.neuralsearch.processor.combination.ArithmeticMeanSc
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 public class HarmonicMeanScoreCombinationTechniqueTests extends BaseScoreCombinationTechniqueTests {
 
@@ -29,21 +33,47 @@ public class HarmonicMeanScoreCombinationTechniqueTests extends BaseScoreCombina
     }
 
     public void testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Float> scores = List.of(1.0f, 0.5f, 0.3f);
         List<Double> weights = List.of(0.9, 0.2, 0.7);
         ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
             scoreCombinationUtil
         );
-        testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
+        float expecteScore = 0.4954f;
+        testLogic_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, scores, expecteScore);
+    }
+
+    public void testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Double> weights = IntStream.range(0, RANDOM_SCORES_SIZE)
+            .mapToObj(i -> RandomizedTest.randomDouble())
+            .collect(Collectors.toList());
+        ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(
+            Map.of(PARAM_NAME_WEIGHTS, weights),
+            scoreCombinationUtil
+        );
+        testRandomValues_whenAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
 
     public void testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Float> scores = List.of(1.0f, -1.0f, 0.6f);
         List<Double> weights = List.of(0.9, 0.2, 0.7);
         ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(
             Map.of(PARAM_NAME_WEIGHTS, weights),
             scoreCombinationUtil
         );
-        testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
+        float expectedScore = 0.7741f;
+        testLogic_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, scores, expectedScore);
+    }
+
+    public void testRandomValues_whenNotAllScoresAndWeightsPresent_thenCorrectScores() {
+        List<Double> weights = IntStream.range(0, RANDOM_SCORES_SIZE)
+            .mapToObj(i -> RandomizedTest.randomDouble())
+            .collect(Collectors.toList());
+        ScoreCombinationTechnique technique = new HarmonicMeanScoreCombinationTechnique(
+            Map.of(PARAM_NAME_WEIGHTS, weights),
+            scoreCombinationUtil
+        );
+        testRandomValues_whenNotAllScoresAndWeightsPresent_thenCorrectScores(technique, weights);
     }
 
     private float harmonicMean(List<Float> scores, List<Double> weights) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactoryTests.java
@@ -27,6 +27,14 @@ public class ScoreCombinationFactoryTests extends OpenSearchQueryTestCase {
         assertTrue(scoreCombinationTechnique instanceof HarmonicMeanScoreCombinationTechnique);
     }
 
+    public void testGeometricWeightedMean_whenCreatingByName_thenReturnCorrectInstance() {
+        ScoreCombinationFactory scoreCombinationFactory = new ScoreCombinationFactory();
+        ScoreCombinationTechnique scoreCombinationTechnique = scoreCombinationFactory.createCombination("geometric_mean");
+
+        assertNotNull(scoreCombinationTechnique);
+        assertTrue(scoreCombinationTechnique instanceof GeometricMeanScoreCombinationTechnique);
+    }
+
     public void testUnsupportedTechnique_whenPassingInvalidName_thenFail() {
         ScoreCombinationFactory scoreCombinationFactory = new ScoreCombinationFactory();
         IllegalArgumentException illegalArgumentException = expectThrows(


### PR DESCRIPTION
### Description
Adding geometric mean technique, that is a generalization of the mean that is based on product and N-th root of N values (more details [here](https://en.wikipedia.org/wiki/Weighted_geometric_mean)). Weights are supported similarly what it's done in arithmetic mean. Example of pipeline with processor config:

```
{
    "description": "Post processor for hybrid search",
    "phase_results_processors": [
        {
            "normalization-processor": {}, 
            "combination": {
                 "technique": "geometric_mean",
                  "parameters": {
                        "weights": [
                            0.4, 0.7
                        ]
                    }
             }
        }
    ]
}
```

In addition to main changes there are some refactoring in integ tests. I have to put it to this PR because with few new tests added for geometric mean auto redeploy feature started acting more aggressively and tests became flaky. 
 
 - move from global model id to reading it at the beginning of each test case. this is required because model can be redeployed by the [auto redeploy feature of ml-commons](https://github.com/opensearch-project/ml-commons/pull/852)
 - split on large class into three smaller ones based on area of responsibility 
 - cleanup outdated tests

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/228, part of solution for https://github.com/opensearch-project/neural-search/issues/126

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
