### PR TITLE
Support for post filter in hybrid query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 - Adding aggregations in hybrid query ([#630](https://github.com/opensearch-project/neural-search/pull/630))
+- Post filter in hybrid query ([#633](https://github.com/opensearch-project/neural-search/pull/633))
 ### Bug Fixes
 - Fix runtime exceptions in hybrid query for case when sub-query scorer return TwoPhase iterator that is incompatible with DISI iterator ([#624](https://github.com/opensearch-project/neural-search/pull/624))
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 - Adding aggregations in hybrid query ([#630](https://github.com/opensearch-project/neural-search/pull/630))
-- Post filter in hybrid query ([#633](https://github.com/opensearch-project/neural-search/pull/633))
+- Support for post filter in hybrid query ([#633](https://github.com/opensearch-project/neural-search/pull/633))
 ### Bug Fixes
 - Fix runtime exceptions in hybrid query for case when sub-query scorer return TwoPhase iterator that is incompatible with DISI iterator ([#624](https://github.com/opensearch-project/neural-search/pull/624))
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -106,7 +106,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
         Collector hybridcollector = new HybridTopScoreDocCollector(numHits, hitsThresholdChecker);
         // Check if filterWeight is present. If it is present then return wrap Hybrid collector object underneath the FilteredCollector
         // object and return it.
-        return filterWeight == null ? hybridcollector : new FilteredCollector(hybridcollector, filterWeight);
+        return Objects.nonNull(filterWeight) ? new FilteredCollector(hybridcollector, filterWeight) : hybridcollector;
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -11,10 +11,15 @@ import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.opensearch.common.lucene.search.FilteredCollector;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.neuralsearch.search.HitsThresholdChecker;
 import org.opensearch.neuralsearch.search.HybridTopScoreDocCollector;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.query.MultiCollectorWrapper;
 import org.opensearch.search.query.QuerySearchResult;
@@ -30,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.Optional;
 
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createDelimiterElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createStartStopElementForHybridSearchResults;
@@ -46,6 +52,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
     private final boolean isSingleShard;
     private final int trackTotalHitsUpTo;
     private final SortAndFormats sortAndFormats;
+    private final Optional<Weight> filterWeight;
 
     /**
      * Create new instance of HybridCollectorManager depending on the concurrent search beeing enabled or disabled.
@@ -60,27 +67,42 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
         int numDocs = Math.min(searchContext.from() + searchContext.size(), totalNumDocs);
         int trackTotalHitsUpTo = searchContext.trackTotalHitsUpTo();
 
+        Weight filteringWeight = null;
+        // Check for post filter to create weight
+        if (Objects.nonNull(searchContext.parsedPostFilter())) {
+            Query filterQuery = searchContext.parsedPostFilter().query();
+            ContextIndexSearcher searcher = searchContext.searcher();
+            filteringWeight = searcher.createWeight(searcher.rewrite(filterQuery), ScoreMode.COMPLETE_NO_SCORES, 1f);
+        }
+
         return searchContext.shouldUseConcurrentSearch()
             ? new HybridCollectorConcurrentSearchManager(
                 numDocs,
                 new HitsThresholdChecker(Math.max(numDocs, searchContext.trackTotalHitsUpTo())),
                 isSingleShard,
                 trackTotalHitsUpTo,
-                searchContext.sort()
+                searchContext.sort(),
+                filteringWeight
             )
             : new HybridCollectorNonConcurrentManager(
                 numDocs,
                 new HitsThresholdChecker(Math.max(numDocs, searchContext.trackTotalHitsUpTo())),
                 isSingleShard,
                 trackTotalHitsUpTo,
-                searchContext.sort()
+                searchContext.sort(),
+                filteringWeight
             );
     }
 
     @Override
     public Collector newCollector() {
         Collector hybridcollector = new HybridTopScoreDocCollector(numHits, hitsThresholdChecker);
-        return hybridcollector;
+        // Check if filterWeight is present. If it is present then return wrap Hybrid collector object underneath the FilteredCollector
+        // object and return it.
+        if (filterWeight.isEmpty()) {
+            return hybridcollector;
+        }
+        return new FilteredCollector(hybridcollector, filterWeight.get());
     }
 
     /**
@@ -108,7 +130,10 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
                 }
             } else if (collector instanceof HybridTopScoreDocCollector) {
                 hybridTopScoreDocCollectors.add((HybridTopScoreDocCollector) collector);
-            }
+            } else if (collector instanceof FilteredCollector
+                && ((FilteredCollector) collector).getCollector() instanceof HybridTopScoreDocCollector) {
+                    hybridTopScoreDocCollectors.add((HybridTopScoreDocCollector) ((FilteredCollector) collector).getCollector());
+                }
         }
 
         if (!hybridTopScoreDocCollectors.isEmpty()) {
@@ -216,9 +241,10 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
             HitsThresholdChecker hitsThresholdChecker,
             boolean isSingleShard,
             int trackTotalHitsUpTo,
-            SortAndFormats sortAndFormats
+            SortAndFormats sortAndFormats,
+            Weight filteringWeight
         ) {
-            super(numHits, hitsThresholdChecker, isSingleShard, trackTotalHitsUpTo, sortAndFormats);
+            super(numHits, hitsThresholdChecker, isSingleShard, trackTotalHitsUpTo, sortAndFormats, Optional.ofNullable(filteringWeight));
             scoreCollector = Objects.requireNonNull(super.newCollector(), "collector for hybrid query cannot be null");
         }
 
@@ -245,9 +271,10 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
             HitsThresholdChecker hitsThresholdChecker,
             boolean isSingleShard,
             int trackTotalHitsUpTo,
-            SortAndFormats sortAndFormats
+            SortAndFormats sortAndFormats,
+            Weight filteringWeight
         ) {
-            super(numHits, hitsThresholdChecker, isSingleShard, trackTotalHitsUpTo, sortAndFormats);
+            super(numHits, hitsThresholdChecker, isSingleShard, trackTotalHitsUpTo, sortAndFormats, Optional.ofNullable(filteringWeight));
         }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createDelimiterElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createStartStopElementForHybridSearchResults;
-import static org.opensearch.neuralsearch.util.HybridQueryUtil.boost_factor;
 
 /**
  * Collector manager based on HybridTopScoreDocCollector that allows users to parallelize counting the number of hits.
@@ -54,6 +53,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
     private final int trackTotalHitsUpTo;
     private final SortAndFormats sortAndFormats;
     private final Optional<Weight> optionalFilterWeight;
+    public static final float boost_factor = 1f;
 
     /**
      * Create new instance of HybridCollectorManager depending on the concurrent search beeing enabled or disabled.
@@ -70,7 +70,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
 
         Weight filteringWeight = null;
         // Check for post filter to create weight for filter query and later use that weight in the search workflow
-        if (Objects.nonNull(searchContext.parsedPostFilter())) {
+        if (Objects.nonNull(searchContext.parsedPostFilter()) && Objects.nonNull(searchContext.parsedPostFilter().query())) {
             Query filterQuery = searchContext.parsedPostFilter().query();
             ContextIndexSearcher searcher = searchContext.searcher();
             // ScoreMode COMPLETE_NO_SCORES will be passed as post_filter does not contribute in scoring. COMPLETE_NO_SCORES means it is not

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.lucene.search.FilteredCollector;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.neuralsearch.search.HitsThresholdChecker;
@@ -35,7 +36,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.Optional;
 
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createDelimiterElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createStartStopElementForHybridSearchResults;
@@ -52,7 +52,8 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
     private final boolean isSingleShard;
     private final int trackTotalHitsUpTo;
     private final SortAndFormats sortAndFormats;
-    private final Optional<Weight> optionalFilterWeight;
+    @Nullable
+    private final Weight filterWeight;
     public static final float boost_factor = 1f;
 
     /**
@@ -105,10 +106,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
         Collector hybridcollector = new HybridTopScoreDocCollector(numHits, hitsThresholdChecker);
         // Check if filterWeight is present. If it is present then return wrap Hybrid collector object underneath the FilteredCollector
         // object and return it.
-        if (optionalFilterWeight.isEmpty()) {
-            return hybridcollector;
-        }
-        return new FilteredCollector(hybridcollector, optionalFilterWeight.get());
+        return filterWeight == null ? hybridcollector : new FilteredCollector(hybridcollector, filterWeight);
     }
 
     /**
@@ -250,7 +248,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
             SortAndFormats sortAndFormats,
             Weight filteringWeight
         ) {
-            super(numHits, hitsThresholdChecker, isSingleShard, trackTotalHitsUpTo, sortAndFormats, Optional.ofNullable(filteringWeight));
+            super(numHits, hitsThresholdChecker, isSingleShard, trackTotalHitsUpTo, sortAndFormats, filteringWeight);
             scoreCollector = Objects.requireNonNull(super.newCollector(), "collector for hybrid query cannot be null");
         }
 
@@ -280,7 +278,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
             SortAndFormats sortAndFormats,
             Weight filteringWeight
         ) {
-            super(numHits, hitsThresholdChecker, isSingleShard, trackTotalHitsUpTo, sortAndFormats, Optional.ofNullable(filteringWeight));
+            super(numHits, hitsThresholdChecker, isSingleShard, trackTotalHitsUpTo, sortAndFormats, filteringWeight);
         }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -54,7 +54,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
     private final SortAndFormats sortAndFormats;
     @Nullable
     private final Weight filterWeight;
-    public static final float boost_factor = 1f;
+    private static final float boost_factor = 1f;
 
     /**
      * Create new instance of HybridCollectorManager depending on the concurrent search beeing enabled or disabled.

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -21,6 +21,8 @@ import org.opensearch.search.internal.SearchContext;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HybridQueryUtil {
 
+    public static final float boost_factor = 1f;
+
     public static boolean isHybridQuery(final Query query, final SearchContext searchContext) {
         if (query instanceof HybridQuery) {
             return true;

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -21,8 +21,6 @@ import org.opensearch.search.internal.SearchContext;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HybridQueryUtil {
 
-    public static final float boost_factor = 1f;
-
     public static boolean isHybridQuery(final Query query, final SearchContext searchContext) {
         if (query instanceof HybridQuery) {
             return true;

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -161,9 +161,11 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         Collector collector = hybridCollectorManager.newCollector();
         assertNotNull(collector);
         assertTrue(collector instanceof FilteredCollector);
+        assertTrue(((FilteredCollector) collector).getCollector() instanceof HybridTopScoreDocCollector);
 
         Collector secondCollector = hybridCollectorManager.newCollector();
         assertSame(collector, secondCollector);
+        assertTrue(((FilteredCollector) secondCollector).getCollector() instanceof HybridTopScoreDocCollector);
     }
 
     @SneakyThrows
@@ -203,9 +205,11 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         Collector collector = hybridCollectorManager.newCollector();
         assertNotNull(collector);
         assertTrue(collector instanceof FilteredCollector);
+        assertTrue(((FilteredCollector) collector).getCollector() instanceof HybridTopScoreDocCollector);
 
         Collector secondCollector = hybridCollectorManager.newCollector();
         assertNotSame(collector, secondCollector);
+        assertTrue(((FilteredCollector) secondCollector).getCollector() instanceof HybridTopScoreDocCollector);
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
This PR adds Support for Post filter in hybrid query. 

The crux of the logic implemented in this PR is when the search request has post filter query in that, then instead of returning plain HybridTopDocCollector Object we would be returning FilteredCollectorObject which will have HybridTopDocCollector object wrapped underneath it.

Also This PR has unit tests and Integration tests for the post_filter scenario.



Testing example on local machine

1) Create index

```
http://localhost:9200/movies

{
  "settings": {
    "index": {
      "number_of_shards": 1,
      "number_of_replicas": 0
    },
    "index.search.concurrent_segment_search.enabled": false
  },
  "mappings": {
    "properties": {
      "name": {
        "type": "text"
      },
      "stock":{
        "type": "integer"
      }
    }
  }
}
```

2) Create pipeline 

```
http://localhost:9200/_search/pipeline/nlp-search-pipeline

{
  "description": "Post processor for hybrid search",
  "phase_results_processors": [
    {
      "normalization-processor": {
        "normalization": {
          "technique": "min_max"
        },
        "combination": {
          "technique": "arithmetic_mean",
          "parameters": {
            "weights": [
              0.3,
              0.6,
              0.1
            ]
          }
        }
      }
    }
  ]
}

```

3) Add documents

```
{
  "name": "Dunes part 1",
  "stock":2
}
```

```
{
  "name": "Dunes part 2",
  "stock":26
}
```
```
{
  "name": "Mission Impossible 1",
  "stock":234
}
```
```
{
  "name": "Mission Impossible 2",
  "stock":238
}
```
```
{
  "name": "Avengers",
  "stock":300
}
```

4) search without post_filter
```
http://localhost:9200/movies/_search?search_pipeline=nlp-search-pipeline

{
   "query": {
      "hybrid":{
          "queries":[
              { 
                "match":{
                    "name": "mission"
                }
              },
              {
                "term":{
                    "name":{
                        "value":"part"
                    }
                }
              },
              {
              "range": {
                 "stock": {
                      "gte": 200,
                      "lte": 400
                  }
                }
              }
          ]
      }

  }
}


{
    "took": 12,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 5,
            "relation": "eq"
        },
        "max_score": 0.70000005,
        "hits": [
            {
                "_index": "movies",
                "_id": "2",
                "_score": 0.70000005,
                "_source": {
                    "name": "Mission Impossible 1",
                    "stock": 234
                }
            },
            {
                "_index": "movies",
                "_id": "3",
                "_score": 0.70000005,
                "_source": {
                    "name": "Mission Impossible 2",
                    "stock": 238
                }
            },
            {
                "_index": "movies",
                "_id": "4",
                "_score": 0.4,
                "_source": {
                    "name": "Avengers",
                    "stock": 300
                }
            },
            {
                "_index": "movies",
                "_id": "1",
                "_score": 0.3,
                "_source": {
                    "name": "Dunes part 1",
                    "stock": 2
                }
            },
            {
                "_index": "movies",
                "_id": "5",
                "_score": 0.3,
                "_source": {
                    "name": "Dunes part 2",
                    "stock": 26
                }
            }
        ]
    }
}
```

5) Search with post_filter

```
{
   "query": {
      "hybrid":{
          "queries":[
              { 
                "match":{
                    "name": "mission"
                }
              },
              {
                "term":{
                    "name":{
                        "value":"part"
                    }
                }
              },
              {
              "range": {
                 "stock": {
                      "gte": 200,
                      "lte": 400
                  }
                }
              }
          ]
      }

  },
  "post_filter":{
      "range": {
                 "stock": {
                      "gte": 230,
                      "lte": 400
                  }
       }
  }
}

{
    "took": 12,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 3,
            "relation": "eq"
        },
        "max_score": 0.70000005,
        "hits": [
            {
                "_index": "movies",
                "_id": "2",
                "_score": 0.70000005,
                "_source": {
                    "name": "Mission Impossible 1",
                    "stock": 234
                }
            },
            {
                "_index": "movies",
                "_id": "3",
                "_score": 0.70000005,
                "_source": {
                    "name": "Mission Impossible 2",
                    "stock": 238
                }
            },
            {
                "_index": "movies",
                "_id": "4",
                "_score": 0.4,
                "_source": {
                    "name": "Avengers",
                    "stock": 300
                }
            }
        ]
    }
}
```


### Issues Resolved
[508](https://github.com/opensearch-project/neural-search/issues/508)

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
