### PR TITLE
Update GA to use latest JDK-21 (#565)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,8 +21,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        # Restricting java 21 to 21.0.1 due to ongoing bug in JDK 21.0.2 https://bugs.openjdk.org/browse/JDK-8323659. Once the fix https://github.com/opensearch-project/OpenSearch/pull/11968 get merged this change will be reverted.
-        java: [11, 17, 21.0.1]
+        java: [11, 17, 21]
         os: [ubuntu-latest]
 
     name: Gradle Check Linux
@@ -57,8 +56,7 @@ jobs:
   Check-neural-search-windows:
     strategy:
       matrix:
-        # Restricting java 21 to 21.0.1 due to ongoing bug in JDK 21.0.2 https://bugs.openjdk.org/browse/JDK-8323659. Once the fix https://github.com/opensearch-project/OpenSearch/pull/11968 get merged this change will be reverted.
-        java: [11, 17, 21.0.1]
+        java: [11, 17, 21]
         os: [windows-latest]
 
     name: Gradle Check Windows
@@ -86,8 +84,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        # Restricting java 21 to 21.0.1 due to ongoing bug in JDK 21.0.2 https://bugs.openjdk.org/browse/JDK-8323659. Once the fix https://github.com/opensearch-project/OpenSearch/pull/11968 get merged this change will be reverted.
-        java: [11, 17, 21.0.1]
+        java: [11, 17, 21]
         os: [ubuntu-latest]
 
     name: Pre-commit Linux
@@ -121,8 +118,7 @@ jobs:
   Precommit-neural-search-windows:
     strategy:
       matrix:
-        # Restricting java 21 to 21.0.1 due to ongoing bug in JDK 21.0.2 https://bugs.openjdk.org/browse/JDK-8323659. Once the fix https://github.com/opensearch-project/OpenSearch/pull/11968 get merged this change will be reverted.
-        java: [11, 17, 21.0.1]
+        java: [11, 17, 21]
         os: [windows-latest]
 
     name: Pre-commit Windows

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -13,8 +13,7 @@ jobs:
   Restart-Upgrade-BWCTests-NeuralSearch:
     strategy:
       matrix:
-        # Restricting java 21 to 21.0.1 due to ongoing bug in JDK 21.0.2 https://bugs.openjdk.org/browse/JDK-8323659. Once the fix https://github.com/opensearch-project/OpenSearch/pull/11968 get merged this change will be reverted.
-        java: [ 11, 17, 21.0.1 ]
+        java: [ 11, 17, 21 ]
         os: [ubuntu-latest,windows-latest]
         bwc_version : ["2.9.0","2.10.0","2.11.0"]
         opensearch_version : [ "2.12.0-SNAPSHOT" ]
@@ -41,8 +40,7 @@ jobs:
   Rolling-Upgrade-BWCTests-NeuralSearch:
     strategy:
       matrix:
-        # Restricting java 21 to 21.0.1 due to ongoing bug in JDK 21.0.2 https://bugs.openjdk.org/browse/JDK-8323659. Once the fix https://github.com/opensearch-project/OpenSearch/pull/11968 get merged this change will be reverted.
-        java: [ 11, 17, 21.0.1 ]
+        java: [ 11, 17, 21 ]
         os: [ubuntu-latest,windows-latest]
         bwc_version: [ "2.11.0" ]
         opensearch_version: [ "2.12.0-SNAPSHOT" ]

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -20,8 +20,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        # Restricting java 21 to 21.0.1 due to ongoing bug in JDK 21.0.2 https://bugs.openjdk.org/browse/JDK-8323659. Once the fix https://github.com/opensearch-project/OpenSearch/pull/11968 get merged this change will be reverted.
-        java: [11, 17, 21.0.1]
+        java: [11, 17, 21]
 
     name: Run Integration Tests on Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backport https://github.com/opensearch-project/neural-search/commit/51f9d6f91f402b7bfe7ec0ac02656d91d1687844 from https://github.com/opensearch-project/neural-search/pull/565
