### PR TITLE
Fix flaky integ tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fixed flaky integration tests caused by model_state transition latency. 
 ### Infrastructure
 ### Documentation
 ### Maintenance


### PR DESCRIPTION
### Description
- Fixed the flaky integration tests in #384. The test failures were due to the `model_state` has not yet changed to `UNDEPLOYED` after the `undeploy` invocation. Added a poller to wait for the state change then move forward.
- Updated `BaseNeuralSearchIT.findDeployedModels()` to ensure `model_state = DEPLOYED`. This will avoid encountering the following exception when performing a neural search in integ tests. 

```
org.opensearch.client.ResponseException: method [POST], host [http://[::1]:56962], URI [/test-neural-basic-index/_search?size=1], status line [HTTP/1.1 400 Bad Request]
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Model not ready yet. Please run this first: POST /_plugins/_ml/models/7oMmqIsBDNjwFOltGQ_N/_deploy"}],"type":"illegal_argument_exception","reason":"Model not ready yet. Please run this first: POST /_plugins/_ml/models/7oMmqIsBDNjwFOltGQ_N/_deploy"},"status":400}

```
### Issues Resolved
- #384 

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] New functionality has been documented.
    - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
