### PR TITLE
Disable memory circuit breaker for integ tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Optimize parameter parsing in text chunking processor ([#733](https://github.com/opensearch-project/neural-search/pull/733))
 ### Bug Fixes
 ### Infrastructure
+- Disable memory circuit breaker for integ tests ([#770](https://github.com/opensearch-project/neural-search/pull/770))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -396,7 +396,7 @@ testClusters.integTest {
 
     // Increase heap size from default of 512mb to 1gb. When heap size is 512mb, our integ tests sporadically fail due
     // to ml-commons memory circuit breaker exception
-    jvmArgs("-Xms1g", "-Xmx4g")
+    jvmArgs("-Xms1g", "-Xmx2g")
 }
 
 // Remote Integration Tests

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
@@ -52,11 +52,6 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
         updateClusterSettings();
     }
 
-    @Override
-    public boolean isUpdateClusterSettings() {
-        return false;
-    }
-
     /**
      * Using search pipelines with config for l2 norm:
      * {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
@@ -94,11 +94,6 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
     }
 
     @Override
-    public boolean isUpdateClusterSettings() {
-        return false;
-    }
-
-    @Override
     protected boolean preserveClusterUponCompletion() {
         return true;
     }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -88,11 +88,6 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     }
 
     @Override
-    public boolean isUpdateClusterSettings() {
-        return false;
-    }
-
-    @Override
     protected boolean preserveClusterUponCompletion() {
         return true;
     }

--- a/src/test/java/org/opensearch/neuralsearch/query/aggregation/BaseAggregationsWithHybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/aggregation/BaseAggregationsWithHybridQueryIT.java
@@ -90,11 +90,6 @@ public class BaseAggregationsWithHybridQueryIT extends BaseNeuralSearchIT {
     }
 
     @Override
-    public boolean isUpdateClusterSettings() {
-        return false;
-    }
-
-    @Override
     protected boolean preserveClusterUponCompletion() {
         return true;
     }


### PR DESCRIPTION
### Description
Adapt fix in memory circuit breaker of ml-commons (https://github.com/opensearch-project/ml-commons/pull/2469) to integ tests. Doing following: 
- lower heap memory allocation for test cluster from 4 to 2Gb. It has been increased to 4Gb under https://github.com/opensearch-project/neural-search/pull/500 to lower the chance of test failure 
- disable memory CB of ml-commons for all integ tests. that will ensure every test executed in cluster with disabled memory CB

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/689

### Check List
- [x] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
