### PR TITLE
Fixing same index name in NeuralQueryIT and HybridQueryIT

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -37,12 +37,12 @@ import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 
 public class HybridQueryIT extends BaseNeuralSearchIT {
-    private static final String TEST_BASIC_INDEX_NAME = "test-neural-basic-index";
-    private static final String TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME = "test-neural-vector-doc-field-index";
-    private static final String TEST_MULTI_DOC_INDEX_NAME = "test-neural-multi-doc-index";
-    private static final String TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD = "test-neural-multi-doc-single-shard-index";
+    private static final String TEST_BASIC_INDEX_NAME = "test-hybrid-basic-index";
+    private static final String TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME = "test-hybrid-vector-doc-field-index";
+    private static final String TEST_MULTI_DOC_INDEX_NAME = "test-hybrid-multi-doc-index";
+    private static final String TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD = "test-hybrid-multi-doc-single-shard-index";
     private static final String TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD =
-        "test-neural-multi-doc-nested-type--single-shard-index";
+        "test-hybrid-multi-doc-nested-type-single-shard-index";
     private static final String TEST_QUERY_TEXT = "greetings";
     private static final String TEST_QUERY_TEXT2 = "salute";
     private static final String TEST_QUERY_TEXT3 = "hello";


### PR DESCRIPTION
### Description
With this PR we are fixing the potential flakiness in the integ tests as the index name is same in hybridqueryIT and neuralqueryIT.


### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
