### PR TITLE
[Backport 2.x]Adding vibrantvarun to repo maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,18 +1,19 @@
 ## Maintainers
 
-| Maintainer             | GitHub ID                                                 | Affiliation |
-|------------------------|-----------------------------------------------------------|-------------|
-| Vamshi Vijay Nakkirtha | [vamshin](https://github.com/vamshin)                     | Amazon      |
-| Sean Zheng             | [sean-zheng-amazon](https://github.com/sean-zheng-amazon) | Amazon      |
-| Jack Mazanec           | [jmazanec15](https://github.com/jmazanec15)               | Amazon      |
-| Charlie Yang           | [model-collapse](https://github.com/model-collapse)       | Amazon      |
-| Navneet Verma          | [navneet1v](https://github.com/navneet1v)                 | Amazon      |
-| Junshen Wu             | [wujunshen](https://github.com/wujunshen)                 | Amazon      |
-| Zan Niu                | [zane-neo](https://github.com/zane-neo)                   | Amazon      |
-| Yaliang Wu             | [ylwu-amzn](https://github.com/ylwu-amzn)                 | Amazon      |
-| Jing Zhang             | [jngz-es](https://github.com/jngz-es)                     | Amazon      |
-| Heemin Kim             | [heemin32](https://github.com/heemin32)                   | Amazon      |
-| Junqiu Lei             | [junqiu-lei](https://github.com/junqiu-lei)               | Amazon      |
-| Martin Gaievski        | [martin-gaievski](https://github.com/martin-gaievski)     | Amazon      |
-| Naveen Tatikonda       | [naveentatikonda](https://github.com/naveentatikonda)     | Amazon      |
-| Vijayan Balasubramanian| [VijayanB](https://github.com/VijayanB)                   | Amazon      |
+| Maintainer              | GitHub ID                                                 | Affiliation |
+|-------------------------|-----------------------------------------------------------| ----------- |
+| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)                     | Amazon      |
+| Sean Zheng              | [sean-zheng-amazon](https://github.com/sean-zheng-amazon) | Amazon      |
+| Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15)               | Amazon      |
+| Charlie Yang            | [model-collapse](https://github.com/model-collapse)       | Amazon      |
+| Navneet Verma           | [navneet1v](https://github.com/navneet1v)                 | Amazon      |
+| Junshen Wu              | [wujunshen](https://github.com/wujunshen)                 | Amazon      |
+| Zan Niu                 | [zane-neo](https://github.com/zane-neo)                   | Amazon      |
+| Yaliang Wu              | [ylwu-amzn](https://github.com/ylwu-amzn)                 | Amazon      |
+| Jing Zhang              | [jngz-es](https://github.com/jngz-es)                     | Amazon      |
+| Heemin Kim              | [heemin32](https://github.com/heemin32)                   | Amazon      |
+| Junqiu Lei              | [junqiu-lei](https://github.com/junqiu-lei)               | Amazon      |
+| Martin Gaievski         | [martin-gaievski](https://github.com/martin-gaievski)     | Amazon      |
+| Naveen Tatikonda        | [naveentatikonda](https://github.com/naveentatikonda)     | Amazon      |
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)                   | Amazon      |
+| Varun Jain              | [vibrantvarun](https://github.com/vibrantvarun)           | Amazon      |


### PR DESCRIPTION
backport [8b27f7a](https://github.com/opensearch-project/neural-search/commit/8b27f7a11d43f112a7ce41d4b731dde774024a80) from [581](https://github.com/opensearch-project/neural-search/pull/581)
