### PR TITLE
Fixed exception for case when Hybrid query being wrapped into bool query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 Fix async actions are left in neural_sparse query ([438](https://github.com/opensearch-project/neural-search/pull/438))
+Fixed exception for case when Hybrid query being wrapped into bool query ([#490](https://github.com/opensearch-project/neural-search/pull/490)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
@@ -83,7 +83,7 @@ public final class HybridQueryScorer extends Scorer {
      */
     @Override
     public float getMaxScore(int upTo) throws IOException {
-        return subScorers.stream().filter(scorer -> scorer.docID() <= upTo).map(scorer -> {
+        return subScorers.stream().filter(Objects::nonNull).filter(scorer -> scorer.docID() <= upTo).map(scorer -> {
             try {
                 return scorer.getMaxScore(upTo);
             } catch (IOException e) {

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.opensearch.indices.IndicesService;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.processor.NeuralQueryEnricherProcessor;
@@ -66,7 +67,8 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
             null,
             mock(IngestService.class),
             null,
-            null
+            null,
+            mock(IndicesService.class)
         );
         Map<String, Processor.Factory> processors = plugin.getProcessors(processorParams);
         assertNotNull(processors);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryWeightTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryWeightTests.java
@@ -61,11 +61,11 @@ public class HybridQueryWeightTests extends OpenSearchQueryTestCase {
             List.of(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT).toQuery(mockQueryShardContext))
         );
         IndexSearcher searcher = newSearcher(reader);
-        Weight weight = searcher.createWeight(hybridQueryWithTerm, ScoreMode.COMPLETE, 1.0f);
+        Weight weight = hybridQueryWithTerm.createWeight(searcher, ScoreMode.TOP_SCORES, 1.0f);
 
         assertNotNull(weight);
 
-        LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
+        LeafReaderContext leafReaderContext = searcher.getIndexReader().leaves().get(0);
         Scorer scorer = weight.scorer(leafReaderContext);
 
         assertNotNull(scorer);


### PR DESCRIPTION
### Description
There is a runtime NullPointer exception in case hybrid query is:
- wrapped into Bool query
AND
- for one of the sub-queries in hybrid query there are no matches. 

It's not directly related to the fact that hybrid is wrapped into some other query. That case needs to be discussed separately, my current opinion is - we should not allow execution of such query, hybrid must be the top level query. This particular PR is focused on a runtime exception, and does not affect or lock us on a particular approach for a wrapped hybrid query case.

For instance if we send following search request:

```
GET /index-test/_search?search_pipeline=nlp-search-pipeline

{
    "query": {
        "bool": {
            "should": [
                {
                    "hybrid": {
                        "queries": [
                            {
                                "match": {
                                    "name": {
                                        "query": "wild west"
                                    }
                                }
                            },
                            {
                                "match": {
                                    "name": {
                                        "query": "team"
                                    }
                                }
                            }
                        ]
                    }
                },
                {
                    "match": {
                        "name": {
                            "query": "university"
                        }
                    }
                }
            ]
        }
    }
}
```

Response looks something like one below:

```
{
    "error": {
        "root_cause": [
            {
                "type": "null_pointer_exception",
                "reason": "Cannot invoke \"org.apache.lucene.search.Scorer.docID()\" because \"scorer\" is null"
            }
        ],
        "type": "search_phase_execution_exception",
        "reason": "all shards failed",
        "phase": "query",
        "grouped": true,
        "failed_shards": [
            {
                "shard": 0,
                "index": "index-test",
                "node": "Ibk3JAobTkO8VygwSsXZ0g",
                "reason": {
                    "type": "null_pointer_exception",
                    "reason": "Cannot invoke \"org.apache.lucene.search.Scorer.docID()\" because \"scorer\" is null"
                }
            }
        ],
        "caused_by": {
            "type": "null_pointer_exception",
            "reason": "Cannot invoke \"org.apache.lucene.search.Scorer.docID()\" because \"scorer\" is null",
            "caused_by": {
                "type": "null_pointer_exception",
                "reason": "Cannot invoke \"org.apache.lucene.search.Scorer.docID()\" because \"scorer\" is null"
            }
        }
    },
    "status": 500
}
```

this is what is the server logs:

```
[2023-11-14T11:35:06,517][WARN ][r.suppressed             ] [integTest-0] path: /index-test/_search, params: {search_pipeline=nlp-search-pipeline, index=index-test}
org.opensearch.action.search.SearchPhaseExecutionException: all shards failed
        at org.opensearch.action.search.AbstractSearchAsyncAction.onPhaseFailure(AbstractSearchAsyncAction.java:708) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
...
Caused by: org.opensearch.OpenSearchException$3: Cannot invoke "org.apache.lucene.search.Scorer.docID()" because "scorer" is null
        at org.opensearch.OpenSearchException.guessRootCauses(OpenSearchException.java:708) ~[opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.executeNextPhase(AbstractSearchAsyncAction.java:378) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        ... 23 more
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.lucene.search.Scorer.docID()" because "scorer" is null
        at org.opensearch.neuralsearch.query.HybridQueryScorer.lambda$getMaxScore$0(HybridQueryScorer.java:88) ~[?:?]
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178) ~[?:?]
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.base/java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:662) ~[?:?]
        at java.base/java.util.stream.ReferencePipeline.max(ReferencePipeline.java:698) ~[?:?]
        at org.opensearch.neuralsearch.query.HybridQueryScorer.getMaxScore(HybridQueryScorer.java:94) ~[?:?]
```

Expected result is that we shouldn't have any exceptions, and individual scores are summarized based on the rules of wrapping Bool query. Below is example of how successful response may look like:

```
{
    "took": 36,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 4,
            "relation": "eq"
        },
        "max_score": 4.3169837,
        "hits": [
            {
                "_index": "index-test",
                "_id": "1",
                "_score": 4.3169837,
                "_source": {
                    "name": "A West Virginia university women 's basketball team , officials , and a small gathering of fans are in a West Virginia arena .",
                    "id": "4319130149.jpg"
                }
            },
            {
                "_index": "index-test",
                "_id": "2",
                "_score": 0.58093566,
                "_source": {
                    "name": "A wild animal races across an uncut field with a minimal amount of trees .",
                    "id": "1775029934.jpg"
                }
            },
            {
                "_index": "index-test",
                "_id": "5",
                "_score": 0.55228686,
                "_source": {
                    "name": "A rodeo cowboy , wearing a cowboy hat , is being thrown off of a wild white horse .",
                    "id": "2691147709.jpg"
                }
            },
            {
                "_index": "index-test",
                "_id": "4",
                "_score": 0.53899646,
                "_source": {
                    "name": "A man who is riding a wild horse in the rodeo is very near to falling off .",
                    "id": "4427058951.jpg"
                }
            }
        ]
    }
}
```

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
