### PR TITLE
Update neural_query_enricher bwc tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.13...2.x)
 ### Features
 ### Enhancements
+- Update bwc tests for neural_query_enricher neural_sparse search ([#652](https://github.com/opensearch-project/neural-search/pull/652))
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
@@ -55,8 +55,8 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRestartUpgradeRestTe
                 Settings.builder().put("index.search.default_pipeline", SPARSE_SEARCH_PIPELINE_NAME)
             );
             assertEquals(
-                    search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
-                    search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
+                search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
+                search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
             );
         } else {
             String modelId = null;

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
@@ -54,6 +54,10 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRestartUpgradeRestTe
                 getIndexNameForTest(),
                 Settings.builder().put("index.search.default_pipeline", SPARSE_SEARCH_PIPELINE_NAME)
             );
+            assertEquals(
+                    search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
+                    search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
+            );
         } else {
             String modelId = null;
             try {

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
@@ -57,11 +57,20 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
                     getIndexNameForTest(),
                     Settings.builder().put("index.search.default_pipeline", SPARSE_SEARCH_PIPELINE_NAME)
                 );
+                assertEquals(
+                        search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
+                        search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
+                );
                 break;
             case MIXED:
                 sparseModelId = TestUtils.getModelId(getIngestionPipeline(SPARSE_INGEST_PIPELINE_NAME), SPARSE_ENCODING_PROCESSOR);
                 loadModel(sparseModelId);
                 sparseEncodingQueryBuilderWithModelId.modelId(sparseModelId);
+
+                assertEquals(
+                        search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
+                        search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
+                );
                 break;
             case UPGRADED:
                 try {
@@ -117,11 +126,6 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
                 loadModel(denseModelId);
                 neuralQueryBuilderWithModelId.modelId(denseModelId);
 
-                createSearchRequestProcessor(denseModelId, DENSE_SEARCH_PIPELINE_NAME);
-                updateIndexSettings(
-                    getIndexNameForTest(),
-                    Settings.builder().put("index.search.default_pipeline", DENSE_SEARCH_PIPELINE_NAME)
-                );
                 assertEquals(
                     search(getIndexNameForTest(), neuralQueryBuilderWithoutModelId, 1).get("hits"),
                     search(getIndexNameForTest(), neuralQueryBuilderWithModelId, 1).get("hits")

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
@@ -58,8 +58,8 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
                     Settings.builder().put("index.search.default_pipeline", SPARSE_SEARCH_PIPELINE_NAME)
                 );
                 assertEquals(
-                        search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
-                        search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
+                    search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
+                    search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
                 );
                 break;
             case MIXED:
@@ -68,8 +68,8 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
                 sparseEncodingQueryBuilderWithModelId.modelId(sparseModelId);
 
                 assertEquals(
-                        search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
-                        search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
+                    search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
+                    search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
                 );
                 break;
             case UPGRADED:


### PR DESCRIPTION
### Description
After the backport PR of #614 get merged, we should update the bwc tests for neural_query_enricher neural_sparse search. Update the behavior of old cluster in version 2.13.

- add neural_query_enricher functional test for old cluster
- remove repetitive code in neural_query_enricher bwc test

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
