### PR TITLE
Consumed latest changes from core, use QueryPhaseSearcherWrapper as parent class for Hybrid QPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,4 +20,5 @@ Support sparse semantic retrieval by introducing `sparse_encoding` ingest proces
 ### Infrastructure
 ### Documentation
 ### Maintenance
+Consumed latest changes from core, use QueryPhaseSearcherWrapper as parent class for Hybrid QPS ([#356](https://github.com/opensearch-project/neural-search/pull/356))
 ### Refactoring

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -33,6 +33,7 @@ import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.query.QueryCollectorContext;
 import org.opensearch.search.query.QueryPhase;
+import org.opensearch.search.query.QueryPhaseSearcherWrapper;
 import org.opensearch.search.query.QuerySearchResult;
 import org.opensearch.search.query.TopDocsCollectorContext;
 import org.opensearch.search.rescore.RescoreContext;
@@ -45,7 +46,11 @@ import com.google.common.annotations.VisibleForTesting;
  * upstream standard implementation of searcher is called.
  */
 @Log4j2
-public class HybridQueryPhaseSearcher extends QueryPhase.DefaultQueryPhaseSearcher {
+public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
+
+    public HybridQueryPhaseSearcher() {
+        super();
+    }
 
     public boolean searchWith(
         final SearchContext searchContext,
@@ -58,7 +63,7 @@ public class HybridQueryPhaseSearcher extends QueryPhase.DefaultQueryPhaseSearch
         if (query instanceof HybridQuery) {
             return searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
         }
-        return super.searchWithCollector(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
+        return super.searchWith(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
### Description
Need to use QueryPhaseSearcherWrapper as this is core new public implementation of the QueryPhaseSearcher. This will be released in core 2.11, came with [this PR](https://github.com/opensearch-project/OpenSearch/pull/7956).

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
