### PR TITLE
Add support for asymmetric embedding models

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -11,16 +11,24 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.opensearch.common.CheckedConsumer;
+import org.opensearch.common.Nullable;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.dataset.MLInputDataset;
 import org.opensearch.ml.common.dataset.TextDocsInputDataSet;
 import org.opensearch.ml.common.dataset.TextSimilarityInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.input.parameter.MLAlgoParams;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.output.model.ModelResultFilter;
 import org.opensearch.ml.common.output.model.ModelTensor;
@@ -40,6 +48,7 @@ import lombok.extern.log4j.Log4j2;
 public class MLCommonsClientAccessor {
     private static final List<String> TARGET_RESPONSE_FILTERS = List.of("sentence_embedding");
     private final MachineLearningNodeClient mlClient;
+    private final Map<String, Boolean> modelAsymmetryCache = new ConcurrentHashMap<>();
 
     /**
      * Wrapper around {@link #inferenceSentences} that expected a single input text and produces a single floating
@@ -54,7 +63,29 @@ public class MLCommonsClientAccessor {
         @NonNull final String inputText,
         @NonNull final ActionListener<List<Float>> listener
     ) {
-        inferenceSentences(TARGET_RESPONSE_FILTERS, modelId, List.of(inputText), ActionListener.wrap(response -> {
+        inferenceSentence(modelId, inputText, null, listener);
+    }
+
+    /**
+     * Wrapper around {@link #inferenceSentences} that expected a single input text and produces a single floating
+     * point vector as a response. Supports passing {@link MLAlgoParams} to the inference. If the model is
+     * asymmetric, passing a
+     * {@link org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters} is
+     * mandatory. This method will check whether the model being used is asymmetric and correctly handle the
+     * parameter, so it's okay to always pass the parameter (even if the model is symmetric).
+     *
+     * @param modelId {@link String}
+     * @param inputText {@link List} of {@link String} on which inference needs to happen
+     * @param mlAlgoParams {@link MLAlgoParams} which will be used to run the inference
+     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out
+     */
+    public void inferenceSentence(
+        @NonNull final String modelId,
+        @NonNull final String inputText,
+        @Nullable final MLAlgoParams mlAlgoParams,
+        @NonNull final ActionListener<List<Float>> listener
+    ) {
+        inferenceSentences(TARGET_RESPONSE_FILTERS, modelId, List.of(inputText), mlAlgoParams, ActionListener.wrap(response -> {
             if (response.size() != 1) {
                 listener.onFailure(
                     new IllegalStateException(
@@ -69,35 +100,62 @@ public class MLCommonsClientAccessor {
     }
 
     /**
-     * Abstraction to call predict function of api of MLClient with default targetResponse filters. It uses the
-     * custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}. The return will be sent
-     * using the actionListener which will have a {@link List} of {@link List} of {@link Float} in the order of
-     * inputText. We are not making this function generic enough to take any function or TaskType as currently we
-     * need to run only TextEmbedding tasks only.
+     * Abstraction to call predict function of api of MLClient with default targetResponse filters. It
+     * uses the custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}. The
+     * return will be sent using the actionListener which will have a {@link List} of {@link List} of
+     * {@link Float} in the order of inputText. We are not making this function generic enough to take
+     * any function or TaskType as currently we need to run only TextEmbedding tasks only.
      *
-     * @param modelId {@link String}
+     * @param modelId   {@link String}
      * @param inputText {@link List} of {@link String} on which inference needs to happen
-     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out
+     * @param listener  {@link ActionListener} which will be called when prediction is completed or
+     *                  errored out
      */
     public void inferenceSentences(
         @NonNull final String modelId,
         @NonNull final List<String> inputText,
         @NonNull final ActionListener<List<List<Float>>> listener
     ) {
-        inferenceSentences(TARGET_RESPONSE_FILTERS, modelId, inputText, listener);
+        inferenceSentences(TARGET_RESPONSE_FILTERS, modelId, inputText, null, listener);
     }
 
     /**
-     * Abstraction to call predict function of api of MLClient with provided targetResponse filters. It uses the
-     * custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}. The return will be sent
-     * using the actionListener which will have a {@link List} of {@link List} of {@link Float} in the order of
-     * inputText. We are not making this function generic enough to take any function or TaskType as currently we
-     * need to run only TextEmbedding tasks only.
+     * Abstraction to call predict function of api of MLClient with default targetResponse filters. It
+     * uses the custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}. The
+     * return will be sent using the actionListener which will have a {@link List} of {@link List} of
+     * {@link Float} in the order of inputText. We are not making this function generic enough to take
+     * any function or TaskType as currently we need to run only TextEmbedding tasks only. Supports
+     * passing {@link MLAlgoParams} to the inference. If the model is asymmetric, passing a
+     * {@link org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters}
+     * is mandatory. This method will check whether the model being used is asymmetric and correctly
+     * handle the parameter, so it's okay to always pass the parameter (even if the model is symmetric).
      *
-     * @param targetResponseFilters {@link List} of {@link String} which filters out the responses
      * @param modelId {@link String}
      * @param inputText {@link List} of {@link String} on which inference needs to happen
-     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out.
+     * @param mlAlgoParams {@link MLAlgoParams} which will be used to run the inference
+     * @param listener {@link ActionListener} which will be called when prediction is completed or
+     */
+    public void inferenceSentences(
+        @NonNull final String modelId,
+        @NonNull final List<String> inputText,
+        @Nullable final MLAlgoParams mlAlgoParams,
+        @NonNull final ActionListener<List<List<Float>>> listener
+    ) {
+        inferenceSentences(TARGET_RESPONSE_FILTERS, modelId, inputText, mlAlgoParams, listener);
+    }
+
+    /**
+     * Abstraction to call predict function of api of MLClient with provided targetResponse filters.
+     * It uses the custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}.
+     * The return will be sent using the actionListener which will have a {@link List} of {@link List}
+     * of {@link Float} in the order of inputText. We are not making this function generic enough to
+     * take any function or TaskType as currently we need to run only TextEmbedding tasks only.
+     *
+     * @param targetResponseFilters {@link List} of {@link String} which filters out the responses
+     * @param modelId               {@link String}
+     * @param inputText             {@link List} of {@link String} on which inference needs to happen
+     * @param listener              {@link ActionListener} which will be called when prediction is
+     *                              completed or errored out.
      */
     public void inferenceSentences(
         @NonNull final List<String> targetResponseFilters,
@@ -105,7 +163,35 @@ public class MLCommonsClientAccessor {
         @NonNull final List<String> inputText,
         @NonNull final ActionListener<List<List<Float>>> listener
     ) {
-        retryableInferenceSentencesWithVectorResult(targetResponseFilters, modelId, inputText, 0, listener);
+        inferenceSentences(targetResponseFilters, modelId, inputText, null, listener);
+    }
+
+    /**
+     * Abstraction to call predict function of api of MLClient with provided targetResponse filters.
+     * It uses the custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}.
+     * The return will be sent using the actionListener which will have a {@link List} of {@link List}
+     * of {@link Float} in the order of inputText. We are not making this function generic enough to
+     * take any function or TaskType as currently we need to run only TextEmbedding tasks only. Supports
+     * passing {@link MLAlgoParams} to the inference. If the model is asymmetric, passing a
+     * {@link org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters}
+     * is mandatory. This method will check whether the model being used is asymmetric and correctly
+     * handle the parameter, so it's okay to always pass the parameter (even if the model is symmetric).
+     *
+     * @param targetResponseFilters {@link List} of {@link String} which filters out the responses
+     * @param modelId               {@link String}
+     * @param inputText             {@link List} of {@link String} on which inference needs to happen
+     * @param mlAlgoParams          {@link MLAlgoParams} which will be used to run the inference
+     * @param listener              {@link ActionListener} which will be called when prediction is
+     *                              completed or errored out.
+     */
+    public void inferenceSentences(
+        @NonNull final List<String> targetResponseFilters,
+        @NonNull final String modelId,
+        @NonNull final List<String> inputText,
+        @Nullable final MLAlgoParams mlAlgoParams,
+        @NonNull final ActionListener<List<List<Float>>> listener
+    ) {
+        retryableInferenceSentencesWithVectorResult(targetResponseFilters, modelId, inputText, mlAlgoParams, 0, listener);
     }
 
     public void inferenceSentencesWithMapResult(
@@ -113,35 +199,65 @@ public class MLCommonsClientAccessor {
         @NonNull final List<String> inputText,
         @NonNull final ActionListener<List<Map<String, ?>>> listener
     ) {
-        retryableInferenceSentencesWithMapResult(modelId, inputText, 0, listener);
+        retryableInferenceSentencesWithMapResult(modelId, inputText, null, 0, listener);
     }
 
     /**
-     * Abstraction to call predict function of api of MLClient with provided targetResponse filters. It uses the
-     * custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}. The return will be sent
-     * using the actionListener which will have a list of floats in the order of inputText.
+     * Abstraction to call predict function of api of MLClient with provided targetResponse filters.
+     * It uses the custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}.
+     * The return will be sent using the actionListener which will have a list of floats in the order
+     * of inputText.
      *
-     * @param modelId {@link String}
-     * @param inputObjects {@link Map} of {@link String}, {@link String} on which inference needs to happen
-     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out.
+     * @param modelId      {@link String}
+     * @param inputObjects {@link Map} of {@link String}, {@link String} on which inference needs to
+     *                     happen
+     * @param listener     {@link ActionListener} which will be called when prediction is completed or
+     *                     errored out.
      */
     public void inferenceSentences(
         @NonNull final String modelId,
         @NonNull final Map<String, String> inputObjects,
         @NonNull final ActionListener<List<Float>> listener
     ) {
-        retryableInferenceSentencesWithSingleVectorResult(TARGET_RESPONSE_FILTERS, modelId, inputObjects, 0, listener);
+        inferenceSentences(modelId, inputObjects, null, listener);
     }
 
     /**
-     * Abstraction to call predict function of api of MLClient. It uses the custom model provided as modelId and the
-     * {@link FunctionName#TEXT_SIMILARITY}. The return will be sent via actionListener as a list of floats representing
-     * the similarity scores of the texts w.r.t. the query text, in the order of the input texts.
+     * Abstraction to call predict function of api of MLClient with provided targetResponse filters.
+     * It uses the custom model provided as modelId and run the {@link FunctionName#TEXT_EMBEDDING}.
+     * The return will be sent using the actionListener which will have a list of floats in the order
+     * of inputText. Supports passing {@link MLAlgoParams} to the inference. If the model is asymmetric,
+     * passing a
+     * {@link org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters}
+     * is mandatory. This method will check whether the model being used is asymmetric and correctly
+     * handle the parameter, so it's okay to always pass the parameter (even if the model is symmetric).
      *
-     * @param modelId {@link String} ML-Commons Model Id
+     * @param modelId      {@link String}
+     * @param inputObjects {@link Map} of {@link String}, {@link String} on which inference needs to
+     *                     happen
+     * @param mlAlgoParams {@link MLAlgoParams} which will be used to run the inference
+     * @param listener     {@link ActionListener} which will be called when prediction is completed or
+     *                     errored out.
+     */
+    public void inferenceSentences(
+        @NonNull final String modelId,
+        @NonNull final Map<String, String> inputObjects,
+        @Nullable final MLAlgoParams mlAlgoParams,
+        @NonNull final ActionListener<List<Float>> listener
+    ) {
+        retryableInferenceSentencesWithSingleVectorResult(TARGET_RESPONSE_FILTERS, modelId, inputObjects, null, 0, listener);
+    }
+
+    /**
+     * Abstraction to call predict function of api of MLClient. It uses the custom model provided as
+     * modelId and the {@link FunctionName#TEXT_SIMILARITY}. The return will be sent via
+     * actionListener as a list of floats representing the similarity scores of the texts w.r.t. the
+     * query text, in the order of the input texts.
+     *
+     * @param modelId   {@link String} ML-Commons Model Id
      * @param queryText {@link String} The query to compare all the inputText to
      * @param inputText {@link List} of {@link String} The texts to compare to the query
-     * @param listener {@link ActionListener} receives the result of the inference
+     * @param listener  {@link ActionListener} receives the result of the inference
      */
     public void inferenceSimilarity(
         @NonNull final String modelId,
@@ -155,42 +271,95 @@ public class MLCommonsClientAccessor {
     private void retryableInferenceSentencesWithMapResult(
         final String modelId,
         final List<String> inputText,
+        final MLAlgoParams mlAlgoParams,
         final int retryTime,
         final ActionListener<List<Map<String, ?>>> listener
     ) {
-        MLInput mlInput = createMLTextInput(null, inputText);
-        mlClient.predict(modelId, mlInput, ActionListener.wrap(mlOutput -> {
-            final List<Map<String, ?>> result = buildMapResultFromResponse(mlOutput);
-            listener.onResponse(result);
-        }, e -> {
-            if (RetryUtil.shouldRetry(e, retryTime)) {
-                final int retryTimeAdd = retryTime + 1;
-                retryableInferenceSentencesWithMapResult(modelId, inputText, retryTimeAdd, listener);
-            } else {
-                listener.onFailure(e);
-            }
-        }));
+
+        Consumer<Boolean> runPrediction = isAsymmetricModel -> {
+            MLInput mlInput = createMLTextInput(null, inputText, isAsymmetricModel ? mlAlgoParams : null);
+            mlClient.predict(modelId, mlInput, ActionListener.wrap(mlOutput -> {
+                final List<Map<String, ?>> result = buildMapResultFromResponse(mlOutput);
+                listener.onResponse(result);
+            }, e -> {
+                if (RetryUtil.shouldRetry(e, retryTime)) {
+                    final int retryTimeAdd = retryTime + 1;
+                    retryableInferenceSentencesWithMapResult(modelId, inputText, mlAlgoParams, retryTimeAdd, listener);
+                } else {
+                    listener.onFailure(e);
+                }
+            }));
+        };
+
+        checkModelAsymmetryAndThenPredict(modelId, listener::onFailure, runPrediction);
     }
 
     private void retryableInferenceSentencesWithVectorResult(
         final List<String> targetResponseFilters,
         final String modelId,
         final List<String> inputText,
+        final MLAlgoParams mlAlgoParams,
         final int retryTime,
         final ActionListener<List<List<Float>>> listener
     ) {
-        MLInput mlInput = createMLTextInput(targetResponseFilters, inputText);
-        mlClient.predict(modelId, mlInput, ActionListener.wrap(mlOutput -> {
-            final List<List<Float>> vector = buildVectorFromResponse(mlOutput);
-            listener.onResponse(vector);
-        }, e -> {
-            if (RetryUtil.shouldRetry(e, retryTime)) {
-                final int retryTimeAdd = retryTime + 1;
-                retryableInferenceSentencesWithVectorResult(targetResponseFilters, modelId, inputText, retryTimeAdd, listener);
-            } else {
-                listener.onFailure(e);
+
+        Consumer<Boolean> runPrediction = isAsymmetricModel -> {
+            MLInput mlInput = createMLTextInput(targetResponseFilters, inputText, isAsymmetricModel ? mlAlgoParams : null);
+            mlClient.predict(modelId, mlInput, ActionListener.wrap(mlOutput -> {
+                final List<List<Float>> vector = buildVectorFromResponse(mlOutput);
+                listener.onResponse(vector);
+            }, e -> {
+                if (RetryUtil.shouldRetry(e, retryTime)) {
+                    final int retryTimeAdd = retryTime + 1;
+                    retryableInferenceSentencesWithVectorResult(
+                        targetResponseFilters,
+                        modelId,
+                        inputText,
+                        mlAlgoParams,
+                        retryTimeAdd,
+                        listener
+                    );
+                } else {
+                    listener.onFailure(e);
+                }
+            }));
+        };
+
+        checkModelAsymmetryAndThenPredict(modelId, listener::onFailure, runPrediction);
+    }
+
+    /**
+     * Check if the model is asymmetric and then run the prediction. Model asymmetry is a concept
+     * that is specific to TextEmbeddingModelConfig. If the model is not a TextEmbeddingModel, then
+     * this check is not applicable.
+     *
+     * The asymmetry of a model is static for a given model. To avoid repeated checks for the same
+     * model, we cache the model asymmetry status. Non-TextEmbeddingModels are cached as false.
+     *
+     * @param modelId    The model id to check
+     * @param onFailure The action to take if the model cannot be retrieved
+     * @param runPrediction The action to take if the model is successfully retrieved
+     */
+    private void checkModelAsymmetryAndThenPredict(String modelId, Consumer<Exception> onFailure, Consumer<Boolean> runPrediction) {
+        CheckedConsumer<MLModel, ? extends Exception> checkModelAsymmetryListener = model -> {
+            MLModelConfig modelConfig = model.getModelConfig();
+            if (!(modelConfig instanceof TextEmbeddingModelConfig)) {
+                modelAsymmetryCache.putIfAbsent(modelId, false);
+                return;
             }
-        }));
+            final TextEmbeddingModelConfig textEmbeddingModelConfig = (TextEmbeddingModelConfig) modelConfig;
+            final boolean isAsymmetricModel = textEmbeddingModelConfig.getPassagePrefix() != null
+                || textEmbeddingModelConfig.getQueryPrefix() != null;
+            modelAsymmetryCache.putIfAbsent(modelId, isAsymmetricModel);
+        };
+        if (modelAsymmetryCache.containsKey(modelId)) {
+            runPrediction.accept(modelAsymmetryCache.get(modelId));
+        } else {
+            mlClient.getModel(modelId, ActionListener.<MLModel>wrap(mlModel -> {
+                checkModelAsymmetryListener.accept(mlModel);
+                runPrediction.accept(modelAsymmetryCache.get(modelId));
+            }, onFailure));
+        }
     }
 
     private void retryableInferenceSimilarityWithVectorResult(
@@ -213,10 +382,10 @@ public class MLCommonsClientAccessor {
         }));
     }
 
-    private MLInput createMLTextInput(final List<String> targetResponseFilters, List<String> inputText) {
+    private MLInput createMLTextInput(final List<String> targetResponseFilters, List<String> inputText, MLAlgoParams mlAlgoParams) {
         final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         final MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
-        return new MLInput(FunctionName.TEXT_EMBEDDING, null, inputDataset);
+        return new MLInput(FunctionName.TEXT_EMBEDDING, mlAlgoParams, inputDataset);
     }
 
     private MLInput createMLTextPairsInput(final String query, final List<String> inputText) {
@@ -264,25 +433,42 @@ public class MLCommonsClientAccessor {
         final List<String> targetResponseFilters,
         final String modelId,
         final Map<String, String> inputObjects,
+        final MLAlgoParams mlAlgoParams,
         final int retryTime,
         final ActionListener<List<Float>> listener
     ) {
-        MLInput mlInput = createMLMultimodalInput(targetResponseFilters, inputObjects);
-        mlClient.predict(modelId, mlInput, ActionListener.wrap(mlOutput -> {
-            final List<Float> vector = buildSingleVectorFromResponse(mlOutput);
-            log.debug("Inference Response for input sentence is : {} ", vector);
-            listener.onResponse(vector);
-        }, e -> {
-            if (RetryUtil.shouldRetry(e, retryTime)) {
-                final int retryTimeAdd = retryTime + 1;
-                retryableInferenceSentencesWithSingleVectorResult(targetResponseFilters, modelId, inputObjects, retryTimeAdd, listener);
-            } else {
-                listener.onFailure(e);
-            }
-        }));
+
+        Consumer<Boolean> predictConsumer = isAsymmetricModel -> {
+            MLInput mlInput = createMLMultimodalInput(targetResponseFilters, inputObjects, isAsymmetricModel ? mlAlgoParams : null);
+            mlClient.predict(modelId, mlInput, ActionListener.wrap(mlOutput -> {
+                final List<Float> vector = buildSingleVectorFromResponse(mlOutput);
+                log.debug("Inference Response for input sentence is : {} ", vector);
+                listener.onResponse(vector);
+            }, e -> {
+                if (RetryUtil.shouldRetry(e, retryTime)) {
+                    final int retryTimeAdd = retryTime + 1;
+                    retryableInferenceSentencesWithSingleVectorResult(
+                        targetResponseFilters,
+                        modelId,
+                        inputObjects,
+                        mlAlgoParams,
+                        retryTimeAdd,
+                        listener
+                    );
+                } else {
+                    listener.onFailure(e);
+                }
+            }));
+        };
+
+        checkModelAsymmetryAndThenPredict(modelId, listener::onFailure, predictConsumer);
     }
 
-    private MLInput createMLMultimodalInput(final List<String> targetResponseFilters, final Map<String, String> input) {
+    private MLInput createMLMultimodalInput(
+        final List<String> targetResponseFilters,
+        final Map<String, String> input,
+        MLAlgoParams mlAlgoParams
+    ) {
         List<String> inputText = new ArrayList<>();
         inputText.add(input.get(INPUT_TEXT));
         if (input.containsKey(INPUT_IMAGE)) {
@@ -290,6 +476,6 @@ public class MLCommonsClientAccessor {
         }
         final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         final MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
-        return new MLInput(FunctionName.TEXT_EMBEDDING, null, inputDataset);
+        return new MLInput(FunctionName.TEXT_EMBEDDING, mlAlgoParams, inputDataset);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -11,6 +11,8 @@ import java.util.function.BiConsumer;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 
 import lombok.extern.log4j.Log4j2;
@@ -43,9 +45,14 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
         List<String> inferenceList,
         BiConsumer<IngestDocument, Exception> handler
     ) {
-        mlCommonsClientAccessor.inferenceSentences(this.modelId, inferenceList, ActionListener.wrap(vectors -> {
-            setVectorFieldsToDocument(ingestDocument, ProcessMap, vectors);
-            handler.accept(ingestDocument, null);
-        }, e -> { handler.accept(null, e); }));
+        mlCommonsClientAccessor.inferenceSentences(
+            this.modelId,
+            inferenceList,
+            AsymmetricTextEmbeddingParameters.builder().embeddingContentType(EmbeddingContentType.PASSAGE).build(),
+            ActionListener.wrap(vectors -> {
+                setVectorFieldsToDocument(ingestDocument, ProcessMap, vectors);
+                handler.accept(ingestDocument, null);
+            }, e -> { handler.accept(null, e); })
+        );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -34,6 +34,8 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 
@@ -312,10 +314,15 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
             inferenceInput.put(INPUT_IMAGE, queryImage());
         }
         queryRewriteContext.registerAsyncAction(
-            ((client, actionListener) -> ML_CLIENT.inferenceSentences(modelId(), inferenceInput, ActionListener.wrap(floatList -> {
-                vectorSetOnce.set(vectorAsListToArray(floatList));
-                actionListener.onResponse(null);
-            }, actionListener::onFailure)))
+            ((client, actionListener) -> ML_CLIENT.inferenceSentences(
+                modelId(),
+                inferenceInput,
+                AsymmetricTextEmbeddingParameters.builder().embeddingContentType(EmbeddingContentType.QUERY).build(),
+                ActionListener.wrap(floatList -> {
+                    vectorSetOnce.set(vectorAsListToArray(floatList));
+                    actionListener.onResponse(null);
+                }, actionListener::onFailure)
+            ))
         );
         return new NeuralQueryBuilder(
             fieldName(),

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -34,7 +34,9 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
     public void testTextEmbeddingProcessor() throws Exception {
         String modelId = null;
         try {
-            modelId = uploadTextEmbeddingModel();
+            modelId = uploadTextEmbeddingModel(
+                Files.readString(Path.of(classLoader.getResource("processor/UploadModelRequestBody.json").toURI()))
+            );
             loadModel(modelId);
             createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_EMBEDDING);
             createTextEmbeddingIndex();
@@ -45,8 +47,7 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
         }
     }
 
-    private String uploadTextEmbeddingModel() throws Exception {
-        String requestBody = Files.readString(Path.of(classLoader.getResource("processor/UploadModelRequestBody.json").toURI()));
+    private String uploadTextEmbeddingModel(String requestBody) throws Exception {
         return registerModelGroupAndUploadModel(requestBody);
     }
 
@@ -56,6 +57,22 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             Files.readString(Path.of(classLoader.getResource("processor/IndexMappings.json").toURI())),
             PIPELINE_NAME
         );
+    }
+
+    public void testAsymmetricTextEmbeddingProcessor() throws Exception {
+        String modelId = null;
+        try {
+            modelId = uploadTextEmbeddingModel(
+                Files.readString(Path.of(classLoader.getResource("processor/UploadAsymmetricModelRequestBody.json").toURI()))
+            );
+            loadModel(modelId);
+            createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_EMBEDDING);
+            createTextEmbeddingIndex();
+            ingestDocument();
+            assertEquals(1, getDocCount(INDEX_NAME));
+        } finally {
+            wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
+        }
     }
 
     private void ingestDocument() throws Exception {

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -34,6 +34,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.Processor;
+import org.opensearch.ml.common.input.parameter.MLAlgoParams;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.factory.TextEmbeddingProcessorFactory;
 import org.opensearch.test.OpenSearchTestCase;
@@ -109,10 +110,10 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(3);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(MLAlgoParams.class), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -133,7 +134,8 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
         config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1Mapped", "key2", "key2Mapped"));
         TextEmbeddingProcessor processor = textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor)
+            .inferenceSentences(anyString(), anyList(), isA(MLAlgoParams.class), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(RuntimeException.class));
@@ -168,10 +170,10 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(3);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(MLAlgoParams.class), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -237,10 +239,10 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(3);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(MLAlgoParams.class), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -294,10 +296,10 @@ public class TextEmbeddingProcessorTests extends OpenSearchTestCase {
         TextEmbeddingProcessor processor = createInstance(createMockVectorWithLength(2));
 
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(3);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(MLAlgoParams.class), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -564,10 +564,10 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         List<Float> expectedVector = Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
         MLCommonsClientAccessor mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         doAnswer(invocation -> {
-            ActionListener<List<Float>> listener = invocation.getArgument(2);
+            ActionListener<List<Float>> listener = invocation.getArgument(3);
             listener.onResponse(expectedVector);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), anyMap(), any());
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), anyMap(), any(), any());
         NeuralQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
@@ -600,10 +600,10 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         List<Float> expectedVector = Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
         MLCommonsClientAccessor mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         doAnswer(invocation -> {
-            ActionListener<List<Float>> listener = invocation.getArgument(2);
+            ActionListener<List<Float>> listener = invocation.getArgument(3);
             listener.onResponse(expectedVector);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), anyMap(), any());
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), anyMap(), any(), any());
         NeuralQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);

--- a/src/test/resources/processor/UploadAsymmetricModelRequestBody.json
+++ b/src/test/resources/processor/UploadAsymmetricModelRequestBody.json
@@ -1,0 +1,17 @@
+{
+  "name": "traced_small_model",
+  "version": "1.0.0",
+  "model_format": "TORCH_SCRIPT",
+  "model_task_type": "text_embedding",
+  "model_content_hash_value": "e13b74006290a9d0f58c1376f9629d4ebc05a0f9385f40db837452b167ae9021",
+  "model_group_id": "%s",
+  "model_config": {
+    "model_type": "bert",
+    "embedding_dimension": 768,
+    "framework_type": "sentence_transformers",
+    "passage_prefix" : "passage: ",
+    "query_prefix" : "query: ",
+    "all_config": "{\"architectures\":[\"BertModel\"],\"max_position_embeddings\":512,\"model_type\":\"bert\",\"num_attention_heads\":12,\"num_hidden_layers\":6}"
+  },
+  "url": "https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/traced_small_model.zip?raw=true"
+}


### PR DESCRIPTION
### Description
This PR adds support for asymmetric embedding models such as https://huggingface.co/intfloat/multilingual-e5-small to the neural-search plugin.

It builds on the work done in https://github.com/opensearch-project/ml-commons/issues/1799.

Asymmetric embedding models behave differently when embedding passages and queries. For that end, the model must "know" on inference time, what kind of data it is embedding.

The changes are:
#### 1. `src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java`
The processor signals it is embedding passages, by passing the new `AsymmetricTextEmbeddingParameters` using the content type `EmbeddingContentType.PASSAGE`.
#### 2. `src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java`
Analogously, the query builder uses `EmbeddingContentType.QUERY`.
#### 3. `src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java`
Here is where most of the work was done. The class has been extended in a backwards-compatible way with inference methods that allow one to pass `MLAlgoParams` objects. Usage of `AsymmetricTextEmbeddingParameters` (which implements `MLAlgoParams`) is mandatory for asymmetric models. At the same time symmetric models do not accept them. 
    
The only way to know whether a model is asymmetric or symmetric is by reading its model configuration (if the models' configuration contains a `passage_prefix` and/or a `query_prefix`, they are asymmetric, otherwise they are symmetric). 
    
The `src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java` class deals with this, keeping the complexity in one place and not requiring any API change to the neural-search plugin (as proposed in #620). When calling the inference methods, clients (such as the `TextEmbeddingProcessor`) may pass the `AsymmetricTextEmbeddingParameters` object without caring if the model they are using is symmetric or asymmetric. The accessor class will first read the model's configuration (by calling the `getModel` API of the `mlClient`) and deal appropriately. 
    
To avoid adding this extra roundtrip to every inference call, the asymmetry information is kept in a cache in memory.

### Issues Resolved
#620 

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [ ] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
