### PR TITLE
Made hybrid search active by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Changed format for hybrid query results to a single list of scores with delimiter ([#259](https://github.com/opensearch-project/neural-search/pull/259))
 * Added validations for score combination weights in Hybrid Search ([#265](https://github.com/opensearch-project/neural-search/pull/265))
+* Made hybrid search active by default ([#274](https://github.com/opensearch-project/neural-search/pull/274))
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/build.gradle
+++ b/build.gradle
@@ -253,10 +253,6 @@ testClusters.integTest {
     // Increase heap size from default of 512mb to 1gb. When heap size is 512mb, our integ tests sporadically fail due
     // to ml-commons memory circuit breaker exception
     jvmArgs("-Xms1g", "-Xmx1g")
-    
-    // enable features for testing
-    // hybrid search
-    systemProperty('plugins.neural_search.hybrid_search_enabled', 'true')
 }
 
 // Remote Integration Tests

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.neuralsearch.plugin;
 
-import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.NEURAL_SEARCH_HYBRID_SEARCH_ENABLED;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.NEURAL_SEARCH_HYBRID_SEARCH_DISABLED;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -99,16 +99,18 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
 
     @Override
     public Optional<QueryPhaseSearcher> getQueryPhaseSearcher() {
-        if (FeatureFlags.isEnabled(NEURAL_SEARCH_HYBRID_SEARCH_ENABLED.getKey())) {
-            log.info("Registering hybrid query phase searcher with feature flag [{}]", NEURAL_SEARCH_HYBRID_SEARCH_ENABLED.getKey());
-            return Optional.of(new HybridQueryPhaseSearcher());
+        // we're using "is_disabled" flag as there are no proper implementation of FeatureFlags.isDisabled(). Both
+        // cases when flag is not set or it is "false" are interpretted in the same way. In such case core is reading
+        // the actual value from settings.
+        if (FeatureFlags.isEnabled(NEURAL_SEARCH_HYBRID_SEARCH_DISABLED.getKey())) {
+            log.info(
+                "Not registering hybrid query phase searcher because feature flag [{}] is disabled",
+                NEURAL_SEARCH_HYBRID_SEARCH_DISABLED.getKey()
+            );
+            return Optional.empty();
         }
-        log.info(
-            "Not registering hybrid query phase searcher because feature flag [{}] is disabled",
-            NEURAL_SEARCH_HYBRID_SEARCH_ENABLED.getKey()
-        );
-        // we want feature be disabled by default due to risk of colliding and breaking concurrent search in core
-        return Optional.empty();
+        log.info("Registering hybrid query phase searcher with feature flag [{}]", NEURAL_SEARCH_HYBRID_SEARCH_DISABLED.getKey());
+        return Optional.of(new HybridQueryPhaseSearcher());
     }
 
     @Override
@@ -123,6 +125,6 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(NEURAL_SEARCH_HYBRID_SEARCH_ENABLED);
+        return List.of(NEURAL_SEARCH_HYBRID_SEARCH_DISABLED);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
+++ b/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
@@ -21,8 +21,8 @@ public final class NeuralSearchSettings {
      * Currently query phase searcher added with hybrid search will conflict with concurrent search in core.
      * Once that problem is resolved this feature flag can be removed.
      */
-    public static final Setting<Boolean> NEURAL_SEARCH_HYBRID_SEARCH_ENABLED = Setting.boolSetting(
-        "plugins.neural_search.hybrid_search_enabled",
+    public static final Setting<Boolean> NEURAL_SEARCH_HYBRID_SEARCH_DISABLED = Setting.boolSetting(
+        "plugins.neural_search.hybrid_search_disabled",
         false,
         Setting.Property.NodeScope
     );

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -38,18 +38,18 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
 
     public void testQueryPhaseSearcher() {
         NeuralSearch plugin = new NeuralSearch();
-        Optional<QueryPhaseSearcher> queryPhaseSearcher = plugin.getQueryPhaseSearcher();
-
-        assertNotNull(queryPhaseSearcher);
-        assertTrue(queryPhaseSearcher.isEmpty());
-
-        initFeatureFlags();
-
         Optional<QueryPhaseSearcher> queryPhaseSearcherWithFeatureFlagDisabled = plugin.getQueryPhaseSearcher();
 
         assertNotNull(queryPhaseSearcherWithFeatureFlagDisabled);
         assertFalse(queryPhaseSearcherWithFeatureFlagDisabled.isEmpty());
         assertTrue(queryPhaseSearcherWithFeatureFlagDisabled.get() instanceof HybridQueryPhaseSearcher);
+
+        initFeatureFlags();
+
+        Optional<QueryPhaseSearcher> queryPhaseSearcher = plugin.getQueryPhaseSearcher();
+
+        assertNotNull(queryPhaseSearcher);
+        assertTrue(queryPhaseSearcher.isEmpty());
     }
 
     public void testProcessors() {

--- a/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
@@ -8,7 +8,7 @@ package org.opensearch.neuralsearch.query;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
-import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.NEURAL_SEARCH_HYBRID_SEARCH_ENABLED;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.NEURAL_SEARCH_HYBRID_SEARCH_DISABLED;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -227,6 +227,6 @@ public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
 
     @SuppressForbidden(reason = "manipulates system properties for testing")
     protected static void initFeatureFlags() {
-        System.setProperty(NEURAL_SEARCH_HYBRID_SEARCH_ENABLED.getKey(), "true");
+        System.setProperty(NEURAL_SEARCH_HYBRID_SEARCH_DISABLED.getKey(), "true");
     }
 }


### PR DESCRIPTION
### Description
Enabling Hybrid Search by default by changing feature flag default to "true". We have tested that with "concurrent search" feature enabled, currently hybrid search takes priority over core feature. 

New flag will be ```plugins.neural_search.hybrid_search_disabled``` and it's ```false``` by default. 

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
