### PR TITLE
Fixed exception in Hybrid Query for one shard and multiple node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Support sparse semantic retrieval by introducing `sparse_encoding` ingest processor and query builder ([#333](https://github.com/opensearch-project/neural-search/pull/333))
 ### Enhancements
 ### Bug Fixes
+Fixed exception in Hybrid Query for one shard and multiple node ([#396](https://github.com/opensearch-project/neural-search/pull/396))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -6,12 +6,12 @@
 package org.opensearch.neuralsearch.processor;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
@@ -52,6 +52,9 @@ public class NormalizationProcessorWorkflow {
         final ScoreNormalizationTechnique normalizationTechnique,
         final ScoreCombinationTechnique combinationTechnique
     ) {
+        // save original state
+        List<Integer> unprocessedDocIds = unprocessedDocIds(querySearchResults);
+
         // pre-process data
         log.debug("Pre-process query results");
         List<CompoundTopDocs> queryTopDocs = getQueryTopDocs(querySearchResults);
@@ -67,7 +70,7 @@ public class NormalizationProcessorWorkflow {
         // post-process data
         log.debug("Post-process query results after score normalization and combination");
         updateOriginalQueryResults(querySearchResults, queryTopDocs);
-        updateOriginalFetchResults(querySearchResults, fetchSearchResultOptional);
+        updateOriginalFetchResults(querySearchResults, fetchSearchResultOptional, unprocessedDocIds);
     }
 
     /**
@@ -123,7 +126,8 @@ public class NormalizationProcessorWorkflow {
      */
     private void updateOriginalFetchResults(
         final List<QuerySearchResult> querySearchResults,
-        final Optional<FetchSearchResult> fetchSearchResultOptional
+        final Optional<FetchSearchResult> fetchSearchResultOptional,
+        final List<Integer> docIds
     ) {
         if (fetchSearchResultOptional.isEmpty()) {
             return;
@@ -135,14 +139,17 @@ public class NormalizationProcessorWorkflow {
         // 3. update original scores to normalized and combined values
         // 4. order scores based on normalized and combined values
         FetchSearchResult fetchSearchResult = fetchSearchResultOptional.get();
-        SearchHits searchHits = fetchSearchResult.hits();
+        SearchHit[] searchHitArray = getSearchHits(docIds, fetchSearchResult);
 
         // create map of docId to index of search hits. This solves (2), duplicates are from
         // delimiter and start/stop elements, they all have same valid doc_id. For this map
         // we use doc_id as a key, and all those special elements are collapsed into a single
         // key-value pair.
-        Map<Integer, SearchHit> docIdToSearchHit = Arrays.stream(searchHits.getHits())
-            .collect(Collectors.toMap(SearchHit::docId, Function.identity(), (a1, a2) -> a1));
+        Map<Integer, SearchHit> docIdToSearchHit = new HashMap<>();
+        for (int i = 0; i < searchHitArray.length; i++) {
+            int originalDocId = docIds.get(i);
+            docIdToSearchHit.put(originalDocId, searchHitArray[i]);
+        }
 
         QuerySearchResult querySearchResult = querySearchResults.get(0);
         TopDocs topDocs = querySearchResult.topDocs().topDocs;
@@ -160,5 +167,24 @@ public class NormalizationProcessorWorkflow {
             querySearchResult.getMaxScore()
         );
         fetchSearchResult.hits(updatedSearchHits);
+    }
+
+    private SearchHit[] getSearchHits(List<Integer> docIds, FetchSearchResult fetchSearchResult) {
+        SearchHits searchHits = fetchSearchResult.hits();
+        SearchHit[] searchHitArray = searchHits.getHits();
+        // validate the both collections are of the same size
+        if (Objects.isNull(searchHitArray) || searchHitArray.length != docIds.size()) {
+            throw new IllegalStateException("Score normalization processor cannot produce final query result");
+        }
+        return searchHitArray;
+    }
+
+    private List<Integer> unprocessedDocIds(List<QuerySearchResult> querySearchResults) {
+        List<Integer> docIds = querySearchResults.isEmpty()
+            ? List.of()
+            : Arrays.stream(querySearchResults.get(0).topDocs().topDocs.scoreDocs)
+                .map(scoreDoc -> scoreDoc.doc)
+                .collect(Collectors.toList());
+        return docIds;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -169,7 +169,7 @@ public class NormalizationProcessorWorkflow {
         fetchSearchResult.hits(updatedSearchHits);
     }
 
-    private SearchHit[] getSearchHits(List<Integer> docIds, FetchSearchResult fetchSearchResult) {
+    private SearchHit[] getSearchHits(final List<Integer> docIds, final FetchSearchResult fetchSearchResult) {
         SearchHits searchHits = fetchSearchResult.hits();
         SearchHit[] searchHitArray = searchHits.getHits();
         // validate the both collections are of the same size
@@ -179,7 +179,7 @@ public class NormalizationProcessorWorkflow {
         return searchHitArray;
     }
 
-    private List<Integer> unprocessedDocIds(List<QuerySearchResult> querySearchResults) {
+    private List<Integer> unprocessedDocIds(final List<QuerySearchResult> querySearchResults) {
         List<Integer> docIds = querySearchResults.isEmpty()
             ? List.of()
             : Arrays.stream(querySearchResults.get(0).topDocs().topDocs.scoreDocs)


### PR DESCRIPTION
### Description
Fixed case when there is one shard and multiple nodes. In such case Fetch phase all results have doc ids as "-1", and it's not possible to merge them with query results using doc id. Result is a runtime exception in search request.
To fix te problem we're storing doc ids before the normalization and combination is done, and them use docs ids to merge with fetch phase results.

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/393

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
