### PR TITLE
fix map type validation issue in processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use lazy initialization for priority queue of hits and scores to improve latencies by 20% ([#746](https://github.com/opensearch-project/neural-search/pull/746))
 ### Bug Fixes
 - Total hit count fix in Hybrid Query ([756](https://github.com/opensearch-project/neural-search/pull/756))
+- Fix map type validation issue in multiple pipeline processors ([#661](https://github.com/opensearch-project/neural-search/pull/661))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -112,9 +112,9 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
         clientAccessor = new MLCommonsClientAccessor(new MachineLearningNodeClient(parameters.client));
         return Map.of(
             TextEmbeddingProcessor.TYPE,
-            new TextEmbeddingProcessorFactory(clientAccessor, parameters.env),
+            new TextEmbeddingProcessorFactory(clientAccessor, parameters.env, parameters.ingestService.getClusterService()),
             SparseEncodingProcessor.TYPE,
-            new SparseEncodingProcessorFactory(clientAccessor, parameters.env),
+            new SparseEncodingProcessorFactory(clientAccessor, parameters.env, parameters.ingestService.getClusterService()),
             TextImageEmbeddingProcessor.TYPE,
             new TextImageEmbeddingProcessorFactory(clientAccessor, parameters.env, parameters.ingestService.getClusterService()),
             TextChunkingProcessor.TYPE,

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -25,6 +25,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
+import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
@@ -333,12 +334,15 @@ public abstract class InferenceProcessor extends AbstractProcessor {
 
     private void validateEmbeddingFieldsValue(IngestDocument ingestDocument) {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
+        String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
         ProcessorDocumentUtils.validateMapTypeValue(
             "field_map",
             sourceAndMetadataMap,
             fieldMap,
             1,
-            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
+            indexName,
+            clusterService,
+            environment,
             false
         );
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -339,7 +339,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
             fieldMap,
             1,
             ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
-            true
+            false
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -119,12 +119,12 @@ public abstract class InferenceProcessor extends AbstractProcessor {
     public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
         try {
             validateEmbeddingFieldsValue(ingestDocument);
-            Map<String, Object> ProcessMap = buildMapWithTargetKeyAndOriginalValue(ingestDocument);
-            List<String> inferenceList = createInferenceList(ProcessMap);
+            Map<String, Object> processMap = buildMapWithTargetKeyAndOriginalValue(ingestDocument);
+            List<String> inferenceList = createInferenceList(processMap);
             if (inferenceList.size() == 0) {
                 handler.accept(ingestDocument, null);
             } else {
-                doExecute(ingestDocument, ProcessMap, inferenceList, handler);
+                doExecute(ingestDocument, processMap, inferenceList, handler);
             }
         } catch (Exception e) {
             handler.accept(null, e);
@@ -338,7 +338,8 @@ public abstract class InferenceProcessor extends AbstractProcessor {
             sourceAndMetadataMap,
             fieldMap,
             1,
-            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment)
+            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
+            true
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -339,7 +339,6 @@ public abstract class InferenceProcessor extends AbstractProcessor {
             FIELD_MAP_FIELD,
             sourceAndMetadataMap,
             fieldMap,
-            1,
             indexName,
             clusterService,
             environment,

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -336,7 +336,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
         String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
         ProcessorDocumentUtils.validateMapTypeValue(
-            "field_map",
+            FIELD_MAP_FIELD,
             sourceAndMetadataMap,
             fieldMap,
             1,

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -24,8 +23,8 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
@@ -35,6 +34,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
 import lombok.extern.log4j.Log4j2;
+import org.opensearch.neuralsearch.util.ProcessorDocumentUtils;
 
 /**
  * The abstract class for text processing use cases. Users provide a field name map and a model id.
@@ -60,6 +60,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
     protected final MLCommonsClientAccessor mlCommonsClientAccessor;
 
     private final Environment environment;
+    private final ClusterService clusterService;
 
     public InferenceProcessor(
         String tag,
@@ -69,18 +70,19 @@ public abstract class InferenceProcessor extends AbstractProcessor {
         String modelId,
         Map<String, Object> fieldMap,
         MLCommonsClientAccessor clientAccessor,
-        Environment environment
+        Environment environment,
+        ClusterService clusterService
     ) {
         super(tag, description);
         this.type = type;
         if (StringUtils.isBlank(modelId)) throw new IllegalArgumentException("model_id is null or empty, cannot process it");
         validateEmbeddingConfiguration(fieldMap);
-
         this.listTypeNestedMapKey = listTypeNestedMapKey;
         this.modelId = modelId;
         this.fieldMap = fieldMap;
         this.mlCommonsClientAccessor = clientAccessor;
         this.environment = environment;
+        this.clusterService = clusterService;
     }
 
     private void validateEmbeddingConfiguration(Map<String, Object> fieldMap) {
@@ -117,7 +119,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
     public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
         try {
             validateEmbeddingFieldsValue(ingestDocument);
-            Map<String, Object> ProcessMap = buildMapWithProcessorKeyAndOriginalValue(ingestDocument);
+            Map<String, Object> ProcessMap = buildMapWithTargetKeyAndOriginalValue(ingestDocument);
             List<String> inferenceList = createInferenceList(ProcessMap);
             if (inferenceList.size() == 0) {
                 handler.accept(ingestDocument, null);
@@ -225,7 +227,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
             List<String> inferenceList = null;
             try {
                 validateEmbeddingFieldsValue(ingestDocumentWrapper.getIngestDocument());
-                processMap = buildMapWithProcessorKeyAndOriginalValue(ingestDocumentWrapper.getIngestDocument());
+                processMap = buildMapWithTargetKeyAndOriginalValue(ingestDocumentWrapper.getIngestDocument());
                 inferenceList = createInferenceList(processMap);
             } catch (Exception e) {
                 ingestDocumentWrapper.update(ingestDocumentWrapper.getIngestDocument(), e);
@@ -273,7 +275,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
     }
 
     @VisibleForTesting
-    Map<String, Object> buildMapWithProcessorKeyAndOriginalValue(IngestDocument ingestDocument) {
+    Map<String, Object> buildMapWithTargetKeyAndOriginalValue(IngestDocument ingestDocument) {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
         Map<String, Object> mapWithProcessorKeys = new LinkedHashMap<>();
         for (Map.Entry<String, Object> fieldMapEntry : fieldMap.entrySet()) {
@@ -331,54 +333,13 @@ public abstract class InferenceProcessor extends AbstractProcessor {
 
     private void validateEmbeddingFieldsValue(IngestDocument ingestDocument) {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
-        for (Map.Entry<String, Object> embeddingFieldsEntry : fieldMap.entrySet()) {
-            Object sourceValue = sourceAndMetadataMap.get(embeddingFieldsEntry.getKey());
-            if (sourceValue != null) {
-                String sourceKey = embeddingFieldsEntry.getKey();
-                Class<?> sourceValueClass = sourceValue.getClass();
-                if (List.class.isAssignableFrom(sourceValueClass) || Map.class.isAssignableFrom(sourceValueClass)) {
-                    validateNestedTypeValue(sourceKey, sourceValue, () -> 1);
-                } else if (!String.class.isAssignableFrom(sourceValueClass)) {
-                    throw new IllegalArgumentException("field [" + sourceKey + "] is neither string nor nested type, cannot process it");
-                } else if (StringUtils.isBlank(sourceValue.toString())) {
-                    throw new IllegalArgumentException("field [" + sourceKey + "] has empty string value, cannot process it");
-                }
-            }
-        }
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    private void validateNestedTypeValue(String sourceKey, Object sourceValue, Supplier<Integer> maxDepthSupplier) {
-        int maxDepth = maxDepthSupplier.get();
-        if (maxDepth > MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.get(environment.settings())) {
-            throw new IllegalArgumentException("map type field [" + sourceKey + "] reached max depth limit, cannot process it");
-        } else if ((List.class.isAssignableFrom(sourceValue.getClass()))) {
-            validateListTypeValue(sourceKey, sourceValue, maxDepthSupplier);
-        } else if (Map.class.isAssignableFrom(sourceValue.getClass())) {
-            ((Map) sourceValue).values()
-                .stream()
-                .filter(Objects::nonNull)
-                .forEach(x -> validateNestedTypeValue(sourceKey, x, () -> maxDepth + 1));
-        } else if (!String.class.isAssignableFrom(sourceValue.getClass())) {
-            throw new IllegalArgumentException("map type field [" + sourceKey + "] has non-string type, cannot process it");
-        } else if (StringUtils.isBlank(sourceValue.toString())) {
-            throw new IllegalArgumentException("map type field [" + sourceKey + "] has empty string, cannot process it");
-        }
-    }
-
-    @SuppressWarnings({ "rawtypes" })
-    private void validateListTypeValue(String sourceKey, Object sourceValue, Supplier<Integer> maxDepthSupplier) {
-        for (Object value : (List) sourceValue) {
-            if (value instanceof Map) {
-                validateNestedTypeValue(sourceKey, value, () -> maxDepthSupplier.get() + 1);
-            } else if (value == null) {
-                throw new IllegalArgumentException("list type field [" + sourceKey + "] has null, cannot process it");
-            } else if (!(value instanceof String)) {
-                throw new IllegalArgumentException("list type field [" + sourceKey + "] has non string value, cannot process it");
-            } else if (StringUtils.isBlank(value.toString())) {
-                throw new IllegalArgumentException("list type field [" + sourceKey + "] has empty string, cannot process it");
-            }
-        }
+        ProcessorDocumentUtils.validateMapTypeValue(
+            "field_map",
+            sourceAndMetadataMap,
+            fieldMap,
+            1,
+            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment)
+        );
     }
 
     protected void setVectorFieldsToDocument(IngestDocument ingestDocument, Map<String, Object> processorMap, List<?> results) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.IngestDocument;
@@ -33,9 +34,10 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
         String modelId,
         Map<String, Object> fieldMap,
         MLCommonsClientAccessor clientAccessor,
-        Environment environment
+        Environment environment,
+        ClusterService clusterService
     ) {
-        super(tag, description, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment);
+        super(tag, description, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -169,7 +169,8 @@ public final class TextChunkingProcessor extends AbstractProcessor {
             sourceAndMetadataMap,
             fieldMap,
             1,
-            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment)
+            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
+            false
         );
         // fixed token length algorithm needs runtime parameter max_token_count for tokenization
         Map<String, Object> runtimeParameters = new HashMap<>();
@@ -287,7 +288,13 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         // leaf type means null, String or List<String>
         // the result should be an empty list when the input is null
         List<String> result = new ArrayList<>();
+        if (value == null) {
+            return result;
+        }
         if (value instanceof String) {
+            if (StringUtils.isBlank(String.valueOf(value))) {
+                return result;
+            }
             result = chunkString(value.toString(), runTimeParameters);
         } else if (isListOfString(value)) {
             result = chunkList((List<String>) value, runTimeParameters);

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -170,7 +170,7 @@ public final class TextChunkingProcessor extends AbstractProcessor {
             fieldMap,
             1,
             ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
-            false
+            true
         );
         // fixed token length algorithm needs runtime parameter max_token_count for tokenization
         Map<String, Object> runtimeParameters = new HashMap<>();

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -169,7 +169,6 @@ public final class TextChunkingProcessor extends AbstractProcessor {
             FIELD_MAP_FIELD,
             sourceAndMetadataMap,
             fieldMap,
-            1,
             indexName,
             clusterService,
             environment,

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -166,7 +166,7 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
         String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
         ProcessorDocumentUtils.validateMapTypeValue(
-            "field_map",
+            FIELD_MAP_FIELD,
             sourceAndMetadataMap,
             fieldMap,
             1,

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -164,12 +164,15 @@ public final class TextChunkingProcessor extends AbstractProcessor {
     @Override
     public IngestDocument execute(final IngestDocument ingestDocument) {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
+        String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
         ProcessorDocumentUtils.validateMapTypeValue(
             "field_map",
             sourceAndMetadataMap,
             fieldMap,
             1,
-            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
+            indexName,
+            clusterService,
+            environment,
             true
         );
         // fixed token length algorithm needs runtime parameter max_token_count for tokenization

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -17,7 +17,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.env.Environment;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.index.analysis.AnalysisRegistry;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
@@ -25,6 +24,7 @@ import org.opensearch.neuralsearch.processor.chunker.Chunker;
 import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.neuralsearch.processor.chunker.ChunkerFactory;
 import org.opensearch.neuralsearch.processor.chunker.FixedTokenLengthChunker;
+import org.opensearch.neuralsearch.util.ProcessorDocumentUtils;
 
 import static org.opensearch.neuralsearch.processor.chunker.Chunker.MAX_CHUNK_LIMIT_FIELD;
 import static org.opensearch.neuralsearch.processor.chunker.Chunker.DEFAULT_MAX_CHUNK_LIMIT;
@@ -164,7 +164,13 @@ public final class TextChunkingProcessor extends AbstractProcessor {
     @Override
     public IngestDocument execute(final IngestDocument ingestDocument) {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
-        validateFieldsValue(sourceAndMetadataMap);
+        ProcessorDocumentUtils.validateMapTypeValue(
+            "field_map",
+            sourceAndMetadataMap,
+            fieldMap,
+            1,
+            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment)
+        );
         // fixed token length algorithm needs runtime parameter max_token_count for tokenization
         Map<String, Object> runtimeParameters = new HashMap<>();
         int maxTokenCount = getMaxTokenCount(sourceAndMetadataMap);
@@ -174,59 +180,6 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         runtimeParameters.put(CHUNK_STRING_COUNT_FIELD, chunkStringCount);
         chunkMapType(sourceAndMetadataMap, fieldMap, runtimeParameters);
         return ingestDocument;
-    }
-
-    private void validateFieldsValue(final Map<String, Object> sourceAndMetadataMap) {
-        for (Map.Entry<String, Object> embeddingFieldsEntry : fieldMap.entrySet()) {
-            Object sourceValue = sourceAndMetadataMap.get(embeddingFieldsEntry.getKey());
-            if (Objects.nonNull(sourceValue)) {
-                String sourceKey = embeddingFieldsEntry.getKey();
-                if (sourceValue instanceof List || sourceValue instanceof Map) {
-                    validateNestedTypeValue(sourceKey, sourceValue, 1);
-                } else if (!(sourceValue instanceof String)) {
-                    throw new IllegalArgumentException(
-                        String.format(Locale.ROOT, "field [%s] is neither string nor nested type, cannot process it", sourceKey)
-                    );
-                }
-            }
-        }
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    private void validateNestedTypeValue(final String sourceKey, final Object sourceValue, final int maxDepth) {
-        if (maxDepth > MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.get(environment.settings())) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "map type field [%s] reached max depth limit, cannot process it", sourceKey)
-            );
-        } else if (sourceValue instanceof List) {
-            validateListTypeValue(sourceKey, sourceValue, maxDepth);
-        } else if (sourceValue instanceof Map) {
-            ((Map) sourceValue).values()
-                .stream()
-                .filter(Objects::nonNull)
-                .forEach(x -> validateNestedTypeValue(sourceKey, x, maxDepth + 1));
-        } else if (!(sourceValue instanceof String)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "map type field [%s] has non-string type, cannot process it", sourceKey)
-            );
-        }
-    }
-
-    @SuppressWarnings({ "rawtypes" })
-    private void validateListTypeValue(final String sourceKey, final Object sourceValue, final int maxDepth) {
-        for (Object value : (List) sourceValue) {
-            if (value instanceof Map) {
-                validateNestedTypeValue(sourceKey, value, maxDepth + 1);
-            } else if (value == null) {
-                throw new IllegalArgumentException(
-                    String.format(Locale.ROOT, "list type field [%s] has null, cannot process it", sourceKey)
-                );
-            } else if (!(value instanceof String)) {
-                throw new IllegalArgumentException(
-                    String.format(Locale.ROOT, "list type field [%s] has non-string value, cannot process it", sourceKey)
-                );
-            }
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.IngestDocument;
@@ -32,9 +33,10 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
         String modelId,
         Map<String, Object> fieldMap,
         MLCommonsClientAccessor clientAccessor,
-        Environment environment
+        Environment environment,
+        ClusterService clusterService
     ) {
-        super(tag, description, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment);
+        super(tag, description, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -177,7 +177,6 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
             FIELD_MAP_FIELD,
             sourceAndMetadataMap,
             fieldMap,
-            1,
             indexName,
             clusterService,
             environment,

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -176,7 +176,8 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
             sourceAndMetadataMap,
             fieldMap,
             1,
-            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment)
+            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
+            true
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -177,7 +177,7 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
             fieldMap,
             1,
             ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
-            true
+            false
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -174,7 +174,7 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
         String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
         ProcessorDocumentUtils.validateMapTypeValue(
-            "field_map",
+            FIELD_MAP_FIELD,
             sourceAndMetadataMap,
             fieldMap,
             1,

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
+import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
@@ -171,12 +172,15 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
 
     private void validateEmbeddingFieldsValue(final IngestDocument ingestDocument) {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
+        String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
         ProcessorDocumentUtils.validateMapTypeValue(
             "field_map",
             sourceAndMetadataMap,
             fieldMap,
             1,
-            ProcessorDocumentUtils.getMaxDepth(sourceAndMetadataMap, clusterService, environment),
+            indexName,
+            clusterService,
+            environment,
             false
         );
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/SparseEncodingProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/SparseEncodingProcessorFactory.java
@@ -12,6 +12,7 @@ import static org.opensearch.neuralsearch.processor.TextEmbeddingProcessor.FIELD
 
 import java.util.Map;
 
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
@@ -26,10 +27,12 @@ import lombok.extern.log4j.Log4j2;
 public class SparseEncodingProcessorFactory implements Processor.Factory {
     private final MLCommonsClientAccessor clientAccessor;
     private final Environment environment;
+    private final ClusterService clusterService;
 
-    public SparseEncodingProcessorFactory(MLCommonsClientAccessor clientAccessor, Environment environment) {
+    public SparseEncodingProcessorFactory(MLCommonsClientAccessor clientAccessor, Environment environment, ClusterService clusterService) {
         this.clientAccessor = clientAccessor;
         this.environment = environment;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -42,6 +45,6 @@ public class SparseEncodingProcessorFactory implements Processor.Factory {
         String modelId = readStringProperty(TYPE, processorTag, config, MODEL_ID_FIELD);
         Map<String, Object> fieldMap = readMap(TYPE, processorTag, config, FIELD_MAP_FIELD);
 
-        return new SparseEncodingProcessor(processorTag, description, modelId, fieldMap, clientAccessor, environment);
+        return new SparseEncodingProcessor(processorTag, description, modelId, fieldMap, clientAccessor, environment, clusterService);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/TextEmbeddingProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/TextEmbeddingProcessorFactory.java
@@ -12,6 +12,7 @@ import static org.opensearch.neuralsearch.processor.TextEmbeddingProcessor.FIELD
 
 import java.util.Map;
 
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
@@ -26,9 +27,16 @@ public class TextEmbeddingProcessorFactory implements Processor.Factory {
 
     private final Environment environment;
 
-    public TextEmbeddingProcessorFactory(final MLCommonsClientAccessor clientAccessor, final Environment environment) {
+    private final ClusterService clusterService;
+
+    public TextEmbeddingProcessorFactory(
+        final MLCommonsClientAccessor clientAccessor,
+        final Environment environment,
+        final ClusterService clusterService
+    ) {
         this.clientAccessor = clientAccessor;
         this.environment = environment;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -40,6 +48,6 @@ public class TextEmbeddingProcessorFactory implements Processor.Factory {
     ) throws Exception {
         String modelId = readStringProperty(TYPE, processorTag, config, MODEL_ID_FIELD);
         Map<String, Object> filedMap = readMap(TYPE, processorTag, config, FIELD_MAP_FIELD);
-        return new TextEmbeddingProcessor(processorTag, description, modelId, filedMap, clientAccessor, environment);
+        return new TextEmbeddingProcessor(processorTag, description, modelId, filedMap, clientAccessor, environment, clusterService);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.Environment;
+import org.opensearch.index.mapper.IndexFieldMapper;
+import org.opensearch.index.mapper.MapperService;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+public class ProcessorDocumentUtils {
+
+    public static long getMaxDepth(Map<String, Object> sourceAndMetadataMap, ClusterService clusterService, Environment environment) {
+        String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
+        IndexMetadata indexMetadata = clusterService.state().metadata().index(indexName);
+        if (indexMetadata != null) {
+            Settings settings = indexMetadata.getSettings();
+            return MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.get(settings);
+        }
+        return MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.get(environment.settings());
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static void validateMapTypeValue(
+        final String sourceKey,
+        final Map<String, Object> sourceValue,
+        final Object fieldMap,
+        final int depth,
+        final long maxDepth
+    ) {
+        if (sourceValue == null) return; // allow map type value to be null.
+        validateDepth(sourceKey, depth, maxDepth);
+        if (!(fieldMap instanceof Map)) { // source value is map type means configuration has to be map type
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.getDefault(),
+                    "[%s] configuration doesn't match actual value type, configuration type is: %s, actual value type is: %s",
+                    sourceKey,
+                    fieldMap.getClass().getName(),
+                    sourceValue.getClass().getName()
+                )
+            );
+        }
+        // next level validation, only validate the keys in configuration.
+        ((Map<String, Object>) fieldMap).forEach((key, nextFieldMap) -> {
+            Object nextSourceValue = sourceValue.get(key);
+            if (nextSourceValue != null) {
+                if (nextSourceValue instanceof List) {
+                    validateListTypeValue(key, (List) nextSourceValue, fieldMap, depth + 1, maxDepth);
+                } else if (nextSourceValue instanceof Map) {
+                    validateMapTypeValue(key, (Map<String, Object>) nextSourceValue, nextFieldMap, depth + 1, maxDepth);
+                } else if (!(nextSourceValue instanceof String)) {
+                    throw new IllegalArgumentException("map type field [" + key + "] is neither string nor nested type, cannot process it");
+                } else if (StringUtils.isBlank((String) nextSourceValue)) {
+                    throw new IllegalArgumentException("map type field [" + key + "] has empty string value, cannot process it");
+                }
+            }
+        });
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static void validateListTypeValue(String sourceKey, List sourceValue, Object fieldMap, int depth, long maxDepth) {
+        validateDepth(sourceKey, depth, maxDepth);
+        if (sourceValue == null || sourceValue.isEmpty()) return;
+        Object firstNonNullElement = sourceValue.stream().filter(Objects::nonNull).findFirst().orElse(null);
+        if (firstNonNullElement == null) return;
+        for (Object element : sourceValue) {
+            if (firstNonNullElement instanceof List) { // nested list case.
+                validateListTypeValue(sourceKey, (List) element, fieldMap, depth + 1, maxDepth);
+            } else if (firstNonNullElement instanceof Map) {
+                validateMapTypeValue(sourceKey, (Map<String, Object>) element, ((Map) fieldMap).get(sourceKey), depth + 1, maxDepth);
+            } else if (!(firstNonNullElement instanceof String)) {
+                throw new IllegalArgumentException("list type field [" + sourceKey + "] has non string value, cannot process it");
+            } else {
+                if (element == null) {
+                    throw new IllegalArgumentException("list type field [" + sourceKey + "] has null, cannot process it");
+                } else if (!(element instanceof String)) {
+                    throw new IllegalArgumentException("list type field [" + sourceKey + "] has non string value, cannot process it");
+                } else if (StringUtils.isBlank(element.toString())) {
+                    throw new IllegalArgumentException("list type field [" + sourceKey + "] has empty string, cannot process it");
+                }
+            }
+        }
+    }
+
+    private static void validateDepth(String sourceKey, int depth, long maxDepth) {
+        if (depth > maxDepth) {
+            throw new IllegalArgumentException("map type field [" + sourceKey + "] reached max depth limit, cannot process it");
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
@@ -30,14 +30,25 @@ public class ProcessorDocumentUtils {
      * @param  sourceKey    the key of the source map being validated, the first level is always the "field_map" key.
      * @param  sourceValue  the source map being validated, the first level is always the sourceAndMetadataMap.
      * @param  fieldMap     the configuration map for validation, the first level is always the value of "field_map" in the processor configuration.
-     * @param  depth        the current depth of recursion
      * @param  clusterService cluster service passed from OpenSearch core.
      * @param  environment   environment passed from OpenSearch core.
      * @param  indexName     the maximum allowed depth for recursion
      * @param  allowEmpty   flag to allow empty values in map type validation.
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     public static void validateMapTypeValue(
+        final String sourceKey,
+        final Map<String, Object> sourceValue,
+        final Object fieldMap,
+        final String indexName,
+        final ClusterService clusterService,
+        final Environment environment,
+        final boolean allowEmpty
+    ) {
+        validateMapTypeValue(sourceKey, sourceValue, fieldMap, 1, indexName, clusterService, environment, allowEmpty);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static void validateMapTypeValue(
         final String sourceKey,
         final Map<String, Object> sourceValue,
         final Object fieldMap,

--- a/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
@@ -15,6 +15,7 @@ import org.opensearch.index.mapper.MapperService;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -58,7 +59,9 @@ public class ProcessorDocumentUtils {
         final Environment environment,
         final boolean allowEmpty
     ) {
-        if (sourceValue == null) return; // allow map type value to be null.
+        if (Objects.isNull(sourceValue)) { // allow map type value to be null.
+            return;
+        }
         validateDepth(sourceKey, depth, indexName, clusterService, environment);
         if (!(fieldMap instanceof Map)) { // source value is map type means configuration has to be map type
             throw new IllegalArgumentException(
@@ -98,9 +101,9 @@ public class ProcessorDocumentUtils {
                         allowEmpty
                     );
                 } else if (!(nextSourceValue instanceof String)) {
-                    throw new IllegalArgumentException("map type field [" + key + "] is neither string nor nested type, cannot process it");
+                    throw new IllegalArgumentException(String.format(Locale.getDefault(), "map type field [%s] is neither string nor nested type, cannot process it", key));
                 } else if (!allowEmpty && StringUtils.isBlank((String) nextSourceValue)) {
-                    throw new IllegalArgumentException("map type field [" + key + "] has empty string value, cannot process it");
+                    throw new IllegalArgumentException(String.format(Locale.getDefault(), "map type field [%s] has empty string value, cannot process it", key));
                 }
             }
         });
@@ -118,13 +121,15 @@ public class ProcessorDocumentUtils {
         final boolean allowEmpty
     ) {
         validateDepth(sourceKey, depth, indexName, clusterService, environment);
-        if (CollectionUtils.isEmpty(sourceValue)) return;
+        if (CollectionUtils.isEmpty(sourceValue)) {
+            return;
+        }
         for (Object element : sourceValue) {
-            if (element == null) {
-                throw new IllegalArgumentException("list type field [" + sourceKey + "] has null, cannot process it");
+            if (Objects.isNull(element)) {
+                throw new IllegalArgumentException(String.format(Locale.getDefault(), "list type field [%s] has null, cannot process it", sourceKey));
             }
             if (element instanceof List) { // nested list case.
-                throw new IllegalArgumentException("list type field [" + sourceKey + "] is nested list type, cannot process it");
+                throw new IllegalArgumentException(String.format(Locale.getDefault(), "list type field [%s] is nested list type, cannot process it", sourceKey));
             } else if (element instanceof Map) {
                 validateMapTypeValue(
                     sourceKey,
@@ -137,9 +142,9 @@ public class ProcessorDocumentUtils {
                     allowEmpty
                 );
             } else if (!(element instanceof String)) {
-                throw new IllegalArgumentException("list type field [" + sourceKey + "] has non string value, cannot process it");
+                throw new IllegalArgumentException(String.format(Locale.getDefault(), "list type field [%s] has non string value, cannot process it", sourceKey));
             } else if (!allowEmpty && StringUtils.isBlank(element.toString())) {
-                throw new IllegalArgumentException("list type field [" + sourceKey + "] has empty string, cannot process it");
+                throw new IllegalArgumentException(String.format(Locale.getDefault(), "list type field [%s] has empty string, cannot process it", sourceKey));
             }
         }
     }
@@ -156,7 +161,7 @@ public class ProcessorDocumentUtils {
             .orElse(environment.settings());
         long maxDepth = MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.get(settings);
         if (depth > maxDepth) {
-            throw new IllegalArgumentException("map type field [" + sourceKey + "] reaches max depth limit, cannot process it");
+            throw new IllegalArgumentException(String.format(Locale.getDefault(), "map type field [%s] reaches max depth limit, cannot process it", sourceKey));
         }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
@@ -66,7 +66,7 @@ public class ProcessorDocumentUtils {
         if (!(fieldMap instanceof Map)) { // source value is map type means configuration has to be map type
             throw new IllegalArgumentException(
                 String.format(
-                    Locale.getDefault(),
+                    Locale.ROOT,
                     "[%s] configuration doesn't match actual value type, configuration type is: %s, actual value type is: %s",
                     sourceKey,
                     fieldMap.getClass().getName(),
@@ -101,9 +101,9 @@ public class ProcessorDocumentUtils {
                         allowEmpty
                     );
                 } else if (!(nextSourceValue instanceof String)) {
-                    throw new IllegalArgumentException(String.format(Locale.getDefault(), "map type field [%s] is neither string nor nested type, cannot process it", key));
+                    throw new IllegalArgumentException(String.format(Locale.ROOT, "map type field [%s] is neither string nor nested type, cannot process it", key));
                 } else if (!allowEmpty && StringUtils.isBlank((String) nextSourceValue)) {
-                    throw new IllegalArgumentException(String.format(Locale.getDefault(), "map type field [%s] has empty string value, cannot process it", key));
+                    throw new IllegalArgumentException(String.format(Locale.ROOT, "map type field [%s] has empty string value, cannot process it", key));
                 }
             }
         });
@@ -126,10 +126,10 @@ public class ProcessorDocumentUtils {
         }
         for (Object element : sourceValue) {
             if (Objects.isNull(element)) {
-                throw new IllegalArgumentException(String.format(Locale.getDefault(), "list type field [%s] has null, cannot process it", sourceKey));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "list type field [%s] has null, cannot process it", sourceKey));
             }
             if (element instanceof List) { // nested list case.
-                throw new IllegalArgumentException(String.format(Locale.getDefault(), "list type field [%s] is nested list type, cannot process it", sourceKey));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "list type field [%s] is nested list type, cannot process it", sourceKey));
             } else if (element instanceof Map) {
                 validateMapTypeValue(
                     sourceKey,
@@ -142,9 +142,9 @@ public class ProcessorDocumentUtils {
                     allowEmpty
                 );
             } else if (!(element instanceof String)) {
-                throw new IllegalArgumentException(String.format(Locale.getDefault(), "list type field [%s] has non string value, cannot process it", sourceKey));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "list type field [%s] has non string value, cannot process it", sourceKey));
             } else if (!allowEmpty && StringUtils.isBlank(element.toString())) {
-                throw new IllegalArgumentException(String.format(Locale.getDefault(), "list type field [%s] has empty string, cannot process it", sourceKey));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "list type field [%s] has empty string, cannot process it", sourceKey));
             }
         }
     }
@@ -161,7 +161,7 @@ public class ProcessorDocumentUtils {
             .orElse(environment.settings());
         long maxDepth = MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.get(settings);
         if (depth > maxDepth) {
-            throw new IllegalArgumentException(String.format(Locale.getDefault(), "map type field [%s] reaches max depth limit, cannot process it", sourceKey));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "map type field [%s] reaches max depth limit, cannot process it", sourceKey));
         }
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTestCase.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.processor;
 
 import com.google.common.collect.ImmutableList;
+import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
 import org.opensearch.test.OpenSearchTestCase;
@@ -21,6 +22,7 @@ public class InferenceProcessorTestCase extends OpenSearchTestCase {
         for (int i = 0; i < count; ++i) {
             Map<String, Object> sourceAndMetadata = new HashMap<>();
             sourceAndMetadata.put("key1", "value1");
+            sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
             wrapperList.add(new IngestDocumentWrapper(i, new IngestDocument(sourceAndMetadata, new HashMap<>()), null));
         }
         return wrapperList;

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
@@ -7,6 +7,7 @@ package org.opensearch.neuralsearch.processor;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
@@ -24,6 +25,7 @@ import java.util.function.Consumer;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,6 +34,8 @@ import static org.mockito.Mockito.when;
 public class InferenceProcessorTests extends InferenceProcessorTestCase {
     private MLCommonsClientAccessor clientAccessor;
     private Environment environment;
+
+    private ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
 
     private static final String TAG = "tag";
     private static final String TYPE = "type";
@@ -175,7 +179,7 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
         Exception exception;
 
         public TestInferenceProcessor(List<?> vectors, Exception exception) {
-            super(TAG, DESCRIPTION, TYPE, MAP_KEY, MODEL_ID, FIELD_MAP, clientAccessor, environment);
+            super(TAG, DESCRIPTION, TYPE, MAP_KEY, MODEL_ID, FIELD_MAP, clientAccessor, environment, clusterService);
             this.vectors = vectors;
             this.exception = exception;
         }

--- a/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.any;
 
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -32,9 +33,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
+import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
 import org.opensearch.ingest.Processor;
@@ -51,10 +54,12 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
     private MLCommonsClientAccessor mlCommonsClientAccessor;
 
     @Mock
-    private Environment env;
+    private Environment environment;
+
+    private ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
 
     @InjectMocks
-    private SparseEncodingProcessorFactory SparseEncodingProcessorFactory;
+    private SparseEncodingProcessorFactory sparseEncodingProcessorFactory;
     private static final String PROCESSOR_TAG = "mockTag";
     private static final String DESCRIPTION = "mockDescription";
 
@@ -62,7 +67,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         Settings settings = Settings.builder().put("index.mapping.depth.limit", 20).build();
-        when(env.settings()).thenReturn(settings);
+        when(clusterService.state().metadata().index(anyString()).getSettings()).thenReturn(settings);
     }
 
     @SneakyThrows
@@ -71,11 +76,12 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put(SparseEncodingProcessor.MODEL_ID_FIELD, "mockModelId");
         config.put(SparseEncodingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1Mapped", "key2", "key2Mapped"));
-        return SparseEncodingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
+        return sparseEncodingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
     }
 
     public void testExecute_successful() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
@@ -96,10 +102,15 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
     @SneakyThrows
     public void testExecute_whenInferenceTextListEmpty_SuccessWithoutAnyMap() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
         Map<String, Processor.Factory> registry = new HashMap<>();
         MLCommonsClientAccessor accessor = mock(MLCommonsClientAccessor.class);
-        SparseEncodingProcessorFactory sparseEncodingProcessorFactory = new SparseEncodingProcessorFactory(accessor, env);
+        SparseEncodingProcessorFactory sparseEncodingProcessorFactory = new SparseEncodingProcessorFactory(
+            accessor,
+            environment,
+            clusterService
+        );
 
         Map<String, Object> config = new HashMap<>();
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
@@ -115,6 +126,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         List<String> list1 = ImmutableList.of("test1", "test2", "test3");
         List<String> list2 = ImmutableList.of("test4", "test5", "test6");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", list1);
         sourceAndMetadata.put("key2", list2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
@@ -134,6 +146,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
 
     public void testExecute_MLClientAccessorThrowFail_handlerFailure() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
@@ -150,14 +163,25 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
+    @SneakyThrows
     public void testExecute_withMapTypeInput_successful() {
-        Map<String, String> map1 = ImmutableMap.of("test1", "test2");
-        Map<String, String> map2 = ImmutableMap.of("test4", "test5");
+        Map<String, String> map1 = new HashMap<>();
+        map1.put("test1", "test2");
+        Map<String, String> map2 = new HashMap<>();
+        map2.put("test4", "test5");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", map1);
         sourceAndMetadata.put("key2", map2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        SparseEncodingProcessor processor = createInstance();
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(SparseEncodingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(
+            SparseEncodingProcessor.FIELD_MAP_FIELD,
+            ImmutableMap.of("key1", Map.of("test1", "test1_knn"), "key2", Map.of("test4", "test4_knn"))
+        );
+        SparseEncodingProcessor processor = sparseEncodingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
 
         List<Map<String, ?>> dataAsMapList = createMockMapResult(2);
         doAnswer(invocation -> {

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
@@ -866,7 +866,7 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> processor.execute(ingestDocument)
         );
-        assertEquals("map type field [body] reached max depth limit, cannot process it", illegalArgumentException.getMessage());
+        assertEquals("map type field [body] reaches max depth limit, cannot process it", illegalArgumentException.getMessage());
     }
 
     @SneakyThrows
@@ -916,7 +916,10 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> processor.execute(ingestDocument)
         );
-        assertEquals("list type field [body] has non string value, cannot process it", illegalArgumentException.getMessage());
+        assertEquals(
+            "[body] configuration doesn't match actual value type, configuration type is: java.lang.String, actual value type is: com.google.common.collect.RegularImmutableMap",
+            illegalArgumentException.getMessage()
+        );
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import static java.util.Collections.singletonList;
@@ -80,7 +79,11 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
     public void setup() {
         Metadata metadata = mock(Metadata.class);
         Environment environment = mock(Environment.class);
-        Settings settings = Settings.builder().put("index.mapping.depth.limit", 20).build();
+        Settings settings = Settings.builder()
+            .put("index.mapping.depth.limit", 20)
+            .put("index.analyze.max_token_count", 10000)
+            .put("index.number_of_shards", 1)
+            .build();
         when(environment.settings()).thenReturn(settings);
         ClusterState clusterState = mock(ClusterState.class);
         ClusterService clusterService = mock(ClusterService.class);
@@ -357,13 +360,11 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
 
     private Map<String, Object> createMaxDepthLimitExceedMap(int maxDepth) {
         if (maxDepth > 21) {
-            return null;
+            return Map.of(INPUT_FIELD, "mapped");
         }
         Map<String, Object> resultMap = new HashMap<>();
         Map<String, Object> innerMap = createMaxDepthLimitExceedMap(maxDepth + 1);
-        if (Objects.nonNull(innerMap)) {
-            resultMap.put(INPUT_FIELD, innerMap);
-        }
+        resultMap.put(INPUT_FIELD, innerMap);
         return resultMap;
     }
 
@@ -597,7 +598,7 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
             () -> processor.execute(ingestDocument)
         );
         assertEquals(
-            String.format(Locale.ROOT, "field [%s] is neither string nor nested type, cannot process it", INPUT_FIELD),
+            String.format(Locale.ROOT, "map type field [%s] is neither string nor nested type, cannot process it", INPUT_FIELD),
             illegalArgumentException.getMessage()
         );
     }
@@ -630,7 +631,7 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
             () -> processor.execute(ingestDocument)
         );
         assertEquals(
-            String.format(Locale.ROOT, "list type field [%s] has non-string value, cannot process it", INPUT_FIELD),
+            String.format(Locale.ROOT, "list type field [%s] has non string value, cannot process it", INPUT_FIELD),
             illegalArgumentException.getMessage()
         );
     }
@@ -855,16 +856,16 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
 
     @SneakyThrows
     public void testExecute_withFixedTokenLength_andMaxDepthLimitExceedFieldMap_thenFail() {
-        TextChunkingProcessor processor = createFixedTokenLengthInstance(createNestedFieldMapSingleField());
-        IngestDocument ingestDocument = createIngestDocumentWithNestedSourceData(createMaxDepthLimitExceedMap(0));
+        Map<String, Object> map = createMaxDepthLimitExceedMap(0);
+        Map<String, Object> config = new HashMap<>();
+        config.put(INPUT_NESTED_FIELD_KEY, map.get("body"));
+        TextChunkingProcessor processor = createFixedTokenLengthInstance(config);
+        IngestDocument ingestDocument = createIngestDocumentWithNestedSourceData(map);
         IllegalArgumentException illegalArgumentException = assertThrows(
             IllegalArgumentException.class,
             () -> processor.execute(ingestDocument)
         );
-        assertEquals(
-            String.format(Locale.ROOT, "map type field [%s] reached max depth limit, cannot process it", INPUT_NESTED_FIELD_KEY),
-            illegalArgumentException.getMessage()
-        );
+        assertEquals("map type field [body] reached max depth limit, cannot process it", illegalArgumentException.getMessage());
     }
 
     @SneakyThrows
@@ -876,7 +877,7 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
             () -> processor.execute(ingestDocument)
         );
         assertEquals(
-            String.format(Locale.ROOT, "map type field [%s] has non-string type, cannot process it", INPUT_NESTED_FIELD_KEY),
+            "[body] configuration doesn't match actual value type, configuration type is: java.lang.String, actual value type is: java.util.ImmutableCollections$Map1",
             illegalArgumentException.getMessage()
         );
     }
@@ -906,15 +907,15 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
     }
 
     @SneakyThrows
-    public void testExecute_withFixedTokenLength_andSourceDataListWithHybridType_thenSucceed() {
+    public void testExecute_withFixedTokenLength_andSourceDataListWithHybridType_thenFail() {
         TextChunkingProcessor processor = createFixedTokenLengthInstance(createStringFieldMap());
         List<Object> sourceDataList = createSourceDataListWithHybridType();
         IngestDocument ingestDocument = createIngestDocumentWithSourceData(sourceDataList);
-        IngestDocument document = processor.execute(ingestDocument);
-        assert document.getSourceAndMetadata().containsKey(INPUT_FIELD);
-        Object listResult = document.getSourceAndMetadata().get(OUTPUT_FIELD);
-        assert (listResult instanceof List);
-        assertEquals(((List<?>) listResult).size(), 0);
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> processor.execute(ingestDocument)
+        );
+        assertEquals("list type field [body] has non string value, cannot process it", illegalArgumentException.getMessage());
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -538,8 +538,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     public void test_batchExecute_exception() {
         final int docCount = 5;
         List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
-        Map<String, Object> config = createPlainStringConfiguration();
-        TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
         doAnswer(invocation -> {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onFailure(new RuntimeException());

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.processor;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -31,9 +32,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
+import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
 import org.opensearch.ingest.Processor;
@@ -51,7 +54,9 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     private MLCommonsClientAccessor mlCommonsClientAccessor;
 
     @Mock
-    private Environment env;
+    private Environment environment;
+
+    private ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
 
     @InjectMocks
     private TextEmbeddingProcessorFactory textEmbeddingProcessorFactory;
@@ -62,15 +67,27 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         Settings settings = Settings.builder().put("index.mapping.depth.limit", 20).build();
-        when(env.settings()).thenReturn(settings);
+        when(clusterService.state().metadata().index(anyString()).getSettings()).thenReturn(settings);
     }
 
     @SneakyThrows
-    private TextEmbeddingProcessor createInstance() {
+    private TextEmbeddingProcessor createInstanceWithLevel2MapConfig() {
         Map<String, Processor.Factory> registry = new HashMap<>();
         Map<String, Object> config = new HashMap<>();
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
-        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1Mapped", "key2", "key2Mapped"));
+        config.put(
+            TextEmbeddingProcessor.FIELD_MAP_FIELD,
+            ImmutableMap.of("key1", ImmutableMap.of("test1", "test1_knn"), "key2", ImmutableMap.of("test3", "test3_knn"))
+        );
+        return textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
+    }
+
+    @SneakyThrows
+    private TextEmbeddingProcessor createInstanceWithLevel1MapConfig() {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1_knn", "key2", "key2_knn"));
         return textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
     }
 
@@ -104,10 +121,11 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
     public void testExecute_successful() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
@@ -129,7 +147,11 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
         Map<String, Processor.Factory> registry = new HashMap<>();
         MLCommonsClientAccessor accessor = mock(MLCommonsClientAccessor.class);
-        TextEmbeddingProcessorFactory textEmbeddingProcessorFactory = new TextEmbeddingProcessorFactory(accessor, env);
+        TextEmbeddingProcessorFactory textEmbeddingProcessorFactory = new TextEmbeddingProcessorFactory(
+            accessor,
+            environment,
+            clusterService
+        );
 
         Map<String, Object> config = new HashMap<>();
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
@@ -144,10 +166,15 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     @SneakyThrows
     public void testExecute_whenInferenceTextListEmpty_SuccessWithoutEmbedding() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
         Map<String, Processor.Factory> registry = new HashMap<>();
         MLCommonsClientAccessor accessor = mock(MLCommonsClientAccessor.class);
-        TextEmbeddingProcessorFactory textEmbeddingProcessorFactory = new TextEmbeddingProcessorFactory(accessor, env);
+        TextEmbeddingProcessorFactory textEmbeddingProcessorFactory = new TextEmbeddingProcessorFactory(
+            accessor,
+            environment,
+            clusterService
+        );
 
         Map<String, Object> config = new HashMap<>();
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
@@ -163,10 +190,11 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         List<String> list1 = ImmutableList.of("test1", "test2", "test3");
         List<String> list2 = ImmutableList.of("test4", "test5", "test6");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", list1);
         sourceAndMetadata.put("key2", list2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
@@ -182,9 +210,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
     public void testExecute_SimpleTypeWithEmptyStringValue_throwIllegalArgumentException() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "    ");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -194,9 +223,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     public void testExecute_listHasEmptyStringValue_throwIllegalArgumentException() {
         List<String> list1 = ImmutableList.of("", "test2", "test3");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", list1);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -206,9 +236,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     public void testExecute_listHasNonStringValue_throwIllegalArgumentException() {
         List<Integer> list2 = ImmutableList.of(1, 2, 3);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key2", list2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
@@ -220,22 +251,26 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         list.add(null);
         list.add("world");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key2", list);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
     public void testExecute_withMapTypeInput_successful() {
-        Map<String, String> map1 = ImmutableMap.of("test1", "test2");
-        Map<String, String> map2 = ImmutableMap.of("test4", "test5");
+        Map<String, String> map1 = new HashMap<>();
+        map1.put("test1", "test2");
+        Map<String, String> map2 = new HashMap<>();
+        map2.put("test3", "test4");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", map1);
         sourceAndMetadata.put("key2", map2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel2MapConfig();
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
@@ -254,10 +289,11 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Map<String, String> map1 = ImmutableMap.of("test1", "test2");
         Map<String, Double> map2 = ImmutableMap.of("test3", 209.3D);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", map1);
         sourceAndMetadata.put("key2", map2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel2MapConfig();
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
@@ -267,10 +303,11 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Map<String, String> map1 = ImmutableMap.of("test1", "test2");
         Map<String, String> map2 = ImmutableMap.of("test3", "   ");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", map1);
         sourceAndMetadata.put("key2", map2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel2MapConfig();
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
@@ -279,10 +316,11 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     public void testExecute_mapDepthReachLimit_throwIllegalArgumentException() {
         Map<String, Object> ret = createMaxDepthLimitExceedMap(() -> 1);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "hello world");
         sourceAndMetadata.put("key2", ret);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
@@ -290,10 +328,11 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
     public void testExecute_MLClientAccessorThrowFail_handlerFailure() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
 
         doAnswer(invocation -> {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
@@ -324,13 +363,14 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put("key2", map1);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel2MapConfig();
         IngestDocument document = processor.execute(ingestDocument);
         assert document.getSourceAndMetadata().containsKey("key2");
     }
 
     public void testExecute_simpleTypeInputWithNonStringValue_handleIllegalArgumentException() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", 100);
         sourceAndMetadata.put("key2", 100.232D);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
@@ -341,13 +381,13 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
     public void testGetType_successful() {
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
         assert processor.getType().equals(TextEmbeddingProcessor.TYPE);
     }
 
@@ -356,7 +396,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         IngestDocument ingestDocument = createPlainIngestDocument();
         TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
 
-        Map<String, Object> knnMap = processor.buildMapWithProcessorKeyAndOriginalValue(ingestDocument);
+        Map<String, Object> knnMap = processor.buildMapWithTargetKeyAndOriginalValue(ingestDocument);
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         processor.setVectorFieldsToDocument(ingestDocument, knnMap, modelTensorList);
@@ -369,7 +409,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         IngestDocument ingestDocument = createPlainIngestDocument();
         TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
 
-        Map<String, Object> knnMap = processor.buildMapWithProcessorKeyAndOriginalValue(ingestDocument);
+        Map<String, Object> knnMap = processor.buildMapWithTargetKeyAndOriginalValue(ingestDocument);
 
         // To assert the order is not changed between config map and generated map.
         List<Object> configValueList = new LinkedList<>(config.values());
@@ -395,7 +435,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Map<String, Object> config = createNestedMapConfiguration();
         IngestDocument ingestDocument = createNestedMapIngestDocument();
         TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
-        Map<String, Object> knnMap = processor.buildMapWithProcessorKeyAndOriginalValue(ingestDocument);
+        Map<String, Object> knnMap = processor.buildMapWithTargetKeyAndOriginalValue(ingestDocument);
         List<List<Float>> modelTensorList = createMockVectorResult();
         processor.buildNLPResult(knnMap, modelTensorList, ingestDocument.getSourceAndMetadata());
         Map<String, Object> favoritesMap = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("favorites");
@@ -411,7 +451,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Map<String, Object> config = createNestedListConfiguration();
         IngestDocument ingestDocument = createNestedListIngestDocument();
         TextEmbeddingProcessor textEmbeddingProcessor = createInstanceWithNestedMapConfiguration(config);
-        Map<String, Object> knnMap = textEmbeddingProcessor.buildMapWithProcessorKeyAndOriginalValue(ingestDocument);
+        Map<String, Object> knnMap = textEmbeddingProcessor.buildMapWithTargetKeyAndOriginalValue(ingestDocument);
         List<List<Float>> modelTensorList = createMockVectorResult();
         textEmbeddingProcessor.buildNLPResult(knnMap, modelTensorList, ingestDocument.getSourceAndMetadata());
         List<Map<String, Object>> nestedObj = (List<Map<String, Object>>) ingestDocument.getSourceAndMetadata().get("nestedField");
@@ -425,7 +465,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Map<String, Object> config = createNestedList2LevelConfiguration();
         IngestDocument ingestDocument = create2LevelNestedListIngestDocument();
         TextEmbeddingProcessor textEmbeddingProcessor = createInstanceWithNestedMapConfiguration(config);
-        Map<String, Object> knnMap = textEmbeddingProcessor.buildMapWithProcessorKeyAndOriginalValue(ingestDocument);
+        Map<String, Object> knnMap = textEmbeddingProcessor.buildMapWithTargetKeyAndOriginalValue(ingestDocument);
         List<List<Float>> modelTensorList = createMockVectorResult();
         textEmbeddingProcessor.buildNLPResult(knnMap, modelTensorList, ingestDocument.getSourceAndMetadata());
         Map<String, Object> nestedLevel1 = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("nestedField");
@@ -440,7 +480,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Map<String, Object> config = createPlainStringConfiguration();
         IngestDocument ingestDocument = createPlainIngestDocument();
         TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
-        Map<String, Object> knnMap = processor.buildMapWithProcessorKeyAndOriginalValue(ingestDocument);
+        Map<String, Object> knnMap = processor.buildMapWithTargetKeyAndOriginalValue(ingestDocument);
         List<List<Float>> modelTensorList = createMockVectorResult();
         processor.setVectorFieldsToDocument(ingestDocument, knnMap, modelTensorList);
 
@@ -453,7 +493,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     public void test_batchExecute_successful() {
         final int docCount = 5;
         List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
-        TextEmbeddingProcessor processor = createInstance();
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
 
         List<List<Float>> modelTensorList = createMockVectorWithLength(10);
         doAnswer(invocation -> {
@@ -476,7 +516,8 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     public void test_batchExecute_exception() {
         final int docCount = 5;
         List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
-        TextEmbeddingProcessor processor = createInstance();
+        Map<String, Object> config = createPlainStringConfiguration();
+        TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
         doAnswer(invocation -> {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onFailure(new RuntimeException());

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
@@ -182,6 +182,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
 
     public void testExecute_successful() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("my_text_field", "value2");
         sourceAndMetadata.put("key3", "value3");
@@ -231,6 +232,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
 
     public void testExecute_withListTypeInput_successful() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("my_text_field", "value1");
         sourceAndMetadata.put("another_text_field", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
@@ -263,6 +265,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
 
     public void testExecute_MLClientAccessorThrowFail_handlerFailure() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("my_text_field", "value1");
         sourceAndMetadata.put("key2", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
@@ -320,6 +323,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
 
     public void testExecute_whenInferencesAreEmpty_thenSuccessful() {
         Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("my_field", "value1");
         sourceAndMetadata.put("another_text_field", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.cluster.metadata.IndexMetadata.TRANSLOG_METADATA_KEY;
 import static org.opensearch.index.mapper.SeqNoFieldMapper.PRIMARY_TERM_NAME;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_PREFIX;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.cluster.metadata.IndexMetadata.TRANSLOG_METADATA_KEY;
 import static org.opensearch.index.mapper.SeqNoFieldMapper.PRIMARY_TERM_NAME;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_PREFIX;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;

--- a/src/test/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtilsTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtilsTests.java
@@ -60,7 +60,6 @@ public class ProcessorDocumentUtilsTests extends OpenSearchQueryTestCase {
                     "field_map",
                     source,
                     fieldMap,
-                    1,
                     "test_index",
                     clusterService,
                     environment,

--- a/src/test/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtilsTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtilsTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.env.Environment;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProcessorDocumentUtilsTests extends OpenSearchQueryTestCase {
+
+    private ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
+
+    @Mock
+    private Environment environment;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void test_with_different_configurations() throws URISyntaxException, IOException {
+        Settings settings = Settings.builder().put("index.mapping.depth.limit", 20).build();
+        when(clusterService.state().metadata().index(anyString()).getSettings()).thenReturn(settings);
+        String processorDocumentTestJson = Files.readString(
+            Path.of(ProcessorDocumentUtils.class.getClassLoader().getResource("util/ProcessorDocumentUtils.json").toURI())
+        );
+        Map<String, Object> processorDocumentTestMap = XContentHelper.convertToMap(
+            XContentType.JSON.xContent(),
+            processorDocumentTestJson,
+            false
+        );
+        for (Map.Entry<String, Object> entry : processorDocumentTestMap.entrySet()) {
+            String testCaseName = entry.getKey();
+            Map<String, Object> metadata = (Map<String, Object>) entry.getValue();
+
+            Map<String, Object> fieldMap = (Map<String, Object>) metadata.get("field_map");
+            Map<String, Object> source = (Map<String, Object>) metadata.get("source");
+            Map<String, Object> expectation = (Map<String, Object>) metadata.get("expectation");
+            try {
+                ProcessorDocumentUtils.validateMapTypeValue(
+                    "field_map",
+                    source,
+                    fieldMap,
+                    1,
+                    "test_index",
+                    clusterService,
+                    environment,
+                    false
+                );
+            } catch (Exception e) {
+                if (expectation != null) {
+                    if (expectation.containsKey("type")) {
+                        assertEquals("test case: " + testCaseName + " failed", expectation.get("type"), e.getClass().getSimpleName());
+                    }
+                    if (expectation.containsKey("message")) {
+                        assertEquals("test case: " + testCaseName + " failed", expectation.get("message"), e.getMessage());
+                    }
+                } else {
+                    fail("test case: " + testCaseName + " failed: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/resources/util/ProcessorDocumentUtils.json
+++ b/src/test/resources/util/ProcessorDocumentUtils.json
@@ -1,0 +1,161 @@
+{
+  "simpleMapConfiguration": {
+    "field_map": {
+      "body": "body_embedding"
+    },
+    "source": {
+      "body": "This is a test body."
+    }
+  },
+  "doublyMapConfiguration": {
+    "field_map": {
+      "passage": {
+        "body": "body_embedding"
+      }
+    },
+    "source": {
+      "passage": {
+        "body": "This is a test body."
+      }
+    }
+  },
+  "mapWithNestedConfiguration": {
+    "field_map": {
+      "passage": {
+        "bodies": "bodies_embedding"
+      }
+    },
+    "source": {
+      "passage": {
+        "bodies": ["test body 1", "test body 2", "test body 3"]
+      }
+    }
+  },
+  "nestedConfiguration": {
+    "field_map": {
+      "bodies": "bodies_embedding"
+    },
+    "source": {
+      "bodies": ["test body 1", "test body 2", "test body 3"]
+    }
+  },
+  "nestedWithMapConfiguration": {
+    "field_map": {
+      "bodies": {
+        "body": "body_embedding"
+      }
+    },
+    "source": {
+      "bodies": [
+        {
+          "body": "This is a test body.",
+          "seq": 1
+        },
+        {
+          "body": "This is another test body.",
+          "seq": 2
+        }]
+    }
+  },
+  "sourceMapFieldNotMapConfiguration": {
+    "field_map": {
+      "passage": "passage_embedding"
+    },
+    "source": {
+      "passage": {
+        "body": "This is a test body."
+      }
+    },
+    "expectation": {
+      "type": "IllegalArgumentException",
+      "message": "[passage] configuration doesn't match actual value type, configuration type is: java.lang.String, actual value type is: java.util.HashMap"
+    }
+  },
+  "sourceMapTypeHasNonNestedNonStringConfiguration": {
+    "field_map": {
+      "passage": {
+        "body": "body_embedding"
+      }
+    },
+    "source": {
+      "passage": {
+        "body": 12345
+      }
+    },
+    "expectation": {
+      "type": "IllegalArgumentException",
+      "message": "map type field [body] is neither string nor nested type, cannot process it"
+    }
+  },
+  "sourceMapTypeHasEmptyStringConfiguration": {
+    "field_map": {
+      "passage": {
+        "body": "body_embedding"
+      }
+    },
+    "source": {
+      "passage": {
+        "body": ""
+      }
+    },
+    "expectation": {
+      "type": "IllegalArgumentException",
+      "message": "map type field [body] has empty string value, cannot process it"
+    }
+  },
+  "sourceListTypeHasNullConfiguration": {
+    "field_map": {
+      "bodies": "bodies_embedding"
+    },
+    "source": {
+      "bodies": ["This is a test", null, "This is another test"]
+    },
+    "expectation": {
+      "type": "IllegalArgumentException",
+      "message": "list type field [bodies] has null, cannot process it"
+    }
+  },
+  "sourceListTypeHasEmptyConfiguration": {
+    "field_map": {
+      "bodies": "bodies_embedding"
+    },
+    "source": {
+      "bodies": ["This is a test", "", "This is another test"]
+    },
+    "expectation": {
+      "type": "IllegalArgumentException",
+      "message": "list type field [bodies] has empty string, cannot process it"
+    }
+  },
+  "sourceListTypeHasNonStringConfiguration": {
+    "field_map": {
+      "bodies": "bodies_embedding"
+    },
+    "source": {
+      "bodies": ["This is a test", 1, "This is another test"]
+    },
+    "expectation": {
+      "type": "IllegalArgumentException",
+      "message": "list type field [bodies] has non string value, cannot process it"
+    }
+  },
+  "sourceDoublyListTypeConfiguration": {
+    "field_map": {
+      "bodies": "bodies_embedding"
+    },
+    "source": {
+      "bodies": [
+        [
+          "This is a test"
+        ],
+        [
+          "This is another tetst"
+        ]
+      ]
+    },
+    "expectation": {
+      "type": "IllegalArgumentException",
+      "message": "list type field [bodies] is nested list type, cannot process it"
+    }
+  }
+}


### PR DESCRIPTION
### Description
When user uses map type configuration in processors, the validation will validate all other fields instead of only the configured fields, sometimes if other fields has unsupported types, user will get exception which is not expected.

Multiple processors uses similar validation logic but code are duplicated, in this PR a new Util is been added to extract the duplicated code to a common place and reused by different processors.

### Issues Resolved
https://github.com/opensearch-project/ml-commons/issues/2309

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
