### PR TITLE
Changed feature flag name for hybrid search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,7 +256,7 @@ testClusters.integTest {
     
     // enable features for testing
     // hybrid search
-    systemProperty('plugins.ml_commons.hybrid_search_enabled', 'true')
+    systemProperty('plugins.neural_search.hybrid_search_enabled', 'true')
 }
 
 // Remote Integration Tests

--- a/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
+++ b/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
@@ -22,7 +22,7 @@ public final class NeuralSearchSettings {
      * Once that problem is resolved this feature flag can be removed.
      */
     public static final Setting<Boolean> NEURAL_SEARCH_HYBRID_SEARCH_ENABLED = Setting.boolSetting(
-        "plugins.ml_commons.hybrid_search_enabled",
+        "plugins.neural_search.hybrid_search_enabled",
         false,
         Setting.Property.NodeScope
     );


### PR DESCRIPTION
### Description
Fixed typo in feature flag name for hybrid search, new name is "plugins.neural_search.hybrid_search_enabled".

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/228

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
