### PR TITLE
Adding aggregations in hybrid query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 - Fix async actions are left in neural_sparse query ([#438](https://github.com/opensearch-project/neural-search/pull/438))
-- Fixed exception for case when Hybrid query being wrapped into bool query ([#490](https://github.com/opensearch-project/neural-search/pull/490))
-- Hybrid query and nested type fields ([#498](https://github.com/opensearch-project/neural-search/pull/498))
 - Fix typo for sparse encoding processor factory([#578](https://github.com/opensearch-project/neural-search/pull/578))
 - Add non-null check for queryBuilder in NeuralQueryEnricherProcessor ([#615](https://github.com/opensearch-project/neural-search/pull/615))
 ### Infrastructure
 ### Documentation
 ### Maintenance
-- Added support for jdk-21 ([#500](https://github.com/opensearch-project/neural-search/pull/500)))
 ### Refactoring
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.12...2.x)
 ### Features
 ### Enhancements
+- Adding aggregations in hybrid query ([#630](https://github.com/opensearch-project/neural-search/pull/630))
 ### Bug Fixes
 - Fix runtime exceptions in hybrid query for case when sub-query scorer return TwoPhase iterator that is incompatible with DISI iterator ([#624](https://github.com/opensearch-project/neural-search/pull/624))
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridAggregationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridAggregationProcessor.java
@@ -16,7 +16,7 @@ import org.opensearch.search.query.ReduceableSearchResult;
 import java.io.IOException;
 import java.util.List;
 
-import static org.opensearch.neuralsearch.search.query.HybridQueryPhaseSearcher.isHybridQuery;
+import static org.opensearch.neuralsearch.util.HybridQueryUtil.isHybridQuery;
 
 /**
  * Defines logic for pre- and post-phases of document scores collection. Responsible for registering custom

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -11,11 +11,9 @@ import java.util.List;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.search.NestedHelper;
 import org.opensearch.neuralsearch.query.HybridQuery;
 import org.opensearch.search.aggregations.AggregationProcessor;
@@ -27,16 +25,14 @@ import org.opensearch.search.query.QueryPhaseSearcherWrapper;
 
 import lombok.extern.log4j.Log4j2;
 
+import static org.opensearch.neuralsearch.util.HybridQueryUtil.isHybridQuery;
+
 /**
  * Custom search implementation to be used at {@link QueryPhase} for Hybrid Query search. For queries other than Hybrid the
  * upstream standard implementation of searcher is called.
  */
 @Log4j2
 public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
-
-    public HybridQueryPhaseSearcher() {
-        super();
-    }
 
     public boolean searchWith(
         final SearchContext searchContext,
@@ -53,46 +49,6 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
             Query hybridQuery = extractHybridQuery(searchContext, query);
             return super.searchWith(searchContext, searcher, hybridQuery, collectors, hasFilterCollector, hasTimeout);
         }
-    }
-
-    @VisibleForTesting
-    static boolean isHybridQuery(final Query query, final SearchContext searchContext) {
-        if (query instanceof HybridQuery) {
-            return true;
-        } else if (isWrappedHybridQuery(query) && hasNestedFieldOrNestedDocs(query, searchContext)) {
-            /* Checking if this is a hybrid query that is wrapped into a Bool query by core Opensearch code
-            https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/DefaultSearchContext.java#L367-L370.
-            main reason for that is performance optimization, at time of writing we are ok with loosing on performance if that's unblocks
-            hybrid query for indexes with nested field types.
-            in such case we consider query a valid hybrid query. Later in the code we will extract it and execute as a main query for
-            this search request.
-            below is sample structure of such query:
-
-            Boolean {
-               should: {
-                   hybrid: {
-                       sub_query1 {}
-                       sub_query2 {}
-                   }
-               }
-               filter: {
-                   exists: {
-                       field: "_primary_term"
-                   }
-               }
-            }
-            TODO Need to add logic for passing hybrid sub-queries through the same logic in core to ensure there is no latency regression */
-            // we have already checked if query in instance of Boolean in higher level else if condition
-            return ((BooleanQuery) query).clauses()
-                .stream()
-                .filter(clause -> !(clause.getQuery() instanceof HybridQuery))
-                .allMatch(clause -> {
-                    return clause.getOccur() == BooleanClause.Occur.FILTER
-                        && clause.getQuery() instanceof FieldExistsQuery
-                        && SeqNoFieldMapper.PRIMARY_TERM_NAME.equals(((FieldExistsQuery) clause.getQuery()).getField());
-                });
-        }
-        return false;
     }
 
     private static boolean hasNestedFieldOrNestedDocs(final Query query, final SearchContext searchContext) {

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.search.NestedHelper;
+import org.opensearch.neuralsearch.query.HybridQuery;
+import org.opensearch.search.internal.SearchContext;
+
+/**
+ * Utility class for anything related to hybrid query
+ */
+public class HybridQueryUtil {
+
+    public static boolean isHybridQuery(final Query query, final SearchContext searchContext) {
+        if (query instanceof HybridQuery) {
+            return true;
+        } else if (isWrappedHybridQuery(query) && hasNestedFieldOrNestedDocs(query, searchContext)) {
+            /* Checking if this is a hybrid query that is wrapped into a Bool query by core Opensearch code
+            https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/DefaultSearchContext.java#L367-L370.
+            main reason for that is performance optimization, at time of writing we are ok with loosing on performance if that's unblocks
+            hybrid query for indexes with nested field types.
+            in such case we consider query a valid hybrid query. Later in the code we will extract it and execute as a main query for
+            this search request.
+            below is sample structure of such query:
+
+            Boolean {
+               should: {
+                   hybrid: {
+                       sub_query1 {}
+                       sub_query2 {}
+                   }
+               }
+               filter: {
+                   exists: {
+                       field: "_primary_term"
+                   }
+               }
+            }
+            TODO Need to add logic for passing hybrid sub-queries through the same logic in core to ensure there is no latency regression */
+            // we have already checked if query in instance of Boolean in higher level else if condition
+            return ((BooleanQuery) query).clauses()
+                .stream()
+                .filter(clause -> clause.getQuery() instanceof HybridQuery == false)
+                .allMatch(clause -> {
+                    return clause.getOccur() == BooleanClause.Occur.FILTER
+                        && clause.getQuery() instanceof FieldExistsQuery
+                        && SeqNoFieldMapper.PRIMARY_TERM_NAME.equals(((FieldExistsQuery) clause.getQuery()).getField());
+                });
+        }
+        return false;
+    }
+
+    private static boolean hasNestedFieldOrNestedDocs(final Query query, final SearchContext searchContext) {
+        return searchContext.mapperService().hasNested() && new NestedHelper(searchContext.mapperService()).mightMatchNestedDocs(query);
+    }
+
+    private static boolean isWrappedHybridQuery(final Query query) {
+        return query instanceof BooleanQuery
+            && ((BooleanQuery) query).clauses().stream().anyMatch(clauseQuery -> clauseQuery.getQuery() instanceof HybridQuery);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -4,6 +4,8 @@
  */
 package org.opensearch.neuralsearch.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.FieldExistsQuery;
@@ -16,6 +18,7 @@ import org.opensearch.search.internal.SearchContext;
 /**
  * Utility class for anything related to hybrid query
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HybridQueryUtil {
 
     public static boolean isHybridQuery(final Query query, final SearchContext searchContext) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -52,6 +52,8 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector4 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector5 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector6 = createRandomVector(TEST_DIMENSION);
 
     @Before
     public void setUp() throws Exception {
@@ -318,7 +320,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
                 "5",
                 Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
-                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(Floats.asList(testVector5).toArray()),
                 Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
                 Collections.singletonList(TEST_DOC_TEXT4)
             );
@@ -365,7 +367,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
                 "5",
                 Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
-                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(Floats.asList(testVector5).toArray()),
                 Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
                 Collections.singletonList(TEST_DOC_TEXT4)
             );
@@ -373,7 +375,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
                 "6",
                 Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
-                Collections.singletonList(Floats.asList(testVector4).toArray()),
+                Collections.singletonList(Floats.asList(testVector6).toArray()),
                 Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
                 Collections.singletonList(TEST_DOC_TEXT5)
             );

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationTechniqueTests.java
@@ -63,7 +63,7 @@ public class ScoreCombinationTechniqueTests extends OpenSearchTestCase {
         assertNotNull(queryTopDocs);
         assertEquals(3, queryTopDocs.size());
 
-        assertEquals(3, queryTopDocs.get(0).getScoreDocs().size());
+        assertEquals(5, queryTopDocs.get(0).getScoreDocs().size());
         assertEquals(.5, queryTopDocs.get(0).getScoreDocs().get(0).score, DELTA_FOR_SCORE_ASSERTION);
         assertEquals(1, queryTopDocs.get(0).getScoreDocs().get(0).doc);
         assertEquals(.5, queryTopDocs.get(0).getScoreDocs().get(1).score, DELTA_FOR_SCORE_ASSERTION);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
@@ -1,0 +1,597 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.SneakyThrows;
+
+import org.junit.Before;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.BucketMetricsPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.MaxBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.MinBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.SumBucketPipelineAggregationBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static org.opensearch.neuralsearch.TestUtils.DELTA_FOR_SCORE_ASSERTION;
+import static org.opensearch.neuralsearch.TestUtils.RELATION_EQUAL_TO;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationBuckets;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationValue;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationValues;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregations;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getNestedHits;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getTotalHits;
+
+/**
+ * Integration tests for base scenarios when aggregations are combined with hybrid query
+ */
+public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
+    private static final String TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS =
+        "test-neural-aggs-pipeline-multi-doc-index-multiple-shards";
+    private static final String TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD = "test-neural-aggs-multi-doc-index-single-shard";
+    private static final String TEST_QUERY_TEXT3 = "hello";
+    private static final String TEST_QUERY_TEXT5 = "welcome";
+    private static final String TEST_DOC_TEXT1 = "Hello world";
+    private static final String TEST_DOC_TEXT2 = "Hi to this place";
+    private static final String TEST_DOC_TEXT3 = "We would like to welcome everyone";
+    private static final String TEST_TEXT_FIELD_NAME_1 = "test-text-field-1";
+    private static final String SEARCH_PIPELINE = "phase-results-hybrid-pipeline";
+    private static final String TEST_DOC_TEXT4 = "Hello, I'm glad to you see you pal";
+    private static final String TEST_DOC_TEXT5 = "People keep telling me orange but I still prefer pink";
+    private static final String TEST_DOC_TEXT6 = "She traveled because it cost the same as therapy and was a lot more enjoyable";
+    private static final String INTEGER_FIELD_1 = "doc_index";
+    private static final int INTEGER_FIELD_1_VALUE = 1234;
+    private static final int INTEGER_FIELD_2_VALUE = 2345;
+    private static final int INTEGER_FIELD_3_VALUE = 3456;
+    private static final int INTEGER_FIELD_4_VALUE = 4567;
+    private static final String KEYWORD_FIELD_1 = "doc_keyword";
+    private static final String KEYWORD_FIELD_1_VALUE = "workable";
+    private static final String KEYWORD_FIELD_2_VALUE = "angry";
+    private static final String KEYWORD_FIELD_3_VALUE = "likeable";
+    private static final String KEYWORD_FIELD_4_VALUE = "entire";
+    private static final String DATE_FIELD_1 = "doc_date";
+    private static final String DATE_FIELD_1_VALUE = "01/03/1995";
+    private static final String DATE_FIELD_2_VALUE = "05/02/2015";
+    private static final String DATE_FIELD_3_VALUE = "07/23/2007";
+    private static final String DATE_FIELD_4_VALUE = "08/21/2012";
+    private static final String INTEGER_FIELD_PRICE = "doc_price";
+    private static final int INTEGER_FIELD_PRICE_1_VALUE = 130;
+    private static final int INTEGER_FIELD_PRICE_2_VALUE = 100;
+    private static final int INTEGER_FIELD_PRICE_3_VALUE = 200;
+    private static final int INTEGER_FIELD_PRICE_4_VALUE = 25;
+    private static final int INTEGER_FIELD_PRICE_5_VALUE = 30;
+    private static final int INTEGER_FIELD_PRICE_6_VALUE = 350;
+    private static final String BUCKET_AGG_DOC_COUNT_FIELD = "doc_count";
+    private static final String KEY = "key";
+    private static final String BUCKET_AGG_KEY_AS_STRING = "key_as_string";
+    private static final String SUM_AGGREGATION_NAME = "sum_aggs";
+    private static final String MAX_AGGREGATION_NAME = "max_aggs";
+    private static final String DATE_AGGREGATION_NAME = "date_aggregation";
+    private static final String GENERIC_AGGREGATION_NAME = "my_aggregation";
+    private static final String BUCKETS_AGGREGATION_NAME_1 = "date_buckets_1";
+    private static final String BUCKETS_AGGREGATION_NAME_2 = "date_buckets_2";
+    private static final String BUCKETS_AGGREGATION_NAME_3 = "date_buckets_3";
+    private static final String BUCKETS_AGGREGATION_NAME_4 = "date_buckets_4";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        updateClusterSettings();
+    }
+
+    @Override
+    public boolean isUpdateClusterSettings() {
+        return false;
+    }
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        return true;
+    }
+
+    @SneakyThrows
+    public void testPipelineAggs_whenConcurrentSearchEnabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        testAvgSumMinMaxAggs();
+    }
+
+    @SneakyThrows
+    public void testPipelineAggs_whenConcurrentSearchDisabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        testAvgSumMinMaxAggs();
+    }
+
+    @SneakyThrows
+    public void testMetricAggsOnSingleShard_whenMaxAggsAndConcurrentSearchEnabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        testMaxAggsOnSingleShardCluster();
+    }
+
+    @SneakyThrows
+    public void testMetricAggsOnSingleShard_whenMaxAggsAndConcurrentSearchDisabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        testMaxAggsOnSingleShardCluster();
+    }
+
+    @SneakyThrows
+    public void testBucketAndNestedAggs_whenConcurrentSearchDisabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        testDateRange();
+    }
+
+    @SneakyThrows
+    public void testBucketAndNestedAggs_whenConcurrentSearchEnabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        testDateRange();
+    }
+
+    @SneakyThrows
+    public void testAggregationNotSupportedConcurrentSearch_whenUseSamplerAgg_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+
+        try {
+            prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
+
+            AggregationBuilder aggsBuilder = AggregationBuilders.sampler(GENERIC_AGGREGATION_NAME)
+                .shardSize(2)
+                .subAggregation(AggregationBuilders.terms(BUCKETS_AGGREGATION_NAME_1).field(KEYWORD_FIELD_1));
+
+            Map<String, Object> searchResponseAsMap = executeQueryAndGetAggsResults(
+                List.of(aggsBuilder),
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
+                3
+            );
+
+            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+            assertNotNull(aggregations);
+
+            Map<String, Object> aggValue = getAggregationValues(aggregations, GENERIC_AGGREGATION_NAME);
+            assertEquals(2, aggValue.size());
+            assertEquals(3, aggValue.get(BUCKET_AGG_DOC_COUNT_FIELD));
+            Map<String, Object> nestedAggs = getAggregationValues(aggValue, BUCKETS_AGGREGATION_NAME_1);
+            assertNotNull(nestedAggs);
+            assertEquals(0, nestedAggs.get("doc_count_error_upper_bound"));
+            List<Map<String, Object>> buckets = getAggregationBuckets(aggValue, BUCKETS_AGGREGATION_NAME_1);
+            assertEquals(2, buckets.size());
+
+            Map<String, Object> firstBucket = buckets.get(0);
+            assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+            assertEquals("likeable", firstBucket.get(KEY));
+
+            Map<String, Object> secondBucket = buckets.get(1);
+            assertEquals(1, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+            assertEquals("workable", secondBucket.get(KEY));
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
+        }
+    }
+
+    @SneakyThrows
+    private void testAvgSumMinMaxAggs() {
+        try {
+            prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
+
+            AggregationBuilder aggsBuilder = AggregationBuilders.dateHistogram(GENERIC_AGGREGATION_NAME)
+                .calendarInterval(DateHistogramInterval.YEAR)
+                .field(DATE_FIELD_1)
+                .subAggregation(AggregationBuilders.sum(SUM_AGGREGATION_NAME).field(INTEGER_FIELD_1));
+
+            BucketMetricsPipelineAggregationBuilder<AvgBucketPipelineAggregationBuilder> aggAvgBucket = PipelineAggregatorBuilders
+                .avgBucket(BUCKETS_AGGREGATION_NAME_1, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
+
+            BucketMetricsPipelineAggregationBuilder<SumBucketPipelineAggregationBuilder> aggSumBucket = PipelineAggregatorBuilders
+                .sumBucket(BUCKETS_AGGREGATION_NAME_2, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
+
+            BucketMetricsPipelineAggregationBuilder<MinBucketPipelineAggregationBuilder> aggMinBucket = PipelineAggregatorBuilders
+                .minBucket(BUCKETS_AGGREGATION_NAME_3, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
+
+            BucketMetricsPipelineAggregationBuilder<MaxBucketPipelineAggregationBuilder> aggMaxBucket = PipelineAggregatorBuilders
+                .maxBucket(BUCKETS_AGGREGATION_NAME_4, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
+
+            Map<String, Object> searchResponseAsMapAnngsBoolQuery = executeQueryAndGetAggsResults(
+                List.of(aggsBuilder, aggAvgBucket, aggSumBucket, aggMinBucket, aggMaxBucket),
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
+                3
+            );
+
+            assertResultsOfPipelineSumtoDateHistogramAggs(searchResponseAsMapAnngsBoolQuery);
+
+            // test only aggregation without query (handled as match_all query)
+            Map<String, Object> searchResponseAsMapAggsNoQuery = executeQueryAndGetAggsResults(
+                List.of(aggsBuilder, aggAvgBucket),
+                null,
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
+                6
+            );
+
+            assertResultsOfPipelineSumtoDateHistogramAggsForMatchAllQuery(searchResponseAsMapAggsNoQuery);
+
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
+        }
+    }
+
+    private void testMaxAggsOnSingleShardCluster() throws Exception {
+        try {
+            prepareResourcesForSingleShardIndex(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD, SEARCH_PIPELINE);
+
+            TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
+            TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT5);
+
+            HybridQueryBuilder hybridQueryBuilderNeuralThenTerm = new HybridQueryBuilder();
+            hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder1);
+            hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder2);
+
+            AggregationBuilder aggsBuilder = AggregationBuilders.max(MAX_AGGREGATION_NAME).field(INTEGER_FIELD_1);
+            Map<String, Object> searchResponseAsMap = search(
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD,
+                hybridQueryBuilderNeuralThenTerm,
+                null,
+                10,
+                Map.of("search_pipeline", SEARCH_PIPELINE),
+                List.of(aggsBuilder)
+            );
+
+            assertHitResultsFromQuery(2, searchResponseAsMap);
+
+            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+            assertNotNull(aggregations);
+            assertTrue(aggregations.containsKey(MAX_AGGREGATION_NAME));
+            double maxAggsValue = getAggregationValue(aggregations, MAX_AGGREGATION_NAME);
+            assertTrue(maxAggsValue >= 0);
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD, null, null, SEARCH_PIPELINE);
+        }
+    }
+
+    private void testDateRange() throws IOException {
+        try {
+            initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS);
+            createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
+            // try {
+            // prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
+
+            AggregationBuilder aggsBuilder = AggregationBuilders.dateRange(DATE_AGGREGATION_NAME)
+                .field(DATE_FIELD_1)
+                .format("MM-yyyy")
+                .addRange("01-2014", "02-2024");
+
+            Map<String, Object> searchResponseAsMap = executeQueryAndGetAggsResults(
+                List.of(aggsBuilder),
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
+                3
+            );
+
+            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+            assertNotNull(aggregations);
+            List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, DATE_AGGREGATION_NAME);
+            assertNotNull(buckets);
+            assertEquals(1, buckets.size());
+
+            Map<String, Object> bucket = buckets.get(0);
+
+            assertEquals(6, bucket.size());
+            assertEquals("01-2014", bucket.get("from_as_string"));
+            assertEquals(2, bucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+            assertEquals("02-2024", bucket.get("to_as_string"));
+            assertTrue(bucket.containsKey("from"));
+            assertTrue(bucket.containsKey("to"));
+            assertTrue(bucket.containsKey(KEY));
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
+        }
+    }
+
+    @SneakyThrows
+    private void initializeIndexIfNotExist(String indexName) throws IOException {
+        if (TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS.equals(indexName)
+            && !indexExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS)) {
+            createIndexWithConfiguration(
+                indexName,
+                buildIndexConfiguration(List.of(), List.of(), List.of(INTEGER_FIELD_1), List.of(KEYWORD_FIELD_1), List.of(DATE_FIELD_1), 3),
+                ""
+            );
+
+            addKnnDoc(
+                indexName,
+                "1",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT1),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_1_VALUE, INTEGER_FIELD_PRICE_1_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_1_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_1_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "2",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT3),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_2_VALUE, INTEGER_FIELD_PRICE_2_VALUE),
+                List.of(),
+                List.of(),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_2_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "3",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT2),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_PRICE_3_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_2_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_3_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "4",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT4),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_3_VALUE, INTEGER_FIELD_PRICE_4_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_3_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_2_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "5",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT5),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_3_VALUE, INTEGER_FIELD_PRICE_5_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_4_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_4_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "6",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT6),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_4_VALUE, INTEGER_FIELD_PRICE_6_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_4_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_4_VALUE)
+            );
+        }
+    }
+
+    @SneakyThrows
+    private void initializeIndexWithOneShardIfNotExists(String indexName) {
+        if (!indexExists(indexName)) {
+            createIndexWithConfiguration(
+                indexName,
+                buildIndexConfiguration(List.of(), List.of(), List.of(INTEGER_FIELD_1), List.of(KEYWORD_FIELD_1), List.of(), 1),
+                ""
+            );
+
+            addKnnDoc(
+                indexName,
+                "1",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT1),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1),
+                List.of(INTEGER_FIELD_1_VALUE),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+            );
+
+            addKnnDoc(
+                indexName,
+                "2",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT3),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1),
+                List.of(INTEGER_FIELD_2_VALUE),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+            );
+        }
+    }
+
+    @SneakyThrows
+    void prepareResources(String indexName, String pipelineName) {
+        initializeIndexIfNotExist(indexName);
+        createSearchPipelineWithResultsPostProcessor(pipelineName);
+    }
+
+    @SneakyThrows
+    void prepareResourcesForSingleShardIndex(String indexName, String pipelineName) {
+        initializeIndexWithOneShardIfNotExists(indexName);
+        createSearchPipelineWithResultsPostProcessor(pipelineName);
+    }
+
+    private void assertResultsOfPipelineSumtoDateHistogramAggs(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+        assertNotNull(aggregations);
+
+        double aggValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_1);
+        assertEquals(3517.5, aggValue, DELTA_FOR_SCORE_ASSERTION);
+
+        double sumValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_2);
+        assertEquals(7035.0, sumValue, DELTA_FOR_SCORE_ASSERTION);
+
+        double minValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_3);
+        assertEquals(1234.0, minValue, DELTA_FOR_SCORE_ASSERTION);
+
+        double maxValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_4);
+        assertEquals(5801.0, maxValue, DELTA_FOR_SCORE_ASSERTION);
+
+        List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, GENERIC_AGGREGATION_NAME);
+        assertNotNull(buckets);
+        assertEquals(21, buckets.size());
+
+        // check content of few buckets
+        Map<String, Object> firstBucket = buckets.get(0);
+        assertEquals(4, firstBucket.size());
+        assertEquals("01/01/1995", firstBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(1234.0, getAggregationValue(firstBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(firstBucket.containsKey(KEY));
+
+        Map<String, Object> secondBucket = buckets.get(1);
+        assertEquals(4, secondBucket.size());
+        assertEquals("01/01/1996", secondBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(0, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(0.0, getAggregationValue(secondBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(secondBucket.containsKey(KEY));
+
+        Map<String, Object> lastBucket = buckets.get(buckets.size() - 1);
+        assertEquals(4, lastBucket.size());
+        assertEquals("01/01/2015", lastBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(2, lastBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(5801.0, getAggregationValue(lastBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(lastBucket.containsKey(KEY));
+    }
+
+    private void assertResultsOfPipelineSumtoDateHistogramAggsForMatchAllQuery(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+        assertNotNull(aggregations);
+
+        double aggValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_1);
+        assertEquals(3764.5, aggValue, DELTA_FOR_SCORE_ASSERTION);
+
+        List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, GENERIC_AGGREGATION_NAME);
+        assertNotNull(buckets);
+        assertEquals(21, buckets.size());
+
+        // check content of few buckets
+        Map<String, Object> firstBucket = buckets.get(0);
+        assertEquals(4, firstBucket.size());
+        assertEquals("01/01/1995", firstBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(1234.0, getAggregationValue(firstBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(firstBucket.containsKey(KEY));
+
+        Map<String, Object> secondBucket = buckets.get(1);
+        assertEquals(4, secondBucket.size());
+        assertEquals("01/01/1996", secondBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(0, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(0.0, getAggregationValue(secondBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(secondBucket.containsKey(KEY));
+
+        Map<String, Object> lastBucket = buckets.get(buckets.size() - 1);
+        assertEquals(4, lastBucket.size());
+        assertEquals("01/01/2015", lastBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(2, lastBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(5801.0, getAggregationValue(lastBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(lastBucket.containsKey(KEY));
+    }
+
+    private Map<String, Object> executeQueryAndGetAggsResults(final List<Object> aggsBuilders, String indexName, int expectedHitsNumber) {
+
+        TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
+        TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT5);
+
+        HybridQueryBuilder hybridQueryBuilderNeuralThenTerm = new HybridQueryBuilder();
+        hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder1);
+        hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder2);
+
+        return executeQueryAndGetAggsResults(aggsBuilders, hybridQueryBuilderNeuralThenTerm, indexName, expectedHitsNumber);
+    }
+
+    private Map<String, Object> executeQueryAndGetAggsResults(
+        final List<Object> aggsBuilders,
+        QueryBuilder queryBuilder,
+        String indexName,
+        int expectedHits
+    ) {
+        Map<String, Object> searchResponseAsMap = search(
+            indexName,
+            queryBuilder,
+            null,
+            10,
+            Map.of("search_pipeline", SEARCH_PIPELINE),
+            aggsBuilders
+        );
+
+        assertHitResultsFromQuery(expectedHits, searchResponseAsMap);
+        return searchResponseAsMap;
+    }
+
+    private void assertHitResultsFromQuery(int expected, Map<String, Object> searchResponseAsMap) {
+        assertEquals(expected, getHitCount(searchResponseAsMap));
+
+        List<Map<String, Object>> hits1NestedList = getNestedHits(searchResponseAsMap);
+        List<String> ids = new ArrayList<>();
+        List<Double> scores = new ArrayList<>();
+        for (Map<String, Object> oneHit : hits1NestedList) {
+            ids.add((String) oneHit.get("_id"));
+            scores.add((Double) oneHit.get("_score"));
+        }
+
+        // verify that scores are in desc order
+        assertTrue(IntStream.range(0, scores.size() - 1).noneMatch(idx -> scores.get(idx) < scores.get(idx + 1)));
+        // verify that all ids are unique
+        assertEquals(Set.copyOf(ids).size(), ids.size());
+
+        Map<String, Object> total = getTotalHits(searchResponseAsMap);
+        assertNotNull(total.get("value"));
+        assertEquals(expected, total.get("value"));
+        assertNotNull(total.get("relation"));
+        assertEquals(RELATION_EQUAL_TO, total.get("relation"));
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -12,10 +12,6 @@ import static org.opensearch.neuralsearch.TestUtils.RELATION_EQUAL_TO;
 import static org.opensearch.neuralsearch.TestUtils.TEST_DIMENSION;
 import static org.opensearch.neuralsearch.TestUtils.TEST_SPACE_TYPE;
 import static org.opensearch.neuralsearch.TestUtils.createRandomVector;
-import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationBuckets;
-import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationValue;
-import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationValues;
-import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregations;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +28,6 @@ import org.opensearch.client.ResponseException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.NestedQueryBuilder;
-import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
@@ -40,15 +35,6 @@ import org.opensearch.neuralsearch.BaseNeuralSearchIT;
 import com.google.common.primitives.Floats;
 
 import lombok.SneakyThrows;
-import org.opensearch.search.aggregations.AggregationBuilder;
-import org.opensearch.search.aggregations.AggregationBuilders;
-import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
-import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.BucketMetricsPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.MaxBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.MinBucketPipelineAggregationBuilder;
-import org.opensearch.search.aggregations.pipeline.SumBucketPipelineAggregationBuilder;
 
 public class HybridQueryIT extends BaseNeuralSearchIT {
     private static final String TEST_BASIC_INDEX_NAME = "test-hybrid-basic-index";
@@ -57,9 +43,6 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     private static final String TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD = "test-hybrid-multi-doc-single-shard-index";
     private static final String TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD =
         "test-hybrid-multi-doc-nested-type-single-shard-index";
-    private static final String TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS =
-        "test-neural-aggs-pipeline-multi-doc-index-multiple-shards";
-    private static final String TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD = "test-neural-aggs-multi-doc-index-single-shard";
     private static final String TEST_QUERY_TEXT = "greetings";
     private static final String TEST_QUERY_TEXT2 = "salute";
     private static final String TEST_QUERY_TEXT3 = "hello";
@@ -80,42 +63,6 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
     private static final String SEARCH_PIPELINE = "phase-results-hybrid-pipeline";
-    private static final String TEST_DOC_TEXT4 = "Hello, I'm glad to you see you pal";
-    private static final String TEST_DOC_TEXT5 = "People keep telling me orange but I still prefer pink";
-    private static final String TEST_DOC_TEXT6 = "She traveled because it cost the same as therapy and was a lot more enjoyable";
-    private static final String INTEGER_FIELD_1 = "doc_index";
-    private static final int INTEGER_FIELD_1_VALUE = 1234;
-    private static final int INTEGER_FIELD_2_VALUE = 2345;
-    private static final int INTEGER_FIELD_3_VALUE = 3456;
-    private static final int INTEGER_FIELD_4_VALUE = 4567;
-    private static final String KEYWORD_FIELD_1 = "doc_keyword";
-    private static final String KEYWORD_FIELD_1_VALUE = "workable";
-    private static final String KEYWORD_FIELD_2_VALUE = "angry";
-    private static final String KEYWORD_FIELD_3_VALUE = "likeable";
-    private static final String KEYWORD_FIELD_4_VALUE = "entire";
-    private static final String DATE_FIELD_1 = "doc_date";
-    private static final String DATE_FIELD_1_VALUE = "01/03/1995";
-    private static final String DATE_FIELD_2_VALUE = "05/02/2015";
-    private static final String DATE_FIELD_3_VALUE = "07/23/2007";
-    private static final String DATE_FIELD_4_VALUE = "08/21/2012";
-    private static final String INTEGER_FIELD_PRICE = "doc_price";
-    private static final int INTEGER_FIELD_PRICE_1_VALUE = 130;
-    private static final int INTEGER_FIELD_PRICE_2_VALUE = 100;
-    private static final int INTEGER_FIELD_PRICE_3_VALUE = 200;
-    private static final int INTEGER_FIELD_PRICE_4_VALUE = 25;
-    private static final int INTEGER_FIELD_PRICE_5_VALUE = 30;
-    private static final int INTEGER_FIELD_PRICE_6_VALUE = 350;
-    private static final String BUCKET_AGG_DOC_COUNT_FIELD = "doc_count";
-    private static final String KEY = "key";
-    private static final String BUCKET_AGG_KEY_AS_STRING = "key_as_string";
-    private static final String SUM_AGGREGATION_NAME = "sum_aggs";
-    private static final String MAX_AGGREGATION_NAME = "max_aggs";
-    private static final String DATE_AGGREGATION_NAME = "date_aggregation";
-    private static final String GENERIC_AGGREGATION_NAME = "my_aggregation";
-    private static final String BUCKETS_AGGREGATION_NAME_1 = "date_buckets_1";
-    private static final String BUCKETS_AGGREGATION_NAME_2 = "date_buckets_2";
-    private static final String BUCKETS_AGGREGATION_NAME_3 = "date_buckets_3";
-    private static final String BUCKETS_AGGREGATION_NAME_4 = "date_buckets_4";
 
     @Before
     public void setUp() throws Exception {
@@ -415,8 +362,10 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
 
     @SneakyThrows
     public void testIndexWithNestedFields_whenHybridQueryIncludesNested_thenSuccess() {
+        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD);
+            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT);
             NestedQueryBuilder nestedQueryBuilder = QueryBuilders.nestedQuery(
@@ -446,200 +395,7 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(total.get("relation"));
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD, null, null, SEARCH_PIPELINE);
-        }
-    }
-
-    @SneakyThrows
-    public void testPipelineAggs_whenConcurrentSearchEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
-        testAvgSumMinMaxAggs();
-    }
-
-    @SneakyThrows
-    public void testPipelineAggs_whenConcurrentSearchDisabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", false);
-        testAvgSumMinMaxAggs();
-    }
-
-    @SneakyThrows
-    public void testMetricAggsOnSingleShard_whenMaxAggsAndConcurrentSearchEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
-        testMaxAggsOnSingleShardCluster();
-    }
-
-    @SneakyThrows
-    public void testMetricAggsOnSingleShard_whenMaxAggsAndConcurrentSearchDisabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", false);
-        testMaxAggsOnSingleShardCluster();
-    }
-
-    @SneakyThrows
-    public void testBucketAndNestedAggs_whenConcurrentSearchDisabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", false);
-        testDateRange();
-    }
-
-    @SneakyThrows
-    public void testBucketAndNestedAggs_whenConcurrentSearchEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
-        testDateRange();
-    }
-
-    @SneakyThrows
-    public void testAggregationNotSupportedConcurrentSearch_whenUseSamplerAgg_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
-
-        try {
-            prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
-
-            AggregationBuilder aggsBuilder = AggregationBuilders.sampler(GENERIC_AGGREGATION_NAME)
-                .shardSize(2)
-                .subAggregation(AggregationBuilders.terms(BUCKETS_AGGREGATION_NAME_1).field(KEYWORD_FIELD_1));
-
-            Map<String, Object> searchResponseAsMap = executeQueryAndGetAggsResults(
-                List.of(aggsBuilder),
-                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
-                3
-            );
-
-            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
-            assertNotNull(aggregations);
-
-            Map<String, Object> aggValue = getAggregationValues(aggregations, GENERIC_AGGREGATION_NAME);
-            assertEquals(2, aggValue.size());
-            assertEquals(3, aggValue.get(BUCKET_AGG_DOC_COUNT_FIELD));
-            Map<String, Object> nestedAggs = getAggregationValues(aggValue, BUCKETS_AGGREGATION_NAME_1);
-            assertNotNull(nestedAggs);
-            assertEquals(0, nestedAggs.get("doc_count_error_upper_bound"));
-            List<Map<String, Object>> buckets = getAggregationBuckets(aggValue, BUCKETS_AGGREGATION_NAME_1);
-            assertEquals(2, buckets.size());
-
-            Map<String, Object> firstBucket = buckets.get(0);
-            assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-            assertEquals("likeable", firstBucket.get(KEY));
-
-            Map<String, Object> secondBucket = buckets.get(1);
-            assertEquals(1, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-            assertEquals("workable", secondBucket.get(KEY));
-        } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
-        }
-    }
-
-    @SneakyThrows
-    private void testAvgSumMinMaxAggs() {
-        try {
-            prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
-
-            AggregationBuilder aggsBuilder = AggregationBuilders.dateHistogram(GENERIC_AGGREGATION_NAME)
-                .calendarInterval(DateHistogramInterval.YEAR)
-                .field(DATE_FIELD_1)
-                .subAggregation(AggregationBuilders.sum(SUM_AGGREGATION_NAME).field(INTEGER_FIELD_1));
-
-            BucketMetricsPipelineAggregationBuilder<AvgBucketPipelineAggregationBuilder> aggAvgBucket = PipelineAggregatorBuilders
-                .avgBucket(BUCKETS_AGGREGATION_NAME_1, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
-
-            BucketMetricsPipelineAggregationBuilder<SumBucketPipelineAggregationBuilder> aggSumBucket = PipelineAggregatorBuilders
-                .sumBucket(BUCKETS_AGGREGATION_NAME_2, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
-
-            BucketMetricsPipelineAggregationBuilder<MinBucketPipelineAggregationBuilder> aggMinBucket = PipelineAggregatorBuilders
-                .minBucket(BUCKETS_AGGREGATION_NAME_3, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
-
-            BucketMetricsPipelineAggregationBuilder<MaxBucketPipelineAggregationBuilder> aggMaxBucket = PipelineAggregatorBuilders
-                .maxBucket(BUCKETS_AGGREGATION_NAME_4, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
-
-            Map<String, Object> searchResponseAsMapAnngsBoolQuery = executeQueryAndGetAggsResults(
-                List.of(aggsBuilder, aggAvgBucket, aggSumBucket, aggMinBucket, aggMaxBucket),
-                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
-                3
-            );
-
-            assertResultsOfPipelineSumtoDateHistogramAggs(searchResponseAsMapAnngsBoolQuery);
-
-            // test only aggregation without query (handled as match_all query)
-            Map<String, Object> searchResponseAsMapAggsNoQuery = executeQueryAndGetAggsResults(
-                List.of(aggsBuilder, aggAvgBucket),
-                null,
-                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
-                6
-            );
-
-            assertResultsOfPipelineSumtoDateHistogramAggsForMatchAllQuery(searchResponseAsMapAggsNoQuery);
-
-        } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
-        }
-    }
-
-    private void testMaxAggsOnSingleShardCluster() throws Exception {
-        try {
-            prepareResourcesForSingleShardIndex(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD, SEARCH_PIPELINE);
-
-            TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
-            TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT5);
-
-            HybridQueryBuilder hybridQueryBuilderNeuralThenTerm = new HybridQueryBuilder();
-            hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder1);
-            hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder2);
-
-            AggregationBuilder aggsBuilder = AggregationBuilders.max(MAX_AGGREGATION_NAME).field(INTEGER_FIELD_1);
-            Map<String, Object> searchResponseAsMap = search(
-                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD,
-                hybridQueryBuilderNeuralThenTerm,
-                null,
-                10,
-                Map.of("search_pipeline", SEARCH_PIPELINE),
-                List.of(aggsBuilder)
-            );
-
-            assertHitResultsFromQuery(2, searchResponseAsMap);
-
-            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
-            assertNotNull(aggregations);
-            assertTrue(aggregations.containsKey(MAX_AGGREGATION_NAME));
-            double maxAggsValue = getAggregationValue(aggregations, MAX_AGGREGATION_NAME);
-            assertTrue(maxAggsValue >= 0);
-        } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD, null, null, SEARCH_PIPELINE);
-        }
-    }
-
-    private void testDateRange() throws IOException {
-        try {
-            initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS);
-            createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
-            // try {
-            // prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
-
-            AggregationBuilder aggsBuilder = AggregationBuilders.dateRange(DATE_AGGREGATION_NAME)
-                .field(DATE_FIELD_1)
-                .format("MM-yyyy")
-                .addRange("01-2014", "02-2024");
-
-            Map<String, Object> searchResponseAsMap = executeQueryAndGetAggsResults(
-                List.of(aggsBuilder),
-                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
-                3
-            );
-
-            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
-            assertNotNull(aggregations);
-            List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, DATE_AGGREGATION_NAME);
-            assertNotNull(buckets);
-            assertEquals(1, buckets.size());
-
-            Map<String, Object> bucket = buckets.get(0);
-
-            assertEquals(6, bucket.size());
-            assertEquals("01-2014", bucket.get("from_as_string"));
-            assertEquals(2, bucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-            assertEquals("02-2024", bucket.get("to_as_string"));
-            assertTrue(bucket.containsKey("from"));
-            assertTrue(bucket.containsKey("to"));
-            assertTrue(bucket.containsKey(KEY));
-        } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD, null, modelId, SEARCH_PIPELINE);
         }
     }
 
@@ -734,157 +490,6 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
                 List.of(Map.of(NESTED_FIELD_1, NESTED_FIELD_1_VALUE, NESTED_FIELD_2, NESTED_FIELD_2_VALUE))
             );
         }
-
-        if (TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS.equals(indexName)
-            && !indexExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS)) {
-            createIndexWithConfiguration(
-                indexName,
-                buildIndexConfiguration(List.of(), List.of(), List.of(INTEGER_FIELD_1), List.of(KEYWORD_FIELD_1), List.of(DATE_FIELD_1), 3),
-                ""
-            );
-
-            addKnnDoc(
-                indexName,
-                "1",
-                List.of(),
-                List.of(),
-                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
-                Collections.singletonList(TEST_DOC_TEXT1),
-                List.of(),
-                List.of(),
-                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
-                List.of(INTEGER_FIELD_1_VALUE, INTEGER_FIELD_PRICE_1_VALUE),
-                List.of(KEYWORD_FIELD_1),
-                List.of(KEYWORD_FIELD_1_VALUE),
-                List.of(DATE_FIELD_1),
-                List.of(DATE_FIELD_1_VALUE)
-            );
-            addKnnDoc(
-                indexName,
-                "2",
-                List.of(),
-                List.of(),
-                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
-                Collections.singletonList(TEST_DOC_TEXT3),
-                List.of(),
-                List.of(),
-                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
-                List.of(INTEGER_FIELD_2_VALUE, INTEGER_FIELD_PRICE_2_VALUE),
-                List.of(),
-                List.of(),
-                List.of(DATE_FIELD_1),
-                List.of(DATE_FIELD_2_VALUE)
-            );
-            addKnnDoc(
-                indexName,
-                "3",
-                List.of(),
-                List.of(),
-                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
-                Collections.singletonList(TEST_DOC_TEXT2),
-                List.of(),
-                List.of(),
-                List.of(INTEGER_FIELD_PRICE),
-                List.of(INTEGER_FIELD_PRICE_3_VALUE),
-                List.of(KEYWORD_FIELD_1),
-                List.of(KEYWORD_FIELD_2_VALUE),
-                List.of(DATE_FIELD_1),
-                List.of(DATE_FIELD_3_VALUE)
-            );
-            addKnnDoc(
-                indexName,
-                "4",
-                List.of(),
-                List.of(),
-                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
-                Collections.singletonList(TEST_DOC_TEXT4),
-                List.of(),
-                List.of(),
-                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
-                List.of(INTEGER_FIELD_3_VALUE, INTEGER_FIELD_PRICE_4_VALUE),
-                List.of(KEYWORD_FIELD_1),
-                List.of(KEYWORD_FIELD_3_VALUE),
-                List.of(DATE_FIELD_1),
-                List.of(DATE_FIELD_2_VALUE)
-            );
-            addKnnDoc(
-                indexName,
-                "5",
-                List.of(),
-                List.of(),
-                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
-                Collections.singletonList(TEST_DOC_TEXT5),
-                List.of(),
-                List.of(),
-                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
-                List.of(INTEGER_FIELD_3_VALUE, INTEGER_FIELD_PRICE_5_VALUE),
-                List.of(KEYWORD_FIELD_1),
-                List.of(KEYWORD_FIELD_4_VALUE),
-                List.of(DATE_FIELD_1),
-                List.of(DATE_FIELD_4_VALUE)
-            );
-            addKnnDoc(
-                indexName,
-                "6",
-                List.of(),
-                List.of(),
-                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
-                Collections.singletonList(TEST_DOC_TEXT6),
-                List.of(),
-                List.of(),
-                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
-                List.of(INTEGER_FIELD_4_VALUE, INTEGER_FIELD_PRICE_6_VALUE),
-                List.of(KEYWORD_FIELD_1),
-                List.of(KEYWORD_FIELD_4_VALUE),
-                List.of(DATE_FIELD_1),
-                List.of(DATE_FIELD_4_VALUE)
-            );
-        }
-    }
-
-    @SneakyThrows
-    private void initializeIndexWithOneShardIfNotExists(String indexName) {
-        if (!indexExists(indexName)) {
-            createIndexWithConfiguration(
-                indexName,
-                buildIndexConfiguration(List.of(), List.of(), List.of(INTEGER_FIELD_1), List.of(KEYWORD_FIELD_1), List.of(), 1),
-                ""
-            );
-
-            addKnnDoc(
-                indexName,
-                "1",
-                List.of(),
-                List.of(),
-                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
-                Collections.singletonList(TEST_DOC_TEXT1),
-                List.of(),
-                List.of(),
-                List.of(INTEGER_FIELD_1),
-                List.of(INTEGER_FIELD_1_VALUE),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of()
-            );
-
-            addKnnDoc(
-                indexName,
-                "2",
-                List.of(),
-                List.of(),
-                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
-                Collections.singletonList(TEST_DOC_TEXT3),
-                List.of(),
-                List.of(),
-                List.of(INTEGER_FIELD_1),
-                List.of(INTEGER_FIELD_2_VALUE),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of()
-            );
-        }
     }
 
     private void addDocsToIndex(final String testMultiDocIndexName) {
@@ -926,148 +531,5 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     private Optional<Float> getMaxScore(Map<String, Object> searchResponseAsMap) {
         Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
         return hitsMap.get("max_score") == null ? Optional.empty() : Optional.of(((Double) hitsMap.get("max_score")).floatValue());
-    }
-
-    @SneakyThrows
-    void prepareResources(String indexName, String pipelineName) {
-        initializeIndexIfNotExist(indexName);
-        createSearchPipelineWithResultsPostProcessor(pipelineName);
-    }
-
-    @SneakyThrows
-    void prepareResourcesForSingleShardIndex(String indexName, String pipelineName) {
-        initializeIndexWithOneShardIfNotExists(indexName);
-        createSearchPipelineWithResultsPostProcessor(pipelineName);
-    }
-
-    private void assertResultsOfPipelineSumtoDateHistogramAggs(Map<String, Object> searchResponseAsMap) {
-        Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
-        assertNotNull(aggregations);
-
-        double aggValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_1);
-        assertEquals(3517.5, aggValue, DELTA_FOR_SCORE_ASSERTION);
-
-        double sumValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_2);
-        assertEquals(7035.0, sumValue, DELTA_FOR_SCORE_ASSERTION);
-
-        double minValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_3);
-        assertEquals(1234.0, minValue, DELTA_FOR_SCORE_ASSERTION);
-
-        double maxValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_4);
-        assertEquals(5801.0, maxValue, DELTA_FOR_SCORE_ASSERTION);
-
-        List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, GENERIC_AGGREGATION_NAME);
-        assertNotNull(buckets);
-        assertEquals(21, buckets.size());
-
-        // check content of few buckets
-        Map<String, Object> firstBucket = buckets.get(0);
-        assertEquals(4, firstBucket.size());
-        assertEquals("01/01/1995", firstBucket.get(BUCKET_AGG_KEY_AS_STRING));
-        assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-        assertEquals(1234.0, getAggregationValue(firstBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
-        assertTrue(firstBucket.containsKey(KEY));
-
-        Map<String, Object> secondBucket = buckets.get(1);
-        assertEquals(4, secondBucket.size());
-        assertEquals("01/01/1996", secondBucket.get(BUCKET_AGG_KEY_AS_STRING));
-        assertEquals(0, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-        assertEquals(0.0, getAggregationValue(secondBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
-        assertTrue(secondBucket.containsKey(KEY));
-
-        Map<String, Object> lastBucket = buckets.get(buckets.size() - 1);
-        assertEquals(4, lastBucket.size());
-        assertEquals("01/01/2015", lastBucket.get(BUCKET_AGG_KEY_AS_STRING));
-        assertEquals(2, lastBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-        assertEquals(5801.0, getAggregationValue(lastBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
-        assertTrue(lastBucket.containsKey(KEY));
-    }
-
-    private void assertResultsOfPipelineSumtoDateHistogramAggsForMatchAllQuery(Map<String, Object> searchResponseAsMap) {
-        Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
-        assertNotNull(aggregations);
-
-        double aggValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_1);
-        assertEquals(3764.5, aggValue, DELTA_FOR_SCORE_ASSERTION);
-
-        List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, GENERIC_AGGREGATION_NAME);
-        assertNotNull(buckets);
-        assertEquals(21, buckets.size());
-
-        // check content of few buckets
-        Map<String, Object> firstBucket = buckets.get(0);
-        assertEquals(4, firstBucket.size());
-        assertEquals("01/01/1995", firstBucket.get(BUCKET_AGG_KEY_AS_STRING));
-        assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-        assertEquals(1234.0, getAggregationValue(firstBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
-        assertTrue(firstBucket.containsKey(KEY));
-
-        Map<String, Object> secondBucket = buckets.get(1);
-        assertEquals(4, secondBucket.size());
-        assertEquals("01/01/1996", secondBucket.get(BUCKET_AGG_KEY_AS_STRING));
-        assertEquals(0, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-        assertEquals(0.0, getAggregationValue(secondBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
-        assertTrue(secondBucket.containsKey(KEY));
-
-        Map<String, Object> lastBucket = buckets.get(buckets.size() - 1);
-        assertEquals(4, lastBucket.size());
-        assertEquals("01/01/2015", lastBucket.get(BUCKET_AGG_KEY_AS_STRING));
-        assertEquals(2, lastBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
-        assertEquals(5801.0, getAggregationValue(lastBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
-        assertTrue(lastBucket.containsKey(KEY));
-    }
-
-    private Map<String, Object> executeQueryAndGetAggsResults(final List<Object> aggsBuilders, String indexName, int expectedHitsNumber) {
-
-        TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
-        TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT5);
-
-        HybridQueryBuilder hybridQueryBuilderNeuralThenTerm = new HybridQueryBuilder();
-        hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder1);
-        hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder2);
-
-        return executeQueryAndGetAggsResults(aggsBuilders, hybridQueryBuilderNeuralThenTerm, indexName, expectedHitsNumber);
-    }
-
-    private Map<String, Object> executeQueryAndGetAggsResults(
-        final List<Object> aggsBuilders,
-        QueryBuilder queryBuilder,
-        String indexName,
-        int expectedHits
-    ) {
-        Map<String, Object> searchResponseAsMap = search(
-            indexName,
-            queryBuilder,
-            null,
-            10,
-            Map.of("search_pipeline", SEARCH_PIPELINE),
-            aggsBuilders
-        );
-
-        assertHitResultsFromQuery(expectedHits, searchResponseAsMap);
-        return searchResponseAsMap;
-    }
-
-    private void assertHitResultsFromQuery(int expected, Map<String, Object> searchResponseAsMap) {
-        assertEquals(expected, getHitCount(searchResponseAsMap));
-
-        List<Map<String, Object>> hits1NestedList = getNestedHits(searchResponseAsMap);
-        List<String> ids = new ArrayList<>();
-        List<Double> scores = new ArrayList<>();
-        for (Map<String, Object> oneHit : hits1NestedList) {
-            ids.add((String) oneHit.get("_id"));
-            scores.add((Double) oneHit.get("_score"));
-        }
-
-        // verify that scores are in desc order
-        assertTrue(IntStream.range(0, scores.size() - 1).noneMatch(idx -> scores.get(idx) < scores.get(idx + 1)));
-        // verify that all ids are unique
-        assertEquals(Set.copyOf(ids).size(), ids.size());
-
-        Map<String, Object> total = getTotalHits(searchResponseAsMap);
-        assertNotNull(total.get("value"));
-        assertEquals(expected, total.get("value"));
-        assertNotNull(total.get("relation"));
-        assertEquals(RELATION_EQUAL_TO, total.get("relation"));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -12,6 +12,10 @@ import static org.opensearch.neuralsearch.TestUtils.RELATION_EQUAL_TO;
 import static org.opensearch.neuralsearch.TestUtils.TEST_DIMENSION;
 import static org.opensearch.neuralsearch.TestUtils.TEST_SPACE_TYPE;
 import static org.opensearch.neuralsearch.TestUtils.createRandomVector;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationBuckets;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationValue;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationValues;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregations;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,6 +32,7 @@ import org.opensearch.client.ResponseException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.NestedQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
@@ -35,6 +40,15 @@ import org.opensearch.neuralsearch.BaseNeuralSearchIT;
 import com.google.common.primitives.Floats;
 
 import lombok.SneakyThrows;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.opensearch.search.aggregations.pipeline.AvgBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.BucketMetricsPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.MaxBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.MinBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.SumBucketPipelineAggregationBuilder;
 
 public class HybridQueryIT extends BaseNeuralSearchIT {
     private static final String TEST_BASIC_INDEX_NAME = "test-hybrid-basic-index";
@@ -43,6 +57,9 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     private static final String TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD = "test-hybrid-multi-doc-single-shard-index";
     private static final String TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD =
         "test-hybrid-multi-doc-nested-type-single-shard-index";
+    private static final String TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS =
+        "test-neural-aggs-pipeline-multi-doc-index-multiple-shards";
+    private static final String TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD = "test-neural-aggs-multi-doc-index-single-shard";
     private static final String TEST_QUERY_TEXT = "greetings";
     private static final String TEST_QUERY_TEXT2 = "salute";
     private static final String TEST_QUERY_TEXT3 = "hello";
@@ -63,6 +80,42 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
     private static final String SEARCH_PIPELINE = "phase-results-hybrid-pipeline";
+    private static final String TEST_DOC_TEXT4 = "Hello, I'm glad to you see you pal";
+    private static final String TEST_DOC_TEXT5 = "People keep telling me orange but I still prefer pink";
+    private static final String TEST_DOC_TEXT6 = "She traveled because it cost the same as therapy and was a lot more enjoyable";
+    private static final String INTEGER_FIELD_1 = "doc_index";
+    private static final int INTEGER_FIELD_1_VALUE = 1234;
+    private static final int INTEGER_FIELD_2_VALUE = 2345;
+    private static final int INTEGER_FIELD_3_VALUE = 3456;
+    private static final int INTEGER_FIELD_4_VALUE = 4567;
+    private static final String KEYWORD_FIELD_1 = "doc_keyword";
+    private static final String KEYWORD_FIELD_1_VALUE = "workable";
+    private static final String KEYWORD_FIELD_2_VALUE = "angry";
+    private static final String KEYWORD_FIELD_3_VALUE = "likeable";
+    private static final String KEYWORD_FIELD_4_VALUE = "entire";
+    private static final String DATE_FIELD_1 = "doc_date";
+    private static final String DATE_FIELD_1_VALUE = "01/03/1995";
+    private static final String DATE_FIELD_2_VALUE = "05/02/2015";
+    private static final String DATE_FIELD_3_VALUE = "07/23/2007";
+    private static final String DATE_FIELD_4_VALUE = "08/21/2012";
+    private static final String INTEGER_FIELD_PRICE = "doc_price";
+    private static final int INTEGER_FIELD_PRICE_1_VALUE = 130;
+    private static final int INTEGER_FIELD_PRICE_2_VALUE = 100;
+    private static final int INTEGER_FIELD_PRICE_3_VALUE = 200;
+    private static final int INTEGER_FIELD_PRICE_4_VALUE = 25;
+    private static final int INTEGER_FIELD_PRICE_5_VALUE = 30;
+    private static final int INTEGER_FIELD_PRICE_6_VALUE = 350;
+    private static final String BUCKET_AGG_DOC_COUNT_FIELD = "doc_count";
+    private static final String KEY = "key";
+    private static final String BUCKET_AGG_KEY_AS_STRING = "key_as_string";
+    private static final String SUM_AGGREGATION_NAME = "sum_aggs";
+    private static final String MAX_AGGREGATION_NAME = "max_aggs";
+    private static final String DATE_AGGREGATION_NAME = "date_aggregation";
+    private static final String GENERIC_AGGREGATION_NAME = "my_aggregation";
+    private static final String BUCKETS_AGGREGATION_NAME_1 = "date_buckets_1";
+    private static final String BUCKETS_AGGREGATION_NAME_2 = "date_buckets_2";
+    private static final String BUCKETS_AGGREGATION_NAME_3 = "date_buckets_3";
+    private static final String BUCKETS_AGGREGATION_NAME_4 = "date_buckets_4";
 
     @Before
     public void setUp() throws Exception {
@@ -362,10 +415,8 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
 
     @SneakyThrows
     public void testIndexWithNestedFields_whenHybridQueryIncludesNested_thenSuccess() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT);
             NestedQueryBuilder nestedQueryBuilder = QueryBuilders.nestedQuery(
@@ -395,7 +446,200 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(total.get("relation"));
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD, null, null, SEARCH_PIPELINE);
+        }
+    }
+
+    @SneakyThrows
+    public void testPipelineAggs_whenConcurrentSearchEnabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        testAvgSumMinMaxAggs();
+    }
+
+    @SneakyThrows
+    public void testPipelineAggs_whenConcurrentSearchDisabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        testAvgSumMinMaxAggs();
+    }
+
+    @SneakyThrows
+    public void testMetricAggsOnSingleShard_whenMaxAggsAndConcurrentSearchEnabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        testMaxAggsOnSingleShardCluster();
+    }
+
+    @SneakyThrows
+    public void testMetricAggsOnSingleShard_whenMaxAggsAndConcurrentSearchDisabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        testMaxAggsOnSingleShardCluster();
+    }
+
+    @SneakyThrows
+    public void testBucketAndNestedAggs_whenConcurrentSearchDisabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        testDateRange();
+    }
+
+    @SneakyThrows
+    public void testBucketAndNestedAggs_whenConcurrentSearchEnabled_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        testDateRange();
+    }
+
+    @SneakyThrows
+    public void testAggregationNotSupportedConcurrentSearch_whenUseSamplerAgg_thenSuccessful() {
+        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+
+        try {
+            prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
+
+            AggregationBuilder aggsBuilder = AggregationBuilders.sampler(GENERIC_AGGREGATION_NAME)
+                .shardSize(2)
+                .subAggregation(AggregationBuilders.terms(BUCKETS_AGGREGATION_NAME_1).field(KEYWORD_FIELD_1));
+
+            Map<String, Object> searchResponseAsMap = executeQueryAndGetAggsResults(
+                List.of(aggsBuilder),
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
+                3
+            );
+
+            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+            assertNotNull(aggregations);
+
+            Map<String, Object> aggValue = getAggregationValues(aggregations, GENERIC_AGGREGATION_NAME);
+            assertEquals(2, aggValue.size());
+            assertEquals(3, aggValue.get(BUCKET_AGG_DOC_COUNT_FIELD));
+            Map<String, Object> nestedAggs = getAggregationValues(aggValue, BUCKETS_AGGREGATION_NAME_1);
+            assertNotNull(nestedAggs);
+            assertEquals(0, nestedAggs.get("doc_count_error_upper_bound"));
+            List<Map<String, Object>> buckets = getAggregationBuckets(aggValue, BUCKETS_AGGREGATION_NAME_1);
+            assertEquals(2, buckets.size());
+
+            Map<String, Object> firstBucket = buckets.get(0);
+            assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+            assertEquals("likeable", firstBucket.get(KEY));
+
+            Map<String, Object> secondBucket = buckets.get(1);
+            assertEquals(1, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+            assertEquals("workable", secondBucket.get(KEY));
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
+        }
+    }
+
+    @SneakyThrows
+    private void testAvgSumMinMaxAggs() {
+        try {
+            prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
+
+            AggregationBuilder aggsBuilder = AggregationBuilders.dateHistogram(GENERIC_AGGREGATION_NAME)
+                .calendarInterval(DateHistogramInterval.YEAR)
+                .field(DATE_FIELD_1)
+                .subAggregation(AggregationBuilders.sum(SUM_AGGREGATION_NAME).field(INTEGER_FIELD_1));
+
+            BucketMetricsPipelineAggregationBuilder<AvgBucketPipelineAggregationBuilder> aggAvgBucket = PipelineAggregatorBuilders
+                .avgBucket(BUCKETS_AGGREGATION_NAME_1, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
+
+            BucketMetricsPipelineAggregationBuilder<SumBucketPipelineAggregationBuilder> aggSumBucket = PipelineAggregatorBuilders
+                .sumBucket(BUCKETS_AGGREGATION_NAME_2, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
+
+            BucketMetricsPipelineAggregationBuilder<MinBucketPipelineAggregationBuilder> aggMinBucket = PipelineAggregatorBuilders
+                .minBucket(BUCKETS_AGGREGATION_NAME_3, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
+
+            BucketMetricsPipelineAggregationBuilder<MaxBucketPipelineAggregationBuilder> aggMaxBucket = PipelineAggregatorBuilders
+                .maxBucket(BUCKETS_AGGREGATION_NAME_4, GENERIC_AGGREGATION_NAME + ">" + SUM_AGGREGATION_NAME);
+
+            Map<String, Object> searchResponseAsMapAnngsBoolQuery = executeQueryAndGetAggsResults(
+                List.of(aggsBuilder, aggAvgBucket, aggSumBucket, aggMinBucket, aggMaxBucket),
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
+                3
+            );
+
+            assertResultsOfPipelineSumtoDateHistogramAggs(searchResponseAsMapAnngsBoolQuery);
+
+            // test only aggregation without query (handled as match_all query)
+            Map<String, Object> searchResponseAsMapAggsNoQuery = executeQueryAndGetAggsResults(
+                List.of(aggsBuilder, aggAvgBucket),
+                null,
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
+                6
+            );
+
+            assertResultsOfPipelineSumtoDateHistogramAggsForMatchAllQuery(searchResponseAsMapAggsNoQuery);
+
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
+        }
+    }
+
+    private void testMaxAggsOnSingleShardCluster() throws Exception {
+        try {
+            prepareResourcesForSingleShardIndex(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD, SEARCH_PIPELINE);
+
+            TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
+            TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT5);
+
+            HybridQueryBuilder hybridQueryBuilderNeuralThenTerm = new HybridQueryBuilder();
+            hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder1);
+            hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder2);
+
+            AggregationBuilder aggsBuilder = AggregationBuilders.max(MAX_AGGREGATION_NAME).field(INTEGER_FIELD_1);
+            Map<String, Object> searchResponseAsMap = search(
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD,
+                hybridQueryBuilderNeuralThenTerm,
+                null,
+                10,
+                Map.of("search_pipeline", SEARCH_PIPELINE),
+                List.of(aggsBuilder)
+            );
+
+            assertHitResultsFromQuery(2, searchResponseAsMap);
+
+            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+            assertNotNull(aggregations);
+            assertTrue(aggregations.containsKey(MAX_AGGREGATION_NAME));
+            double maxAggsValue = getAggregationValue(aggregations, MAX_AGGREGATION_NAME);
+            assertTrue(maxAggsValue >= 0);
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD, null, null, SEARCH_PIPELINE);
+        }
+    }
+
+    private void testDateRange() throws IOException {
+        try {
+            initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS);
+            createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
+            // try {
+            // prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
+
+            AggregationBuilder aggsBuilder = AggregationBuilders.dateRange(DATE_AGGREGATION_NAME)
+                .field(DATE_FIELD_1)
+                .format("MM-yyyy")
+                .addRange("01-2014", "02-2024");
+
+            Map<String, Object> searchResponseAsMap = executeQueryAndGetAggsResults(
+                List.of(aggsBuilder),
+                TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS,
+                3
+            );
+
+            Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+            assertNotNull(aggregations);
+            List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, DATE_AGGREGATION_NAME);
+            assertNotNull(buckets);
+            assertEquals(1, buckets.size());
+
+            Map<String, Object> bucket = buckets.get(0);
+
+            assertEquals(6, bucket.size());
+            assertEquals("01-2014", bucket.get("from_as_string"));
+            assertEquals(2, bucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+            assertEquals("02-2024", bucket.get("to_as_string"));
+            assertTrue(bucket.containsKey("from"));
+            assertTrue(bucket.containsKey("to"));
+            assertTrue(bucket.containsKey(KEY));
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, null, null, SEARCH_PIPELINE);
         }
     }
 
@@ -490,6 +734,157 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
                 List.of(Map.of(NESTED_FIELD_1, NESTED_FIELD_1_VALUE, NESTED_FIELD_2, NESTED_FIELD_2_VALUE))
             );
         }
+
+        if (TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS.equals(indexName)
+            && !indexExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS)) {
+            createIndexWithConfiguration(
+                indexName,
+                buildIndexConfiguration(List.of(), List.of(), List.of(INTEGER_FIELD_1), List.of(KEYWORD_FIELD_1), List.of(DATE_FIELD_1), 3),
+                ""
+            );
+
+            addKnnDoc(
+                indexName,
+                "1",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT1),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_1_VALUE, INTEGER_FIELD_PRICE_1_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_1_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_1_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "2",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT3),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_2_VALUE, INTEGER_FIELD_PRICE_2_VALUE),
+                List.of(),
+                List.of(),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_2_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "3",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT2),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_PRICE_3_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_2_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_3_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "4",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT4),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_3_VALUE, INTEGER_FIELD_PRICE_4_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_3_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_2_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "5",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT5),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_3_VALUE, INTEGER_FIELD_PRICE_5_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_4_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_4_VALUE)
+            );
+            addKnnDoc(
+                indexName,
+                "6",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT6),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1, INTEGER_FIELD_PRICE),
+                List.of(INTEGER_FIELD_4_VALUE, INTEGER_FIELD_PRICE_6_VALUE),
+                List.of(KEYWORD_FIELD_1),
+                List.of(KEYWORD_FIELD_4_VALUE),
+                List.of(DATE_FIELD_1),
+                List.of(DATE_FIELD_4_VALUE)
+            );
+        }
+    }
+
+    @SneakyThrows
+    private void initializeIndexWithOneShardIfNotExists(String indexName) {
+        if (!indexExists(indexName)) {
+            createIndexWithConfiguration(
+                indexName,
+                buildIndexConfiguration(List.of(), List.of(), List.of(INTEGER_FIELD_1), List.of(KEYWORD_FIELD_1), List.of(), 1),
+                ""
+            );
+
+            addKnnDoc(
+                indexName,
+                "1",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT1),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1),
+                List.of(INTEGER_FIELD_1_VALUE),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+            );
+
+            addKnnDoc(
+                indexName,
+                "2",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+                Collections.singletonList(TEST_DOC_TEXT3),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1),
+                List.of(INTEGER_FIELD_2_VALUE),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()
+            );
+        }
     }
 
     private void addDocsToIndex(final String testMultiDocIndexName) {
@@ -531,5 +926,148 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     private Optional<Float> getMaxScore(Map<String, Object> searchResponseAsMap) {
         Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
         return hitsMap.get("max_score") == null ? Optional.empty() : Optional.of(((Double) hitsMap.get("max_score")).floatValue());
+    }
+
+    @SneakyThrows
+    void prepareResources(String indexName, String pipelineName) {
+        initializeIndexIfNotExist(indexName);
+        createSearchPipelineWithResultsPostProcessor(pipelineName);
+    }
+
+    @SneakyThrows
+    void prepareResourcesForSingleShardIndex(String indexName, String pipelineName) {
+        initializeIndexWithOneShardIfNotExists(indexName);
+        createSearchPipelineWithResultsPostProcessor(pipelineName);
+    }
+
+    private void assertResultsOfPipelineSumtoDateHistogramAggs(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+        assertNotNull(aggregations);
+
+        double aggValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_1);
+        assertEquals(3517.5, aggValue, DELTA_FOR_SCORE_ASSERTION);
+
+        double sumValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_2);
+        assertEquals(7035.0, sumValue, DELTA_FOR_SCORE_ASSERTION);
+
+        double minValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_3);
+        assertEquals(1234.0, minValue, DELTA_FOR_SCORE_ASSERTION);
+
+        double maxValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_4);
+        assertEquals(5801.0, maxValue, DELTA_FOR_SCORE_ASSERTION);
+
+        List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, GENERIC_AGGREGATION_NAME);
+        assertNotNull(buckets);
+        assertEquals(21, buckets.size());
+
+        // check content of few buckets
+        Map<String, Object> firstBucket = buckets.get(0);
+        assertEquals(4, firstBucket.size());
+        assertEquals("01/01/1995", firstBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(1234.0, getAggregationValue(firstBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(firstBucket.containsKey(KEY));
+
+        Map<String, Object> secondBucket = buckets.get(1);
+        assertEquals(4, secondBucket.size());
+        assertEquals("01/01/1996", secondBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(0, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(0.0, getAggregationValue(secondBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(secondBucket.containsKey(KEY));
+
+        Map<String, Object> lastBucket = buckets.get(buckets.size() - 1);
+        assertEquals(4, lastBucket.size());
+        assertEquals("01/01/2015", lastBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(2, lastBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(5801.0, getAggregationValue(lastBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(lastBucket.containsKey(KEY));
+    }
+
+    private void assertResultsOfPipelineSumtoDateHistogramAggsForMatchAllQuery(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
+        assertNotNull(aggregations);
+
+        double aggValue = getAggregationValue(aggregations, BUCKETS_AGGREGATION_NAME_1);
+        assertEquals(3764.5, aggValue, DELTA_FOR_SCORE_ASSERTION);
+
+        List<Map<String, Object>> buckets = getAggregationBuckets(aggregations, GENERIC_AGGREGATION_NAME);
+        assertNotNull(buckets);
+        assertEquals(21, buckets.size());
+
+        // check content of few buckets
+        Map<String, Object> firstBucket = buckets.get(0);
+        assertEquals(4, firstBucket.size());
+        assertEquals("01/01/1995", firstBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(1, firstBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(1234.0, getAggregationValue(firstBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(firstBucket.containsKey(KEY));
+
+        Map<String, Object> secondBucket = buckets.get(1);
+        assertEquals(4, secondBucket.size());
+        assertEquals("01/01/1996", secondBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(0, secondBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(0.0, getAggregationValue(secondBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(secondBucket.containsKey(KEY));
+
+        Map<String, Object> lastBucket = buckets.get(buckets.size() - 1);
+        assertEquals(4, lastBucket.size());
+        assertEquals("01/01/2015", lastBucket.get(BUCKET_AGG_KEY_AS_STRING));
+        assertEquals(2, lastBucket.get(BUCKET_AGG_DOC_COUNT_FIELD));
+        assertEquals(5801.0, getAggregationValue(lastBucket, SUM_AGGREGATION_NAME), DELTA_FOR_SCORE_ASSERTION);
+        assertTrue(lastBucket.containsKey(KEY));
+    }
+
+    private Map<String, Object> executeQueryAndGetAggsResults(final List<Object> aggsBuilders, String indexName, int expectedHitsNumber) {
+
+        TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
+        TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT5);
+
+        HybridQueryBuilder hybridQueryBuilderNeuralThenTerm = new HybridQueryBuilder();
+        hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder1);
+        hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder2);
+
+        return executeQueryAndGetAggsResults(aggsBuilders, hybridQueryBuilderNeuralThenTerm, indexName, expectedHitsNumber);
+    }
+
+    private Map<String, Object> executeQueryAndGetAggsResults(
+        final List<Object> aggsBuilders,
+        QueryBuilder queryBuilder,
+        String indexName,
+        int expectedHits
+    ) {
+        Map<String, Object> searchResponseAsMap = search(
+            indexName,
+            queryBuilder,
+            null,
+            10,
+            Map.of("search_pipeline", SEARCH_PIPELINE),
+            aggsBuilders
+        );
+
+        assertHitResultsFromQuery(expectedHits, searchResponseAsMap);
+        return searchResponseAsMap;
+    }
+
+    private void assertHitResultsFromQuery(int expected, Map<String, Object> searchResponseAsMap) {
+        assertEquals(expected, getHitCount(searchResponseAsMap));
+
+        List<Map<String, Object>> hits1NestedList = getNestedHits(searchResponseAsMap);
+        List<String> ids = new ArrayList<>();
+        List<Double> scores = new ArrayList<>();
+        for (Map<String, Object> oneHit : hits1NestedList) {
+            ids.add((String) oneHit.get("_id"));
+            scores.add((Double) oneHit.get("_score"));
+        }
+
+        // verify that scores are in desc order
+        assertTrue(IntStream.range(0, scores.size() - 1).noneMatch(idx -> scores.get(idx) < scores.get(idx + 1)));
+        // verify that all ids are unique
+        assertEquals(Set.copyOf(ids).size(), ids.size());
+
+        Map<String, Object> total = getTotalHits(searchResponseAsMap);
+        assertNotNull(total.get("value"));
+        assertEquals(expected, total.get("value"));
+        assertNotNull(total.get("relation"));
+        assertEquals(RELATION_EQUAL_TO, total.get("relation"));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/util/AggregationsTestUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/AggregationsTestUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Util class for routines associated with aggregations testing
+ */
+public class AggregationsTestUtils {
+
+    public static List<Map<String, Object>> getNestedHits(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
+        return (List<Map<String, Object>>) hitsMap.get("hits");
+    }
+
+    public static Map<String, Object> getTotalHits(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
+        return (Map<String, Object>) hitsMap.get("total");
+    }
+
+    public static Map<String, Object> getAggregations(final Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> aggsMap = (Map<String, Object>) searchResponseAsMap.get("aggregations");
+        return aggsMap;
+    }
+
+    public static <T> T getAggregationValue(final Map<String, Object> aggsMap, final String aggName) {
+        Map<String, Object> aggValues = (Map<String, Object>) aggsMap.get(aggName);
+        return (T) aggValues.get("value");
+    }
+
+    public static <T> T getAggregationBuckets(final Map<String, Object> aggsMap, final String aggName) {
+        Map<String, Object> aggValues = (Map<String, Object>) aggsMap.get(aggName);
+        return (T) aggValues.get("buckets");
+    }
+
+    public static <T> T getAggregationValues(final Map<String, Object> aggsMap, final String aggName) {
+        return (T) aggsMap.get(aggName);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/util/HybridQueryUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/HybridQueryUtilTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.search.Query;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.neuralsearch.query.HybridQuery;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+import org.opensearch.search.internal.SearchContext;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HybridQueryUtilTests extends OpenSearchQueryTestCase {
+
+    private static final String TERM_QUERY_TEXT = "keyword";
+    private static final String RANGE_FIELD = "date _range";
+    private static final String FROM_TEXT = "123";
+    private static final String TO_TEXT = "456";
+    private static final String TEXT_FIELD_NAME = "field";
+
+    @SneakyThrows
+    public void testIsHybridQueryCheck_whenQueryIsHybridQueryInstance_thenSuccess() {
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        HybridQuery query = new HybridQuery(
+            List.of(
+                QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT).toQuery(mockQueryShardContext),
+                QueryBuilders.rangeQuery(RANGE_FIELD)
+                    .from(FROM_TEXT)
+                    .to(TO_TEXT)
+                    .rewrite(mockQueryShardContext)
+                    .rewrite(mockQueryShardContext)
+                    .toQuery(mockQueryShardContext),
+                QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT).toQuery(mockQueryShardContext)
+            )
+        );
+        SearchContext searchContext = mock(SearchContext.class);
+
+        assertTrue(HybridQueryUtil.isHybridQuery(query, searchContext));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryCheck_whenHybridWrappedIntoBoolAndNoNested_thenSuccess() {
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        MapperService mapperService = createMapperService();
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) mapperService.fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
+        hybridQueryBuilder.add(
+            QueryBuilders.rangeQuery(RANGE_FIELD).from(FROM_TEXT).to(TO_TEXT).rewrite(mockQueryShardContext).rewrite(mockQueryShardContext)
+        );
+
+        Query booleanQuery = QueryBuilders.boolQuery()
+            .should(hybridQueryBuilder)
+            .should(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT))
+            .toQuery(mockQueryShardContext);
+        SearchContext searchContext = mock(SearchContext.class);
+        when(searchContext.mapperService()).thenReturn(mapperService);
+
+        assertFalse(HybridQueryUtil.isHybridQuery(booleanQuery, searchContext));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryCheck_whenNoHybridQuery_thenSuccess() {
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        MapperService mapperService = createMapperService();
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) mapperService.fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        Query booleanQuery = QueryBuilders.boolQuery()
+            .should(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT))
+            .should(
+                QueryBuilders.rangeQuery(RANGE_FIELD)
+                    .from(FROM_TEXT)
+                    .to(TO_TEXT)
+                    .rewrite(mockQueryShardContext)
+                    .rewrite(mockQueryShardContext)
+            )
+            .toQuery(mockQueryShardContext);
+        SearchContext searchContext = mock(SearchContext.class);
+        when(searchContext.mapperService()).thenReturn(mapperService);
+
+        assertFalse(HybridQueryUtil.isHybridQuery(booleanQuery, searchContext));
+    }
+}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -413,13 +413,53 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final int resultSize,
         final Map<String, String> requestParams
     ) {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field("query");
-        queryBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return search(index, queryBuilder, rescorer, resultSize, requestParams, null);
+    }
+
+    @SneakyThrows
+    protected Map<String, Object> search(
+        String index,
+        QueryBuilder queryBuilder,
+        QueryBuilder rescorer,
+        int resultSize,
+        Map<String, String> requestParams,
+        List<Object> aggs
+    ) {
+        return search(index, queryBuilder, rescorer, resultSize, requestParams, aggs, null);
+    }
+
+    @SneakyThrows
+    protected Map<String, Object> search(
+        String index,
+        QueryBuilder queryBuilder,
+        QueryBuilder rescorer,
+        int resultSize,
+        Map<String, String> requestParams,
+        List<Object> aggs,
+        QueryBuilder postFilterBuilder
+    ) {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+
+        if (queryBuilder != null) {
+            builder.field("query");
+            queryBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        }
 
         if (rescorer != null) {
             builder.startObject("rescore").startObject("query").field("query_weight", 0.0f).field("rescore_query");
             rescorer.toXContent(builder, ToXContent.EMPTY_PARAMS);
             builder.endObject().endObject();
+        }
+        if (Objects.nonNull(aggs)) {
+            builder.startObject("aggs");
+            for (Object agg : aggs) {
+                builder.value(agg);
+            }
+            builder.endObject();
+        }
+        if (Objects.nonNull(postFilterBuilder)) {
+            builder.field("post_filter");
+            postFilterBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
         }
 
         builder.endObject();
@@ -463,6 +503,35 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         addKnnDoc(index, docId, vectorFieldNames, vectors, textFieldNames, texts, Collections.emptyList(), Collections.emptyList());
     }
 
+    @SneakyThrows
+    protected void addKnnDoc(
+        String index,
+        String docId,
+        List<String> vectorFieldNames,
+        List<Object[]> vectors,
+        List<String> textFieldNames,
+        List<String> texts,
+        List<String> nestedFieldNames,
+        List<Map<String, String>> nestedFields
+    ) {
+        addKnnDoc(
+            index,
+            docId,
+            vectorFieldNames,
+            vectors,
+            textFieldNames,
+            texts,
+            nestedFieldNames,
+            nestedFields,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+    }
+
     /**
      * Add a set of knn vectors and text to an index
      *
@@ -484,7 +553,13 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final List<String> textFieldNames,
         final List<String> texts,
         final List<String> nestedFieldNames,
-        final List<Map<String, String>> nestedFields
+        final List<Map<String, String>> nestedFields,
+        final List<String> integerFieldNames,
+        final List<Integer> integerFieldValues,
+        final List<String> keywordFieldNames,
+        final List<String> keywordFieldValues,
+        final List<String> dateFieldNames,
+        final List<String> dateFieldValues
     ) {
         Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=true");
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
@@ -504,6 +579,18 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
                 builder.field(entry.getKey(), entry.getValue());
             }
             builder.endObject();
+        }
+
+        for (int i = 0; i < integerFieldNames.size(); i++) {
+            builder.field(integerFieldNames.get(i), integerFieldValues.get(i));
+        }
+
+        for (int i = 0; i < keywordFieldNames.size(); i++) {
+            builder.field(keywordFieldNames.get(i), keywordFieldValues.get(i));
+        }
+
+        for (int i = 0; i < dateFieldNames.size(); i++) {
+            builder.field(dateFieldNames.get(i), dateFieldValues.get(i));
         }
         builder.endObject();
 
@@ -668,6 +755,25 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final List<String> nestedFields,
         final int numberOfShards
     ) {
+        return buildIndexConfiguration(
+            knnFieldConfigs,
+            nestedFields,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            numberOfShards
+        );
+    }
+
+    @SneakyThrows
+    protected String buildIndexConfiguration(
+        final List<KNNFieldConfig> knnFieldConfigs,
+        final List<String> nestedFields,
+        final List<String> intFields,
+        final List<String> keywordFields,
+        final List<String> dateFields,
+        final int numberOfShards
+    ) {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("settings")
@@ -688,9 +794,31 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
                 .endObject()
                 .endObject();
         }
+        // treat the list in a manner that first element is always the type name and all others are keywords
+        if (!nestedFields.isEmpty()) {
+            String nestedFieldName = nestedFields.get(0);
+            xContentBuilder.startObject(nestedFieldName).field("type", "nested");
+            if (nestedFields.size() > 1) {
+                xContentBuilder.startObject("properties");
+                for (int i = 1; i < nestedFields.size(); i++) {
+                    String innerNestedTypeField = nestedFields.get(i);
+                    xContentBuilder.startObject(innerNestedTypeField).field("type", "keyword").endObject();
+                }
+                xContentBuilder.endObject();
+            }
+            xContentBuilder.endObject();
+        }
 
-        for (String nestedField : nestedFields) {
-            xContentBuilder.startObject(nestedField).field("type", "nested").endObject();
+        for (String intField : intFields) {
+            xContentBuilder.startObject(intField).field("type", "integer").endObject();
+        }
+
+        for (String keywordField : keywordFields) {
+            xContentBuilder.startObject(keywordField).field("type", "keyword").endObject();
+        }
+
+        for (String dateField : dateFields) {
+            xContentBuilder.startObject(dateField).field("type", "date").field("format", "MM/dd/yyyy").endObject();
         }
 
         xContentBuilder.endObject().endObject().endObject();


### PR DESCRIPTION
### Description
Adding aggregations to hybrid query. 
Implementation is based on [design RFC ](https://github.com/opensearch-project/neural-search/issues/604). Big chunk of implementation is done under https://github.com/opensearch-project/neural-search/pull/624, in this PR we mainly:
- changing way of getting total hits, it's number of unique documents from all sub-queries. in today's implementation it's max of results from individual sub-queries
- adding base integ test for 1) metric, bucket and pipeline aggressions and 2) with and without concurrent search (as there was an overlap in initial implementation of hybrid query) 

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/509

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] New functionality has been documented.
    - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
