### PR TITLE
Fix: text chunking processor ingestion bug on multi-node cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed map of subquery to subquery index in favor of storing index as part of disi wrapper to improve hybrid query latencies by 20% ([#711](https://github.com/opensearch-project/neural-search/pull/711))
 ### Bug Fixes
 - Add support for request_cache flag in hybrid query ([#663](https://github.com/opensearch-project/neural-search/pull/663))
+- Fix multi node "no such index" error in text chunking processor ([#713](https://github.com/opensearch-project/neural-search/pull/713))
 - Avoid change max_chunk_limit exceed exception in text chunking processor ([#717](https://github.com/opensearch-project/neural-search/pull/717))
 ### Infrastructure
 ### Documentation

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/TextChunkingProcessorIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/TextChunkingProcessorIT.java
@@ -28,7 +28,7 @@ public class TextChunkingProcessorIT extends AbstractRestartUpgradeRestTestCase 
         "standard tokenizer in OpenSearch."
     );
 
-    // Test rolling-upgrade text chunking processor
+    // Test restart-upgrade text chunking processor
     // Create Text Chunking Processor, Ingestion Pipeline and add document
     // Validate process, pipeline and document count in restart-upgrade scenario
     public void testTextChunkingProcessor_E2EFlow() throws Exception {

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -118,12 +118,7 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
             TextImageEmbeddingProcessor.TYPE,
             new TextImageEmbeddingProcessorFactory(clientAccessor, parameters.env, parameters.ingestService.getClusterService()),
             TextChunkingProcessor.TYPE,
-            new TextChunkingProcessorFactory(
-                parameters.env,
-                parameters.ingestService.getClusterService(),
-                parameters.indicesService,
-                parameters.analysisRegistry
-            )
+            new TextChunkingProcessorFactory(parameters.env, parameters.ingestService.getClusterService(), parameters.analysisRegistry)
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.env.Environment;
 import org.opensearch.cluster.service.ClusterService;
@@ -154,8 +153,7 @@ public final class TextChunkingProcessor extends AbstractProcessor {
             return defaultMaxTokenCount;
         }
         // if the index is specified in the metadata, read maxTokenCount from the index setting
-        String maxTokenCountString = indexMetadata.getSettings().get("index.analyze.max_token_count");
-        return NumberUtils.toInt(maxTokenCountString, defaultMaxTokenCount);
+        return IndexSettings.MAX_TOKEN_COUNT_SETTING.get(indexMetadata.getSettings());
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -152,8 +152,11 @@ public final class TextChunkingProcessor extends AbstractProcessor {
             return IndexSettings.MAX_TOKEN_COUNT_SETTING.get(environment.settings());
         }
         // if the index is specified in the metadata, read maxTokenCount from the index setting
-        IndexSettings indexSettings = new IndexSettings(indexMetadata, indexMetadata.getSettings());
-        return indexSettings.getMaxTokenCount();
+        String maxTokenCountString = indexMetadata.getSettings().get("index.analyze.max_token_count");
+        if (Objects.isNull(maxTokenCountString)) {
+            return IndexSettings.MAX_TOKEN_COUNT_SETTING.get(environment.settings());
+        }
+        return Integer.parseInt(maxTokenCountString);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -15,11 +15,9 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.env.Environment;
-import org.opensearch.index.IndexService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
@@ -52,7 +50,6 @@ public final class TextChunkingProcessor extends AbstractProcessor {
     private Chunker chunker;
     private final Map<String, Object> fieldMap;
     private final ClusterService clusterService;
-    private final IndicesService indicesService;
     private final AnalysisRegistry analysisRegistry;
     private final Environment environment;
 
@@ -63,14 +60,12 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         final Map<String, Object> algorithmMap,
         final Environment environment,
         final ClusterService clusterService,
-        final IndicesService indicesService,
         final AnalysisRegistry analysisRegistry
     ) {
         super(tag, description);
         this.fieldMap = fieldMap;
         this.environment = environment;
         this.clusterService = clusterService;
-        this.indicesService = indicesService;
         this.analysisRegistry = analysisRegistry;
         parseAlgorithmMap(algorithmMap);
     }
@@ -157,8 +152,7 @@ public final class TextChunkingProcessor extends AbstractProcessor {
             return IndexSettings.MAX_TOKEN_COUNT_SETTING.get(environment.settings());
         }
         // if the index is specified in the metadata, read maxTokenCount from the index setting
-        IndexService indexService = indicesService.indexServiceSafe(indexMetadata.getIndex());
-        return indexService.getIndexSettings().getMaxTokenCount();
+        return Integer.parseInt(indexMetadata.getSettings().get("index.analyze.max_token_count"));
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -153,6 +153,7 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         }
         // if the index is specified in the metadata, read maxTokenCount from the index setting
         String maxTokenCountString = indexMetadata.getSettings().get("index.analyze.max_token_count");
+        // if maxTokenCount is not specified in the index, return the default setting
         if (Objects.isNull(maxTokenCountString)) {
             return IndexSettings.MAX_TOKEN_COUNT_SETTING.get(environment.settings());
         }

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.env.Environment;
 import org.opensearch.cluster.service.ClusterService;
@@ -146,18 +147,19 @@ public final class TextChunkingProcessor extends AbstractProcessor {
     }
 
     private int getMaxTokenCount(final Map<String, Object> sourceAndMetadataMap) {
+        int defaultMaxTokenCount = IndexSettings.MAX_TOKEN_COUNT_SETTING.get(environment.settings());
         String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
         IndexMetadata indexMetadata = clusterService.state().metadata().index(indexName);
         if (Objects.isNull(indexMetadata)) {
-            return IndexSettings.MAX_TOKEN_COUNT_SETTING.get(environment.settings());
+            return defaultMaxTokenCount;
         }
         // if the index is specified in the metadata, read maxTokenCount from the index setting
         String maxTokenCountString = indexMetadata.getSettings().get("index.analyze.max_token_count");
         // if maxTokenCount is not specified in the index, return the default setting
         if (Objects.isNull(maxTokenCountString)) {
-            return IndexSettings.MAX_TOKEN_COUNT_SETTING.get(environment.settings());
+            return defaultMaxTokenCount;
         }
-        return Integer.parseInt(maxTokenCountString);
+        return NumberUtils.toInt(maxTokenCountString, defaultMaxTokenCount);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -152,7 +152,8 @@ public final class TextChunkingProcessor extends AbstractProcessor {
             return IndexSettings.MAX_TOKEN_COUNT_SETTING.get(environment.settings());
         }
         // if the index is specified in the metadata, read maxTokenCount from the index setting
-        return Integer.parseInt(indexMetadata.getSettings().get("index.analyze.max_token_count"));
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, indexMetadata.getSettings());
+        return indexSettings.getMaxTokenCount();
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -155,10 +155,6 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         }
         // if the index is specified in the metadata, read maxTokenCount from the index setting
         String maxTokenCountString = indexMetadata.getSettings().get("index.analyze.max_token_count");
-        // if maxTokenCount is not specified in the index, return the default setting
-        if (Objects.isNull(maxTokenCountString)) {
-            return defaultMaxTokenCount;
-        }
         return NumberUtils.toInt(maxTokenCountString, defaultMaxTokenCount);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/TextChunkingProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/TextChunkingProcessorFactory.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
 import org.opensearch.index.analysis.AnalysisRegistry;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.processor.TextChunkingProcessor;
 import static org.opensearch.neuralsearch.processor.TextChunkingProcessor.TYPE;
@@ -29,19 +28,11 @@ public class TextChunkingProcessorFactory implements Processor.Factory {
 
     private final ClusterService clusterService;
 
-    private final IndicesService indicesService;
-
     private final AnalysisRegistry analysisRegistry;
 
-    public TextChunkingProcessorFactory(
-        Environment environment,
-        ClusterService clusterService,
-        IndicesService indicesService,
-        AnalysisRegistry analysisRegistry
-    ) {
+    public TextChunkingProcessorFactory(Environment environment, ClusterService clusterService, AnalysisRegistry analysisRegistry) {
         this.environment = environment;
         this.clusterService = clusterService;
-        this.indicesService = indicesService;
         this.analysisRegistry = analysisRegistry;
     }
 
@@ -54,15 +45,6 @@ public class TextChunkingProcessorFactory implements Processor.Factory {
     ) throws Exception {
         Map<String, Object> fieldMap = readMap(TYPE, processorTag, config, FIELD_MAP_FIELD);
         Map<String, Object> algorithmMap = readMap(TYPE, processorTag, config, ALGORITHM_FIELD);
-        return new TextChunkingProcessor(
-            processorTag,
-            description,
-            fieldMap,
-            algorithmMap,
-            environment,
-            clusterService,
-            indicesService,
-            analysisRegistry
-        );
+        return new TextChunkingProcessor(processorTag, description, fieldMap, algorithmMap, environment, clusterService, analysisRegistry);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextChunkingProcessorTests.java
@@ -32,7 +32,6 @@ import org.opensearch.env.TestEnvironment;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.analysis.TokenizerFactory;
 import org.opensearch.index.mapper.IndexFieldMapper;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.analysis.AnalysisModule;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.Processor;
@@ -85,11 +84,10 @@ public class TextChunkingProcessorTests extends OpenSearchTestCase {
         when(environment.settings()).thenReturn(settings);
         ClusterState clusterState = mock(ClusterState.class);
         ClusterService clusterService = mock(ClusterService.class);
-        IndicesService indicesService = mock(IndicesService.class);
         when(metadata.index(anyString())).thenReturn(null);
         when(clusterState.metadata()).thenReturn(metadata);
         when(clusterService.state()).thenReturn(clusterState);
-        textChunkingProcessorFactory = new TextChunkingProcessorFactory(environment, clusterService, indicesService, getAnalysisRegistry());
+        textChunkingProcessorFactory = new TextChunkingProcessorFactory(environment, clusterService, getAnalysisRegistry());
     }
 
     private Map<String, Object> createFixedTokenLengthParameters() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/TextChunkingProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/TextChunkingProcessorFactoryTests.java
@@ -19,7 +19,6 @@ import org.opensearch.env.Environment;
 import org.opensearch.env.TestEnvironment;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.analysis.TokenizerFactory;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.analysis.AnalysisModule;
 import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.processor.TextChunkingProcessor;
@@ -62,13 +61,7 @@ public class TextChunkingProcessorFactoryTests extends OpenSearchTestCase {
     public void setup() {
         Environment environment = mock(Environment.class);
         ClusterService clusterService = mock(ClusterService.class);
-        IndicesService indicesService = mock(IndicesService.class);
-        this.textChunkingProcessorFactory = new TextChunkingProcessorFactory(
-            environment,
-            clusterService,
-            indicesService,
-            getAnalysisRegistry()
-        );
+        this.textChunkingProcessorFactory = new TextChunkingProcessorFactory(environment, clusterService, getAnalysisRegistry());
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
For multi node cluster, the text chunking processor would produce "no such index" error if the configured shard number is less than the number of nodes. This is because some node does not contain the shard information. When we get max token count setting, `indicesService` fails to find the index information.
```
IndexService indexService = indicesService.indexServiceSafe(indexMetadata.getIndex());
```

### Issues Resolved
Fix ingestion bug on multi-node cluster

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
