### PR TITLE
[Backport 2.x]Add 2.11 release note (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/neural-search/compare/2.x...HEAD)
 ### Features
-- Enabled support for applying default modelId in neural search query ([#337](https://github.com/opensearch-project/neural-search/pull/337)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
@@ -13,14 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 ### Refactoring
 
-## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.10...2.x)
+## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.11...2.x)
 ### Features
-Support sparse semantic retrieval by introducing `sparse_encoding` ingest processor and query builder ([#333](https://github.com/opensearch-project/neural-search/pull/333))
 ### Enhancements
-Add `max_token_score` parameter to improve the execution efficiency for `neural_sparse` query clause ([#348](https://github.com/opensearch-project/neural-search/pull/348))
 ### Bug Fixes
 ### Infrastructure
 ### Documentation
 ### Maintenance
-Consumed latest changes from core, use QueryPhaseSearcherWrapper as parent class for Hybrid QPS ([#356](https://github.com/opensearch-project/neural-search/pull/356))
 ### Refactoring

--- a/release-notes/opensearch-neural-search.release-notes-2.11.0.0.md
+++ b/release-notes/opensearch-neural-search.release-notes-2.11.0.0.md
@@ -1,0 +1,14 @@
+## Version 2.11.0.0 Release Notes
+
+Compatible with OpenSearch 2.11.0
+
+### Features
+* Support sparse semantic retrieval by introducing `sparse_encoding` ingest processor and query builder ([#333](https://github.com/opensearch-project/neural-search/pull/333))
+* Enabled support for applying default modelId in neural search query ([#337](https://github.com/opensearch-project/neural-search/pull/337)
+* Added Multimodal semantic search feature ([#359](https://github.com/opensearch-project/neural-search/pull/359))
+### Enhancements
+* Add `max_token_score` parameter to improve the execution efficiency for `neural_sparse` query clause ([#348](https://github.com/opensearch-project/neural-search/pull/348))
+### Bug Fixes
+* Fixed exception in Hybrid Query for one shard and multiple node ([#396](https://github.com/opensearch-project/neural-search/pull/396))
+### Maintenance
+* Consumed latest changes from core, use QueryPhaseSearcherWrapper as parent class for Hybrid QPS ([#356](https://github.com/opensearch-project/neural-search/pull/356))


### PR DESCRIPTION
Backport https://github.com/opensearch-project/neural-search/pull/392/commits/cfbb6a6f97471668e570bc7df9451ec946b25d51 from https://github.com/opensearch-project/neural-search/pull/392

Signed-off-by: Heemin Kim <heemin@amazon.com>
(cherry picked from commit 0f73cc69d033b84f193405045eb2e0d57dcea69b)