### PR TITLE
Fix Failing build due to slf4j from k-NN Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,7 +250,9 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
     secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
-    compileOnly fileTree(dir: knnJarDirectory, include: '*.jar')
+    compileOnly fileTree(dir: knnJarDirectory, include: "opensearch-knn-${opensearch_build}.jar")
+    compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
+    compileOnly group: 'commons-lang', name: 'commons-lang', version: '2.6'
     api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
@@ -265,8 +267,8 @@ dependencies {
     runtimeOnly group: 'org.json', name: 'json', version: '20231013'
     testFixturesImplementation "org.opensearch:common-utils:${version}"
     testFixturesImplementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
-    testFixturesCompileOnly group: 'com.google.guava', name: 'guava', version:'32.0.1-jre'
-    testFixturesCompileOnly fileTree(dir: knnJarDirectory, include: '*.jar')
+    testFixturesCompileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
+    testFixturesCompileOnly fileTree(dir: knnJarDirectory, include: "opensearch-knn-${opensearch_build}.jar")
 }
 
 // In order to add the jar to the classpath, we need to unzip the

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -31,7 +31,9 @@ dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
-    compileOnly fileTree(dir: knnJarDirectory, include: '*.jar')
+    compileOnly fileTree(dir: knnJarDirectory, include: "opensearch-knn-${opensearch_build}.jar")
+    compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
+    compileOnly group: 'commons-lang', name: 'commons-lang', version: '2.6'
     api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     api "junit:junit:${versions.junit}"


### PR DESCRIPTION
### Description
Fix failing build by only including `opensearch-knn-${opensearch_version}.jar` and adding other required dependencies `guava` and `commons-lang`

### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
