### PR TITLE
Fixed failing tests after ml-commons added model_group feature

### DIFF
--- a/src/test/resources/processor/CreateModelGroupRequestBody.json
+++ b/src/test/resources/processor/CreateModelGroupRequestBody.json
@@ -1,0 +1,5 @@
+{
+  "name": "test_model_group_public",
+  "description": "This is a public model group",
+  "access_mode": "public"
+}

--- a/src/test/resources/processor/UploadModelRequestBody.json
+++ b/src/test/resources/processor/UploadModelRequestBody.json
@@ -4,6 +4,7 @@
   "model_format": "TORCH_SCRIPT",
   "model_task_type": "text_embedding",
   "model_content_hash_value": "e13b74006290a9d0f58c1376f9629d4ebc05a0f9385f40db837452b167ae9021",
+  "model_group_id": "<MODEL_GROUP_ID>",
   "model_config": {
     "model_type": "bert",
     "embedding_dimension": 768,


### PR DESCRIPTION
### Description
Fixed integ tests after model_group feature is enabled in ml-commons plugin https://github.com/opensearch-project/ml-commons/pull/1243

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
