### PR TITLE
Fix flaky integ test caused by latency of undeploy model

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
@@ -550,6 +550,13 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
 
+        // after model undeploy returns, the max interval to update model status is 3s in ml-commons CronJob.
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         makeRequest(
             client(),
             "DELETE",

--- a/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
@@ -551,11 +551,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         );
 
         // after model undeploy returns, the max interval to update model status is 3s in ml-commons CronJob.
-        try {
-            Thread.sleep(3000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        Thread.sleep(3000);
 
         makeRequest(
             client(),


### PR DESCRIPTION
### Description
For ml-commons plugin, after model undeploy returns, the max interval to update model status is 3s in ml-commons CronJob. This can cause flaky integ test in neural-search plugin. Add 3s sleep to fix this.
example: https://github.com/opensearch-project/neural-search/actions/runs/6321926472/job/17166662817

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
