### PR TITLE
[Backport to 2.x] Fix flaky integ test caused by latency of undeploy …

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/common/BaseNeuralSearchIT.java
@@ -576,7 +576,10 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             toHttpEntity(""),
             ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
-        Thread.sleep(DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND);
+
+        // after model undeploy returns, the max interval to update model status is 3s in ml-commons CronJob.
+        Thread.sleep(3000);
+
         makeRequest(
             client(),
             "DELETE",


### PR DESCRIPTION
### Description

Fix flaky integ test caused by latency of undeploy model (#345)
Backport https://github.com/opensearch-project/neural-search/pull/345 to 2.x

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
