### PR TITLE
Allowing execution of hybrid query on index alias with filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.13...2.x)
 ### Features
 ### Enhancements
+- Allowing execution of hybrid query on index alias with filters ([#670](https://github.com/opensearch-project/neural-search/pull/670))
 ### Bug Fixes
 - Add support for request_cache flag in hybrid query ([#663](https://github.com/opensearch-project/neural-search/pull/663))
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
@@ -32,21 +32,21 @@ public final class HybridQuery extends Query implements Iterable<Query> {
     /**
      * Create new instance of hybrid query object based on collection of sub queries and filter query
      * @param subQueries collection of queries that are executed individually and contribute to a final list of combined scores
-     * @param filterQuery filter that will be applied to each sub query. If this is null sub queries will be executed as is
+     * @param filterQueries list of filters that will be applied to each sub query. Each filter from the list is added as bool "filter" clause. If this is null sub queries will be executed as is
      */
-    public HybridQuery(final Collection<Query> subQueries, final Query filterQuery) {
+    public HybridQuery(final Collection<Query> subQueries, final List<Query> filterQueries) {
         Objects.requireNonNull(subQueries, "collection of queries must not be null");
         if (subQueries.isEmpty()) {
             throw new IllegalArgumentException("collection of queries must not be empty");
         }
-        if (Objects.isNull(filterQuery)) {
+        if (Objects.isNull(filterQueries) || filterQueries.isEmpty()) {
             this.subQueries = new ArrayList<>(subQueries);
         } else {
             List<Query> modifiedSubQueries = new ArrayList<>();
             for (Query subQuery : subQueries) {
                 BooleanQuery.Builder builder = new BooleanQuery.Builder();
                 builder.add(subQuery, BooleanClause.Occur.MUST);
-                builder.add(filterQuery, BooleanClause.Occur.FILTER);
+                filterQueries.forEach(filterQuery -> builder.add(filterQuery, BooleanClause.Occur.FILTER));
                 modifiedSubQueries.add(builder.build());
             }
             this.subQueries = modifiedSubQueries;
@@ -54,7 +54,7 @@ public final class HybridQuery extends Query implements Iterable<Query> {
     }
 
     public HybridQuery(final Collection<Query> subQueries) {
-        this(subQueries, null);
+        this(subQueries, List.of());
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -69,7 +69,6 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
             }
             HybridQuery hybridQuery = (HybridQuery) booleanClauses.stream().findFirst().get().getQuery();
             List<Query> filterQueries = booleanClauses.stream()
-                .skip(1)
                 .filter(clause -> BooleanClause.Occur.FILTER == clause.getOccur())
                 .map(BooleanClause::getQuery)
                 .collect(Collectors.toList());

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -15,6 +15,8 @@ import org.opensearch.index.search.NestedHelper;
 import org.opensearch.neuralsearch.query.HybridQuery;
 import org.opensearch.search.internal.SearchContext;
 
+import java.util.Objects;
+
 /**
  * Utility class for anything related to hybrid query
  */
@@ -24,48 +26,58 @@ public class HybridQueryUtil {
     public static boolean isHybridQuery(final Query query, final SearchContext searchContext) {
         if (query instanceof HybridQuery) {
             return true;
-        } else if (isWrappedHybridQuery(query) && hasNestedFieldOrNestedDocs(query, searchContext)) {
-            /* Checking if this is a hybrid query that is wrapped into a Bool query by core Opensearch code
-            https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/DefaultSearchContext.java#L367-L370.
-            main reason for that is performance optimization, at time of writing we are ok with loosing on performance if that's unblocks
-            hybrid query for indexes with nested field types.
-            in such case we consider query a valid hybrid query. Later in the code we will extract it and execute as a main query for
-            this search request.
-            below is sample structure of such query:
+        } else if (isWrappedHybridQuery(query)) {
+            if ((hasNestedFieldOrNestedDocs(query, searchContext))) {
+                /* Checking if this is a hybrid query that is wrapped into a Bool query by core Opensearch code
+                https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/DefaultSearchContext.java#L367-L370.
+                main reason for that is performance optimization, at time of writing we are ok with loosing on performance if that's unblocks
+                hybrid query for indexes with nested field types.
+                in such case we consider query a valid hybrid query. Later in the code we will extract it and execute as a main query for
+                this search request.
+                below is sample structure of such query:
 
-            Boolean {
-               should: {
-                   hybrid: {
-                       sub_query1 {}
-                       sub_query2 {}
+                Boolean {
+                   should: {
+                       hybrid: {
+                           sub_query1 {}
+                           sub_query2 {}
+                       }
                    }
-               }
-               filter: {
-                   exists: {
-                       field: "_primary_term"
+                   filter: {
+                       exists: {
+                           field: "_primary_term"
+                       }
                    }
-               }
+                }
+                TODO Need to add logic for passing hybrid sub-queries through the same logic in core to ensure there is no latency regression */
+                // we have already checked if query in instance of Boolean in higher level else if condition
+                return ((BooleanQuery) query).clauses()
+                    .stream()
+                    .filter(clause -> clause.getQuery() instanceof HybridQuery == false)
+                    .allMatch(
+                        clause -> clause.getOccur() == BooleanClause.Occur.FILTER
+                            && clause.getQuery() instanceof FieldExistsQuery
+                            && SeqNoFieldMapper.PRIMARY_TERM_NAME.equals(((FieldExistsQuery) clause.getQuery()).getField())
+                    );
+            } else if (hasAliasFilter(query, searchContext)) {
+                // Checking case with alias that has a filter
+                return true;
             }
-            TODO Need to add logic for passing hybrid sub-queries through the same logic in core to ensure there is no latency regression */
-            // we have already checked if query in instance of Boolean in higher level else if condition
-            return ((BooleanQuery) query).clauses()
-                .stream()
-                .filter(clause -> clause.getQuery() instanceof HybridQuery == false)
-                .allMatch(clause -> {
-                    return clause.getOccur() == BooleanClause.Occur.FILTER
-                        && clause.getQuery() instanceof FieldExistsQuery
-                        && SeqNoFieldMapper.PRIMARY_TERM_NAME.equals(((FieldExistsQuery) clause.getQuery()).getField());
-                });
+            return false;
         }
         return false;
     }
 
-    private static boolean hasNestedFieldOrNestedDocs(final Query query, final SearchContext searchContext) {
+    public static boolean hasNestedFieldOrNestedDocs(final Query query, final SearchContext searchContext) {
         return searchContext.mapperService().hasNested() && new NestedHelper(searchContext.mapperService()).mightMatchNestedDocs(query);
     }
 
     private static boolean isWrappedHybridQuery(final Query query) {
         return query instanceof BooleanQuery
             && ((BooleanQuery) query).clauses().stream().anyMatch(clauseQuery -> clauseQuery.getQuery() instanceof HybridQuery);
+    }
+
+    public static boolean hasAliasFilter(final Query query, final SearchContext searchContext) {
+        return Objects.nonNull(searchContext.aliasFilter());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -580,7 +580,7 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     }
 
     @SneakyThrows
-    public void testIndexAlias_whenHybridQueryAndIndexAliasHasFilter_thenSuccess() {
+    public void testWrappedQueryWithFilter_whenIndexAliasHasFilterAndIndexWithNestedFields_thenSuccess() {
         String modelId = null;
         String alias = "alias_with_filter";
         try {
@@ -678,10 +678,19 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
         }
 
         if (TEST_MULTI_DOC_INDEX_NAME.equals(indexName) && !indexExists(TEST_MULTI_DOC_INDEX_NAME)) {
-            prepareKnnIndex(
+            createIndexWithConfiguration(
+                indexName,
+                buildIndexConfiguration(
+                    Collections.singletonList(new KNNFieldConfig(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DIMENSION, TEST_SPACE_TYPE)),
+                    List.of(TEST_NESTED_TYPE_FIELD_NAME_1),
+                    1
+                ),
+                ""
+            );
+            /*prepareKnnIndex(
                 TEST_MULTI_DOC_INDEX_NAME,
                 Collections.singletonList(new KNNFieldConfig(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DIMENSION, TEST_SPACE_TYPE))
-            );
+            );*/
             addDocsToIndex(TEST_MULTI_DOC_INDEX_NAME);
         }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
@@ -292,7 +292,7 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
                 QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT).toQuery(mockQueryShardContext),
                 QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_ANOTHER_QUERY_TEXT).toQuery(mockQueryShardContext)
             ),
-            filter
+            List.of(filter)
         );
         QueryUtils.check(hybridQuery);
 

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -15,11 +15,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryDelimiterElement;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,7 +37,6 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.opensearch.action.OriginalIndices;
@@ -887,47 +884,113 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
     }
 
     @SneakyThrows
-    private void assertQueryResults(TopDocs subQueryTopDocs, List<Integer> expectedDocIds, IndexReader reader) {
-        assertEquals(expectedDocIds.size(), subQueryTopDocs.totalHits.value);
-        assertNotNull(subQueryTopDocs.scoreDocs);
-        assertEquals(expectedDocIds.size(), subQueryTopDocs.scoreDocs.length);
-        assertEquals(TotalHits.Relation.EQUAL_TO, subQueryTopDocs.totalHits.relation);
-        for (int i = 0; i < expectedDocIds.size(); i++) {
-            int expectedDocId = expectedDocIds.get(i);
-            ScoreDoc scoreDoc = subQueryTopDocs.scoreDocs[i];
-            assertNotNull(scoreDoc);
-            int actualDocId = Integer.parseInt(reader.document(scoreDoc.doc).getField("id").stringValue());
-            assertEquals(expectedDocId, actualDocId);
-            assertTrue(scoreDoc.score > 0.0f);
-        }
+    public void testAliasWithFilter_whenHybridWrappedIntoBoolBecauseOfIndexAlias_thenSuccess() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = new HybridQueryPhaseSearcher();
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("field");
+            b.field("type", "text")
+                .field("fielddata", true)
+                .startObject("fielddata_frequency_filter")
+                .field("min", 2d)
+                .field("min_segment_size", 1000)
+                .endObject();
+            b.endObject();
+        }));
+
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) mapperService.fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+        when(mockQueryShardContext.getMapperService()).thenReturn(mapperService);
+        when(mockQueryShardContext.simpleMatchToIndexNames(anyString())).thenReturn(Set.of(TEXT_FIELD_NAME));
+
+        Directory directory = newDirectory();
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+        int docId1 = RandomizedTest.randomInt();
+        int docId2 = RandomizedTest.randomInt();
+        int docId3 = RandomizedTest.randomInt();
+        int docId4 = RandomizedTest.randomInt();
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId1, TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId2, TEST_DOC_TEXT2, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId4, TEST_DOC_TEXT4, ft));
+        w.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+        SearchContext searchContext = mock(SearchContext.class);
+
+        ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null,
+            searchContext
+        );
+
+        ShardId shardId = new ShardId(dummyIndex, 1);
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            randomAlphaOfLength(10),
+            shardId,
+            randomAlphaOfLength(10),
+            OriginalIndices.NONE
+        );
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        when(searchContext.size()).thenReturn(4);
+        QuerySearchResult querySearchResult = new QuerySearchResult();
+        when(searchContext.queryResult()).thenReturn(querySearchResult);
+        when(searchContext.numberOfShards()).thenReturn(1);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        IndexShard indexShard = mock(IndexShard.class);
+        when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+        when(searchContext.mapperService()).thenReturn(mapperService);
+
+        LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
+        boolean hasFilterCollector = randomBoolean();
+        boolean hasTimeout = randomBoolean();
+
+        HybridQueryBuilder queryBuilder = new HybridQueryBuilder();
+
+        queryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1));
+        queryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT2));
+        Query termFilter = QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1).toQuery(mockQueryShardContext);
+
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(queryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.SHOULD).add(termFilter, BooleanClause.Occur.FILTER);
+        Query query = builder.build();
+
+        when(searchContext.query()).thenReturn(query);
+        when(searchContext.aliasFilter()).thenReturn(termFilter);
+
+        hybridQueryPhaseSearcher.searchWith(searchContext, contextIndexSearcher, query, collectors, hasFilterCollector, hasTimeout);
+
+        assertNotNull(querySearchResult.topDocs());
+        TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
+        TopDocs topDocs = topDocsAndMaxScore.topDocs;
+        assertTrue(topDocs.totalHits.value > 0);
+        ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+        assertNotNull(scoreDocs);
+        assertEquals(1, scoreDocs.length);
+        ScoreDoc scoreDoc = scoreDocs[0];
+        assertTrue(scoreDoc.score > 0);
+        assertEquals(0, scoreDoc.doc);
+
+        releaseResources(directory, w, reader);
     }
 
     private void releaseResources(Directory directory, IndexWriter w, IndexReader reader) throws IOException {
         w.close();
         reader.close();
         directory.close();
-    }
-
-    private List<TopDocs> getSubQueryResultsForSingleShard(final TopDocs topDocs) {
-        assertNotNull(topDocs);
-        List<TopDocs> topDocsList = new ArrayList<>();
-        ScoreDoc[] scoreDocs = topDocs.scoreDocs;
-        // skipping 0 element, it's a start-stop element
-        List<ScoreDoc> scoreDocList = new ArrayList<>();
-        for (int index = 2; index < scoreDocs.length; index++) {
-            // getting first element of score's series
-            ScoreDoc scoreDoc = scoreDocs[index];
-            if (isHybridQueryDelimiterElement(scoreDoc) || isHybridQueryStartStopElement(scoreDoc)) {
-                ScoreDoc[] subQueryScores = scoreDocList.toArray(new ScoreDoc[0]);
-                TotalHits totalHits = new TotalHits(subQueryScores.length, TotalHits.Relation.EQUAL_TO);
-                TopDocs subQueryTopDocs = new TopDocs(totalHits, subQueryScores);
-                topDocsList.add(subQueryTopDocs);
-                scoreDocList.clear();
-            } else {
-                scoreDocList.add(scoreDoc);
-            }
-        }
-        return topDocsList;
     }
 
     private BooleanQuery createNestedBoolQuery(final Query query1, final Query query2, int level) {

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -348,6 +348,43 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         assertEquals("true", node.get("acknowledged").toString());
     }
 
+    protected void createIndexAlias(final String index, final String alias, final QueryBuilder filterBuilder) throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.startArray("actions");
+        builder.startObject();
+        builder.startObject("add");
+        builder.field("index", index);
+        builder.field("alias", alias);
+        // filter object
+        if (Objects.nonNull(filterBuilder)) {
+            builder.field("filter");
+            filterBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        }
+        builder.endObject();
+        builder.endObject();
+        builder.endArray();
+        builder.endObject();
+
+        Request request = new Request("POST", "/_aliases");
+        request.setJsonEntity(builder.toString());
+
+        Response response = client().performRequest(request);
+
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    @SneakyThrows
+    protected void deleteIndexAlias(final String index, final String alias) {
+        makeRequest(
+            client(),
+            "DELETE",
+            String.format(Locale.ROOT, "%s/_alias/%s", index, alias),
+            null,
+            null,
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+    }
+
     /**
      * Get the number of documents in a particular index
      *


### PR DESCRIPTION
### Description
Allowing scenario when hybrid query is executed for index alias that has filter. Today we're blocking such queries because of high level bool query that wraps the hybrid query to incorporate filtering logic. By design we are blocking such queries, hybrid query must be a high level query. 

To change this we doing following:
- extract hybrid query from compound query with the alias filter
- wrap each sub query of the hybrid query into bool query in a following form:
 ```
   bool : {
      must: [
        <original_sub_query>
      ],
      filter: {
        <alias_filter>
      }
   }
```

- rewrite hybrid query to following form:
```
 hybrid: {
      queries: [
          { sub_query1_wrapped_into_bool },
          { sub_query2_wrapped_into_bool }
      ]
 }
```

Part of this change is enhanced logic of query phase searcher for checking if the incoming query is  "hybrid query". We need to add a special case when index alias filter is present and incoming query is a bool query that wraps hybrid query.

We're changing logic for nested fields case by making it similar to alias filters. Instead of simply removing filter query we're rewriting hybrid query and adding filter query to every sub-query 

In addition to new integ tests I've run few scenarios manually. Below is example that is similar to one reported in original GH issue:

Create index with keyword and integer fields, ingest following 8 documents:

```
POST /_bulk

{ "index": { "_index": "my-nlp-index" } }
{ "category": "permission", "doc_keyword": "workable", "doc_index": 4976, "doc_price": 100}
{ "index": { "_index": "my-nlp-index" } }
{ "category": "sister", "doc_keyword": "angry", "doc_index": 2231, "doc_price": 200 }
{ "index": { "_index": "my-nlp-index" } }
{ "category": "hair", "doc_keyword": "likeable", "doc_price": 25 }
{ "index": { "_index": "my-nlp-index" } }
{ "category": "editor", "doc_index": 9871, "doc_price": 30 }
{ "index": { "_index": "my-nlp-index" } }
{ "category": "statement", "doc_keyword": "entire", "doc_index": 8242, "doc_price": 350  } 
{ "index": { "_index": "my-nlp-index" } }
{ "category": "statement", "doc_keyword": "idea", "doc_index": 5212, "doc_price": 200  } 
{ "index": { "_index": "my-nlp-index" } }
{ "category": "editor", "doc_keyword": "bubble", "doc_index": 1298, "doc_price": 130 } 
{ "index": { "_index": "my-nlp-index" } }
{ "category": "editor", "doc_keyword": "bubble", "doc_index": 521, "doc_price": 75  } 
```

create new index alias with filter:

```
POST /_aliases
{
    "actions": [
        {
            "add": {
                "index": "my-nlp-index",
                "alias": "alias_filter_1",
                "filter": {
                    "bool": {
                        "must_not": {
                            "term": {
                                "category": "statement"
                            }
                        }
                    }
                }
            }
        }
    ]
}
```
run following query against index alias:
```
GET /alias_filter_1/_search?search_pipeline=nlp-search-pipeline
{
    "query": {
        "hybrid": {
            "queries": [
                {
                    "range": {
                        "doc_index": {
                            "gte": 20,
                            "lte": 100
                        }
                    }
                },
                {
                    "bool": {
                        "should": [
                            {
                                "match": {
                                    "doc_keyword": "likeable"
                                }
                            },
                            {
                                "term": {
                                    "category": "statement"
                                }
                            }
                        ]
                    }
                }
            ]
        }
    }
}
```
following is result of the query. filter has been applied, but it's not part of the query itself, it's  pulled based on the alias name:
```
{
    "took": 5,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 1,
            "relation": "eq"
        },
        "max_score": 0.5,
        "hits": [
            {
                "_index": "my-nlp-index",
                "_id": "jNJ7p44B1ntc6ZjxQK8q",
                "_score": 0.5,
                "_source": {
                    "category": "hair",
                    "doc_keyword": "likeable",
                    "doc_price": 25
                }
            }
        ]
    }
}
```

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/627

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] New functionality has been documented.
    - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
