### PR TITLE
Treat . as a nested field in field_map of text embedding processor

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -6,6 +6,7 @@
 package org.opensearch.neuralsearch.processor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,9 @@ public abstract class InferenceProcessor extends AbstractProcessor {
                 || fieldMap.entrySet()
                         .stream()
                         .anyMatch(
-                                x -> StringUtils.isBlank(x.getKey()) || Objects.isNull(x.getValue())
+                                x -> StringUtils.startsWith(x.getKey(), ".") || StringUtils.endsWith(x.getKey(), ".")
+                                        || Arrays.stream(x.getKey().split("\\.")).anyMatch(y -> StringUtils.isBlank(y))
+                                        || Objects.isNull(x.getValue())
                                         || StringUtils.isBlank(x.getValue().toString()))) {
             throw new IllegalArgumentException("Unable to create the processor as field_map has invalid key or value");
         }

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -154,6 +154,16 @@ public abstract class InferenceProcessor extends AbstractProcessor {
         for (Map.Entry<String, Object> fieldMapEntry : fieldMap.entrySet()) {
             String originalKey = fieldMapEntry.getKey();
             Object targetKey = fieldMapEntry.getValue();
+            
+            int nestedDotIndex = originalKey.indexOf('.');
+            if (nestedDotIndex != -1) {
+                Map<String, Object> temp = new LinkedHashMap<>();
+                temp.put(originalKey.substring(nestedDotIndex + 1), targetKey);
+                targetKey = temp;
+
+                originalKey = originalKey.substring(0, nestedDotIndex);
+            }
+            
             if (targetKey instanceof Map) {
                 Map<String, Object> treeRes = new LinkedHashMap<>();
                 buildMapWithProcessorKeyAndOriginalValueForMapType(originalKey, targetKey, sourceAndMetadataMap, treeRes);

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -154,7 +154,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
         for (Map.Entry<String, Object> fieldMapEntry : fieldMap.entrySet()) {
             String originalKey = fieldMapEntry.getKey();
             Object targetKey = fieldMapEntry.getValue();
-            
+
             int nestedDotIndex = originalKey.indexOf('.');
             if (nestedDotIndex != -1) {
                 Map<String, Object> temp = new LinkedHashMap<>();
@@ -163,7 +163,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
 
                 originalKey = originalKey.substring(0, nestedDotIndex);
             }
-            
+
             if (targetKey instanceof Map) {
                 Map<String, Object> treeRes = new LinkedHashMap<>();
                 buildMapWithProcessorKeyAndOriginalValueForMapType(originalKey, targetKey, sourceAndMetadataMap, treeRes);


### PR DESCRIPTION
### Description
These changes will allow embeddings to be computed when using a nested source field for a text embedding processor as shown in the configuration below:  

```
PUT /_ingest/pipeline/nlp-ingest-pipeline
{
  "description": "An NLP ingest pipeline",
  "processors": [
    {
      "text_embedding": {
        "model_id": "",
        "field_map": {
          “message.text": “message_embedding”
        }
      }
    }
  ]
}

PUT /my-nlp-index
{
    "settings": {
        "index.knn": true,
        "default_pipeline": “nlp-ingest-pipeline”
    },
    "mappings": {
        "properties": {
            "message_embedding": {
                "type": "knn_vector",
                "dimension": 384,
                "method": {
                    "name": "hnsw",
                    "engine": "lucene"
                }
            },
            "message.text": { 
                "type": "text"            
            },
            "color": {
                "type": "text"
            }
        }
    }
}

PUT /my-nlp-index/_doc/1
{
  "message: {"text": "Blueberry smoothie"},
  "color": "blue"
}

GET /my-nlp-index/_doc/1
```

### Issues Resolved
[#110 ](https://github.com/opensearch-project/neural-search/issues/110)

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
