### PR TITLE
Removed map of subquery to subquery index in favor of storing index as part of DISI wrapper to improve hybrid query latencies by 20%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allowing execution of hybrid query on index alias with filters ([#670](https://github.com/opensearch-project/neural-search/pull/670))
 - Allowing query by raw tokens in neural_sparse query ([#693](https://github.com/opensearch-project/neural-search/pull/693))
 - Removed stream.findFirst implementation to use more native iteration implement to improve hybrid query latencies by 35% ([#706](https://github.com/opensearch-project/neural-search/pull/706))
+- Removed map of subquery to subquery index in favor of storing index as part of disi wrapper to improve hybrid query latencies by 20% ([#711](https://github.com/opensearch-project/neural-search/pull/711))
 ### Bug Fixes
 - Add support for request_cache flag in hybrid query ([#663](https://github.com/opensearch-project/neural-search/pull/663))
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
@@ -190,7 +190,8 @@ public final class HybridQueryScorer extends Scorer {
      */
     public float[] hybridScores() throws IOException {
         float[] scores = new float[subScores.length];
-        if (subScorersPQ.topList() instanceof HybridDisiWrapper == false) {
+        DisiWrapper topList = subScorersPQ.topList();
+        if (topList instanceof HybridDisiWrapper == false) {
             log.error(
                 String.format(
                     Locale.ROOT,
@@ -199,10 +200,12 @@ public final class HybridQueryScorer extends Scorer {
                     subScorersPQ.topList().getClass().getSimpleName()
                 )
             );
-            throw new IllegalStateException();
+            throw new IllegalStateException(
+                "Unable to collect scores for one of the sub-queries, encountered an unexpected type of score iterator."
+            );
         }
-        HybridDisiWrapper topList = (HybridDisiWrapper) subScorersPQ.topList();
-        for (HybridDisiWrapper disiWrapper = topList; disiWrapper != null; disiWrapper = (HybridDisiWrapper) disiWrapper.next) {
+        for (HybridDisiWrapper disiWrapper = (HybridDisiWrapper) topList; disiWrapper != null; disiWrapper =
+            (HybridDisiWrapper) disiWrapper.next) {
             // check if this doc has match in the subQuery. If not, add score as 0.0 and continue
             Scorer scorer = disiWrapper.scorer;
             if (scorer.docID() == DocIdSetIterator.NO_MORE_DOCS) {

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridDisiWrapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridDisiWrapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search;
+
+import lombok.Getter;
+import org.apache.lucene.search.DisiWrapper;
+import org.apache.lucene.search.Scorer;
+
+/**
+ * Wrapper for DisiWrapper, saves state of sub-queries for performance reasons
+ */
+@Getter
+public class HybridDisiWrapper extends DisiWrapper {
+    // index of disi wrapper sub-query object when its part of the hybrid query
+    int subQueryIndex = -1;
+
+    public HybridDisiWrapper(Scorer scorer, int subQueryIndex) {
+        super(scorer);
+        this.subQueryIndex = subQueryIndex;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridDisiWrapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridDisiWrapper.java
@@ -14,7 +14,7 @@ import org.apache.lucene.search.Scorer;
 @Getter
 public class HybridDisiWrapper extends DisiWrapper {
     // index of disi wrapper sub-query object when its part of the hybrid query
-    int subQueryIndex = -1;
+    private final int subQueryIndex;
 
     public HybridDisiWrapper(Scorer scorer, int subQueryIndex) {
         super(scorer);

--- a/src/test/java/org/opensearch/neuralsearch/search/HybridDisiWrapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/HybridDisiWrapperTests.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Scorer;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HybridDisiWrapperTests extends OpenSearchQueryTestCase {
+
+    public void testSubQueryIndex_whenCreateNewInstanceAndSetIndex_thenSuccessful() {
+        Scorer scorer = mock(Scorer.class);
+        DocIdSetIterator docIdSetIterator = mock(DocIdSetIterator.class);
+        when(scorer.iterator()).thenReturn(docIdSetIterator);
+        int subQueryIndex = 2;
+        HybridDisiWrapper hybridDisiWrapper = new HybridDisiWrapper(scorer, subQueryIndex);
+        assertEquals(2, hybridDisiWrapper.getSubQueryIndex());
+    }
+}


### PR DESCRIPTION
In this PR we're continue to improve latency of hybrid query as part of meta issue https://github.com/opensearch-project/neural-search/issues/705. 

Based on following flamegraph next area that may give high boost is a lookup of sub-query index by the query. That is needed to get index of sub-query and store score of that sub-query for one document ([code ref](https://github.com/opensearch-project/neural-search/blob/2.13/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java#L204-L224)).

![profile_hybqr_15_04_no_concurrent](https://github.com/opensearch-project/neural-search/assets/94878159/a2beafc9-1deb-4f55-b85b-3c8260ab69bb)

Most time (~28%) is taken by store and lookup of the index based on query as a key. Depending on the exact sub-query calculation of its hash code can be slow (hybrid query works with any type of OpenSearch query). That is a problem on large datasets as this is done for each doc by each sub-query.

We can avoid creation and usage of that query to index map by storing sub-query index at [time we create collection of DISIWrapers](https://github.com/opensearch-project/neural-search/blob/2.13/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java#L253-L260). 

As per benchmark results that gives about 20% performance boost. I've run it on 2.13 using [noaa OSB workload](https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/noaa), all times are in ms:

Before the change (baseline)

```
One sub-query that selects 11M documents

Bool: p50 88.2863 | p90 103.777
Hybrid: p50 299.427 | p90 319.797

One sub-query that selects 1.6K documents

Bool: p50 92.7222 | p90 98.6847
Hybrid: p50 94.5511 | p90 111.645

Three sub-query that select 15M documents

Bool: p50 98.0301 | p90 108.948
Hybrid: p50 475.319 | p90 515.999
```

After the change:

```
One sub-query that selects 11M documents

Bool: p50 97.9306 | p90 116.299
Hybrid: p50 228.696 | p90 249.665

One sub-query that selects 1.6K documents

Bool: p50 87.3152 | p90 89.3061
Hybrid: p50 89.9654 | p90 92.349

Three sub-query that select 15M documents

Bool: p50 97.9891 | p90 114.396
Hybrid: p50 353.631 | p90 377.527
```

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/705

### Check List
- [X] New functionality includes testing.
    - [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
