### PR TITLE
Use lazy initialization for priority queue of hits and scores to improve latencies by 20%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 - Pass empty doc collector instead of top docs collector to improve hybrid query latencies by 20% ([#731](https://github.com/opensearch-project/neural-search/pull/731))
 - Optimize parameter parsing in text chunking processor ([#733](https://github.com/opensearch-project/neural-search/pull/733))
+- Use lazy initialization for priority queue of hits and scores to improve latencies by 20% ([#746](https://github.com/opensearch-project/neural-search/pull/746))
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollector.java
@@ -112,10 +112,10 @@ public class HybridTopScoreDocCollector implements Collector {
                     }
                     totalHits[i]++;
                     PriorityQueue<ScoreDoc> pq = compoundScores[i];
-                    ScoreDoc topDoc = new ScoreDoc(doc + docBase, score);
+                    ScoreDoc currentDoc = new ScoreDoc(doc + docBase, score);
                     // this way we're inserting into heap and do nothing else unless we reach the capacity
                     // after that we pull out the lowest score element on each insert
-                    pq.insertWithOverflow(topDoc);
+                    pq.insertWithOverflow(currentDoc);
                 }
             }
         };

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerTests.java
@@ -142,7 +142,11 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
                 int idx = Arrays.binarySearch(docs2, doc);
                 expectedScore += scores2[idx];
             }
-            assertEquals(expectedScore, hybridQueryScorer.score(), 0.001f);
+            float hybridScore = 0.0f;
+            for (float score : hybridQueryScorer.hybridScores()) {
+                hybridScore += score;
+            }
+            assertEquals(expectedScore, hybridScore, 0.001f);
             numOfActualDocs++;
         }
 

--- a/src/test/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/HybridTopScoreDocCollectorTests.java
@@ -36,7 +36,6 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
-import org.apache.lucene.util.PriorityQueue;
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryShardContext;
@@ -446,13 +445,6 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         int nextDoc = hybridQueryScorer.iterator().nextDoc();
         leafCollector.collect(nextDoc);
 
-        assertNotNull(hybridTopScoreDocCollector.getCompoundScores());
-        PriorityQueue<ScoreDoc>[] compoundScoresPQ = hybridTopScoreDocCollector.getCompoundScores();
-        assertEquals(1, compoundScoresPQ.length);
-        PriorityQueue<ScoreDoc> scoreDoc = compoundScoresPQ[0];
-        assertNotNull(scoreDoc);
-        assertNotNull(scoreDoc.top());
-
         w.close();
         reader.close();
         directory.close();
@@ -496,13 +488,6 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         leafCollector.setScorer(hybridQueryScorer);
         int nextDoc = hybridQueryScorer.iterator().nextDoc();
         leafCollector.collect(nextDoc);
-
-        assertNotNull(hybridTopScoreDocCollector.getCompoundScores());
-        PriorityQueue<ScoreDoc>[] compoundScoresPQ = hybridTopScoreDocCollector.getCompoundScores();
-        assertEquals(1, compoundScoresPQ.length);
-        PriorityQueue<ScoreDoc> scoreDoc = compoundScoresPQ[0];
-        assertNotNull(scoreDoc);
-        assertNotNull(scoreDoc.top());
 
         w.close();
         reader.close();


### PR DESCRIPTION
### Description
In this change we're improving hybrid query latencies by changing allocation of query hits objects for hybrid scores. Currently those objects are pre-populated, then for new element top of the priority queue is updated and heap is rebalanced. We're changing this to lazy initialization - priority queue is initially empty, for each hit we're inserting element. If we reach the capacity then element with low score is pushed out of the heap. As per benchmark results this alone gives 10% improvement.

With several other minor changes like pre calculate and store size instead of calling size() for each doc and each sub-query we can get 10% percent. 

Below are metrics for hybrid query latency that I've collected after this change. There are based on 2.x (2.14) version and [noaa OSB workload](https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/noaa), all times are in ms:

```
One sub-query that selects 11M documents

Bool: p50 76.5531 | p90 77.8108
Hybrid: p50 133.644 | p90 151.903

One sub-query that selects 1.6K documents

Bool: p50 69.9585 | p90 70.2855
Hybrid: p50 70.1703 | p90 70.5498

Three sub-query that select 15M documents

Bool: p50 87.1001 | p90 87.7131
Hybrid: p50 234.802 | p90 262.876
```

following are the baseline results
```
One sub-query that selects 11M documents

Bool: p50 77.8893 | p90 78.1916
Hybrid: p50 186.709 | p90 197.739

One sub-query that selects 1.6K documents

Bool: p50 71.0947 | p90 71.691
Hybrid: p50 71.5156 | p90 72.8801

Three sub-query that select 15M documents

Bool: p50 87.0556 | p90 90.9105
Hybrid: p50 287.255 | p90 313.868
```

Following framegraph has been captured after this change:

![profile_hybrq_step4v2_59_1610](https://github.com/opensearch-project/neural-search/assets/94878159/dd058f71-00a5-4adb-95ac-c9f945b7a020)


### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/745
https://github.com/opensearch-project/neural-search/issues/704

### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
