### PR TITLE
[Feature] Neural Sparse Query Two Phase Search pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.14...2.x)
 ### Features
+- Speed up NeuralSparseQuery by two-phase using a custom search pipeline.([#646](https://github.com/opensearch-project/neural-search/issues/646))
 ### Enhancements
 - Pass empty doc collector instead of top docs collector to improve hybrid query latencies by 20% ([#731](https://github.com/opensearch-project/neural-search/pull/731))
 ### Bug Fixes

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -27,6 +27,7 @@ import org.opensearch.ingest.Processor;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.NeuralQueryEnricherProcessor;
+import org.opensearch.neuralsearch.processor.NeuralSparseTwoPhaseProcessor;
 import org.opensearch.neuralsearch.processor.NormalizationProcessor;
 import org.opensearch.neuralsearch.processor.NormalizationProcessorWorkflow;
 import org.opensearch.neuralsearch.processor.SparseEncodingProcessor;
@@ -157,7 +158,12 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
     public Map<String, org.opensearch.search.pipeline.Processor.Factory<SearchRequestProcessor>> getRequestProcessors(
         Parameters parameters
     ) {
-        return Map.of(NeuralQueryEnricherProcessor.TYPE, new NeuralQueryEnricherProcessor.Factory());
+        return Map.of(
+            NeuralQueryEnricherProcessor.TYPE,
+            new NeuralQueryEnricherProcessor.Factory(),
+            NeuralSparseTwoPhaseProcessor.TYPE,
+            new NeuralSparseTwoPhaseProcessor.Factory()
+        );
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
@@ -122,13 +122,15 @@ public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements 
      *
      * @param queryTokens    the queryTokens map, key is the token String, value is the score.
      * @param thresholdRatio The ratio that control how tokens map be split.
-     * @return A map has two element, {[True, token map whose value above threshold],[False, token map whose value below threshold]}
+     * @return A tuple has two element, { token map whose value above threshold, token map whose value below threshold }
      */
     public static Tuple<Map<String, Float>, Map<String, Float>> splitQueryTokensByRatioedMaxScoreAsThreshold(
         final Map<String, Float> queryTokens,
         final float thresholdRatio
     ) {
-
+        if (Objects.isNull(queryTokens)) {
+            throw new IllegalArgumentException("Query tokens cannot be null or empty.");
+        }
         float max = 0f;
         for (Float value : queryTokens.values()) {
             max = Math.max(value, max);
@@ -143,8 +145,8 @@ public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements 
 
         Map<String, Float> highScoreTokens = queryTokensByScore.get(Boolean.TRUE);
         Map<String, Float> lowScoreTokens = queryTokensByScore.get(Boolean.FALSE);
-        if (Objects.isNull(highScoreTokens) || highScoreTokens.isEmpty()) {
-            throw new IllegalArgumentException("Query tokens cannot be null or empty.");
+        if (Objects.isNull(highScoreTokens)) {
+            highScoreTokens = Collections.emptyMap();
         }
         if (Objects.isNull(lowScoreTokens)) {
             lowScoreTokens = Collections.emptyMap();

--- a/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
@@ -236,15 +236,15 @@ public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements 
             Map<String, Object> twoPhaseConfigMap = ConfigurationUtils.readOptionalMap(TYPE, tag, config, PARAMETER_KEY);
 
             float ratio = DEFAULT_RATIO;
-            float window_expansion = DEFAULT_WINDOW_EXPANSION;
-            int max_window_size = DEFAULT_MAX_WINDOW_SIZE;
+            float windowExpansion = DEFAULT_WINDOW_EXPANSION;
+            int maxWindowSize = DEFAULT_MAX_WINDOW_SIZE;
             if (Objects.nonNull(twoPhaseConfigMap)) {
                 ratio = ((Number) twoPhaseConfigMap.getOrDefault(RATIO_KEY, ratio)).floatValue();
-                window_expansion = ((Number) twoPhaseConfigMap.getOrDefault(EXPANSION_KEY, window_expansion)).floatValue();
-                max_window_size = ((Number) twoPhaseConfigMap.getOrDefault(MAX_WINDOW_SIZE_KEY, max_window_size)).intValue();
+                windowExpansion = ((Number) twoPhaseConfigMap.getOrDefault(EXPANSION_KEY, windowExpansion)).floatValue();
+                maxWindowSize = ((Number) twoPhaseConfigMap.getOrDefault(MAX_WINDOW_SIZE_KEY, maxWindowSize)).intValue();
             }
 
-            return new NeuralSparseTwoPhaseProcessor(tag, description, ignoreFailure, enabled, ratio, window_expansion, max_window_size);
+            return new NeuralSparseTwoPhaseProcessor(tag, description, ignoreFailure, enabled, ratio, windowExpansion, maxWindowSize);
         }
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
@@ -12,6 +12,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.ingest.ConfigurationUtils;
 import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
 import org.opensearch.search.pipeline.AbstractProcessor;
 import org.opensearch.search.pipeline.Processor;
@@ -20,6 +21,7 @@ import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.rescore.RescorerBuilder;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -28,21 +30,56 @@ import java.util.stream.Collectors;
 public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements SearchRequestProcessor {
 
     public static String TYPE = "neural_sparse_two_phase_processor";
-    public float ratio = 0.4F;
+    boolean enable;
+    float ratio;
+    float window_expansion;
+    int max_window_size;
+    static final String PARAMETER_KEY = "two_phase_parameter";
+    static final String RATIO_KEY = "prune_ratio";
+    static final String ENABLE_KEY = "enabled";
+    static final String EXPANSION_KEY = "expansion";
+    static final String MAX_WINDOW_SIZE_KEY = "max_window_size";
 
-    protected NeuralSparseTwoPhaseProcessor(String tag, String description, boolean ignoreFailure) {
+    protected NeuralSparseTwoPhaseProcessor(
+        String tag,
+        String description,
+        boolean ignoreFailure,
+        boolean enabled,
+        float ratio,
+        float window_expansion,
+        int max_window_size
+    ) {
         super(tag, description, ignoreFailure);
+        this.enable = enabled;
+        if (ratio < 0f || ratio > 1f) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "The prune ratio must be within [0, 1]. Received: %f", ratio));
+        }
+        this.ratio = ratio;
+        if (window_expansion < 1.0) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "The window expansion must be greater than or equal to 1.0. Received: %f", window_expansion)
+            );
+        }
+        this.window_expansion = window_expansion;
+        if (max_window_size < 50) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "The maximum window size must be greater than or equal to 50. Received: %n" + max_window_size)
+            );
+        }
+        this.max_window_size = max_window_size;
     }
 
     @Override
     public SearchRequest processRequest(SearchRequest request) throws Exception {
+        if (!enable) return request;
         QueryBuilder queryBuilder = request.source().query();
         Map<NeuralSparseQueryBuilder, Float> queryBuilderMap = new HashMap<>();
-        QueryBuilderVisitor queryBuilderVisitor = new TwoPhaseQueryBuilderVisitor(queryBuilderMap);
+        QueryBuilderVisitor queryBuilderVisitor = new TwoPhaseQueryBuilderVisitor(queryBuilderMap, 1.0f);
         queryBuilder.visit(queryBuilderVisitor);
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
         queryBuilderMap.forEach((key, value) -> boolQueryBuilder.should(((QueryBuilder) key).boost(value)));
         RescorerBuilder<QueryRescorerBuilder> rescorerBuilder = new QueryRescorerBuilder(boolQueryBuilder);
+        rescorerBuilder.windowSize((int) (request.source().size() == -1 ? 10 : request.source().size() * window_expansion));
         request.source().addRescorer(rescorerBuilder);
         return request;
     }
@@ -52,7 +89,7 @@ public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements 
         return TYPE;
     }
 
-    public static Map<Boolean, SetOnce<Map<String, Float>>> splitSetOnce(Map<String, Float> queryTokens) {
+    public static Map<Boolean, SetOnce<Map<String, Float>>> getSplitSetOnceByScoreThreshold(Map<String, Float> queryTokens) {
         float max = 0f;
         for (Float value : queryTokens.values())
             max = value > max ? value : max;
@@ -78,33 +115,54 @@ public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements 
             Map<String, Object> config,
             PipelineContext pipelineContext
         ) throws IllegalArgumentException {
-            return new NeuralSparseTwoPhaseProcessor(tag, description, ignoreFailure);
+
+            boolean enabled = ConfigurationUtils.readBooleanProperty(TYPE, tag, config, ENABLE_KEY, true);
+            Map<String, Object> map = ConfigurationUtils.readOptionalMap(TYPE, tag, config, PARAMETER_KEY);
+            float ratio = 0.4f;
+            float window_expansion = 5.0f;
+            int max_window_size = 10000;
+            if (map != null) {
+                if (map.containsKey(RATIO_KEY)) {
+                    ratio = ((Number) map.get(RATIO_KEY)).floatValue();
+                }
+                if (map.containsKey(EXPANSION_KEY)) {
+                    window_expansion = ((Number) map.get(EXPANSION_KEY)).floatValue();
+                }
+                if (map.containsKey(MAX_WINDOW_SIZE_KEY)) {
+                    max_window_size = ((Number) map.get(MAX_WINDOW_SIZE_KEY)).intValue();
+                }
+            }
+            return new NeuralSparseTwoPhaseProcessor(tag, description, ignoreFailure, enabled, ratio, window_expansion, max_window_size);
+
         }
 
     }
 
     @Setter
-    static class TwoPhaseQueryBuilderVisitor implements QueryBuilderVisitor {
-
-        float boost = 1;
+    static private class TwoPhaseQueryBuilderVisitor implements QueryBuilderVisitor {
+        @Setter
+        float boost;
+        float subBoost;
         Map<NeuralSparseQueryBuilder, Float> queryBuilderMap;
 
-        public TwoPhaseQueryBuilderVisitor(Map<NeuralSparseQueryBuilder, Float> queryBuilderMap) {
+        public TwoPhaseQueryBuilderVisitor(Map<NeuralSparseQueryBuilder, Float> queryBuilderMap, float boost) {
             this.queryBuilderMap = queryBuilderMap;
+            this.boost = boost;
+            this.subBoost = boost;
         }
 
         @Override
         public void accept(QueryBuilder qb) {
             if (qb instanceof NeuralSparseQueryBuilder) {
-                this.queryBuilderMap.put(((NeuralSparseQueryBuilder) qb).copyForTwoPhase(), boost);
+                this.queryBuilderMap.put(((NeuralSparseQueryBuilder) qb).copyForTwoPhase(), boost * qb.boost());
             } else {
-                boost *= qb.boost();
+                subBoost *= qb.boost();
             }
         }
 
         @Override
         public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
-            if (occur.equals(BooleanClause.Occur.SHOULD)) return this;
+            if (occur.equals(BooleanClause.Occur.SHOULD)) return new TwoPhaseQueryBuilderVisitor(queryBuilderMap, subBoost);
             return NO_OP_VISITOR;
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
@@ -158,8 +158,7 @@ public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements 
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
         queryBuilderFloatMap.asMap().forEach((neuralSparseQueryBuilder, boosts) -> {
             float reduceBoost = boosts.stream().reduce(0.0f, Float::sum);
-            final float finalBoost = neuralSparseQueryBuilder.boost() * reduceBoost;
-            boolQueryBuilder.should(neuralSparseQueryBuilder.boost(finalBoost));
+            boolQueryBuilder.should(neuralSparseQueryBuilder.boost(reduceBoost));
         });
         return boolQueryBuilder;
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.lucene.search.BooleanClause;
+import org.opensearch.common.SetOnce;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
+import org.opensearch.search.pipeline.AbstractProcessor;
+import org.opensearch.search.pipeline.Processor;
+import org.opensearch.search.pipeline.SearchRequestProcessor;
+import org.opensearch.search.rescore.QueryRescorerBuilder;
+import org.opensearch.search.rescore.RescorerBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Setter
+@Getter
+public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements SearchRequestProcessor {
+
+    public static String TYPE = "neural_sparse_two_phase_processor";
+    public float ratio = 0.4F;
+
+    protected NeuralSparseTwoPhaseProcessor(String tag, String description, boolean ignoreFailure) {
+        super(tag, description, ignoreFailure);
+    }
+
+    @Override
+    public SearchRequest processRequest(SearchRequest request) throws Exception {
+        QueryBuilder queryBuilder = request.source().query();
+        Map<NeuralSparseQueryBuilder, Float> queryBuilderMap = new HashMap<>();
+        QueryBuilderVisitor queryBuilderVisitor = new TwoPhaseQueryBuilderVisitor(queryBuilderMap);
+        queryBuilder.visit(queryBuilderVisitor);
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+        queryBuilderMap.forEach((key, value) -> boolQueryBuilder.should(((QueryBuilder) key).boost(value)));
+        RescorerBuilder<QueryRescorerBuilder> rescorerBuilder = new QueryRescorerBuilder(boolQueryBuilder);
+        request.source().addRescorer(rescorerBuilder);
+        return request;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public static Map<Boolean, SetOnce<Map<String, Float>>> splitSetOnce(Map<String, Float> queryTokens) {
+        float max = 0f;
+        for (Float value : queryTokens.values())
+            max = value > max ? value : max;
+        float threshold = max * 0.4f;
+        Map<Boolean, Map<String, Float>> queryTokensByScore = queryTokens.entrySet()
+            .stream()
+            .collect(
+                Collectors.partitioningBy(entry -> entry.getValue() >= threshold, Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+            );
+        SetOnce<Map<String, Float>> highScoreTksSetOnce = new SetOnce<>(queryTokensByScore.get(Boolean.TRUE));
+        SetOnce<Map<String, Float>> lowScoreTksSetOnce = new SetOnce<>(queryTokensByScore.get(Boolean.FALSE));
+        if (highScoreTksSetOnce.get() == null) throw new IllegalArgumentException();
+        return Map.of(Boolean.TRUE, highScoreTksSetOnce, Boolean.FALSE, lowScoreTksSetOnce);
+    }
+
+    public static class Factory implements Processor.Factory<SearchRequestProcessor> {
+        @Override
+        public NeuralSparseTwoPhaseProcessor create(
+            Map<String, Processor.Factory<SearchRequestProcessor>> processorFactories,
+            String tag,
+            String description,
+            boolean ignoreFailure,
+            Map<String, Object> config,
+            PipelineContext pipelineContext
+        ) throws IllegalArgumentException {
+            return new NeuralSparseTwoPhaseProcessor(tag, description, ignoreFailure);
+        }
+
+    }
+
+    @Setter
+    static class TwoPhaseQueryBuilderVisitor implements QueryBuilderVisitor {
+
+        float boost = 1;
+        Map<NeuralSparseQueryBuilder, Float> queryBuilderMap;
+
+        public TwoPhaseQueryBuilderVisitor(Map<NeuralSparseQueryBuilder, Float> queryBuilderMap) {
+            this.queryBuilderMap = queryBuilderMap;
+        }
+
+        @Override
+        public void accept(QueryBuilder qb) {
+            if (qb instanceof NeuralSparseQueryBuilder) {
+                this.queryBuilderMap.put(((NeuralSparseQueryBuilder) qb).copyForTwoPhase(), boost);
+            } else {
+                boost *= qb.boost();
+            }
+        }
+
+        @Override
+        public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+            if (occur.equals(BooleanClause.Occur.SHOULD)) return this;
+            return NO_OP_VISITOR;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -103,7 +103,6 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
     private QueryBuilder filter;
     private static final Version MINIMAL_SUPPORTED_VERSION_DEFAULT_MODEL_ID = Version.V_2_11_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_RADIAL_SEARCH = Version.V_2_14_0;
-
     /**
      * Constructor from stream input
      *

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -103,6 +103,7 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
     private QueryBuilder filter;
     private static final Version MINIMAL_SUPPORTED_VERSION_DEFAULT_MODEL_ID = Version.V_2_11_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_RADIAL_SEARCH = Version.V_2_14_0;
+
     /**
      * Constructor from stream input
      *

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -184,7 +184,9 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
         if (Objects.nonNull(modelId)) {
             xContentBuilder.field(MODEL_ID_FIELD.getPreferredName(), modelId);
         }
-        if (Objects.nonNull(maxTokenScore)) xContentBuilder.field(MAX_TOKEN_SCORE_FIELD.getPreferredName(), maxTokenScore);
+        if (Objects.nonNull(maxTokenScore)) {
+            xContentBuilder.field(MAX_TOKEN_SCORE_FIELD.getPreferredName(), maxTokenScore);
+        }
         if (Objects.nonNull(queryTokensSupplier) && Objects.nonNull(queryTokensSupplier.get())) {
             xContentBuilder.field(QUERY_TOKENS_FIELD.getPreferredName(), queryTokensSupplier.get());
         }
@@ -315,8 +317,8 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
         // We need to inference the sentence to get the queryTokens. The logic is similar to NeuralQueryBuilder
         // If the inference is finished, then rewrite to self and call doToQuery, otherwise, continue doRewrite
         // QueryTokensSupplier means 2 case now,
-        //  1. It's the queryBuilder built for two-phase, doesn't need any rewrite.
-        //  2. It's registerAsyncAction has been registered successful.
+        // 1. It's the queryBuilder built for two-phase, doesn't need any rewrite.
+        // 2. It's registerAsyncAction has been registered successful.
         if (Objects.nonNull(queryTokensSupplier)) {
             return this;
         }
@@ -387,7 +389,7 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
     }
 
     private static void validateFieldType(MappedFieldType fieldType) {
-        if (null == fieldType || !fieldType.typeName().equals("rank_features")) {
+        if (Objects.isNull(fieldType) || !fieldType.typeName().equals("rank_features")) {
             throw new IllegalArgumentException("[" + NAME + "] query only works on [rank_features] fields");
         }
     }
@@ -425,12 +427,10 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
             .append(queryText)
             .append(modelId)
             .append(maxTokenScore)
-            .append(twoPhasePruneRatio);
-        if (queryTokensSupplier != null) {
+            .append(twoPhasePruneRatio)
+            .append(twoPhaseSharedQueryToken);
+        if (Objects.nonNull(queryTokensSupplier)) {
             builder.append(queryTokensSupplier.get());
-        }
-        if (twoPhaseSharedQueryToken != null) {
-            builder.append(twoPhaseSharedQueryToken);
         }
         return builder.toHashCode();
     }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -80,7 +80,7 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
     private String modelId;
     private Float maxTokenScore;
     private Supplier<Map<String, Float>> queryTokensSupplier;
-    // A filed that for neural_sparse_two_phase_processor, if twoPhaseSharedQueryToken is not null,
+    // A field that for neural_sparse_two_phase_processor, if twoPhaseSharedQueryToken is not null,
     // it means it's origin NeuralSparseQueryBuilder and should split the low score tokens form itself then put it into
     // twoPhaseSharedQueryToken.
     private Map<String, Float> twoPhaseSharedQueryToken;

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -135,7 +135,7 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
             .modelId(this.modelId)
             .maxTokenScore(this.maxTokenScore)
             .twoPhasePruneRatio(-1f);
-        if (this.queryTokensSupplier != null) {
+        if (Objects.nonNull(this.queryTokensSupplier)) {
             Map<String, Float> tokens = queryTokensSupplier.get();
             Map<String, SetOnce<Map<String, Float>>> splitTokens = splitQueryTokensByRatioedMaxScoreAsThreshold(tokens, ratio);
             this.queryTokensSupplier(splitTokens.get(UP_THRESHOLD)::get);
@@ -328,7 +328,7 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
             List.of(queryText),
             ActionListener.wrap(mapResultList -> {
                 Map<String, Float> queryTokens = TokenWeightUtil.fetchListOfTokenWeightMap(mapResultList).get(0);
-                if (twoPhaseSharedQueryToken != null) {
+                if (Objects.nonNull(twoPhaseSharedQueryToken)) {
                     Map<String, SetOnce<Map<String, Float>>> splitSetOnce = splitQueryTokensByRatioedMaxScoreAsThreshold(
                         queryTokens,
                         twoPhasePruneRatio

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -17,6 +17,7 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.processor.NeuralQueryEnricherProcessor;
+import org.opensearch.neuralsearch.processor.NeuralSparseTwoPhaseProcessor;
 import org.opensearch.neuralsearch.processor.NormalizationProcessor;
 import org.opensearch.neuralsearch.processor.TextEmbeddingProcessor;
 import org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory;
@@ -102,5 +103,6 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
         );
         assertNotNull(processors);
         assertNotNull(processors.get(NeuralQueryEnricherProcessor.TYPE));
+        assertNotNull(processors.get(NeuralSparseTwoPhaseProcessor.TYPE));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorIT.java
@@ -1,0 +1,537 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
+import org.opensearch.index.query.DisMaxQueryBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.opensearch.neuralsearch.util.TestUtils.createRandomTokenWeightMap;
+import static org.opensearch.neuralsearch.util.TestUtils.objectToFloat;
+
+public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
+
+    private static final String index = "two-phase-index";
+    private static final String search_pipeline = "two-phase-search-pipeline";
+    private final String TYPE = "neural_sparse_two_phase_processor";
+    private static final String TEST_TWO_PHASE_BASIC_INDEX_NAME = "test-sparse-basic-index-two-phase";
+    private static final String TEST_BASIC_INDEX_NAME = "test-sparse-basic-index";
+    private static final String TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME = "test-sparse-multi-field-index";
+    private static final String TEST_TEXT_AND_NEURAL_SPARSE_FIELD_INDEX_NAME = "test-sparse-text-and-field-index";
+    private static final String TEST_NESTED_INDEX_NAME = "test-sparse-nested-index";
+    private static final String TEST_QUERY_TEXT = "Hello world a b";
+    private static final String TEST_NEURAL_SPARSE_FIELD_NAME_1 = "test-sparse-encoding-1";
+    private static final String TEST_NEURAL_SPARSE_FIELD_NAME_2 = "test-sparse-encoding-2";
+    private static final String TEST_TEXT_FIELD_NAME_1 = "test-text-field";
+    private static final String TEST_NEURAL_SPARSE_FIELD_NAME_NESTED = "nested.neural_sparse.field";
+
+    private static final List<String> TEST_TOKENS = List.of("hello", "world", "a", "b", "c");
+
+    private static final Float DELTA = 1e-5f;
+    private final Map<String, Float> testRankFeaturesDoc = createRandomTokenWeightMap(TEST_TOKENS);
+    private static final List<String> TWO_PHASE_TEST_TOKEN = List.of("hello", "world");
+
+    private static final Map<String, Float> testFixedQueryTokens = new HashMap<>();
+    private static final Supplier<Map<String, Float>> testFixedQueryTokenSupplier = () -> testFixedQueryTokens;
+    static {
+        testFixedQueryTokens.put("hello", 5.0f);
+        testFixedQueryTokens.put("world", 4.0f);
+        testFixedQueryTokens.put("a", 3.0f);
+        testFixedQueryTokens.put("b", 2.0f);
+        testFixedQueryTokens.put("c", 1.0f);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        updateClusterSettings();
+    }
+
+    @SneakyThrows
+    public void testCreateOutOfRangePipeline_thenThrowsException() {
+        expectThrows(ResponseException.class, () -> createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 1.1f, 5.0f, 1000));
+        expectThrows(ResponseException.class, () -> createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.1f, 0.0f, 1000));
+        expectThrows(ResponseException.class, () -> createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.1f, 3.0f, 4));
+    }
+
+    @SneakyThrows
+    public void testBooleanQuery_withMultipleSparseEncodingQueries_whenTwoPhaseEnabled() {
+        try {
+            initializeTwoPhaseProcessor();
+            initializeIndexIfNotExist(TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME);
+            updateIndexTwoPhaseProcessor(TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME);
+            BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+            Map<String, Float> randomTokenWeight = createRandomTokenWeightMap(TWO_PHASE_TEST_TOKEN);
+            Supplier<Map<String, Float>> randomTokenWeightSupplier = () -> randomTokenWeight;
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder1 = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryTokensSupplier(randomTokenWeightSupplier);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder2 = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_2)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(randomTokenWeightSupplier);
+            boolQueryBuilder.should(sparseEncodingQueryBuilder1).should(sparseEncodingQueryBuilder2);
+
+            Map<String, Object> searchResponseAsMap = search(TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME, boolQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 2 * computeExpectedScore(testRankFeaturesDoc, randomTokenWeightSupplier.get());
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    @SneakyThrows
+    private void initializeTwoPhaseProcessor() {
+        createNeuralSparseTwoPhaseSearchProcessor(search_pipeline);
+    }
+
+    @SneakyThrows
+    private void updateIndexTwoPhaseProcessor(String indexName) {
+        updateIndexSettings(indexName, Settings.builder().put("index.search.default_pipeline", search_pipeline));
+    }
+
+    /**
+     * Tests the neuralSparseQuery when twoPhase enabled with DSL query:
+     * {
+     *     "query": {
+     *         "bool": {
+     *             "should": [
+     *                 {
+     *                     "neural_sparse": {
+     *                         "field": "test-sparse-encoding-1",
+     *                         "query_text": "TEST_QUERY_TEXT",
+     *                         "model_id": "dcsdcasd",
+     *                         "boost": 2.0
+     *                     }
+     *                 }
+     *             ]
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    public void testBasicQueryUsingQueryText_whenTwoPhaseEnabled_thenGetExpectedScore() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            initializeTwoPhaseProcessor();
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(2.0f);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, sparseEncodingQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 2 * computeExpectedScore(testRankFeaturesDoc, testFixedQueryTokens);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    @SneakyThrows
+    public void testBasicQueryUsingQueryText_whenTwoPhaseEnabledAndDisabled_thenGetSameScore() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            initializeTwoPhaseProcessor();
+
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(2.0f);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, sparseEncodingQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float scoreWithoutTwoPhase = objectToFloat(firstInnerHit.get("_score"));
+
+            sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(2.0f);
+            searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, sparseEncodingQueryBuilder, 1);
+            firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float scoreWithTwoPhase = objectToFloat(firstInnerHit.get("_score"));
+            assertEquals(scoreWithTwoPhase, scoreWithoutTwoPhase, DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    /**
+     * Tests neuralSparseQuery as rescoreQuery with DSL query:
+     * {
+     *     "query": {
+     *         "match_all": {}
+     *     },
+     *     "rescore": {
+     *         "query": {
+     *             "bool": {
+     *                 "should": [
+     *                     {
+     *                         "neural_sparse": {
+     *                             "field": "test-sparse-encoding-1",
+     *                             "query_text": "Hello world a b",
+     *                             "model_id": "dcsdcasd",
+     *                             "boost": 2.0
+     *                         }
+     *                     }
+     *                 ]
+     *             }
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    public void testNeuralSparseQueryAsRescoreQuery_whenTwoPhase_thenGetExpectedScore() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            initializeTwoPhaseProcessor();
+
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(2.0f);
+            QueryBuilder queryBuilder = new MatchAllQueryBuilder();
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, queryBuilder, sparseEncodingQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 2 * computeExpectedScore(testRankFeaturesDoc, testFixedQueryTokens);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    /**
+     * Tests multi neuralSparseQuery in BooleanQuery with DSL query:
+     * {
+     *     "query": {
+     *         "bool": {
+     *             "should": [
+     *                 {
+     *                     "neural_sparse": {
+     *                         "field": "test-sparse-encoding-1",
+     *                         "query_text": "Hello world a b",
+     *                         "model_id": "dcsdcasd",
+     *                         "boost": 2.0
+     *                     }
+     *                 },
+     *                 {
+     *                     "neural_sparse": {
+     *                         "field": "test-sparse-encoding-1",
+     *                         "query_text": "Hello world a b",
+     *                         "model_id": "dcsdcasd",
+     *                         "boost": 2.0
+     *                     }
+     *                 }
+     *             ]
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    public void testMultiNeuralSparseQuery_whenTwoPhase_thenGetExpectedScore() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            initializeTwoPhaseProcessor();
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(2.0f);
+            boolQueryBuilder.should(sparseEncodingQueryBuilder);
+            boolQueryBuilder.should(sparseEncodingQueryBuilder);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, boolQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 4 * computeExpectedScore(testRankFeaturesDoc, testFixedQueryTokens);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    /**
+    * This test case aim to test different score caused by different two-phase parameters.
+    * First, with a default parameter, two-phase get same score at most times.
+    * Second, With a high ratio, there may some docs including lots of low score tokens are missed.
+    * And then, lower ratio or higher windows size can improve accuracy.
+    */
+    @SneakyThrows
+    public void testNeuralSparseQuery_whenDifferentTwoPhaseParameter_thenGetDifferentResult() {
+        try {
+            initializeIndexIfNotExist(TEST_TWO_PHASE_BASIC_INDEX_NAME);
+            Map<String, Float> queryToken = new HashMap<>();
+            for (int i = 1; i < 6; i++) {
+                queryToken.put(String.valueOf(i + 10), (float) i);
+            }
+            for (int i = 1; i < 8; i++) {
+                queryToken.put(String.valueOf(i), (float) i);
+            }
+            Supplier<Map<String, Float>> queryTokenSupplier = () -> queryToken;
+
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryTokensSupplier(queryTokenSupplier);
+            assertSearchScore(sparseEncodingQueryBuilder, TEST_TWO_PHASE_BASIC_INDEX_NAME, 110);
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.3f, 1f, 10000);
+            updateIndexTwoPhaseProcessor(TEST_TWO_PHASE_BASIC_INDEX_NAME);
+            assertSearchScore(sparseEncodingQueryBuilder, TEST_TWO_PHASE_BASIC_INDEX_NAME, 110);
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.7f, 1f, 10000);
+            updateIndexTwoPhaseProcessor(TEST_TWO_PHASE_BASIC_INDEX_NAME);
+            assertSearchScore(sparseEncodingQueryBuilder, TEST_TWO_PHASE_BASIC_INDEX_NAME, 61);
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.7f, 30f, 10000);
+            updateIndexTwoPhaseProcessor(TEST_TWO_PHASE_BASIC_INDEX_NAME);
+            assertSearchScore(sparseEncodingQueryBuilder, TEST_TWO_PHASE_BASIC_INDEX_NAME, 110);
+        } finally {
+            wipeOfTestResources(TEST_TWO_PHASE_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    @SneakyThrows
+    public void testMultiNeuralSparseQuery_whenTwoPhaseAndFilter_thenGetExpectedScore() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, .8f, 5f, 1000);
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(2.0f);
+            boolQueryBuilder.should(sparseEncodingQueryBuilder);
+            boolQueryBuilder.filter(sparseEncodingQueryBuilder);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, boolQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 2 * computeExpectedScore(testRankFeaturesDoc, testFixedQueryTokens);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    @SneakyThrows
+    public void testMultiNeuralSparseQuery_whenTwoPhaseAndMultiBoolean_thenGetExpectedScore() {
+        String modelId = null;
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, .6f, 5f, 1000);
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            modelId = prepareSparseEncodingModel();
+            BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder1 = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .boost(1.0f);
+            boolQueryBuilder.should(sparseEncodingQueryBuilder1);
+            boolQueryBuilder.should(sparseEncodingQueryBuilder1);
+            BoolQueryBuilder subBoolQueryBuilder = new BoolQueryBuilder();
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder2 = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .boost(2.0f);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder3 = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .boost(3.0f);
+            subBoolQueryBuilder.should(sparseEncodingQueryBuilder2);
+            subBoolQueryBuilder.should(sparseEncodingQueryBuilder3);
+            subBoolQueryBuilder.boost(2.0f);
+            boolQueryBuilder.should(subBoolQueryBuilder);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, boolQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 12 * computeExpectedScore(modelId, testRankFeaturesDoc, TEST_QUERY_TEXT);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, null);
+        }
+    }
+
+    @SneakyThrows
+    public void testMultiNeuralSparseQuery_whenTwoPhaseAndNoLowScoreToken_thenGetExpectedScore() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, .6f, 5f, 1000);
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            Map<String, Float> queryTokens = new HashMap<>();
+            queryTokens.put("hello", 10.0f);
+            queryTokens.put("world", 10.0f);
+            queryTokens.put("a", 10.0f);
+            queryTokens.put("b", 10.0f);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryTokensSupplier(() -> queryTokens)
+                .boost(2.0f);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, sparseEncodingQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 2 * computeExpectedScore(testRankFeaturesDoc, sparseEncodingQueryBuilder.queryTokensSupplier().get());
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, null);
+        }
+    }
+
+    @SneakyThrows
+    public void testNeuralSParseQuery_whenTwoPhaseAndNestedInConstantScoreQuery_thenSuccess() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.6f, 5f, 10000);
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(1.0f);
+            ConstantScoreQueryBuilder constantScoreQueryBuilder = new ConstantScoreQueryBuilder(sparseEncodingQueryBuilder);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, constantScoreQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            assertEquals(1.0f, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    @SneakyThrows
+    public void testNeuralSParseQuery_whenTwoPhaseAndNestedInDisjunctionMaxQuery_thenSuccess() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.6f, 5f, 10000);
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(5.0f);
+            DisMaxQueryBuilder disMaxQueryBuilder = new DisMaxQueryBuilder();
+            disMaxQueryBuilder.add(sparseEncodingQueryBuilder);
+            disMaxQueryBuilder.add(new MatchAllQueryBuilder());
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, disMaxQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 5f * computeExpectedScore(testRankFeaturesDoc, testFixedQueryTokens);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    @SneakyThrows
+    public void testNeuralSParseQuery_whenTwoPhaseAndNestedInFunctionScoreQuery_thenSuccess() {
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.6f, 5f, 10000);
+            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryTokensSupplier(testFixedQueryTokenSupplier)
+                .boost(5.0f);
+            FunctionScoreQueryBuilder functionScoreQueryBuilder = new FunctionScoreQueryBuilder(sparseEncodingQueryBuilder);
+            functionScoreQueryBuilder.boost(2.0f);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, functionScoreQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 10f * computeExpectedScore(testRankFeaturesDoc, testFixedQueryTokens);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+
+    @SneakyThrows
+    protected void initializeIndexIfNotExist(String indexName) {
+        if (TEST_BASIC_INDEX_NAME.equals(indexName) && !indexExists(indexName)) {
+            prepareSparseEncodingIndex(indexName, List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1));
+            addSparseEncodingDoc(indexName, "1", List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1), List.of(testRankFeaturesDoc));
+            assertEquals(1, getDocCount(indexName));
+        }
+
+        if (TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME.equals(indexName) && !indexExists(indexName)) {
+            prepareSparseEncodingIndex(indexName, List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1, TEST_NEURAL_SPARSE_FIELD_NAME_2));
+            addSparseEncodingDoc(
+                indexName,
+                "1",
+                List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1, TEST_NEURAL_SPARSE_FIELD_NAME_2),
+                List.of(testRankFeaturesDoc, testRankFeaturesDoc)
+            );
+            assertEquals(1, getDocCount(indexName));
+        }
+
+        if (TEST_TEXT_AND_NEURAL_SPARSE_FIELD_INDEX_NAME.equals(indexName) && !indexExists(indexName)) {
+            prepareSparseEncodingIndex(indexName, List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1));
+            addSparseEncodingDoc(
+                indexName,
+                "1",
+                List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1),
+                List.of(testRankFeaturesDoc),
+                List.of(TEST_TEXT_FIELD_NAME_1),
+                List.of(TEST_QUERY_TEXT)
+            );
+            assertEquals(1, getDocCount(indexName));
+        }
+
+        if (TEST_NESTED_INDEX_NAME.equals(indexName) && !indexExists(indexName)) {
+            prepareSparseEncodingIndex(indexName, List.of(TEST_NEURAL_SPARSE_FIELD_NAME_NESTED));
+            addSparseEncodingDoc(indexName, "1", List.of(TEST_NEURAL_SPARSE_FIELD_NAME_NESTED), List.of(testRankFeaturesDoc));
+            assertEquals(1, getDocCount(TEST_NESTED_INDEX_NAME));
+        }
+
+        if (TEST_TWO_PHASE_BASIC_INDEX_NAME.equals(indexName) && !indexExists(indexName)) {
+            Map<String, Float> twoPhaseRandFeatures = new HashMap<>();
+            Map<String, Float> normalRandFeatures = new HashMap<>();
+            prepareSparseEncodingIndex(indexName, List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1));
+            // put [(5,5.0), (6,6.0)] into twoPhaseRandFeatures
+            for (int i = 5; i < 7; i++) {
+                twoPhaseRandFeatures.put(String.valueOf(i), (float) i);
+            }
+
+            // put 10 token [(1,1.0),(11,1.0),....(5,5.0),(55,5.0)] into normalRandFeatures
+            for (int i = 1; i < 6; i++) {
+                normalRandFeatures.put(String.valueOf(i), (float) i);
+                normalRandFeatures.put(String.valueOf(10 + i), (float) i);
+
+            }
+
+            for (int i = 0; i < 10; i++) {
+                addSparseEncodingDoc(indexName, String.valueOf(i), List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1), List.of(normalRandFeatures));
+                addSparseEncodingDoc(
+                    indexName,
+                    String.valueOf(i + 10),
+                    List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1),
+                    List.of(twoPhaseRandFeatures)
+                );
+                ;
+            }
+            assertEquals(20, getDocCount(indexName));
+        }
+    }
+
+    private void assertSearchScore(NeuralSparseQueryBuilder builder, String indexName, float expectedScore) {
+        Map<String, Object> searchResponse = search(indexName, builder, 10);
+        Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponse);
+        assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+    }
+
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorIT.java
@@ -459,7 +459,6 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         }
     }
 
-
     @SneakyThrows
     protected void initializeIndexIfNotExist(String indexName) {
         if (TEST_BASIC_INDEX_NAME.equals(indexName) && !indexExists(indexName)) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorIT.java
@@ -75,7 +75,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         try {
             initializeTwoPhaseProcessor();
             initializeIndexIfNotExist(TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME);
-            updateIndexTwoPhaseProcessor(TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_MULTI_NEURAL_SPARSE_FIELD_INDEX_NAME);
             BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
             Map<String, Float> randomTokenWeight = createRandomTokenWeightMap(TWO_PHASE_TEST_TOKEN);
             Supplier<Map<String, Float>> randomTokenWeightSupplier = () -> randomTokenWeight;
@@ -103,7 +103,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
     }
 
     @SneakyThrows
-    private void updateIndexTwoPhaseProcessor(String indexName) {
+    private void setDefaultSearchPipelineForIndex(String indexName) {
         updateIndexSettings(indexName, Settings.builder().put("index.search.default_pipeline", search_pipeline));
     }
 
@@ -131,7 +131,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             initializeTwoPhaseProcessor();
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
                 .queryText(TEST_QUERY_TEXT)
                 .queryTokensSupplier(testFixedQueryTokenSupplier)
@@ -153,7 +153,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             initializeTwoPhaseProcessor();
 
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
                 .queryText(TEST_QUERY_TEXT)
                 .queryTokensSupplier(testFixedQueryTokenSupplier)
@@ -207,7 +207,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             initializeTwoPhaseProcessor();
 
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
                 .queryText(TEST_QUERY_TEXT)
                 .queryTokensSupplier(testFixedQueryTokenSupplier)
@@ -255,7 +255,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             initializeTwoPhaseProcessor();
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
                 .queryTokensSupplier(testFixedQueryTokenSupplier)
@@ -295,13 +295,13 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
                 .queryTokensSupplier(queryTokenSupplier);
             assertSearchScore(sparseEncodingQueryBuilder, TEST_TWO_PHASE_BASIC_INDEX_NAME, 110);
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.3f, 1f, 10000);
-            updateIndexTwoPhaseProcessor(TEST_TWO_PHASE_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_TWO_PHASE_BASIC_INDEX_NAME);
             assertSearchScore(sparseEncodingQueryBuilder, TEST_TWO_PHASE_BASIC_INDEX_NAME, 110);
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.7f, 1f, 10000);
-            updateIndexTwoPhaseProcessor(TEST_TWO_PHASE_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_TWO_PHASE_BASIC_INDEX_NAME);
             assertSearchScore(sparseEncodingQueryBuilder, TEST_TWO_PHASE_BASIC_INDEX_NAME, 61);
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.7f, 30f, 10000);
-            updateIndexTwoPhaseProcessor(TEST_TWO_PHASE_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_TWO_PHASE_BASIC_INDEX_NAME);
             assertSearchScore(sparseEncodingQueryBuilder, TEST_TWO_PHASE_BASIC_INDEX_NAME, 110);
         } finally {
             wipeOfTestResources(TEST_TWO_PHASE_BASIC_INDEX_NAME, null, null, search_pipeline);
@@ -313,7 +313,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, .8f, 5f, 1000);
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
                 .queryText(TEST_QUERY_TEXT)
@@ -338,7 +338,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
 
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, .6f, 5f, 1000);
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             modelId = prepareSparseEncodingModel();
             BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder1 = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
@@ -375,7 +375,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, .6f, 5f, 1000);
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             Map<String, Float> queryTokens = new HashMap<>();
             queryTokens.put("hello", 10.0f);
             queryTokens.put("world", 10.0f);
@@ -399,7 +399,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.6f, 5f, 10000);
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
                 .queryText(TEST_QUERY_TEXT)
                 .queryTokensSupplier(testFixedQueryTokenSupplier)
@@ -419,7 +419,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.6f, 5f, 10000);
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
                 .queryText(TEST_QUERY_TEXT)
                 .queryTokensSupplier(testFixedQueryTokenSupplier)
@@ -438,11 +438,11 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
     }
 
     @SneakyThrows
-    public void testNeuralSParseQuery_whenTwoPhaseAndNestedInFunctionScoreQuery_thenSuccess() {
+    public void testNeuralSparseQuery_whenTwoPhaseAndNestedInFunctionScoreQuery_thenSuccess() {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             createNeuralSparseTwoPhaseSearchProcessor(search_pipeline, 0.6f, 5f, 10000);
-            updateIndexTwoPhaseProcessor(TEST_BASIC_INDEX_NAME);
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
             NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
                 .queryText(TEST_QUERY_TEXT)
                 .queryTokensSupplier(testFixedQueryTokenSupplier)
@@ -456,6 +456,57 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
             assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
         } finally {
             wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, search_pipeline);
+        }
+    }
+
+    /**
+     * Tests multi neuralSparseQuery in BooleanQuery with DSL query:
+     * {
+     *     "query": {
+     *         "bool": {
+     *             "should": [
+     *                 {
+     *                     "neural_sparse": {
+     *                         "field": "test-sparse-encoding-1",
+     *                         "query_text": "Hello world a b",
+     *                         "model_id": "dcsdcasd",
+     *                         "boost": 2.0
+     *                     }
+     *                 },
+     *                 {
+     *                     "neural_sparse": {
+     *                         "field": "test-sparse-encoding-1",
+     *                         "query_text": "Hello world a b",
+     *                         "model_id": "dcsdcasd",
+     *                         "boost": 2.0
+     *                     }
+     *                 }
+     *             ]
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    public void testMultiNeuralSparseQuery_whenTwoPhaseAndModelInference_thenGetExpectedScore() {
+        String modelId = null;
+        try {
+            initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
+            initializeTwoPhaseProcessor();
+            setDefaultSearchPipelineForIndex(TEST_BASIC_INDEX_NAME);
+            modelId = prepareSparseEncodingModel();
+            BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+            NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_NEURAL_SPARSE_FIELD_NAME_1)
+                .modelId(modelId)
+                .boost(3.0f);
+            boolQueryBuilder.should(sparseEncodingQueryBuilder);
+            boolQueryBuilder.should(sparseEncodingQueryBuilder);
+            Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, boolQueryBuilder, 1);
+            Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
+            assertEquals("1", firstInnerHit.get("_id"));
+            float expectedScore = 6 * computeExpectedScore(testRankFeaturesDoc, testFixedQueryTokens);
+            assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+        } finally {
+            wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, modelId, search_pipeline);
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NeuralSparseTwoPhaseProcessorTests extends OpenSearchTestCase {
+    static final private String PARAMETER_KEY = "two_phase_parameter";
+    static final private String RATIO_KEY = "prune_ratio";
+    static final private String ENABLE_KEY = "enabled";
+    static final private String EXPANSION_KEY = "expansion_rate";
+    static final private String MAX_WINDOW_SIZE_KEY = "max_window_size";
+
+    public void testFactory_whenCreateDefaultPipeline_thenSuccess() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory);
+        assertEquals(0.3f, processor.getRatio(), 1e-3);
+        assertEquals(4.0f, processor.getWindow_expansion(), 1e-3);
+        assertEquals(10000, processor.getMax_window_size());
+
+        NeuralSparseTwoPhaseProcessor defaultProcessor = factory.create(
+            Collections.emptyMap(),
+            null,
+            null,
+            false,
+            Collections.emptyMap(),
+            null
+        );
+        assertEquals(0.4f, defaultProcessor.getRatio(), 1e-3);
+        assertEquals(5.0f, defaultProcessor.getWindow_expansion(), 1e-3);
+        assertEquals(10000, defaultProcessor.getMax_window_size());
+    }
+
+    public void testFactory_whenRatioOutOfRange_thenThrowException() {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        expectThrows(IllegalArgumentException.class, () -> createTestProcessor(factory, 1.1f, true, 5.0f, 10000));
+    }
+
+    public void testFactory_whenWindowExpansionOutOfRange_thenThrowException() {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        expectThrows(IllegalArgumentException.class, () -> createTestProcessor(factory, 0.1f, true, 0.5f, 10000));
+        expectThrows(IllegalArgumentException.class, () -> createTestProcessor(factory, 0.1f, true, -0.5f, 10000));
+    }
+
+    public void testFactory_whenMaxWindowSizeOutOfRange_thenThrowException() {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        expectThrows(IllegalArgumentException.class, () -> createTestProcessor(factory, 0.1f, true, 5.5f, -1));
+    }
+
+    public void testProcessRequest_whenTwoPhaseEnabled_thenSuccess() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseQueryBuilder neuralQueryBuilder = new NeuralSparseQueryBuilder();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(new SearchSourceBuilder().query(neuralQueryBuilder));
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory, 0.5f, true, 4.0f, 10000);
+        processor.processRequest(searchRequest);
+        NeuralSparseQueryBuilder queryBuilder = (NeuralSparseQueryBuilder) searchRequest.source().query();
+        assertEquals(queryBuilder.twoPhasePruneRatio(), 0.5f, 1e-3);
+        assertNotNull(searchRequest.source().rescores());
+    }
+
+    public void testProcessRequest_whenTwoPhaseDisabled_thenSuccess() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseQueryBuilder neuralQueryBuilder = new NeuralSparseQueryBuilder();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(new SearchSourceBuilder().query(neuralQueryBuilder));
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory, 0.5f, false, 4.0f, 10000);
+        processor.processRequest(searchRequest);
+        NeuralSparseQueryBuilder queryBuilder = (NeuralSparseQueryBuilder) searchRequest.source().query();
+        assertEquals(queryBuilder.twoPhasePruneRatio(), 0f, 1e-3);
+        assertNull(searchRequest.source().rescores());
+    }
+
+    public void testType() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory);
+        assertEquals(NeuralSparseTwoPhaseProcessor.TYPE, processor.getType());
+    }
+
+    private NeuralSparseTwoPhaseProcessor createTestProcessor(
+        NeuralSparseTwoPhaseProcessor.Factory factory,
+        float ratio,
+        boolean enabled,
+        float expand,
+        int max_window
+    ) throws Exception {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(ENABLE_KEY, enabled);
+        Map<String, Object> twoPhaseParaMap = new HashMap<>();
+        twoPhaseParaMap.put(RATIO_KEY, ratio);
+        twoPhaseParaMap.put(EXPANSION_KEY, expand);
+        twoPhaseParaMap.put(MAX_WINDOW_SIZE_KEY, max_window);
+        configMap.put(PARAMETER_KEY, twoPhaseParaMap);
+        return factory.create(Collections.emptyMap(), null, null, false, configMap, null);
+    }
+
+    private NeuralSparseTwoPhaseProcessor createTestProcessor(NeuralSparseTwoPhaseProcessor.Factory factory) throws Exception {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(ENABLE_KEY, true);
+        Map<String, Object> twoPhaseParaMap = new HashMap<>();
+        twoPhaseParaMap.put(RATIO_KEY, 0.3f);
+        twoPhaseParaMap.put(EXPANSION_KEY, 4.0f);
+        twoPhaseParaMap.put(MAX_WINDOW_SIZE_KEY, 10000);
+        configMap.put(PARAMETER_KEY, twoPhaseParaMap);
+        return factory.create(Collections.emptyMap(), null, null, false, configMap, null);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
@@ -158,8 +158,8 @@ public class NeuralSparseTwoPhaseProcessorTests extends OpenSearchTestCase {
     }
 
     @SneakyThrows
-    public void testGetSplitSetOnceByScoreThreshold_whenHighScoreTokenIsNull_thenThrowException() {
-        Map<String, Float> queryTokens = new HashMap<>();
+    public void testGetSplitSetOnceByScoreThreshold_whenNullQueryToken_thenThrowException() {
+        Map<String, Float> queryTokens = null;
         expectThrows(
             IllegalArgumentException.class,
             () -> NeuralSparseTwoPhaseProcessor.splitQueryTokensByRatioedMaxScoreAsThreshold(queryTokens, 0.4f)

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
@@ -29,8 +29,8 @@ public class NeuralSparseTwoPhaseProcessorTests extends OpenSearchTestCase {
         NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
         NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory);
         assertEquals(0.3f, processor.getRatio(), 1e-3);
-        assertEquals(4.0f, processor.getWindow_expansion(), 1e-3);
-        assertEquals(10000, processor.getMax_window_size());
+        assertEquals(4.0f, processor.getWindowExpansion(), 1e-3);
+        assertEquals(10000, processor.getMaxWindowSize());
 
         NeuralSparseTwoPhaseProcessor defaultProcessor = factory.create(
             Collections.emptyMap(),
@@ -41,8 +41,8 @@ public class NeuralSparseTwoPhaseProcessorTests extends OpenSearchTestCase {
             null
         );
         assertEquals(0.4f, defaultProcessor.getRatio(), 1e-3);
-        assertEquals(5.0f, defaultProcessor.getWindow_expansion(), 1e-3);
-        assertEquals(10000, defaultProcessor.getMax_window_size());
+        assertEquals(5.0f, defaultProcessor.getWindowExpansion(), 1e-3);
+        assertEquals(10000, defaultProcessor.getMaxWindowSize());
     }
 
     public void testFactory_whenRatioOutOfRange_thenThrowException() {
@@ -134,18 +134,18 @@ public class NeuralSparseTwoPhaseProcessorTests extends OpenSearchTestCase {
         for (int i = 0; i < 10; i++) {
             queryTokens.put(String.valueOf(i), (float) i);
         }
-        Map<Boolean, SetOnce<Map<String, Float>>> splitSetOnce = NeuralSparseTwoPhaseProcessor.getSplitSetOnceByScoreThreshold(
+        Map<String, SetOnce<Map<String, Float>>> splitSetOnce = NeuralSparseTwoPhaseProcessor.splitQueryTokensByRatioedMaxScoreAsThreshold(
             queryTokens,
             0.4f
         );
         assertNotNull(splitSetOnce);
-        SetOnce<Map<String, Float>> upSet = splitSetOnce.get(true);
-        SetOnce<Map<String, Float>> downSet = splitSetOnce.get(false);
+        SetOnce<Map<String, Float>> upSet = splitSetOnce.get("UP_THRESHOLD");
+        SetOnce<Map<String, Float>> downSet = splitSetOnce.get("DOWN_THRESHOLD");
         assertNotNull(upSet);
         assertEquals(6, upSet.get().size());
         assertNotNull(downSet);
         assertEquals(4, downSet.get().size());
-        assertNotNull(splitSetOnce.get(false));
+        assertNotNull(splitSetOnce.get("DOWN_THRESHOLD"));
     }
 
     public void testType() throws Exception {

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilderTests.java
@@ -17,6 +17,7 @@ import static org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder.QUERY_T
 import static org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder.QUERY_TOKENS_FIELD;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -685,4 +686,19 @@ public class NeuralSparseQueryBuilderTests extends OpenSearchTestCase {
 
         assertEquals(sparseEncodingQueryBuilder.doToQuery(mockedQueryShardContext), targetQueryBuilder.build());
     }
+
+    @SneakyThrows
+    public void testDoToQuery_whenEmptyQueryToken_thenThrowException() {
+        NeuralSparseQueryBuilder sparseEncodingQueryBuilder = new NeuralSparseQueryBuilder().fieldName(FIELD_NAME)
+            .maxTokenScore(MAX_TOKEN_SCORE)
+            .queryText(QUERY_TEXT)
+            .modelId(MODEL_ID)
+            .queryTokensSupplier(() -> Collections.emptyMap());
+        QueryShardContext mockedQueryShardContext = mock(QueryShardContext.class);
+        MappedFieldType mockedMappedFieldType = mock(MappedFieldType.class);
+        doAnswer(invocation -> "rank_features").when(mockedMappedFieldType).typeName();
+        doAnswer(invocation -> mockedMappedFieldType).when(mockedQueryShardContext).fieldMapper(any());
+        expectThrows(IllegalArgumentException.class, () -> sparseEncodingQueryBuilder.doToQuery(mock(QueryShardContext.class)));
+    }
+
 }

--- a/src/test/resources/processor/NeuralSparseTwoPhaseProcessorConfiguration.json
+++ b/src/test/resources/processor/NeuralSparseTwoPhaseProcessorConfiguration.json
@@ -1,0 +1,16 @@
+{
+  "request_processors": [
+    {
+      "neural_sparse_two_phase_processor": {
+        "tag": "neural-sparse",
+        "description": "This processor is making two-phase rescorer.",
+        "enabled": true,
+        "two_phase_parameter": {
+          "prune_ratio": %f,
+          "expansion_rate": %f,
+          "max_window_size": %d
+        }
+      }
+    }
+  ]
+}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -310,6 +310,36 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         assertEquals("true", node.get("acknowledged").toString());
     }
 
+    protected void createNeuralSparseTwoPhaseSearchProcessor(final String pipelineName) throws Exception {
+        createNeuralSparseTwoPhaseSearchProcessor(pipelineName, 0.4f, 5.0f, 10000);
+    }
+
+    protected void createNeuralSparseTwoPhaseSearchProcessor(
+        final String pipelineName,
+        float pruneRatio,
+        float expansionRate,
+        int maxWindowSize
+    ) throws Exception {
+        String jsonTemplate = Files.readString(
+            Path.of(Objects.requireNonNull(classLoader.getResource("processor/NeuralSparseTwoPhaseProcessorConfiguration.json")).toURI())
+        );
+        String customizedJson = String.format(Locale.ROOT, jsonTemplate, pruneRatio, expansionRate, maxWindowSize);
+        Response pipelineCreateResponse = makeRequest(
+            client(),
+            "PUT",
+            "/_search/pipeline/" + pipelineName,
+            null,
+            toHttpEntity(customizedJson),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> node = XContentHelper.convertToMap(
+            XContentType.JSON.xContent(),
+            EntityUtils.toString(pipelineCreateResponse.getEntity()),
+            false
+        );
+        assertEquals("true", node.get("acknowledged").toString());
+    }
+
     protected void createSearchRequestProcessor(final String modelId, final String pipelineName) throws Exception {
         Response pipelineCreateResponse = makeRequest(
             client(),


### PR DESCRIPTION
### Description
This change implement for #646 
- Enhance the speed of neuralsparse query by two-phase.
- Now support top-level, boolean and boost compound query; for other compound query will degrade into origin logic and speed.

### Feature support query
- [x] NeuralSparseQuery
- [x] NeuralSparseQuery nested in BoostQuery
- [x] NeuralSparseQuery nested in BooleanQuery

### Issues Resolved
Resolve #646 

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
