### PR TITLE
Optimize parameter parsing in text chunking processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.14...2.x)
 ### Features
 ### Enhancements
-- Optimize parameter parsing in text chunking processor
+- Optimize parameter parsing in text chunking processor ([#733](https://github.com/opensearch-project/neural-search/pull/733))
 ### Bug Fixes
 - Fix multi node "no such index" error in text chunking processor ([#713](https://github.com/opensearch-project/neural-search/pull/713))
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.14...2.x)
 ### Features
 ### Enhancements
+- Optimize parameter parsing in text chunking processor
 ### Bug Fixes
 - Fix multi node "no such index" error in text chunking processor ([#713](https://github.com/opensearch-project/neural-search/pull/713))
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -30,7 +30,8 @@ import static org.opensearch.neuralsearch.processor.chunker.Chunker.MAX_CHUNK_LI
 import static org.opensearch.neuralsearch.processor.chunker.Chunker.DEFAULT_MAX_CHUNK_LIMIT;
 import static org.opensearch.neuralsearch.processor.chunker.Chunker.DISABLED_MAX_CHUNK_LIMIT;
 import static org.opensearch.neuralsearch.processor.chunker.Chunker.CHUNK_STRING_COUNT_FIELD;
-import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseIntegerParameter;
+import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseInteger;
+import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseIntegerWithDefault;
 
 /**
  * This processor is used for text chunking.
@@ -115,8 +116,8 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         }
         Map<String, Object> chunkerParameters = (Map<String, Object>) algorithmValue;
         // parse processor level max chunk limit
-        this.maxChunkLimit = parseIntegerParameter(chunkerParameters, MAX_CHUNK_LIMIT_FIELD, DEFAULT_MAX_CHUNK_LIMIT);
-        if (maxChunkLimit < 0 && maxChunkLimit != DISABLED_MAX_CHUNK_LIMIT) {
+        this.maxChunkLimit = parseIntegerWithDefault(chunkerParameters, MAX_CHUNK_LIMIT_FIELD, DEFAULT_MAX_CHUNK_LIMIT);
+        if (maxChunkLimit <= 0 && maxChunkLimit != DISABLED_MAX_CHUNK_LIMIT) {
             throw new IllegalArgumentException(
                 String.format(
                     Locale.ROOT,
@@ -309,10 +310,10 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         }
         List<String> contentResult = chunker.chunk(content, runTimeParameters);
         // update chunk_string_count for each string
-        int chunkStringCount = parseIntegerParameter(runTimeParameters, CHUNK_STRING_COUNT_FIELD, 1);
+        int chunkStringCount = parseInteger(runTimeParameters, CHUNK_STRING_COUNT_FIELD);
         runTimeParameters.put(CHUNK_STRING_COUNT_FIELD, chunkStringCount - 1);
         // update runtime max_chunk_limit if not disabled
-        int runtimeMaxChunkLimit = parseIntegerParameter(runTimeParameters, MAX_CHUNK_LIMIT_FIELD, maxChunkLimit);
+        int runtimeMaxChunkLimit = parseInteger(runTimeParameters, MAX_CHUNK_LIMIT_FIELD);
         if (runtimeMaxChunkLimit != DISABLED_MAX_CHUNK_LIMIT) {
             runTimeParameters.put(MAX_CHUNK_LIMIT_FIELD, runtimeMaxChunkLimit - contentResult.size());
         }

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
@@ -20,13 +20,10 @@ public final class ChunkerParameterParser {
 
     /**
      * Parse String type parameter.
+     * Return default value if the parameter is missing.
      * Throw IllegalArgumentException if parameter is not a string or an empty string.
      */
-    public static String parseStringParameter(final Map<String, Object> parameters, final String fieldName, final String defaultValue) {
-        if (!parameters.containsKey(fieldName)) {
-            // all string parameters are optional
-            return defaultValue;
-        }
+    public static String parseString(final Map<String, Object> parameters, final String fieldName) {
         Object fieldValue = parameters.get(fieldName);
         if (!(fieldValue instanceof String)) {
             throw new IllegalArgumentException(
@@ -40,18 +37,22 @@ public final class ChunkerParameterParser {
     }
 
     /**
-     * Parse integer type parameter.
-     * Throw IllegalArgumentException if both parameter and default value is missing or parameter is not an integer.
+     * Parse String type parameter.
+     * Throw IllegalArgumentException if parameter is not a string or an empty string.
      */
-    public static int parseIntegerParameter(final Map<String, Object> parameters, final String fieldName, final Integer defaultValue) {
+    public static String parseStringWithDefault(final Map<String, Object> parameters, final String fieldName, final String defaultValue) {
         if (!parameters.containsKey(fieldName)) {
-            // return the default value when parameter is not existing
-            if (defaultValue == null) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT, "Parameter [%s] is missing", fieldName));
-            } else {
-                return defaultValue;
-            }
+            // all string parameters are optional
+            return defaultValue;
         }
+        return parseString(parameters, fieldName);
+    }
+
+    /**
+     * Parse integer type parameter with default value.
+     * Throw IllegalArgumentException if the parameter is not an integer.
+     */
+    public static int parseInteger(final Map<String, Object> parameters, final String fieldName) {
         String fieldValueString = parameters.get(fieldName).toString();
         try {
             return NumberUtils.createInteger(fieldValueString);
@@ -63,15 +64,25 @@ public final class ChunkerParameterParser {
     }
 
     /**
-     * Parse integer type parameter with positive value.
-     * Throw IllegalArgumentException if both parameter and default value is missing or parameter is not a positive integer.
+     * Parse integer type parameter with default value.
+     * Return default value if the parameter is missing.
+     * Throw IllegalArgumentException if the parameter is not an integer.
      */
-    public static int parsePositiveIntegerParameter(
-        final Map<String, Object> parameters,
-        final String fieldName,
-        final Integer defaultValue
-    ) {
-        int fieldValueInt = parseIntegerParameter(parameters, fieldName, defaultValue);
+    public static int parseIntegerWithDefault(final Map<String, Object> parameters, final String fieldName, final int defaultValue) {
+        if (!parameters.containsKey(fieldName)) {
+            // return the default value when parameter is missing
+            return defaultValue;
+        }
+        return parseInteger(parameters, fieldName);
+    }
+
+    /**
+     * Parse integer type parameter with positive value.
+     * Return default value if the parameter is missing.
+     * Throw IllegalArgumentException if the parameter is not a positive integer.
+     */
+    public static int parsePositiveInteger(final Map<String, Object> parameters, final String fieldName) {
+        int fieldValueInt = parseInteger(parameters, fieldName);
         if (fieldValueInt <= 0) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Parameter [%s] must be positive.", fieldName));
         }
@@ -79,14 +90,27 @@ public final class ChunkerParameterParser {
     }
 
     /**
-     * Parse double type parameter.
-     * Throw IllegalArgumentException if parameter is not a double.
+     * Parse integer type parameter with positive value.
+     * Return default value if the parameter is missing.
+     * Throw IllegalArgumentException if the parameter is not a positive integer.
      */
-    public static double parseDoubleParameter(final Map<String, Object> parameters, final String fieldName, final double defaultValue) {
+    public static int parsePositiveIntegerWithDefault(
+        final Map<String, Object> parameters,
+        final String fieldName,
+        final Integer defaultValue
+    ) {
         if (!parameters.containsKey(fieldName)) {
             // all double parameters are optional
             return defaultValue;
         }
+        return parsePositiveInteger(parameters, fieldName);
+    }
+
+    /**
+     * Parse double type parameter.
+     * Throw IllegalArgumentException if parameter is not a double.
+     */
+    public static double parseDouble(final Map<String, Object> parameters, final String fieldName) {
         String fieldValueString = parameters.get(fieldName).toString();
         try {
             return NumberUtils.createDouble(fieldValueString);
@@ -95,5 +119,18 @@ public final class ChunkerParameterParser {
                 String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Double.class.getName())
             );
         }
+    }
+
+    /**
+     * Parse double type parameter.
+     * Return default value if the parameter is missing.
+     * Throw IllegalArgumentException if parameter is not a double.
+     */
+    public static double parseDoubleWithDefault(final Map<String, Object> parameters, final String fieldName, final double defaultValue) {
+        if (!parameters.containsKey(fieldName)) {
+            // all double parameters are optional
+            return defaultValue;
+        }
+        return parseDouble(parameters, fieldName);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
@@ -40,13 +40,39 @@ public final class ChunkerParameterParser {
     }
 
     /**
-     * Parse integer type parameter.
-     * Throw IllegalArgumentException if parameter is not an integer.
+     * Parse integer type parameter without default value
+     * Throw IllegalArgumentException if parameter is missing or is not an integer.
      */
-    public static int parseIntegerParameter(final Map<String, Object> parameters, final String fieldName, final int defaultValue) {
+    public static int parseIntegerParameter(final Map<String, Object> parameters, final String fieldName) {
         if (!parameters.containsKey(fieldName)) {
-            // all integer parameters are optional
-            return defaultValue;
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "Parameter [%s] is missing", fieldName)
+            );
+        }
+        String fieldValueString = parameters.get(fieldName).toString();
+        try {
+            return NumberUtils.createInteger(fieldValueString);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName())
+            );
+        }
+    }
+
+    /**
+     * Parse integer type parameter.
+     * Throw IllegalArgumentException if both parameter and default value is missing or parameter is not an integer.
+     */
+    public static int parseIntegerParameter(final Map<String, Object> parameters, final String fieldName, final Integer defaultValue) {
+        if (!parameters.containsKey(fieldName)) {
+            // return the default value when parameter is not existing
+            if (defaultValue == null) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "Parameter [%s] is missing", fieldName)
+                );
+            } else {
+                return defaultValue;
+            }
         }
         String fieldValueString = parameters.get(fieldName).toString();
         try {
@@ -60,9 +86,9 @@ public final class ChunkerParameterParser {
 
     /**
      * Parse integer type parameter with positive value.
-     * Throw IllegalArgumentException if parameter is not a positive integer.
+     * Throw IllegalArgumentException if both parameter and default value is missing or parameter is not a positive integer.
      */
-    public static int parsePositiveIntegerParameter(final Map<String, Object> parameters, final String fieldName, final int defaultValue) {
+    public static int parsePositiveIntegerParameter(final Map<String, Object> parameters, final String fieldName, final Integer defaultValue) {
         int fieldValueInt = parseIntegerParameter(parameters, fieldName, defaultValue);
         if (fieldValueInt <= 0) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Parameter [%s] must be positive.", fieldName));

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
@@ -20,7 +20,6 @@ public final class ChunkerParameterParser {
 
     /**
      * Parse String type parameter.
-     * Return default value if the parameter is missing.
      * Throw IllegalArgumentException if parameter is not a string or an empty string.
      */
     public static String parseString(final Map<String, Object> parameters, final String fieldName) {
@@ -38,6 +37,7 @@ public final class ChunkerParameterParser {
 
     /**
      * Parse String type parameter.
+     * Return default value if the parameter is missing.
      * Throw IllegalArgumentException if parameter is not a string or an empty string.
      */
     public static String parseStringWithDefault(final Map<String, Object> parameters, final String fieldName, final String defaultValue) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
@@ -40,24 +40,6 @@ public final class ChunkerParameterParser {
     }
 
     /**
-     * Parse integer type parameter without default value
-     * Throw IllegalArgumentException if parameter is missing or is not an integer.
-     */
-    public static int parseIntegerParameter(final Map<String, Object> parameters, final String fieldName) {
-        if (!parameters.containsKey(fieldName)) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "Parameter [%s] is missing", fieldName));
-        }
-        String fieldValueString = parameters.get(fieldName).toString();
-        try {
-            return NumberUtils.createInteger(fieldValueString);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName())
-            );
-        }
-    }
-
-    /**
      * Parse integer type parameter.
      * Throw IllegalArgumentException if both parameter and default value is missing or parameter is not an integer.
      */

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParser.java
@@ -45,9 +45,7 @@ public final class ChunkerParameterParser {
      */
     public static int parseIntegerParameter(final Map<String, Object> parameters, final String fieldName) {
         if (!parameters.containsKey(fieldName)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "Parameter [%s] is missing", fieldName)
-            );
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Parameter [%s] is missing", fieldName));
         }
         String fieldValueString = parameters.get(fieldName).toString();
         try {
@@ -67,9 +65,7 @@ public final class ChunkerParameterParser {
         if (!parameters.containsKey(fieldName)) {
             // return the default value when parameter is not existing
             if (defaultValue == null) {
-                throw new IllegalArgumentException(
-                    String.format(Locale.ROOT, "Parameter [%s] is missing", fieldName)
-                );
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Parameter [%s] is missing", fieldName));
             } else {
                 return defaultValue;
             }
@@ -88,7 +84,11 @@ public final class ChunkerParameterParser {
      * Parse integer type parameter with positive value.
      * Throw IllegalArgumentException if both parameter and default value is missing or parameter is not a positive integer.
      */
-    public static int parsePositiveIntegerParameter(final Map<String, Object> parameters, final String fieldName, final Integer defaultValue) {
+    public static int parsePositiveIntegerParameter(
+        final Map<String, Object> parameters,
+        final String fieldName,
+        final Integer defaultValue
+    ) {
         int fieldValueInt = parseIntegerParameter(parameters, fieldName, defaultValue);
         if (fieldValueInt <= 0) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Parameter [%s] must be positive.", fieldName));

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunker.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunker.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
 
-import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseIntegerParameter;
-import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseStringParameter;
+import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseInteger;
+import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseStringWithDefault;
 
 /**
  * The implementation {@link Chunker} for delimiter algorithm
@@ -38,7 +38,7 @@ public final class DelimiterChunker implements Chunker {
      */
     @Override
     public void parseParameters(Map<String, Object> parameters) {
-        this.delimiter = parseStringParameter(parameters, DELIMITER_FIELD, DEFAULT_DELIMITER);
+        this.delimiter = parseStringWithDefault(parameters, DELIMITER_FIELD, DEFAULT_DELIMITER);
     }
 
     /**
@@ -51,8 +51,8 @@ public final class DelimiterChunker implements Chunker {
      */
     @Override
     public List<String> chunk(final String content, final Map<String, Object> runtimeParameters) {
-        int runtimeMaxChunkLimit = parseIntegerParameter(runtimeParameters, MAX_CHUNK_LIMIT_FIELD, null);
-        int chunkStringCount = parseIntegerParameter(runtimeParameters, CHUNK_STRING_COUNT_FIELD, null);
+        int runtimeMaxChunkLimit = parseInteger(runtimeParameters, MAX_CHUNK_LIMIT_FIELD);
+        int chunkStringCount = parseInteger(runtimeParameters, CHUNK_STRING_COUNT_FIELD);
 
         List<String> chunkResult = new ArrayList<>();
         int start = 0, end;

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunker.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunker.java
@@ -23,7 +23,6 @@ public final class DelimiterChunker implements Chunker {
     public static final String DEFAULT_DELIMITER = "\n\n";
 
     private String delimiter;
-    private int maxChunkLimit;
 
     public DelimiterChunker(final Map<String, Object> parameters) {
         parseParameters(parameters);
@@ -40,7 +39,6 @@ public final class DelimiterChunker implements Chunker {
     @Override
     public void parseParameters(Map<String, Object> parameters) {
         this.delimiter = parseStringParameter(parameters, DELIMITER_FIELD, DEFAULT_DELIMITER);
-        this.maxChunkLimit = parseIntegerParameter(parameters, MAX_CHUNK_LIMIT_FIELD, DEFAULT_MAX_CHUNK_LIMIT);
     }
 
     /**
@@ -53,8 +51,8 @@ public final class DelimiterChunker implements Chunker {
      */
     @Override
     public List<String> chunk(final String content, final Map<String, Object> runtimeParameters) {
-        int runtimeMaxChunkLimit = parseIntegerParameter(runtimeParameters, MAX_CHUNK_LIMIT_FIELD, maxChunkLimit);
-        int chunkStringCount = parseIntegerParameter(runtimeParameters, CHUNK_STRING_COUNT_FIELD, 1);
+        int runtimeMaxChunkLimit = parseIntegerParameter(runtimeParameters, MAX_CHUNK_LIMIT_FIELD, null);
+        int chunkStringCount = parseIntegerParameter(runtimeParameters, CHUNK_STRING_COUNT_FIELD, null);
 
         List<String> chunkResult = new ArrayList<>();
         int start = 0, end;

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/FixedTokenLengthChunker.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/FixedTokenLengthChunker.java
@@ -14,10 +14,10 @@ import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.action.admin.indices.analyze.AnalyzeAction;
 import org.opensearch.action.admin.indices.analyze.AnalyzeAction.AnalyzeToken;
 import static org.opensearch.action.admin.indices.analyze.TransportAnalyzeAction.analyze;
-import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseStringParameter;
-import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseDoubleParameter;
-import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseIntegerParameter;
-import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parsePositiveIntegerParameter;
+import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseInteger;
+import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseStringWithDefault;
+import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parseDoubleWithDefault;
+import static org.opensearch.neuralsearch.processor.chunker.ChunkerParameterParser.parsePositiveIntegerWithDefault;
 
 /**
  * The implementation {@link Chunker} for fixed token length algorithm.
@@ -79,9 +79,9 @@ public final class FixedTokenLengthChunker implements Chunker {
      */
     @Override
     public void parseParameters(Map<String, Object> parameters) {
-        this.tokenLimit = parsePositiveIntegerParameter(parameters, TOKEN_LIMIT_FIELD, DEFAULT_TOKEN_LIMIT);
-        this.overlapRate = parseDoubleParameter(parameters, OVERLAP_RATE_FIELD, DEFAULT_OVERLAP_RATE);
-        this.tokenizer = parseStringParameter(parameters, TOKENIZER_FIELD, DEFAULT_TOKENIZER);
+        this.tokenLimit = parsePositiveIntegerWithDefault(parameters, TOKEN_LIMIT_FIELD, DEFAULT_TOKEN_LIMIT);
+        this.overlapRate = parseDoubleWithDefault(parameters, OVERLAP_RATE_FIELD, DEFAULT_OVERLAP_RATE);
+        this.tokenizer = parseStringWithDefault(parameters, TOKENIZER_FIELD, DEFAULT_TOKENIZER);
         if (overlapRate < OVERLAP_RATE_LOWER_BOUND || overlapRate > OVERLAP_RATE_UPPER_BOUND) {
             throw new IllegalArgumentException(
                 String.format(
@@ -118,9 +118,9 @@ public final class FixedTokenLengthChunker implements Chunker {
      */
     @Override
     public List<String> chunk(final String content, final Map<String, Object> runtimeParameters) {
-        int maxTokenCount = parsePositiveIntegerParameter(runtimeParameters, MAX_TOKEN_COUNT_FIELD, null);
-        int runtimeMaxChunkLimit = parseIntegerParameter(runtimeParameters, MAX_CHUNK_LIMIT_FIELD, null);
-        int chunkStringCount = parseIntegerParameter(runtimeParameters, CHUNK_STRING_COUNT_FIELD, null);
+        int maxTokenCount = parseInteger(runtimeParameters, MAX_TOKEN_COUNT_FIELD);
+        int runtimeMaxChunkLimit = parseInteger(runtimeParameters, MAX_CHUNK_LIMIT_FIELD);
+        int chunkStringCount = parseInteger(runtimeParameters, CHUNK_STRING_COUNT_FIELD);
 
         List<AnalyzeToken> tokens = tokenize(content, tokenizer, maxTokenCount);
         List<String> chunkResult = new ArrayList<>();

--- a/src/main/java/org/opensearch/neuralsearch/processor/chunker/FixedTokenLengthChunker.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/chunker/FixedTokenLengthChunker.java
@@ -33,10 +33,9 @@ public final class FixedTokenLengthChunker implements Chunker {
     public static final String MAX_TOKEN_COUNT_FIELD = "max_token_count";
     public static final String TOKENIZER_FIELD = "tokenizer";
 
-    // default values for each parameter
+    // default values for each non-runtime parameter
     private static final int DEFAULT_TOKEN_LIMIT = 384;
     private static final double DEFAULT_OVERLAP_RATE = 0.0;
-    private static final int DEFAULT_MAX_TOKEN_COUNT = 10000;
     private static final String DEFAULT_TOKENIZER = "standard";
 
     // parameter restrictions
@@ -54,7 +53,6 @@ public final class FixedTokenLengthChunker implements Chunker {
 
     // parameter value
     private int tokenLimit;
-    private int maxChunkLimit;
     private String tokenizer;
     private double overlapRate;
     private final AnalysisRegistry analysisRegistry;
@@ -84,7 +82,6 @@ public final class FixedTokenLengthChunker implements Chunker {
         this.tokenLimit = parsePositiveIntegerParameter(parameters, TOKEN_LIMIT_FIELD, DEFAULT_TOKEN_LIMIT);
         this.overlapRate = parseDoubleParameter(parameters, OVERLAP_RATE_FIELD, DEFAULT_OVERLAP_RATE);
         this.tokenizer = parseStringParameter(parameters, TOKENIZER_FIELD, DEFAULT_TOKENIZER);
-        this.maxChunkLimit = parseIntegerParameter(parameters, MAX_CHUNK_LIMIT_FIELD, DEFAULT_MAX_CHUNK_LIMIT);
         if (overlapRate < OVERLAP_RATE_LOWER_BOUND || overlapRate > OVERLAP_RATE_UPPER_BOUND) {
             throw new IllegalArgumentException(
                 String.format(
@@ -121,9 +118,9 @@ public final class FixedTokenLengthChunker implements Chunker {
      */
     @Override
     public List<String> chunk(final String content, final Map<String, Object> runtimeParameters) {
-        int maxTokenCount = parsePositiveIntegerParameter(runtimeParameters, MAX_TOKEN_COUNT_FIELD, DEFAULT_MAX_TOKEN_COUNT);
-        int runtimeMaxChunkLimit = parseIntegerParameter(runtimeParameters, MAX_CHUNK_LIMIT_FIELD, this.maxChunkLimit);
-        int chunkStringCount = parseIntegerParameter(runtimeParameters, CHUNK_STRING_COUNT_FIELD, 1);
+        int maxTokenCount = parsePositiveIntegerParameter(runtimeParameters, MAX_TOKEN_COUNT_FIELD, null);
+        int runtimeMaxChunkLimit = parseIntegerParameter(runtimeParameters, MAX_CHUNK_LIMIT_FIELD, null);
+        int chunkStringCount = parseIntegerParameter(runtimeParameters, CHUNK_STRING_COUNT_FIELD, null);
 
         List<AnalyzeToken> tokens = tokenize(content, tokenizer, maxTokenCount);
         List<String> chunkResult = new ArrayList<>();

--- a/src/test/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParserTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/chunker/ChunkerParameterParserTests.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.chunker;
+
+import org.junit.Assert;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Locale;
+import java.util.Map;
+
+public class ChunkerParameterParserTests extends OpenSearchTestCase {
+
+    private static final String fieldName = "parameter";
+    private static final String defaultString = "default_string";
+    private static final Integer defaultInteger = 0;
+    private static final Integer defaultPositiveInteger = 100;
+    private static final Double defaultDouble = 0.0;
+
+    public void testParseString_withFieldValueNotString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, 1);
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseString(parameters, fieldName)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, String.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseString_withFieldValueEmptyString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseString(parameters, fieldName)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] should not be empty.", fieldName),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseString_withFieldValueValidString_thenSucceed() {
+        String parameterValue = "string_parameter_value";
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        String parsedStringValue = ChunkerParameterParser.parseString(parameters, fieldName);
+        assertEquals(parameterValue, parsedStringValue);
+    }
+
+    public void testParseStringWithDefault_withFieldValueNotString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, 1);
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseStringWithDefault(parameters, fieldName, defaultString)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, String.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseStringWithDefault_withFieldValueEmptyString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseStringWithDefault(parameters, fieldName, defaultString)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] should not be empty.", fieldName),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseStringWithDefault_withFieldValueValidString_thenSucceed() {
+        String parameterValue = "string_parameter_value";
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        String parsedStringValue = ChunkerParameterParser.parseStringWithDefault(parameters, fieldName, defaultString);
+        assertEquals(parameterValue, parsedStringValue);
+    }
+
+    public void testParseStringWithDefault_withFieldValueMissing_thenSucceed() {
+        Map<String, Object> parameters = Map.of();
+        String parsedStringValue = ChunkerParameterParser.parseStringWithDefault(parameters, fieldName, defaultString);
+        assertEquals(defaultString, parsedStringValue);
+    }
+
+    public void testParseInteger_withFieldValueString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "a");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseInteger(parameters, fieldName)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseInteger_withFieldValueDouble_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "1.0");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseInteger(parameters, fieldName)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseInteger_withFieldValueValidInteger_thenSucceed() {
+        String parameterValue = "1";
+        Integer expectedIntegerValue = 1;
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        Integer parsedIntegerValue = ChunkerParameterParser.parseInteger(parameters, fieldName);
+        assertEquals(expectedIntegerValue, parsedIntegerValue);
+    }
+
+    public void testParseIntegerWithDefault_withFieldValueString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "a");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseIntegerWithDefault(parameters, fieldName, defaultInteger)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseIntegerWithDefault_withFieldValueDouble_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "1.0");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseIntegerWithDefault(parameters, fieldName, defaultInteger)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseIntegerWithDefault_withFieldValueValidInteger_thenSucceed() {
+        String parameterValue = "1";
+        Integer expectedIntegerValue = 1;
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        Integer parsedIntegerValue = ChunkerParameterParser.parseIntegerWithDefault(parameters, fieldName, defaultInteger);
+        assertEquals(expectedIntegerValue, parsedIntegerValue);
+    }
+
+    public void testParseIntegerWithDefault_withFieldValueMissing_thenSucceed() {
+        Map<String, Object> parameters = Map.of();
+        Integer parsedIntegerValue = ChunkerParameterParser.parseIntegerWithDefault(parameters, fieldName, defaultInteger);
+        assertEquals(defaultInteger, parsedIntegerValue);
+    }
+
+    public void testParsePositiveInteger_withFieldValueString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "a");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parsePositiveInteger(parameters, fieldName)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParsePositiveInteger_withFieldValueDouble_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "1.0");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parsePositiveInteger(parameters, fieldName)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParsePositiveInteger_withFieldValueNegativeInteger_thenFail() {
+        String parameterValue = "-1";
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parsePositiveInteger(parameters, fieldName)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be positive.", fieldName),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParsePositiveInteger_withFieldValueValidInteger_thenSucceed() {
+        String parameterValue = "1";
+        Integer expectedIntegerValue = 1;
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        Integer parsedIntegerValue = ChunkerParameterParser.parsePositiveInteger(parameters, fieldName);
+        assertEquals(expectedIntegerValue, parsedIntegerValue);
+    }
+
+    public void testParsePositiveIntegerWithDefault_withFieldValueString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "a");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parsePositiveIntegerWithDefault(parameters, fieldName, defaultPositiveInteger)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParsePositiveIntegerWithDefault_withFieldValueDouble_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "1.0");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parsePositiveIntegerWithDefault(parameters, fieldName, defaultPositiveInteger)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Integer.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParsePositiveIntegerWithDefault_withFieldValueNegativeInteger_thenFail() {
+        String parameterValue = "-1";
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parsePositiveIntegerWithDefault(parameters, fieldName, defaultPositiveInteger)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be positive.", fieldName),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParsePositiveIntegerWithDefault_withFieldValueValidInteger_thenSucceed() {
+        String parameterValue = "1";
+        Integer expectedIntegerValue = 1;
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        Integer parsedIntegerValue = ChunkerParameterParser.parsePositiveIntegerWithDefault(parameters, fieldName, defaultPositiveInteger);
+        assertEquals(expectedIntegerValue, parsedIntegerValue);
+    }
+
+    public void testParsePositiveIntegerWithDefault_withFieldValueMissing_thenSucceed() {
+        Map<String, Object> parameters = Map.of();
+        Integer parsedIntegerValue = ChunkerParameterParser.parsePositiveIntegerWithDefault(parameters, fieldName, defaultPositiveInteger);
+        assertEquals(defaultPositiveInteger, parsedIntegerValue);
+    }
+
+    public void testParseDouble_withFieldValueString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "a");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseDouble(parameters, fieldName)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Double.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseDouble_withFieldValueValidDouble_thenSucceed() {
+        String parameterValue = "1";
+        Double expectedDoubleValue = 1.0;
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        Double parsedDoubleValue = ChunkerParameterParser.parseDouble(parameters, fieldName);
+        assertEquals(expectedDoubleValue, parsedDoubleValue);
+    }
+
+    public void testParseDoubleWithDefault_withFieldValueString_thenFail() {
+        Map<String, Object> parameters = Map.of(fieldName, "a");
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChunkerParameterParser.parseDoubleWithDefault(parameters, fieldName, defaultDouble)
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", fieldName, Double.class.getName()),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    public void testParseDoubleWithDefault_withFieldValueValidDouble_thenSucceed() {
+        String parameterValue = "1";
+        Double expectedDoubleValue = 1.0;
+        Map<String, Object> parameters = Map.of(fieldName, parameterValue);
+        Double parsedDoubleValue = ChunkerParameterParser.parseDoubleWithDefault(parameters, fieldName, defaultDouble);
+        assertEquals(expectedDoubleValue, parsedDoubleValue);
+    }
+
+    public void testParseDoubleWithDefault_withFieldValueMissing_thenSucceed() {
+        Map<String, Object> parameters = Map.of();
+        Double parsedDoubleValue = ChunkerParameterParser.parseDoubleWithDefault(parameters, fieldName, defaultDouble);
+        assertEquals(defaultDouble, parsedDoubleValue);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunkerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunkerTests.java
@@ -18,7 +18,7 @@ import static org.opensearch.neuralsearch.processor.chunker.DelimiterChunker.DEL
 
 public class DelimiterChunkerTests extends OpenSearchTestCase {
 
-    private final Map<String, Object> runTimeParameters = Map.of(MAX_CHUNK_LIMIT_FIELD, 100, CHUNK_STRING_COUNT_FIELD, 1);
+    private final Map<String, Object> runtimeParameters = Map.of(MAX_CHUNK_LIMIT_FIELD, 100, CHUNK_STRING_COUNT_FIELD, 1);
 
     public void testCreate_withDelimiterFieldInvalidType_thenFail() {
         Exception exception = assertThrows(
@@ -39,7 +39,7 @@ public class DelimiterChunkerTests extends OpenSearchTestCase {
     public void testChunk_withNewlineDelimiter_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n"));
         String content = "a\nb\nc\nd";
-        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
         assertEquals(List.of("a\n", "b\n", "c\n", "d"), chunkResult);
     }
 
@@ -47,35 +47,35 @@ public class DelimiterChunkerTests extends OpenSearchTestCase {
         // default delimiter is \n\n
         DelimiterChunker chunker = new DelimiterChunker(Map.of());
         String content = "a.b\n\nc.d";
-        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
         assertEquals(List.of("a.b\n\n", "c.d"), chunkResult);
     }
 
     public void testChunk_withOnlyDelimiterContent_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n"));
         String content = "\n";
-        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
         assertEquals(List.of("\n"), chunkResult);
     }
 
     public void testChunk_WithAllDelimiterContent_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n"));
         String content = "\n\n\n";
-        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
         assertEquals(List.of("\n", "\n", "\n"), chunkResult);
     }
 
     public void testChunk_WithPeriodDelimiters_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "."));
         String content = "a.b.cc.d.";
-        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
         assertEquals(List.of("a.", "b.", "cc.", "d."), chunkResult);
     }
 
     public void testChunk_withDoubleNewlineDelimiter_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n"));
         String content = "\n\na\n\n\n";
-        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
         assertEquals(List.of("\n\n", "a\n\n", "\n"), chunkResult);
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunkerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunkerTests.java
@@ -18,6 +18,8 @@ import static org.opensearch.neuralsearch.processor.chunker.DelimiterChunker.DEL
 
 public class DelimiterChunkerTests extends OpenSearchTestCase {
 
+    private final Map<String, Object> runTimeParameters = Map.of(MAX_CHUNK_LIMIT_FIELD, 100, CHUNK_STRING_COUNT_FIELD, 1);
+
     public void testCreate_withDelimiterFieldInvalidType_thenFail() {
         Exception exception = assertThrows(
             IllegalArgumentException.class,
@@ -37,7 +39,7 @@ public class DelimiterChunkerTests extends OpenSearchTestCase {
     public void testChunk_withNewlineDelimiter_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n"));
         String content = "a\nb\nc\nd";
-        List<String> chunkResult = chunker.chunk(content, Map.of());
+        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
         assertEquals(List.of("a\n", "b\n", "c\n", "d"), chunkResult);
     }
 
@@ -45,72 +47,59 @@ public class DelimiterChunkerTests extends OpenSearchTestCase {
         // default delimiter is \n\n
         DelimiterChunker chunker = new DelimiterChunker(Map.of());
         String content = "a.b\n\nc.d";
-        List<String> chunkResult = chunker.chunk(content, Map.of());
+        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
         assertEquals(List.of("a.b\n\n", "c.d"), chunkResult);
     }
 
     public void testChunk_withOnlyDelimiterContent_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n"));
         String content = "\n";
-        List<String> chunkResult = chunker.chunk(content, Map.of());
+        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
         assertEquals(List.of("\n"), chunkResult);
     }
 
     public void testChunk_WithAllDelimiterContent_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n"));
         String content = "\n\n\n";
-        List<String> chunkResult = chunker.chunk(content, Map.of());
+        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
         assertEquals(List.of("\n", "\n", "\n"), chunkResult);
     }
 
     public void testChunk_WithPeriodDelimiters_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "."));
         String content = "a.b.cc.d.";
-        List<String> chunkResult = chunker.chunk(content, Map.of());
+        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
         assertEquals(List.of("a.", "b.", "cc.", "d."), chunkResult);
     }
 
     public void testChunk_withDoubleNewlineDelimiter_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n"));
         String content = "\n\na\n\n\n";
-        List<String> chunkResult = chunker.chunk(content, Map.of());
+        List<String> chunkResult = chunker.chunk(content, runTimeParameters);
+        assertEquals(List.of("\n\n", "a\n\n", "\n"), chunkResult);
+    }
+
+    public void testChunk_whenWithinMaxChunkLimit_thenSucceed() {
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n"));
+        String content = "\n\na\n\n\n";
+        int runtimeMaxChunkLimit = 3;
+        List<String> chunkResult = chunker.chunk(content, Map.of(CHUNK_STRING_COUNT_FIELD, 1, MAX_CHUNK_LIMIT_FIELD, runtimeMaxChunkLimit));
         assertEquals(List.of("\n\n", "a\n\n", "\n"), chunkResult);
     }
 
     public void testChunk_whenExceedMaxChunkLimit_thenLastPassageGetConcatenated() {
-        int maxChunkLimit = 2;
-        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n", MAX_CHUNK_LIMIT_FIELD, maxChunkLimit));
-        String content = "\n\na\n\n\n";
-        List<String> passages = chunker.chunk(content, Map.of());
-        List<String> expectedPassages = new ArrayList<>();
-        expectedPassages.add("\n\n");
-        expectedPassages.add("a\n\n\n");
-        assertEquals(expectedPassages, passages);
-    }
-
-    public void testChunk_whenWithinMaxChunkLimit_thenSucceed() {
-        int maxChunkLimit = 3;
-        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n", MAX_CHUNK_LIMIT_FIELD, maxChunkLimit));
-        String content = "\n\na\n\n\n";
-        List<String> chunkResult = chunker.chunk(content, Map.of());
-        assertEquals(List.of("\n\n", "a\n\n", "\n"), chunkResult);
-    }
-
-    public void testChunk_whenExceedRuntimeMaxChunkLimit_thenLastPassageGetConcatenated() {
-        int maxChunkLimit = 3;
-        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n", MAX_CHUNK_LIMIT_FIELD, maxChunkLimit));
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n"));
         String content = "\n\na\n\n\n";
         int runtimeMaxChunkLimit = 2;
-        List<String> passages = chunker.chunk(content, Map.of(MAX_CHUNK_LIMIT_FIELD, runtimeMaxChunkLimit));
+        List<String> passages = chunker.chunk(content, Map.of(CHUNK_STRING_COUNT_FIELD, 1, MAX_CHUNK_LIMIT_FIELD, runtimeMaxChunkLimit));
         List<String> expectedPassages = new ArrayList<>();
         expectedPassages.add("\n\n");
         expectedPassages.add("a\n\n\n");
         assertEquals(expectedPassages, passages);
     }
 
-    public void testChunk_whenExceedRuntimeMaxChunkLimit_withTwoStringsTobeChunked_thenLastPassageGetConcatenated() {
-        int maxChunkLimit = 3;
-        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n", MAX_CHUNK_LIMIT_FIELD, maxChunkLimit));
+    public void testChunk_whenExceedMaxChunkLimit_withTwoStringsTobeChunked_thenLastPassageGetConcatenated() {
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n"));
         String content = "\n\na\n\n\n";
         int runtimeMaxChunkLimit = 2, chunkStringCount = 2;
         List<String> passages = chunker.chunk(

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;


### PR DESCRIPTION
### Description
There PR optimizes the parameter parsing step in chunking algorithms. For both algorithms, all runtime parameters for text chunking processor is always available. Therefore, default value is not needed.

### Issues Resolved

Optimize parameter parsing in text chunking processor. 

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
