### PR TITLE
Exclude radial search in some rolling-upgrade bwc

### DIFF
--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -203,6 +203,13 @@ task testAgainstTwoThirdsUpgradedCluster(type: StandaloneRestIntegTestTask) {
         }
     }
 
+    // Excluding the k-NN radial search tests because we introduce this feature in 2.14
+    if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12") || ext.neural_search_bwc_version.startsWith("2.13")){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.KnnRadialSearchIT.*"
+        }
+    }
+
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.security.manager', 'false'
@@ -249,6 +256,13 @@ task testRollingUpgrade(type: StandaloneRestIntegTestTask) {
     if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12")){
         filter {
             excludeTestsMatching "org.opensearch.neuralsearch.bwc.TextChunkingProcessorIT.*"
+        }
+    }
+
+    // Excluding the k-NN radial search tests because we introduce this feature in 2.14
+    if (ext.neural_search_bwc_version.startsWith("2.9") || ext.neural_search_bwc_version.startsWith("2.10") || ext.neural_search_bwc_version.startsWith("2.11") || ext.neural_search_bwc_version.startsWith("2.12") || ext.neural_search_bwc_version.startsWith("2.13")){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.KnnRadialSearchIT.*"
         }
     }
 


### PR DESCRIPTION
### Description
Exclude radial search in some rolling-upgrade bwc, no need backport this PR to 2.x since this part of code already exists in 2.x.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
