### PR TITLE
 [Backport 2.x] Add release notes for 2.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 ### Refactoring
 
-## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.12...2.x)
+## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.13...2.x)
 ### Features
-- Implement document chunking processor with fixed token length and delimiter algorithm ([#607](https://github.com/opensearch-project/neural-search/pull/607/))
-- Enabled support for applying default modelId in neural sparse query ([#614](https://github.com/opensearch-project/neural-search/pull/614)
 ### Enhancements
-- Adding aggregations in hybrid query ([#630](https://github.com/opensearch-project/neural-search/pull/630))
-- Support for post filter in hybrid query ([#633](https://github.com/opensearch-project/neural-search/pull/633))
 ### Bug Fixes
-- Fix typo for sparse encoding processor factory([#600](https://github.com/opensearch-project/neural-search/pull/600))
-- Add non-null check for queryBuilder in NeuralQueryEnricherProcessor ([#619](https://github.com/opensearch-project/neural-search/pull/619))
-- Fix runtime exceptions in hybrid query for case when sub-query scorer return TwoPhase iterator that is incompatible with DISI iterator ([#624](https://github.com/opensearch-project/neural-search/pull/624))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/release-notes/opensearch-neural-search.release-notes-2.13.0.0.md
+++ b/release-notes/opensearch-neural-search.release-notes-2.13.0.0.md
@@ -1,0 +1,14 @@
+## Version 2.13.0.0 Release Notes
+
+Compatible with OpenSearch 2.13.0
+
+### Features
+- Implement document chunking processor with fixed token length and delimiter algorithm ([#607](https://github.com/opensearch-project/neural-search/pull/607/))
+- Enabled support for applying default modelId in neural sparse query ([#614](https://github.com/opensearch-project/neural-search/pull/614)
+### Enhancements
+- Adding aggregations in hybrid query ([#630](https://github.com/opensearch-project/neural-search/pull/630))
+- Support for post filter in hybrid query ([#633](https://github.com/opensearch-project/neural-search/pull/633))
+### Bug Fixes
+- Fix typo for sparse encoding processor factory([#600](https://github.com/opensearch-project/neural-search/pull/600))
+- Add non-null check for queryBuilder in NeuralQueryEnricherProcessor ([#619](https://github.com/opensearch-project/neural-search/pull/619))
+- Fix runtime exceptions in hybrid query for case when sub-query scorer return TwoPhase iterator that is incompatible with DISI iterator ([#624](https://github.com/opensearch-project/neural-search/pull/624))


### PR DESCRIPTION
### Description
backport [648](https://github.com/opensearch-project/neural-search/pull/648) from [d0a0e31](https://github.com/opensearch-project/neural-search/commit/d0a0e31434bef0543922f72b10d35050f859cb77)

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
