### PR TITLE
[Backport 2.x]Update bwc workflow to include 2.13.0-SNAPSHOT

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         java: [ 11, 17, 21 ]
         os: [ubuntu-latest,windows-latest]
-        bwc_version : ["2.9.0","2.10.0","2.11.0"]
-        opensearch_version : [ "2.12.0-SNAPSHOT" ]
+        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0"]
+        opensearch_version : [ "2.13.0-SNAPSHOT" ]
 
     name: NeuralSearch Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -42,8 +42,8 @@ jobs:
       matrix:
         java: [ 11, 17, 21 ]
         os: [ubuntu-latest,windows-latest]
-        bwc_version: [ "2.11.0" ]
-        opensearch_version: [ "2.12.0-SNAPSHOT" ]
+        bwc_version: [ "2.11.0","2.12.0" ]
+        opensearch_version: [ "2.13.0-SNAPSHOT" ]
 
     name: NeuralSearch Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=2.12.0-SNAPSHOT
-systemProp.bwc.bundle.version=2.11.0
+systemProp.bwc.version=2.13.0-SNAPSHOT
+systemProp.bwc.bundle.version=2.12.0
 
 # For fixing Spotless check with Java 17
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION
### Description
backport [ab59d66](https://github.com/opensearch-project/neural-search/commit/ab59d666bcd9e7b3216d648ed579243d429b0cba) from [602](https://github.com/opensearch-project/neural-search/pull/602)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
