### PR TITLE
Enable support for default model id on HybridQueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 - Fixing multiple issues reported in #497 ([#524](https://github.com/opensearch-project/neural-search/pull/524))
 - Fix Flaky test reported in #433 ([#533](https://github.com/opensearch-project/neural-search/pull/533))
+- Enable support for default model id on HybridQueryBuilder ([#541](https://github.com/opensearch-project/neural-search/pull/541))
 ### Infrastructure
 - BWC tests for Neural Search ([#515](https://github.com/opensearch-project/neural-search/pull/515))
 - Github action to run integ tests in secure opensearch cluster ([#535](https://github.com/opensearch-project/neural-search/pull/535))

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.Query;
 import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.core.ParseField;
@@ -27,6 +28,7 @@ import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
 import org.opensearch.index.query.Rewriteable;
+import org.opensearch.index.query.QueryBuilderVisitor;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -294,5 +296,18 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             }
         }).filter(Objects::nonNull).collect(Collectors.toList());
         return queries;
+    }
+
+    /**
+     * visit method to parse the HybridQueryBuilder by a visitor
+     * @return
+     */
+    @Override
+    public void visit(QueryBuilderVisitor visitor) {
+        visitor.accept(this);
+        QueryBuilderVisitor subVisitor = visitor.getChildVisitor(Occur.MUST);
+        for (QueryBuilder subQueryBuilder : queries) {
+            subQueryBuilder.visit(subVisitor);
+        }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -304,6 +304,8 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     @Override
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
+        // getChildVisitor of NeuralSearchQueryVisitor return this.
+        // therefore any argument can be passed. Here we have used Occcur.MUST as an argument.
         QueryBuilderVisitor subVisitor = visitor.getChildVisitor(Occur.MUST);
         for (QueryBuilder subQueryBuilder : queries) {
             subQueryBuilder.visit(subVisitor);

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -300,7 +300,6 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
 
     /**
      * visit method to parse the HybridQueryBuilder by a visitor
-     * @return
      */
     @Override
     public void visit(QueryBuilderVisitor visitor) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
@@ -15,6 +15,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
 
 import com.google.common.primitives.Floats;
@@ -57,6 +58,25 @@ public class NeuralQueryEnricherProcessorIT extends BaseNeuralSearchIT {
         neuralQueryBuilder.queryText("Hello World");
         neuralQueryBuilder.k(1);
         Map<String, Object> response = search(index, neuralQueryBuilder, 2);
+
+        assertFalse(response.isEmpty());
+
+    }
+
+    @SneakyThrows
+    public void testNeuralQueryEnricherProcessor_whenHybridQueryBuilderAndNoModelIdPassed_thenSuccess() {
+        initializeIndexIfNotExist();
+        String modelId = getDeployedModelId();
+        createSearchRequestProcessor(modelId, search_pipeline);
+        createPipelineProcessor(modelId, ingest_pipeline);
+        updateIndexSettings(index, Settings.builder().put("index.search.default_pipeline", search_pipeline));
+        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
+        neuralQueryBuilder.fieldName(TEST_KNN_VECTOR_FIELD_NAME_1);
+        neuralQueryBuilder.queryText("Hello World");
+        neuralQueryBuilder.k(1);
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(neuralQueryBuilder);
+        Map<String, Object> response = search(index, hybridQueryBuilder, 2);
 
         assertFalse(response.isEmpty());
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -9,12 +9,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
-import org.opensearch.index.query.MatchAllQueryBuilder;
-import org.opensearch.index.query.QueryBuilder;
-import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.QueryShardContext;
-import org.opensearch.index.query.TermQueryBuilder;
-import org.opensearch.index.query.QueryBuilderVisitor;
 import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
 import static org.opensearch.index.query.AbstractQueryBuilder.DEFAULT_BOOST;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.FILTER_FIELD;
@@ -48,6 +42,11 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNQuery;
@@ -713,7 +712,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     public void testVisit() {
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new NeuralQueryBuilder()).add(new NeuralSparseQueryBuilder());
         List<QueryBuilder> visitedQueries = new ArrayList<>();
-        hybridQueryBuilder.visit(QueryBuilderVisitor.NO_OP_VISITOR);
+        hybridQueryBuilder.visit(createTestVisitor(visitedQueries));
         assertEquals(3, visitedQueries.size());
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -9,6 +9,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
 import static org.opensearch.index.query.AbstractQueryBuilder.DEFAULT_BOOST;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.FILTER_FIELD;
@@ -42,18 +48,12 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.mapper.TextFieldMapper;
-import org.opensearch.index.query.MatchAllQueryBuilder;
-import org.opensearch.index.query.QueryBuilder;
-import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.QueryShardContext;
-import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterTestUtils;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
-import static org.opensearch.neuralsearch.TestUtils.createTestVisitor;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 
@@ -713,7 +713,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     public void testVisit() {
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new NeuralQueryBuilder()).add(new NeuralSparseQueryBuilder());
         List<QueryBuilder> visitedQueries = new ArrayList<>();
-        hybridQueryBuilder.visit(createTestVisitor(visitedQueries));
+        hybridQueryBuilder.visit(QueryBuilderVisitor.NO_OP_VISITOR);
         assertEquals(3, visitedQueries.size());
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -20,6 +20,7 @@ import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.QUERY_TEXT_FI
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
 import java.util.function.Supplier;
 
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -52,6 +53,7 @@ import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterTestUtils;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
+import static org.opensearch.neuralsearch.TestUtils.createTestVisitor;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 
@@ -706,6 +708,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
 
         HybridQueryBuilder hybridQueryBuilder = HybridQueryBuilder.fromXContent(contentParser);
         assertNotNull(hybridQueryBuilder);
+    }
+
+    public void testVisit() {
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new NeuralQueryBuilder()).add(new NeuralSparseQueryBuilder());
+        List<QueryBuilder> visitedQueries = new ArrayList<>();
+        hybridQueryBuilder.visit(createTestVisitor(visitedQueries));
+        assertEquals(3, visitedQueries.size());
     }
 
     private Map<String, Object> getInnerMap(Object innerObject, String queryName, String fieldName) {

--- a/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
@@ -7,6 +7,14 @@ package org.opensearch.neuralsearch.query;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.BooleanClause;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.NEURAL_SEARCH_HYBRID_SEARCH_DISABLED;
 
 import java.io.IOException;
@@ -20,11 +28,6 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.Explanation;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.Weight;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.CheckedConsumer;
@@ -229,5 +232,19 @@ public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
     @SuppressForbidden(reason = "manipulates system properties for testing")
     protected static void initFeatureFlags() {
         System.setProperty(NEURAL_SEARCH_HYBRID_SEARCH_DISABLED.getKey(), "true");
+    }
+
+    protected static QueryBuilderVisitor createTestVisitor(List<QueryBuilder> visitedQueries) {
+        return new QueryBuilderVisitor() {
+            @Override
+            public void accept(QueryBuilder qb) {
+                visitedQueries.add(qb);
+            }
+
+            @Override
+            public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+                return this;
+            }
+        };
     }
 }

--- a/src/testFixtures/java/org/opensearch/neuralsearch/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/TestUtils.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import org.opensearch.index.query.QueryBuilder;
-import org.opensearch.index.query.QueryBuilderVisitor;
 import static org.opensearch.test.OpenSearchTestCase.randomFloat;
 
 import java.util.ArrayList;
@@ -311,9 +309,5 @@ public class TestUtils {
         Map<String, Object> textEmbeddingProcessor = (Map<String, Object>) processors.get(0).get(processor);
 
         return (String) textEmbeddingProcessor.get("model_id");
-    }
-
-    public static QueryBuilderVisitor createTestVisitor(List<QueryBuilder> visitedQueries) {
-        return QueryBuilderVisitor.NO_OP_VISITOR;
     }
 }

--- a/src/testFixtures/java/org/opensearch/neuralsearch/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/TestUtils.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import static org.opensearch.test.OpenSearchTestCase.randomFloat;
 
 import java.util.ArrayList;
@@ -309,5 +311,9 @@ public class TestUtils {
         Map<String, Object> textEmbeddingProcessor = (Map<String, Object>) processors.get(0).get(processor);
 
         return (String) textEmbeddingProcessor.get("model_id");
+    }
+
+    public static QueryBuilderVisitor createTestVisitor(List<QueryBuilder> visitedQueries) {
+        return QueryBuilderVisitor.NO_OP_VISITOR;
     }
 }


### PR DESCRIPTION
### Description
This PR enables the support for Default model Id in Hybrid Query Builder.

Premise:
A customer is facing an issue while using the feature of default model id when neural query is a part of hybrid query.
See example below
```
query{
     hybrid{
            queries[
                  neural {
                       // do not pass model id here as you expect that neural query enricher will add it here.
                  }
           ]  
     }
}
```

```
{
  "from" : 0,
  "size" : 1000,
  "query": {
    "hybrid": {
      "queries": [
        {
          "match": {
            "passage": {
              "query": "how many camels are there in the world."
            }
          }
        },
        {
          "neural": {
            "content_vector": {
              "query_text": "how many camels are there in the world.",
              "k": 10,
              "filter" :
              {
                "bool" :
                {
                  "must": [
                    {
                      "term": {
                      "publisher_id": {
                        "value": "abc"
                        }
                      }
                    },
                    {
                      "term": {
                      "published": {
                        "value": true
                        }
                      }
                    }
                  ]
                }
              }
            }
          }
        }
      ]
    }
  },
  "_source": true
}
```
Reason:
NeuralQueryEnricher processor triggers a neural query visitor to visit all the querybuilders present in the search query and find the neuralquerybuilder and update the model id in it if not present. Visitor finds the visit method in the querybuilder and parses them. However, in hybridquerybuilder the definition of visit method was not there, therefore it was not able to parse the inner sub queries in it.

### Issues Resolved
[https://github.com/opensearch-project/neural-search/issues/539](https://github.com/opensearch-project/neural-search/issues/539)

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
