### PR TITLE
Reworked feature flag usage for Hybrid search feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,9 +256,7 @@ testClusters.integTest {
     
     // enable features for testing
     // hybrid search
-    systemProperty('neural_search_hybrid_search_enabled', 'true')
-    // search pipelines
-    systemProperty('opensearch.experimental.feature.search_pipeline.enabled', 'true')
+    systemProperty('plugins.ml_commons.hybrid_search_enabled', 'true')
 }
 
 // Remote Integration Tests

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessor.java
@@ -51,7 +51,8 @@ public class NormalizationProcessor implements SearchPhaseResultsProcessor {
         final SearchPhaseResults<Result> searchPhaseResult,
         final SearchPhaseContext searchPhaseContext
     ) {
-        if (shouldRunProcessor(searchPhaseResult)) {
+        if (shouldSkipProcessor(searchPhaseResult)) {
+            log.debug("Query results are not compatible with normalization processor");
             return;
         }
         List<QuerySearchResult> querySearchResults = getQueryPhaseSearchResults(searchPhaseResult);
@@ -88,7 +89,7 @@ public class NormalizationProcessor implements SearchPhaseResultsProcessor {
         return false;
     }
 
-    private <Result extends SearchPhaseResult> boolean shouldRunProcessor(SearchPhaseResults<Result> searchPhaseResult) {
+    private <Result extends SearchPhaseResult> boolean shouldSkipProcessor(SearchPhaseResults<Result> searchPhaseResult) {
         if (Objects.isNull(searchPhaseResult) || !(searchPhaseResult instanceof QueryPhaseResultConsumer)) {
             return true;
         }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
@@ -24,6 +25,7 @@ import org.opensearch.search.query.QuerySearchResult;
  * and post-processing of final results
  */
 @AllArgsConstructor
+@Log4j2
 public class NormalizationProcessorWorkflow {
 
     private final ScoreNormalizer scoreNormalizer;
@@ -41,15 +43,19 @@ public class NormalizationProcessorWorkflow {
         final ScoreCombinationTechnique combinationTechnique
     ) {
         // pre-process data
+        log.debug("Pre-process query results");
         List<CompoundTopDocs> queryTopDocs = getQueryTopDocs(querySearchResults);
 
         // normalize
+        log.debug("Do score normalization");
         scoreNormalizer.normalizeScores(queryTopDocs, normalizationTechnique);
 
         // combine
+        log.debug("Do score combination");
         scoreCombiner.combineScores(queryTopDocs, combinationTechnique);
 
         // post-process data
+        log.debug("Post-process query results after score normalization and combination");
         updateOriginalQueryResults(querySearchResults, queryTopDocs);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
@@ -9,11 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import lombok.ToString;
+
 /**
  * Abstracts combination of scores based on arithmetic mean method
  */
+@ToString(onlyExplicitlyIncluded = true)
 public class ArithmeticMeanScoreCombinationTechnique implements ScoreCombinationTechnique {
-
+    @ToString.Include
     public static final String TECHNIQUE_NAME = "arithmetic_mean";
     public static final String PARAM_NAME_WEIGHTS = "weights";
     private static final Set<String> SUPPORTED_PARAMS = Set.of(PARAM_NAME_WEIGHTS);

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/GeometricMeanScoreCombinationTechnique.java
@@ -9,11 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import lombok.ToString;
+
 /**
  * Abstracts combination of scores based on geometrical mean method
  */
+@ToString(onlyExplicitlyIncluded = true)
 public class GeometricMeanScoreCombinationTechnique implements ScoreCombinationTechnique {
-
+    @ToString.Include
     public static final String TECHNIQUE_NAME = "geometric_mean";
     public static final String PARAM_NAME_WEIGHTS = "weights";
     private static final Set<String> SUPPORTED_PARAMS = Set.of(PARAM_NAME_WEIGHTS);

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/HarmonicMeanScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/HarmonicMeanScoreCombinationTechnique.java
@@ -9,11 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import lombok.ToString;
+
 /**
  * Abstracts combination of scores based on harmonic mean method
  */
+@ToString(onlyExplicitlyIncluded = true)
 public class HarmonicMeanScoreCombinationTechnique implements ScoreCombinationTechnique {
-
+    @ToString.Include
     public static final String TECHNIQUE_NAME = "harmonic_mean";
     public static final String PARAM_NAME_WEIGHTS = "weights";
     private static final Set<String> SUPPORTED_PARAMS = Set.of(PARAM_NAME_WEIGHTS);

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 import org.opensearch.neuralsearch.processor.NormalizationProcessor;
 import org.opensearch.neuralsearch.processor.NormalizationProcessorWorkflow;
@@ -28,6 +29,7 @@ import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
  * Factory for query results normalization processor for search pipeline. Instantiates processor based on user provided input.
  */
 @AllArgsConstructor
+@Log4j2
 public class NormalizationProcessorFactory implements Processor.Factory<SearchPhaseResultsProcessor> {
     public static final String NORMALIZATION_CLAUSE = "normalization";
     public static final String COMBINATION_CLAUSE = "combination";
@@ -75,7 +77,12 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
             Map<String, Object> combinationParams = readOptionalMap(NormalizationProcessor.TYPE, tag, combinationClause, PARAMETERS);
             scoreCombinationTechnique = scoreCombinationFactory.createCombination(combinationTechnique, combinationParams);
         }
-
+        log.info(
+            "Creating search phase results processor of type [{}] with normalization [{}] and combination [{}]",
+            NormalizationProcessor.TYPE,
+            normalizationTechnique,
+            scoreCombinationTechnique
+        );
         return new NormalizationProcessor(
             tag,
             description,

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import lombok.ToString;
+
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.opensearch.neuralsearch.search.CompoundTopDocs;
@@ -16,8 +18,9 @@ import org.opensearch.neuralsearch.search.CompoundTopDocs;
 /**
  * Abstracts normalization of scores based on L2 method
  */
+@ToString(onlyExplicitlyIncluded = true)
 public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechnique {
-
+    @ToString.Include
     public static final String TECHNIQUE_NAME = "l2";
     private static final float MIN_SCORE = 0.001f;
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import lombok.ToString;
+
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.opensearch.neuralsearch.search.CompoundTopDocs;
@@ -18,8 +20,9 @@ import com.google.common.primitives.Floats;
 /**
  * Abstracts normalization of scores based on min-max method
  */
+@ToString(onlyExplicitlyIncluded = true)
 public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTechnique {
-
+    @ToString.Include
     public static final String TECHNIQUE_NAME = "min_max";
     private static final float MIN_SCORE = 0.001f;
     private static final float SINGLE_RESULT_SCORE = 1.0f;

--- a/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
+++ b/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.settings;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import org.opensearch.common.settings.Setting;
+
+/**
+ * Class defines settings specific to neural-search plugin
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class NeuralSearchSettings {
+
+    /**
+     * Gates the functionality of hybrid search
+     * Currently query phase searcher added with hybrid search will conflict with concurrent search in core.
+     * Once that problem is resolved this feature flag can be removed.
+     */
+    public static final Setting<Boolean> NEURAL_SEARCH_HYBRID_SEARCH_ENABLED = Setting.boolSetting(
+        "plugins.ml_commons.hybrid_search_enabled",
+        false,
+        Setting.Property.NodeScope
+    );
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
@@ -8,7 +8,7 @@ package org.opensearch.neuralsearch.query;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
-import static org.opensearch.neuralsearch.plugin.NeuralSearch.NEURAL_SEARCH_HYBRID_SEARCH_ENABLED;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.NEURAL_SEARCH_HYBRID_SEARCH_ENABLED;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -227,6 +227,6 @@ public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
 
     @SuppressForbidden(reason = "manipulates system properties for testing")
     protected static void initFeatureFlags() {
-        System.setProperty(NEURAL_SEARCH_HYBRID_SEARCH_ENABLED, "true");
+        System.setProperty(NEURAL_SEARCH_HYBRID_SEARCH_ENABLED.getKey(), "true");
     }
 }


### PR DESCRIPTION
### Description
Reworked feature flag to a plugin setting. Previous approach is failing with below error when feature is set in opensearch.yml, which supposed to be the main way of enabling hybrid search for customers:

```
org.opensearch.common.settings.SettingsException: unknown setting [neural_search_hybrid_search_enabled] please check that any required plugins are installed, or check the breaking changes documentation for removed settings
        at org.opensearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:606) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:547) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:517) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:487) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.common.settings.SettingsModule.<init>(SettingsModule.java:179) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.node.Node.<init>(Node.java:555) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.node.Node.<init>(Node.java:388) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:242) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.bootstrap.Bootstrap.setup(Bootstrap.java:242) ~[opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:404) [opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:180) [opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:171) [opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104) [opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138) [opensearch-cli-3.0.0.jar:3.0.0]
        at org.opensearch.cli.Command.main(Command.java:101) [opensearch-cli-3.0.0.jar:3.0.0]
        at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:137) [opensearch-3.0.0.jar:3.0.0]
        at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:103) [opensearch-3.0.0.jar:3.0.0]
```

Added more logging statements for easier debugging.

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/123

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
