### PR TITLE
Fix for Flaky test for issue 433

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 - Fixing multiple issues reported in #497 ([#524](https://github.com/opensearch-project/neural-search/pull/524))
+- Fix Flaky test reported in #433 ([#533](https://github.com/opensearch-project/neural-search/pull/533))
 ### Infrastructure
 - BWC tests for Neural Search ([#515](https://github.com/opensearch-project/neural-search/pull/515))
 ### Documentation

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -48,7 +48,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
     private static final String TEST_KNN_VECTOR_FIELD_NAME_1 = "test-knn-vector-1";
     private static final String TEST_TEXT_FIELD_NAME_1 = "test-text-field-1";
     private static final String TEST_TEXT_FIELD_NAME_2 = "test-text-field-2";
-    private static final String SEARCH_PIPELINE = "phase-results-pipeline";
+    private static final String SEARCH_PIPELINE = "phase-results-normalization-processor-pipeline";
     private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
@@ -42,7 +42,7 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
     private static final String TEST_DOC_TEXT5 = "Say hello and enter my friend";
     private static final String TEST_KNN_VECTOR_FIELD_NAME_1 = "test-knn-vector-1";
     private static final String TEST_TEXT_FIELD_NAME_1 = "test-text-field-1";
-    private static final String SEARCH_PIPELINE = "phase-results-pipeline";
+    private static final String SEARCH_PIPELINE = "phase-results-score-combination-pipeline";
     private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
@@ -34,7 +34,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
     private static final String TEST_DOC_TEXT4 = "Hello, I'm glad to you see you pal";
     private static final String TEST_KNN_VECTOR_FIELD_NAME_1 = "test-knn-vector-1";
     private static final String TEST_TEXT_FIELD_NAME_1 = "test-text-field-1";
-    private static final String SEARCH_PIPELINE = "phase-results-pipeline";
+    private static final String SEARCH_PIPELINE = "phase-results-normalization-pipeline";
     private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -63,7 +63,7 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
-    private static final String SEARCH_PIPELINE = "phase-results-pipeline";
+    private static final String SEARCH_PIPELINE = "phase-results-hybrid-pipeline";
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
### Description
Currently we were using the "phase-results-pipeline" pipeline name at 4 places. This is creating the below issue
```
    {"error":{"root_cause":[{"type":"resource_not_found_exception","reason":"pipeline [phase-results-pipeline] is missing"}],"type":"resource_not_found_exception","reason":"pipeline [phase-results-pipeline] is missing"},"status":404}

```

The issue is coming when integ tests run in multithreaded environment. 

Consider a scenario where test1 starts executing and it creates a pipeline with name "phase-results-pipeline" . At the same time test2 is about to end(Which also use the search pipeline with the same name) it is at the stage of cleaning up the resources. So when the test 1 tries to use the search pipeline it will not find the pipeline because test2 deleted it.  This is the reason of flakiness.


The Fix is

I have used different names in all the impacted test classes

### Issues Resolved
[https://github.com/opensearch-project/neural-search/issues/433](https://github.com/opensearch-project/neural-search/issues/433)

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
