### PR TITLE
Cleanup integ tests by removing redundant model uploads

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
@@ -86,12 +86,10 @@ public class NeuralQueryEnricherProcessorIT extends BaseNeuralSearchIT {
 
     @SneakyThrows
     public void testNeuralQueryEnricherProcessor_whenGetEmptyQueryBody_thenSuccess() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(index);
-            modelId = prepareModel();
-            createSearchRequestProcessor(modelId, search_pipeline);
-            createPipelineProcessor(modelId, ingest_pipeline, ProcessorType.TEXT_EMBEDDING);
+            createSearchRequestProcessor(null, search_pipeline);
+            createPipelineProcessor(null, ingest_pipeline, ProcessorType.TEXT_EMBEDDING);
             updateIndexSettings(index, Settings.builder().put("index.search.default_pipeline", search_pipeline));
             Request request = new Request("POST", "/" + index + "/_search");
             Response response = client().performRequest(request);
@@ -101,7 +99,7 @@ public class NeuralQueryEnricherProcessorIT extends BaseNeuralSearchIT {
             assertFalse(responseInMap.isEmpty());
             assertEquals(3, ((Map) responseInMap.get("hits")).size());
         } finally {
-            wipeOfTestResources(index, ingest_pipeline, modelId, search_pipeline);
+            wipeOfTestResources(index, ingest_pipeline, null, search_pipeline);
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -230,10 +230,8 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
 
     @SneakyThrows
     public void testResultProcessor_whenMultipleShardsAndNoMatches_thenSuccessful() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -249,16 +247,14 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             );
             assertQueryResults(searchResponseAsMap, 0, true);
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME, null, null, SEARCH_PIPELINE);
         }
     }
 
     @SneakyThrows
     public void testResultProcessor_whenMultipleShardsAndPartialMatches_thenSuccessful() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -275,7 +271,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             );
             assertQueryResults(searchResponseAsMap, 4, true, Range.between(0.33f, 1.0f));
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME, null, null, SEARCH_PIPELINE);
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
@@ -85,10 +85,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
      */
     @SneakyThrows
     public void testArithmeticWeightedMean_whenWeightsPassed_thenSuccessful() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME);
-            modelId = prepareModel();
             // check case when number of weights and sub-queries are same
             createSearchPipeline(
                 SEARCH_PIPELINE,
@@ -189,7 +187,7 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
                 )
             );
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME, null, null, SEARCH_PIPELINE);
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -131,10 +131,8 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
      */
     @SneakyThrows
     public void testComplexQuery_whenMultipleSubqueries_thenSuccessful() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
             TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4);
@@ -175,7 +173,7 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(total.get("relation"));
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, null, SEARCH_PIPELINE);
         }
     }
 
@@ -207,10 +205,8 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
      */
     @SneakyThrows
     public void testComplexQuery_whenMultipleIdenticalSubQueries_thenSuccessful() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
             TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4);
@@ -250,16 +246,14 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(total.get("relation"));
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, null, SEARCH_PIPELINE);
         }
     }
 
     @SneakyThrows
     public void testNoMatchResults_whenOnlyTermSubQueryWithoutMatch_thenEmptyResult() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_WITH_NESTED_FIELDS_INDEX_NAME);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT);
             TermQueryBuilder termQuery2Builder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT2);
@@ -285,16 +279,14 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(total.get("relation"));
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_WITH_NESTED_FIELDS_INDEX_NAME, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_WITH_NESTED_FIELDS_INDEX_NAME, null, null, SEARCH_PIPELINE);
         }
     }
 
     @SneakyThrows
     public void testNestedQuery_whenHybridQueryIsWrappedIntoOtherQuery_thenFail() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
             MatchQueryBuilder matchQuery2Builder = QueryBuilders.matchQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4);
@@ -338,16 +330,14 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
                 )
             );
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD, null, null, SEARCH_PIPELINE);
         }
     }
 
     @SneakyThrows
     public void testIndexWithNestedFields_whenHybridQuery_thenSuccess() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
             TermQueryBuilder termQuery2Builder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT2);
@@ -373,16 +363,14 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(total.get("relation"));
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD, null, null, SEARCH_PIPELINE);
         }
     }
 
     @SneakyThrows
     public void testIndexWithNestedFields_whenHybridQueryIncludesNested_thenSuccess() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT);
             NestedQueryBuilder nestedQueryBuilder = QueryBuilders.nestedQuery(
@@ -412,16 +400,14 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(total.get("relation"));
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_WITH_NESTED_TYPE_NAME_ONE_SHARD, null, null, SEARCH_PIPELINE);
         }
     }
 
     @SneakyThrows
     public void testRequestCache_whenOneShardAndQueryReturnResults_thenSuccessful() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_INDEX_WITH_KEYWORDS_ONE_SHARD);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery(KEYWORD_FIELD_1, KEYWORD_FIELD_2_VALUE);
             RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(INTEGER_FIELD_PRICE).gte(10).lte(1000);
@@ -494,16 +480,14 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(totalSecondQuery.get("relation"));
             assertEquals(RELATION_EQUAL_TO, totalSecondQuery.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_INDEX_WITH_KEYWORDS_ONE_SHARD, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_INDEX_WITH_KEYWORDS_ONE_SHARD, null, null, SEARCH_PIPELINE);
         }
     }
 
     @SneakyThrows
     public void testRequestCache_whenMultipleShardsQueryReturnResults_thenSuccessful() {
-        String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_INDEX_WITH_KEYWORDS_THREE_SHARDS);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery(KEYWORD_FIELD_1, KEYWORD_FIELD_2_VALUE);
             RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(INTEGER_FIELD_PRICE).gte(10).lte(1000);
@@ -576,7 +560,7 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertNotNull(totalSecondQuery.get("relation"));
             assertEquals(RELATION_EQUAL_TO, totalSecondQuery.get("relation"));
         } finally {
-            wipeOfTestResources(TEST_INDEX_WITH_KEYWORDS_THREE_SHARDS, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_INDEX_WITH_KEYWORDS_THREE_SHARDS, null, null, SEARCH_PIPELINE);
         }
     }
 


### PR DESCRIPTION
### Description
Cleaning integ tests by removing redundant model uploads. Model upload/delete consumes lot of resources including memory for keeping local model. 
That is a problem for jdk21 (default for distribution infra) as default GC may be slow with memory cleanup and tests will fail in environment with limited heap amount.

In this PR I've removed model upload from 12 out of 64 tests. Logic of these test remains unchanged, those models were not necessary as queries are text based (bm25) queries. 

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/667

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
