### PR TITLE
Support k-NN radial search parameters in neural search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/neural-search/compare/2.x...HEAD)
 ### Features
-- Support k-NN radial search parameters in neural search([#697](https://github.com/opensearch-project/neural-search/pull/697)) 
+- Support k-NN radial search parameters in neural search([#697](https://github.com/opensearch-project/neural-search/pull/697))
 ### Enhancements
 ### Bug Fixes
 - Fix async actions are left in neural_sparse query ([#438](https://github.com/opensearch-project/neural-search/pull/438))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/neural-search/compare/2.x...HEAD)
 ### Features
+- Support k-NN radial search parameters in neural search([#697](https://github.com/opensearch-project/neural-search/pull/697)) 
 ### Enhancements
 ### Bug Fixes
 - Fix async actions are left in neural_sparse query ([#438](https://github.com/opensearch-project/neural-search/pull/438))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/neural-search/compare/2.x...HEAD)
 ### Features
-- Support k-NN radial search parameters in neural search([#697](https://github.com/opensearch-project/neural-search/pull/697))
 ### Enhancements
 ### Bug Fixes
 - Fix async actions are left in neural_sparse query ([#438](https://github.com/opensearch-project/neural-search/pull/438))
@@ -20,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.13...2.x)
 ### Features
+- Support k-NN radial search parameters in neural search([#697](https://github.com/opensearch-project/neural-search/pull/697))
 ### Enhancements
 - BWC tests for text chunking processor ([#661](https://github.com/opensearch-project/neural-search/pull/661))
 - Allowing execution of hybrid query on index alias with filters ([#670](https://github.com/opensearch-project/neural-search/pull/670))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Include tests that check your new feature or bug fix. Ideally, we're looking for unit, integration, and BWC tests, but that depends on how big and critical your change is. 
-If you're adding an integration test and it is using local ML models, please make sure that the number of model deployments is limited, and you're using the smallest possible model. 
+3. Include tests that check your new feature or bug fix. Ideally, we're looking for unit, integration, and BWC tests, but that depends on how big and critical your change is.
+If you're adding an integration test and it is using local ML models, please make sure that the number of model deployments is limited, and you're using the smallest possible model.
 Each model deployment consumes resources, and having too many models may cause unexpected test failures.
 4. Ensure local tests pass.
 5. Commit to your fork using clear commit messages.

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -90,6 +90,13 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
         }
     }
 
+    // Excluding the k-NN radial search tests because we introduce this feature in 2.14
+    if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12") || ext.neural_search_bwc_version.startsWith("2.13")){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.KnnRadialSearchIT.*"
+        }
+    }
+
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.security.manager', 'false'
@@ -136,6 +143,13 @@ task testAgainstNewCluster(type: StandaloneRestIntegTestTask) {
     if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12")){
         filter {
             excludeTestsMatching "org.opensearch.neuralsearch.bwc.TextChunkingProcessorIT.*"
+        }
+    }
+
+    // Excluding the k-NN radial search tests because we introduce this feature in 2.14
+    if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12") || ext.neural_search_bwc_version.startsWith("2.13")){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.KnnRadialSearchIT.*"
         }
     }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -12,8 +12,8 @@ import static org.opensearch.neuralsearch.util.TestUtils.TEXT_IMAGE_EMBEDDING_PR
 import static org.opensearch.neuralsearch.util.TestUtils.getModelId;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
 
-public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
-    private static final String PIPELINE_NAME = "nlp-ingest-pipeline";
+public class KnnRadialSearchIT extends AbstractRestartUpgradeRestTestCase {
+    private static final String PIPELINE_NAME = "radial-search-pipeline";
     private static final String TEST_FIELD = "passage_text";
     private static final String TEST_IMAGE_FIELD = "passage_image";
     private static final String TEXT = "Hello world";
@@ -21,10 +21,10 @@ public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
     private static final String TEST_IMAGE_TEXT = "/9j/4AAQSkZJRgABAQAASABIAAD";
     private static final String TEST_IMAGE_TEXT_1 = "/9j/4AAQSkZJRgbdwoeicfhoid";
 
-    // Test restart-upgrade test image embedding processor
+    // Test rolling-upgrade with kNN radial search
     // Create Text Image Embedding Processor, Ingestion Pipeline and add document
-    // Validate process , pipeline and document count in restart-upgrade scenario
-    public void testTextImageEmbeddingProcessor_E2EFlow() throws Exception {
+    // Validate radial query, pipeline and document count in restart-upgrade scenario
+    public void testKnnRadialSearch_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
 
         if (isRunningAgainstOldCluster()) {
@@ -43,29 +43,40 @@ public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
                 modelId = getModelId(getIngestionPipeline(PIPELINE_NAME), TEXT_IMAGE_EMBEDDING_PROCESSOR);
                 loadModel(modelId);
                 addDocument(getIndexNameForTest(), "1", TEST_FIELD, TEXT_1, TEST_IMAGE_FIELD, TEST_IMAGE_TEXT_1);
-                validateTestIndex(modelId);
+                validateIndexQuery(modelId);
             } finally {
                 wipeOfTestResources(getIndexNameForTest(), PIPELINE_NAME, modelId, null);
             }
         }
     }
 
-    private void validateTestIndex(final String modelId) throws Exception {
-        int docCount = getDocCount(getIndexNameForTest());
-        assertEquals(2, docCount);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
+    private void validateIndexQuery(final String modelId) {
+        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = new NeuralQueryBuilder(
             "passage_embedding",
             TEXT,
             TEST_IMAGE_TEXT,
             modelId,
-            1,
             null,
+            null,
+            0.01f,
+            null,
+            null
+        );
+        Map<String, Object> responseWithMinScoreQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
+        assertNotNull(responseWithMinScoreQuery);
+
+        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = new NeuralQueryBuilder(
+            "passage_embedding",
+            TEXT,
+            TEST_IMAGE_TEXT,
+            modelId,
+            null,
+            100000f,
             null,
             null,
             null
         );
-        Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
-        assertNotNull(response);
+        Map<String, Object> responseWithMaxDistanceQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);
+        assertNotNull(responseWithMaxDistanceQuery);
     }
-
 }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -50,10 +50,10 @@ public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
         }
     }
 
-    private void validateTestIndex(final String modelId) throws Exception {
+    private void validateTestIndex(final String modelId) {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(2, docCount);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
+        NeuralQueryBuilder neuralQueryBuilderWithKQuery = new NeuralQueryBuilder(
             "passage_embedding",
             TEXT,
             TEST_IMAGE_TEXT,
@@ -64,8 +64,35 @@ public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
             null,
             null
         );
-        Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
-        assertNotNull(response);
-    }
+        Map<String, Object> responseWithKQuery = search(getIndexNameForTest(), neuralQueryBuilderWithKQuery, 1);
+        assertNotNull(responseWithKQuery);
 
+        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = new NeuralQueryBuilder(
+            "passage_embedding",
+            TEXT,
+            TEST_IMAGE_TEXT,
+            modelId,
+            null,
+            null,
+            0.01f,
+            null,
+            null
+        );
+        Map<String, Object> responseWithMinScoreQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
+        assertNotNull(responseWithMinScoreQuery);
+
+        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = new NeuralQueryBuilder(
+            "passage_embedding",
+            TEXT,
+            TEST_IMAGE_TEXT,
+            modelId,
+            null,
+            10000f,
+            null,
+            null,
+            null
+        );
+        Map<String, Object> responseWithMaxDistanceQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);
+        assertNotNull(responseWithMaxDistanceQuery);
+    }
 }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -53,7 +53,17 @@ public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
     private void validateTestIndex(final String modelId) throws Exception {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(2, docCount);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder("passage_embedding", TEXT, TEST_IMAGE_TEXT, modelId, 1, null, null);
+        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
+            "passage_embedding",
+            TEXT,
+            TEST_IMAGE_TEXT,
+            modelId,
+            1,
+            null,
+            null,
+            null,
+            null
+        );
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertNotNull(response);
     }

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -90,6 +90,13 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
         }
     }
 
+    // Excluding the k-NN radial search tests because we introduce this feature in 2.14
+    if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12") || ext.neural_search_bwc_version.startsWith("2.13")){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.KnnRadialSearchIT.*"
+        }
+    }
+
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.security.manager', 'false'
@@ -137,6 +144,13 @@ task testAgainstOneThirdUpgradedCluster(type: StandaloneRestIntegTestTask) {
     if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12")){
         filter {
             excludeTestsMatching "org.opensearch.neuralsearch.bwc.TextChunkingProcessorIT.*"
+        }
+    }
+
+    // Excluding the k-NN radial search tests because we introduce this feature in 2.14
+    if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12") || ext.neural_search_bwc_version.startsWith("2.13")){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.KnnRadialSearchIT.*"
         }
     }
 

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -12,8 +12,8 @@ import static org.opensearch.neuralsearch.util.TestUtils.TEXT_IMAGE_EMBEDDING_PR
 import static org.opensearch.neuralsearch.util.TestUtils.getModelId;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
 
-public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
-    private static final String PIPELINE_NAME = "nlp-ingest-pipeline";
+public class KnnRadialSearchIT extends AbstractRollingUpgradeTestCase {
+    private static final String PIPELINE_NAME = "radial-search-pipeline";
     private static final String TEST_FIELD = "passage_text";
     private static final String TEST_IMAGE_FIELD = "passage_image";
     private static final String TEXT = "Hello world";
@@ -26,10 +26,10 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
     private static final int NUM_DOCS_PER_ROUND = 1;
     private static String modelId = "";
 
-    // Test rolling-upgrade test image embedding processor
+    // Test rolling-upgrade with kNN radial search
     // Create Text Image Embedding Processor, Ingestion Pipeline and add document
-    // Validate process , pipeline and document count in rolling-upgrade scenario
-    public void testTextImageEmbeddingProcessor_E2EFlow() throws Exception {
+    // Validate radial query, pipeline and document count in rolling-upgrade scenario
+    public void testKnnRadialSearch_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
@@ -48,11 +48,11 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
                 int totalDocsCountMixed;
                 if (isFirstMixedRound()) {
                     totalDocsCountMixed = NUM_DOCS_PER_ROUND;
-                    validateTestIndexOnUpgrade(totalDocsCountMixed, modelId, TEXT, TEST_IMAGE_TEXT);
+                    validateIndexQueryOnUpgrade(totalDocsCountMixed, modelId, TEXT, TEST_IMAGE_TEXT);
                     addDocument(getIndexNameForTest(), "1", TEST_FIELD, TEXT_MIXED, TEST_IMAGE_FIELD, TEST_IMAGE_TEXT_MIXED);
                 } else {
                     totalDocsCountMixed = 2 * NUM_DOCS_PER_ROUND;
-                    validateTestIndexOnUpgrade(totalDocsCountMixed, modelId, TEXT_MIXED, TEST_IMAGE_TEXT_MIXED);
+                    validateIndexQueryOnUpgrade(totalDocsCountMixed, modelId, TEXT_MIXED, TEST_IMAGE_TEXT_MIXED);
                 }
                 break;
             case UPGRADED:
@@ -61,7 +61,7 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
                     int totalDocsCountUpgraded = 3 * NUM_DOCS_PER_ROUND;
                     loadModel(modelId);
                     addDocument(getIndexNameForTest(), "2", TEST_FIELD, TEXT_UPGRADED, TEST_IMAGE_FIELD, TEST_IMAGE_TEXT_UPGRADED);
-                    validateTestIndexOnUpgrade(totalDocsCountUpgraded, modelId, TEXT_UPGRADED, TEST_IMAGE_TEXT_UPGRADED);
+                    validateIndexQueryOnUpgrade(totalDocsCountUpgraded, modelId, TEXT_UPGRADED, TEST_IMAGE_TEXT_UPGRADED);
                 } finally {
                     wipeOfTestResources(getIndexNameForTest(), PIPELINE_NAME, modelId, null);
                 }
@@ -71,23 +71,38 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
         }
     }
 
-    private void validateTestIndexOnUpgrade(final int numberOfDocs, final String modelId, final String text, final String imageText)
+    private void validateIndexQueryOnUpgrade(final int numberOfDocs, final String modelId, final String text, final String imageText)
         throws Exception {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
-        NeuralQueryBuilder neuralQueryBuilderWithKQuery = new NeuralQueryBuilder(
+
+        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = new NeuralQueryBuilder(
             "passage_embedding",
             text,
             imageText,
             modelId,
-            1,
             null,
+            null,
+            0.01f,
+            null,
+            null
+        );
+        Map<String, Object> responseWithMinScore = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
+        assertNotNull(responseWithMinScore);
+
+        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = new NeuralQueryBuilder(
+            "passage_embedding",
+            text,
+            imageText,
+            modelId,
+            null,
+            100000f,
             null,
             null,
             null
         );
-        Map<String, Object> responseWithKQuery = search(getIndexNameForTest(), neuralQueryBuilderWithKQuery, 1);
-        assertNotNull(responseWithKQuery);
+        Map<String, Object> responseWithMaxScore = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);
+        assertNotNull(responseWithMaxScore);
     }
 }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -76,7 +76,17 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder("passage_embedding", text, imageText, modelId, 1, null, null);
+        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
+            "passage_embedding",
+            text,
+            imageText,
+            modelId,
+            1,
+            null,
+            null,
+            null,
+            null
+        );
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertNotNull(response);
     }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -76,7 +76,7 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
+        NeuralQueryBuilder neuralQueryBuilderWithKQuery = new NeuralQueryBuilder(
             "passage_embedding",
             text,
             imageText,
@@ -87,7 +87,35 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
             null,
             null
         );
-        Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
-        assertNotNull(response);
+        Map<String, Object> responseWithKQuery = search(getIndexNameForTest(), neuralQueryBuilderWithKQuery, 1);
+        assertNotNull(responseWithKQuery);
+
+        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = new NeuralQueryBuilder(
+            "passage_embedding",
+            text,
+            imageText,
+            modelId,
+            null,
+            null,
+            0.01f,
+            null,
+            null
+        );
+        Map<String, Object> responseWithMinScore = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
+        assertNotNull(responseWithMinScore);
+
+        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = new NeuralQueryBuilder(
+            "passage_embedding",
+            text,
+            imageText,
+            modelId,
+            null,
+            10000f,
+            null,
+            null,
+            null
+        );
+        Map<String, Object> responseWithMaxScore = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);
+        assertNotNull(responseWithMaxScore);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -125,7 +125,6 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
         } else {
             this.k = in.readVInt();
         }
-        this.k = in.readVInt();
         this.filter = in.readOptionalNamedWriteable(QueryBuilder.class);
         if (isClusterOnOrAfterMinReqVersionForRadialSearch()) {
             this.maxDistance = in.readOptionalFloat();

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -94,6 +94,8 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 modelId,
                 5,
                 null,
+                null,
+                null,
                 null
             );
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
@@ -142,6 +144,8 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 modelId,
                 5,
                 null,
+                null,
+                null,
                 null
             );
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
@@ -178,6 +182,8 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 6,
+                null,
+                null,
                 null,
                 null
             );

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
@@ -224,7 +224,7 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
             hybridQueryBuilderDefaultNorm.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null)
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
             );
             hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -248,7 +248,9 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             );
 
             HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
-            hybridQueryBuilderL2Norm.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null));
+            hybridQueryBuilderL2Norm.add(
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
+            );
             hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
             Map<String, Object> searchResponseAsMapL2Norm = search(
@@ -297,7 +299,7 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
             hybridQueryBuilderDefaultNorm.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null)
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
             );
             hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -321,7 +323,9 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             );
 
             HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
-            hybridQueryBuilderL2Norm.add(new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null));
+            hybridQueryBuilderL2Norm.add(
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
+            );
             hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
             Map<String, Object> searchResponseAsMapL2Norm = search(

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
@@ -90,7 +90,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
             hybridQueryBuilderArithmeticMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null)
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
             );
             hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -115,7 +115,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
             hybridQueryBuilderHarmonicMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null)
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
             );
             hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -140,7 +140,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
             hybridQueryBuilderGeometricMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null)
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
             );
             hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -190,7 +190,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
             hybridQueryBuilderArithmeticMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null)
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
             );
             hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -215,7 +215,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
             hybridQueryBuilderHarmonicMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null)
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
             );
             hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -240,7 +240,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
             hybridQueryBuilderGeometricMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null)
+                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null)
             );
             hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -294,7 +294,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         NeuralQueryBuilder neuralQueryBuilder = (NeuralQueryBuilder) queryTwoSubQueries.queries().get(0);
         assertEquals(VECTOR_FIELD_NAME, neuralQueryBuilder.fieldName());
         assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
-        assertEquals(K, neuralQueryBuilder.k());
+        assertEquals(K, (int) neuralQueryBuilder.k());
         assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
         assertEquals(BOOST, neuralQueryBuilder.boost(), 0f);
         // verify term query
@@ -602,7 +602,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertTrue(queryBuilders.get(0) instanceof KNNQueryBuilder);
         KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) queryBuilders.get(0);
         assertEquals(neuralQueryBuilder.fieldName(), knnQueryBuilder.fieldName());
-        assertEquals(neuralQueryBuilder.k(), knnQueryBuilder.getK());
+        assertEquals((int) neuralQueryBuilder.k(), knnQueryBuilder.getK());
         assertTrue(queryBuilders.get(1) instanceof TermQueryBuilder);
         TermQueryBuilder termQueryBuilder = (TermQueryBuilder) queryBuilders.get(1);
         assertEquals(termSubQuery.fieldName(), termQueryBuilder.fieldName());

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -710,7 +710,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
         assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
         assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
-        assertEquals(MAX_DISTANCE, neuralQueryBuilder.max_distance());
+        assertEquals(MAX_DISTANCE, neuralQueryBuilder.maxDistance());
     }
 
     @SneakyThrows
@@ -742,7 +742,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
         assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
         assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
-        assertEquals(MIN_SCORE, neuralQueryBuilder.min_score());
+        assertEquals(MIN_SCORE, neuralQueryBuilder.minScore());
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -14,6 +14,8 @@ import static org.opensearch.index.query.AbstractQueryBuilder.NAME_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.FILTER_FIELD;
 import static org.opensearch.neuralsearch.util.TestUtils.xContentBuilderToMap;
 import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.K_FIELD;
+import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.MAX_DISTANCE_FIELD;
+import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.MIN_SCORE_FIELD;
 import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.MODEL_ID_FIELD;
 import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.NAME;
 import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.QUERY_IMAGE_FIELD;
@@ -64,7 +66,9 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
     private static final String QUERY_TEXT = "Hello world!";
     private static final String IMAGE_TEXT = "base641234567890";
     private static final String MODEL_ID = "mfgfgdsfgfdgsde";
-    private static final int K = 10;
+    private static final Integer K = 10;
+    private static final Float MAX_DISTANCE = 1.0f;
+    private static final Float MIN_SCORE = 0.985f;
     private static final float BOOST = 1.8f;
     private static final String QUERY_NAME = "queryName";
     private static final Supplier<float[]> TEST_VECTOR_SUPPLIER = () -> new float[10];
@@ -645,7 +649,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         assertTrue(queryBuilder instanceof KNNQueryBuilder);
         KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) queryBuilder;
         assertEquals(neuralQueryBuilder.fieldName(), knnQueryBuilder.fieldName());
-        assertEquals(neuralQueryBuilder.k(), knnQueryBuilder.getK());
+        assertEquals((int) neuralQueryBuilder.k(), knnQueryBuilder.getK());
         assertArrayEquals(TEST_VECTOR_SUPPLIER.get(), (float[]) knnQueryBuilder.vector(), 0.0f);
     }
 
@@ -675,6 +679,104 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             () -> neuralQueryBuilder.doToQuery(queryShardContext)
         );
         assertEquals("Query cannot be created by NeuralQueryBuilder directly", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testFromXContent_whenBuiltWithDefaults_whenBuiltWithMaxDistance_thenBuildSuccessfully() {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "query_image": "string",
+                "model_id": "string",
+                "max_distance": float
+              }
+          }
+        */
+        setUpClusterService(Version.V_2_14_0);
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(FIELD_NAME)
+            .field(QUERY_TEXT_FIELD.getPreferredName(), QUERY_TEXT)
+            .field(MODEL_ID_FIELD.getPreferredName(), MODEL_ID)
+            .field(MAX_DISTANCE_FIELD.getPreferredName(), MAX_DISTANCE)
+            .endObject()
+            .endObject();
+
+        XContentParser contentParser = createParser(xContentBuilder);
+        contentParser.nextToken();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.fromXContent(contentParser);
+
+        assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
+        assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
+        assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
+        assertEquals(MAX_DISTANCE, neuralQueryBuilder.max_distance());
+    }
+
+    @SneakyThrows
+    public void testFromXContent_whenBuiltWithDefaults_whenBuiltWithMinScore_thenBuildSuccessfully() {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "query_image": "string",
+                "model_id": "string",
+                "min_score": float
+              }
+          }
+        */
+        setUpClusterService(Version.V_2_14_0);
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(FIELD_NAME)
+            .field(QUERY_TEXT_FIELD.getPreferredName(), QUERY_TEXT)
+            .field(MODEL_ID_FIELD.getPreferredName(), MODEL_ID)
+            .field(MIN_SCORE_FIELD.getPreferredName(), MIN_SCORE)
+            .endObject()
+            .endObject();
+
+        XContentParser contentParser = createParser(xContentBuilder);
+        contentParser.nextToken();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.fromXContent(contentParser);
+
+        assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
+        assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
+        assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
+        assertEquals(MIN_SCORE, neuralQueryBuilder.min_score());
+    }
+
+    @SneakyThrows
+    public void testFromXContent_whenBuiltWithDefaults_whenBuiltWithMinScoreAndK_thenFail() {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "query_image": "string",
+                "model_id": "string",
+                "min_score": float,
+                "k": int
+              }
+          }
+        */
+        setUpClusterService(Version.V_2_14_0);
+        XContentBuilder xContentBuilder = null;
+        try {
+            xContentBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(FIELD_NAME)
+                .field(QUERY_TEXT_FIELD.getPreferredName(), QUERY_TEXT)
+                .field(MODEL_ID_FIELD.getPreferredName(), MODEL_ID)
+                .field(MIN_SCORE_FIELD.getPreferredName(), MIN_SCORE)
+                .field(K_FIELD.getPreferredName(), K)
+                .endObject()
+                .endObject();
+        } catch (IOException e) {
+            fail("Failed to create XContentBuilder");
+        }
+
+        XContentParser contentParser = createParser(xContentBuilder);
+        contentParser.nextToken();
+        expectThrows(IllegalArgumentException.class, () -> NeuralQueryBuilder.fromXContent(contentParser));
     }
 
     private void setUpClusterService(Version version) {

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
@@ -119,6 +119,49 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 objectToFloat(firstInnerHitMultimodalQuery.get("_score")),
                 DELTA_FOR_SCORE_ASSERTION
             );
+
+            // To save test resources, IT tests for radial search are added below.
+            // Context: https://github.com/opensearch-project/neural-search/pull/697#discussion_r1571549776
+
+            // Test radial search max distance query
+            NeuralQueryBuilder neuralQueryWithMaxDistanceBuilder = new NeuralQueryBuilder(
+                TEST_KNN_VECTOR_FIELD_NAME_1,
+                TEST_QUERY_TEXT,
+                "",
+                modelId,
+                null,
+                100.0f,
+                null,
+                null,
+                null
+            );
+
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, neuralQueryWithMaxDistanceBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScoreWithMaxDistanceQuery = computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
+            assertEquals(expectedScoreWithMaxDistanceQuery, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
+
+            // Test radial search min score query
+            NeuralQueryBuilder neuralQueryWithMinScoreBuilder = new NeuralQueryBuilder(
+                TEST_KNN_VECTOR_FIELD_NAME_1,
+                TEST_QUERY_TEXT,
+                "",
+                modelId,
+                null,
+                null,
+                0.01f,
+                null,
+                null
+            );
+
+            searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, neuralQueryWithMinScoreBuilder, 1);
+            firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScoreWithMinScoreQuery = computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
+            assertEquals(expectedScoreWithMinScoreQuery, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
         } finally {
             wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, null);
         }
@@ -390,64 +433,6 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
         } finally {
             wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME, null, modelId, null);
-        }
-    }
-
-    @SneakyThrows
-    public void testQueryWithMaxDistance() {
-        String modelId = null;
-        try {
-            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
-            modelId = prepareModel();
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                null,
-                100.0f,
-                null,
-                null,
-                null
-            );
-
-            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, neuralQueryBuilder, 1);
-            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
-
-            assertEquals("1", firstInnerHit.get("_id"));
-            float expectedScore = computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
-            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
-        } finally {
-            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, null);
-        }
-    }
-
-    @SneakyThrows
-    public void testQueryWithMinScore() {
-        String modelId = null;
-        try {
-            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
-            modelId = prepareModel();
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                null,
-                null,
-                0.01f,
-                null,
-                null
-            );
-
-            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, neuralQueryBuilder, 1);
-            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
-
-            assertEquals("1", firstInnerHit.get("_id"));
-            float expectedScore = computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
-            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
-        } finally {
-            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, null);
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
@@ -70,9 +70,33 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
      *         }
      *     }
      * }
+     * and query with radial search max distance and min score:
+     * {
+     *     "query": {
+     *         "neural": {
+     *             "text_knn": {
+     *                 "query_text": "Hello world",
+     *                 "model_id": "dcsdcasd",
+     *                 "max_distance": 100.0f,
+     *             }
+     *         }
+     *     }
+     * }
+     * {
+     *     "query": {
+     *         "neural": {
+     *             "text_knn": {
+     *                 "query_text": "Hello world",
+     *                 "model_id": "dcsdcasd",
+     *                 "min_score": 0.01f,
+     *             }
+     *         }
+     *     }
+     * }
+     *
      */
     @SneakyThrows
-    public void testQueryWithBoostAndImageQuery() {
+    public void testQueryWithBoostAndImageQueryAndRadialQuery() {
         String modelId = null;
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
@@ -136,12 +160,20 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 null
             );
 
-            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, neuralQueryWithMaxDistanceBuilder, 1);
-            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            Map<String, Object> searchResponseAsMapWithMaxDistanceQuery = search(
+                TEST_BASIC_INDEX_NAME,
+                neuralQueryWithMaxDistanceBuilder,
+                1
+            );
+            Map<String, Object> firstInnerHitWithMaxDistanceQuery = getFirstInnerHit(searchResponseAsMapWithMaxDistanceQuery);
 
-            assertEquals("1", firstInnerHit.get("_id"));
+            assertEquals("1", firstInnerHitWithMaxDistanceQuery.get("_id"));
             float expectedScoreWithMaxDistanceQuery = computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
-            assertEquals(expectedScoreWithMaxDistanceQuery, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
+            assertEquals(
+                expectedScoreWithMaxDistanceQuery,
+                objectToFloat(firstInnerHitWithMaxDistanceQuery.get("_score")),
+                DELTA_FOR_SCORE_ASSERTION
+            );
 
             // Test radial search min score query
             NeuralQueryBuilder neuralQueryWithMinScoreBuilder = new NeuralQueryBuilder(
@@ -156,12 +188,16 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 null
             );
 
-            searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, neuralQueryWithMinScoreBuilder, 1);
-            firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            Map<String, Object> searchResponseAsMapWithMinScoreQuery = search(TEST_BASIC_INDEX_NAME, neuralQueryWithMinScoreBuilder, 1);
+            Map<String, Object> firstInnerHitWithMinScoreQuery = getFirstInnerHit(searchResponseAsMapWithMinScoreQuery);
 
-            assertEquals("1", firstInnerHit.get("_id"));
+            assertEquals("1", firstInnerHitWithMinScoreQuery.get("_id"));
             float expectedScoreWithMinScoreQuery = computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
-            assertEquals(expectedScoreWithMinScoreQuery, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
+            assertEquals(
+                expectedScoreWithMinScoreQuery,
+                objectToFloat(firstInnerHitWithMinScoreQuery.get("_score")),
+                DELTA_FOR_SCORE_ASSERTION
+            );
         } finally {
             wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, null);
         }

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
@@ -84,6 +84,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 modelId,
                 1,
                 null,
+                null,
+                null,
                 null
             );
 
@@ -102,6 +104,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 TEST_IMAGE_TEXT,
                 modelId,
                 1,
+                null,
+                null,
                 null,
                 null
             );
@@ -153,6 +157,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 1,
+                null,
+                null,
                 null,
                 null
             );
@@ -229,6 +235,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 modelId,
                 1,
                 null,
+                null,
+                null,
                 null
             );
             NeuralQueryBuilder neuralQueryBuilder2 = new NeuralQueryBuilder(
@@ -237,6 +245,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 1,
+                null,
+                null,
                 null,
                 null
             );
@@ -262,6 +272,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 1,
+                null,
+                null,
                 null,
                 null
             );
@@ -316,6 +328,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 modelId,
                 1,
                 null,
+                null,
+                null,
                 null
             );
 
@@ -364,6 +378,8 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 modelId,
                 1,
                 null,
+                null,
+                null,
                 new MatchQueryBuilder("_id", "3")
             );
             Map<String, Object> searchResponseAsMap = search(TEST_MULTI_DOC_INDEX_NAME, neuralQueryBuilder, 3);
@@ -374,6 +390,64 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
         } finally {
             wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME, null, modelId, null);
+        }
+    }
+
+    @SneakyThrows
+    public void testQueryWithMaxDistance() {
+        String modelId = null;
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            modelId = prepareModel();
+            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
+                TEST_KNN_VECTOR_FIELD_NAME_1,
+                TEST_QUERY_TEXT,
+                "",
+                modelId,
+                null,
+                100.0f,
+                null,
+                null,
+                null
+            );
+
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, neuralQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, null);
+        }
+    }
+
+    @SneakyThrows
+    public void testQueryWithMinScore() {
+        String modelId = null;
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            modelId = prepareModel();
+            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
+                TEST_KNN_VECTOR_FIELD_NAME_1,
+                TEST_QUERY_TEXT,
+                "",
+                modelId,
+                null,
+                null,
+                0.01f,
+                null,
+                null
+            );
+
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, neuralQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA_FOR_SCORE_ASSERTION);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, null);
         }
     }
 


### PR DESCRIPTION
### Description
Since radial search is supported in k-NN plugin recently, this PR allows neural search to have the ability to use radial search parameters, so finally it can be allowed to use one of `k`, `min_score`, `max_distance`  for vector search.

### Issues Resolved
Part of https://github.com/opensearch-project/k-NN/issues/814

### Benchmark in k-NN plugin
https://github.com/opensearch-project/k-NN/issues/814#issuecomment-2060195145

### Check List
- [x] New functionality includes testing.
    - [ ] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
