### PR TITLE
[Backport 2.x][Fix] add non-null check for queryBuilder in NeuralQueryEnricherProcessor 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 Fix typo for sparse encoding processor factory([#600](https://github.com/opensearch-project/neural-search/pull/600))
-Add non-null check for queryBuilder in NeuralQueryEnricherProcessor ([#618](https://github.com/opensearch-project/neural-search/pull/618))
+Add non-null check for queryBuilder in NeuralQueryEnricherProcessor ([#619](https://github.com/opensearch-project/neural-search/pull/619))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 Fix typo for sparse encoding processor factory([#600](https://github.com/opensearch-project/neural-search/pull/600))
+Add non-null check for queryBuilder in NeuralQueryEnricherProcessor ([#618](https://github.com/opensearch-project/neural-search/pull/618))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessor.java
@@ -67,7 +67,10 @@ public class NeuralQueryEnricherProcessor extends AbstractProcessor implements S
     @Override
     public SearchRequest processRequest(SearchRequest searchRequest) {
         QueryBuilder queryBuilder = searchRequest.source().query();
-        queryBuilder.visit(new NeuralSearchQueryVisitor(modelId, neuralFieldDefaultIdMap));
+        /* Use null check for the case where users are using empty query body. i.e. GET /index_name/_search */
+        if (queryBuilder != null) {
+            queryBuilder.visit(new NeuralSearchQueryVisitor(modelId, neuralFieldDefaultIdMap));
+        }
         return searchRequest;
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
@@ -11,7 +11,7 @@ import static org.opensearch.neuralsearch.TestUtils.createRandomVector;
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.http.util.EntityUtils;
 import org.junit.Before;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
@@ -11,8 +11,14 @@ import static org.opensearch.neuralsearch.TestUtils.createRandomVector;
 import java.util.Collections;
 import java.util.Map;
 
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Before;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
@@ -50,6 +56,27 @@ public class NeuralQueryEnricherProcessorIT extends BaseNeuralSearchIT {
             neuralQueryBuilder.k(1);
             Map<String, Object> response = search(index, neuralQueryBuilder, 2);
             assertFalse(response.isEmpty());
+        } finally {
+            wipeOfTestResources(index, ingest_pipeline, modelId, search_pipeline);
+        }
+    }
+
+    @SneakyThrows
+    public void testNeuralQueryEnricherProcessor_whenGetEmptyQueryBody_thenSuccess() {
+        String modelId = null;
+        try {
+            initializeIndexIfNotExist(index);
+            modelId = prepareModel();
+            createSearchRequestProcessor(modelId, search_pipeline);
+            createPipelineProcessor(modelId, ingest_pipeline, ProcessorType.TEXT_EMBEDDING);
+            updateIndexSettings(index, Settings.builder().put("index.search.default_pipeline", search_pipeline));
+            Request request = new Request("POST", "/" + index + "/_search");
+            Response response = client().performRequest(request);
+            assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+            String responseBody = EntityUtils.toString(response.getEntity());
+            Map<String, Object> responseInMap = XContentHelper.convertToMap(XContentType.JSON.xContent(), responseBody, false);
+            assertFalse(responseInMap.isEmpty());
+            assertEquals(3, ((Map) responseInMap.get("hits")).size());
         } finally {
             wipeOfTestResources(index, ingest_pipeline, modelId, search_pipeline);
         }

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorTests.java
@@ -46,6 +46,17 @@ public class NeuralQueryEnricherProcessorTests extends OpenSearchTestCase {
         assertEquals(processSearchRequest, searchRequest);
     }
 
+    public void testProcessRequest_whenVisitingEmptyQueryBody_thenSuccess() throws Exception {
+        NeuralQueryEnricherProcessor.Factory factory = new NeuralQueryEnricherProcessor.Factory();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(new SearchSourceBuilder());
+        assertNull(searchRequest.source().query());
+        NeuralQueryEnricherProcessor processor = createTestProcessor(factory);
+        SearchRequest processSearchRequest = processor.processRequest(searchRequest);
+        // should do nothing
+        assertNull(processSearchRequest.source().query());
+    }
+
     public void testType() throws Exception {
         NeuralQueryEnricherProcessor.Factory factory = new NeuralQueryEnricherProcessor.Factory();
         NeuralQueryEnricherProcessor processor = createTestProcessor(factory);


### PR DESCRIPTION
### Description
The automatic backport for https://github.com/opensearch-project/neural-search/pull/615 failed. Backport it manually.

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
