### PR TITLE
Add map result support in neural search for non text embedding models

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -177,14 +177,16 @@ public class MLCommonsClientAccessor {
     private Map<String, ?> buildMapResultFromResponse(MLOutput mlOutput) {
         final ModelTensorOutput modelTensorOutput = (ModelTensorOutput) mlOutput;
         final List<ModelTensors> tensorOutputList = modelTensorOutput.getMlModelOutputs();
-        if (CollectionUtils.isEmpty(tensorOutputList)) {
-            log.error("No tensor output found!");
-            return null;
+        if (CollectionUtils.isEmpty(tensorOutputList) || CollectionUtils.isEmpty(tensorOutputList.get(0).getMlModelTensors())) {
+            throw new IllegalStateException(
+                "Empty model result produced. Expected 1 tensor output and 1 model tensor, but got [0]"
+            );
         }
         List<ModelTensor> tensorList = tensorOutputList.get(0).getMlModelTensors();
-        if (CollectionUtils.isEmpty(tensorList)) {
-            log.error("No tensor found!");
-            return null;
+        if (tensorList.size() != 1) {
+            throw new IllegalStateException(
+                "Unexpected number of map result produced. Expected 1 map result to be returned, but got [" + tensorList.size() + "]"
+            );
         }
         return tensorList.get(0).getDataAsMap();
     }

--- a/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.neuralsearch.ml;
 
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
@@ -163,7 +162,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
     }
 
     public void test_inferenceSentencesWithMapResult_whenValidInput_thenSuccess() {
-        final Map<String, String> map = ImmutableMap.of("key", "value");
+        final Map<String, String> map = Map.of("key", "value");
         final ActionListener<Map<String, ?>> resultListener = mock(ActionListener.class);
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
@@ -262,7 +261,9 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             output,
             new long[] { 1, 2 },
             MLResultDataType.FLOAT64,
-            ByteBuffer.wrap(new byte[12])
+            ByteBuffer.wrap(new byte[12]),
+            "someValue",
+            Map.of()
         );
         mlModelTensorList.add(tensor);
         final ModelTensors modelTensors = new ModelTensors(mlModelTensorList);


### PR DESCRIPTION
### Description
Neural search only support text embedding model result which are usually in List<List> structure, for other models that returns non vector list like OpenAI, SPLADE etc, there's no available functions to get extract the json object result. This PR is to add several new functions to support these cases, the response are in Map<String, ?> structure and upper layer can extract more information from the map based on their purpose.

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/260

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
