### PR TITLE
Optimizing integ tests for less model upload calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,13 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+3. Include tests that check your new feature or bug fix. Ideally, we're looking for unit, integration, and BWC tests, but that depends on how big and critical your change is. 
+If you're adding an integration test and it is using local ML models, please make sure that the number of model deployments is limited, and you're using the smallest possible model. 
+Each model deployment consumes resources, and having too many models may cause unexpected test failures.
+4. Ensure local tests pass.
+5. Commit to your fork using clear commit messages.
+6. Send us a pull request, answering any default questions in the pull request interface.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/AbstractRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/AbstractRollingUpgradeTestCase.java
@@ -130,4 +130,13 @@ public abstract class AbstractRollingUpgradeTestCase extends BaseNeuralSearchIT 
         );
         createPipelineProcessor(requestBody, pipelineName, modelId);
     }
+
+    @Override
+    protected void updateClusterSettings() {
+        updateClusterSettings("plugins.ml_commons.only_run_on_ml_node", false);
+        // default threshold for native circuit breaker is 90, it may be not enough on test runner machine
+        updateClusterSettings("plugins.ml_commons.native_memory_threshold", 100);
+        updateClusterSettings("plugins.ml_commons.jvm_heap_memory_threshold", 85);
+        updateClusterSettings("plugins.ml_commons.allow_registering_model_via_url", true);
+    }
 }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/AbstractRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/AbstractRollingUpgradeTestCase.java
@@ -130,13 +130,4 @@ public abstract class AbstractRollingUpgradeTestCase extends BaseNeuralSearchIT 
         );
         createPipelineProcessor(requestBody, pipelineName, modelId);
     }
-
-    @Override
-    protected void updateClusterSettings() {
-        updateClusterSettings("plugins.ml_commons.only_run_on_ml_node", false);
-        // default threshold for native circuit breaker is 90, it may be not enough on test runner machine
-        updateClusterSettings("plugins.ml_commons.native_memory_threshold", 100);
-        updateClusterSettings("plugins.ml_commons.jvm_heap_memory_threshold", 85);
-        updateClusterSettings("plugins.ml_commons.allow_registering_model_via_url", true);
-    }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -224,7 +224,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             // verify that all ids are unique
             assertEquals(Set.copyOf(ids).size(), ids.size());
 
-            // very case when there are partial match
+            // verify case when there are partial match
             HybridQueryBuilder hybridQueryBuilderPartialMatch = new HybridQueryBuilder();
             hybridQueryBuilderPartialMatch.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
             hybridQueryBuilderPartialMatch.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4));

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorIT.java
@@ -34,29 +34,19 @@ public class TextImageEmbeddingProcessorIT extends BaseNeuralSearchIT {
         updateClusterSettings();
     }
 
-    public void testEmbeddingProcessor_whenIngestingDocumentWithSourceMatchingTextMapping_thenSuccessful() throws Exception {
+    public void testEmbeddingProcessor_whenIngestingDocumentWithOrWithoutSourceMatchingMapping_thenSuccessful() throws Exception {
         String modelId = null;
         try {
             modelId = uploadModel();
             loadModel(modelId);
             createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_IMAGE_EMBEDDING);
             createTextImageEmbeddingIndex();
+            // verify doc with mapping
             ingestDocumentWithTextMappedToEmbeddingField();
             assertEquals(1, getDocCount(INDEX_NAME));
-        } finally {
-            wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
-        }
-    }
-
-    public void testEmbeddingProcessor_whenIngestingDocumentWithSourceWithoutMatchingInMapping_thenSuccessful() throws Exception {
-        String modelId = null;
-        try {
-            modelId = uploadModel();
-            loadModel(modelId);
-            createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_IMAGE_EMBEDDING);
-            createTextImageEmbeddingIndex();
+            // verify doc without mapping
             ingestDocumentWithoutMappedFields();
-            assertEquals(1, getDocCount(INDEX_NAME));
+            assertEquals(2, getDocCount(INDEX_NAME));
         } finally {
             wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
         }

--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessorIT.java
@@ -12,8 +12,6 @@ import java.util.Map;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicHeader;
-import org.junit.After;
-import org.junit.Before;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -36,33 +34,19 @@ public class MLOpenSearchRerankProcessorIT extends BaseNeuralSearchIT {
     private final static String TEXT_REP_1 = "Jacques loves fish. Fish make Jacques happy";
     private final static String TEXT_REP_2 = "Fish like to eat plankton";
     private final static String INDEX_CONFIG = "{\"mappings\": {\"properties\": {\"text_representation\": {\"type\": \"text\"}}}}";
-    private String modelId;
-
-    @After
-    @SneakyThrows
-    public void tearDown() {
-        super.tearDown();
-        /* this is required to minimize chance of model not being deployed due to open memory CB,
-         * this happens in case we leave model from previous test case. We use new model for every test, and old model
-         * can be undeployed and deleted to free resources after each test case execution.
-         */
-        deleteModel(modelId);
-        deleteSearchPipeline(PIPELINE_NAME);
-        deleteIndex(INDEX_NAME);
-    }
-
-    @Before
-    @SneakyThrows
-    public void setup() {
-        modelId = uploadTextSimilarityModel();
-        loadModel(modelId);
-    }
 
     @SneakyThrows
     public void testCrossEncoderRerankProcessor() {
-        createSearchPipelineViaConfig(modelId, PIPELINE_NAME, "processor/RerankMLOpenSearchPipelineConfiguration.json");
-        setupIndex();
-        runQueries();
+        String modelId = null;
+        try {
+            modelId = uploadTextSimilarityModel();
+            loadModel(modelId);
+            createSearchPipelineViaConfig(modelId, PIPELINE_NAME, "processor/RerankMLOpenSearchPipelineConfiguration.json");
+            setupIndex();
+            runQueries();
+        } finally {
+            wipeOfTestResources(INDEX_NAME, null, modelId, PIPELINE_NAME);
+        }
     }
 
     private String uploadTextSimilarityModel() throws Exception {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -566,28 +566,17 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
 
     @SneakyThrows
     public void testWrappedQueryWithFilter_whenIndexAliasHasFilterAndIndexWithNestedFields_thenSuccess() {
-        String modelId = null;
         String alias = "alias_with_filter";
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_WITH_NESTED_FIELDS_INDEX_NAME);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             // create alias for index
             QueryBuilder aliasFilter = QueryBuilders.boolQuery()
                 .mustNot(QueryBuilders.matchQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
             createIndexAlias(TEST_MULTI_DOC_WITH_NESTED_FIELDS_INDEX_NAME, alias, aliasFilter);
 
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                5,
-                null,
-                null
-            );
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
-            hybridQueryBuilder.add(neuralQueryBuilder);
+            hybridQueryBuilder.add(QueryBuilders.existsQuery(TEST_TEXT_FIELD_NAME_1));
 
             Map<String, Object> searchResponseAsMap = search(
                 alias,
@@ -608,34 +597,23 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
             deleteIndexAlias(TEST_MULTI_DOC_WITH_NESTED_FIELDS_INDEX_NAME, alias);
-            wipeOfTestResources(TEST_MULTI_DOC_WITH_NESTED_FIELDS_INDEX_NAME, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_WITH_NESTED_FIELDS_INDEX_NAME, null, null, SEARCH_PIPELINE);
         }
     }
 
     @SneakyThrows
     public void testWrappedQueryWithFilter_whenIndexAliasHasFilters_thenSuccess() {
-        String modelId = null;
         String alias = "alias_with_filter";
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_NAME);
-            modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             // create alias for index
             QueryBuilder aliasFilter = QueryBuilders.boolQuery()
                 .mustNot(QueryBuilders.matchQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
             createIndexAlias(TEST_MULTI_DOC_INDEX_NAME, alias, aliasFilter);
 
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                5,
-                null,
-                null
-            );
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
-            hybridQueryBuilder.add(neuralQueryBuilder);
+            hybridQueryBuilder.add(QueryBuilders.existsQuery(TEST_TEXT_FIELD_NAME_1));
 
             Map<String, Object> searchResponseAsMap = search(
                 alias,
@@ -656,7 +634,7 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             assertEquals(RELATION_EQUAL_TO, total.get("relation"));
         } finally {
             deleteIndexAlias(TEST_MULTI_DOC_INDEX_NAME, alias);
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME, null, modelId, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME, null, null, SEARCH_PIPELINE);
         }
     }
 
@@ -892,7 +870,15 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
             Collections.singletonList(TEST_DOC_TEXT2)
         );
-        assertEquals(3, getDocCount(testMultiDocIndexName));
+        addKnnDoc(
+            testMultiDocIndexName,
+            "4",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.singletonList(TEST_TEXT_FIELD_NAME_1),
+            Collections.singletonList(TEST_DOC_TEXT3)
+        );
+        assertEquals(4, getDocCount(testMultiDocIndexName));
     }
 
     private List<Map<String, Object>> getNestedHits(Map<String, Object> searchResponseAsMap) {

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryIT.java
@@ -42,40 +42,7 @@ public class NeuralSparseQueryIT extends BaseNeuralSearchIT {
     }
 
     /**
-     * Tests basic query:
-     * {
-     *     "query": {
-     *         "neural_sparse": {
-     *             "text_sparse": {
-     *                 "query_text": "Hello world a b",
-     *                 "model_id": "dcsdcasd"
-     *             }
-     *         }
-     *     }
-     * }
-     */
-    @SneakyThrows
-    public void testBasicQueryUsingQueryText() {
-        String modelId = null;
-        try {
-            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
-            modelId = prepareSparseEncodingModel();
-            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
-                .queryText(TEST_QUERY_TEXT)
-                .modelId(modelId);
-            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, sparseEncodingQueryBuilder, 1);
-            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
-
-            assertEquals("1", firstInnerHit.get("_id"));
-            float expectedScore = computeExpectedScore(modelId, testRankFeaturesDoc, TEST_QUERY_TEXT);
-            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
-        } finally {
-            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, null);
-        }
-    }
-
-    /**
-     * Tests basic query:
+     * Tests basic query with boost:
      * {
      *     "query": {
      *         "neural_sparse": {
@@ -89,7 +56,7 @@ public class NeuralSparseQueryIT extends BaseNeuralSearchIT {
      * }
      */
     @SneakyThrows
-    public void testBoostQuery() {
+    public void testBasicQueryUsingQueryText() {
         String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -82,6 +82,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         ProcessorType.TEXT_IMAGE_EMBEDDING,
         "processor/PipelineForTextImageEmbeddingProcessorConfiguration.json"
     );
+    private static final Set<RestStatus> SUCCESS_STATUSES = Set.of(RestStatus.CREATED, RestStatus.OK);
 
     protected final ClassLoader classLoader = this.getClass().getClassLoader();
 
@@ -114,6 +115,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         updateClusterSettings("plugins.ml_commons.only_run_on_ml_node", false);
         // default threshold for native circuit breaker is 90, it may be not enough on test runner machine
         updateClusterSettings("plugins.ml_commons.native_memory_threshold", 100);
+        updateClusterSettings("plugins.ml_commons.jvm_heap_memory_threshold", 95);
         updateClusterSettings("plugins.ml_commons.allow_registering_model_via_url", true);
     }
 
@@ -633,7 +635,10 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
         request.setJsonEntity(builder.toString());
         Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.CREATED, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        assertTrue(
+            request.getEndpoint() + ": failed",
+            SUCCESS_STATUSES.contains(RestStatus.fromCode(response.getStatusLine().getStatusCode()))
+        );
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
Refactored integration tests to minimize number of local model uploads/deployments. This is a first step in attempt to solve test failures in distribution build pipeline. With multiple model redeployments at some point we're reaching the state when memory circuit breaker on ml-commons side opens and next model upload call is failing.  

There is a separate issue opened for `ml-commons` for possible long term fix on their side https://github.com/opensearch-project/ml-commons/issues/2308. As of now there are no plans to work on it, as per their suggestions I'm trying to optimize tests on `neural-search` side.

In this PR I'm doing following:
 - replacing knn vector search queries with other types of queries, mainly bm25 text searchers
 - merging simple tests into a single method with multiple search queries. This should help as such single test method uses one model, while for multiple smaller methods there will be many model uploads. Now number of integ test methods lowered 64 -> 57.
 - increasing threshold for amount of memory that can be allocated for JVM heap in ml-commons. Default is 85%, I'm setting it to 95%. I tested it with 100%, it gives worse results, I assume that's because memory cannot be allocated to some code paths with native code.

Tested in copy of infra environment, tests are passing:

```
2024-04-10 22:12:51 INFO     ===============================================
2024-04-10 22:12:51 INFO     Running integration tests for neural-search without-security
2024-04-10 22:12:51 INFO     ===============================================
2024-04-10 22:12:51 INFO     Executing "bash /local/home/dev/opensearch/opensearch-build/scripts/default/integtest.sh -b localhost -p 9200 -s false -v 3.0.0" in /tmp/tmpvo11uccc/neural-search
2024-04-10 22:16:48 INFO     Recording component test results for neural-search at /local/home/dev/opensearch/opensearch-build/test-results/32ef973a0cb743f5bf2f8c29df105e83/integ-test/neural-search/without-security
2024-04-10 22:16:48 INFO     Stderr reported for component: neural-search
2024-04-10 22:16:48 INFO     Note: /tmp/tmpvo11uccc/neural-search/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationUtil.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Apr 10, 2024 10:13:26 PM sun.util.locale.provider.LocaleProviderAdapter <clinit>
WARNING: COMPAT locale provider will be removed in a future release

2024-04-10 22:16:48 INFO     Sending SIGKILL to PID 2755
2024-04-10 22:16:48 INFO     Process killed with exit code None
2024-04-10 22:16:48 INFO     Recording local cluster logs for neural-search with test configuration as without-security at /local/home/dev/opensearch/opensearch-build/test-results/32ef973a0cb743f5bf2f8c29df105e83/integ-test/neural-search/without-security/local-cluster-logs/id-0
2024-04-10 22:16:48 INFO     Cleanup /tmp/tmpvo11uccc/1/local-test-cluster/opensearch-3.0.0 content after the test
2024-04-10 22:16:48 INFO     Walking tree from /local/home/dev/opensearch/opensearch-build/test-results/32ef973a0cb743f5bf2f8c29df105e83/integ-test/neural-search/without-security
2024-04-10 22:16:48 INFO     Removing /tmp/tmpvo11uccc
2024-04-10 22:16:48 INFO     | neural-search        | without-security     | PASS  |
``` 

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/667

### Check List
- [ ] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
