### PR TITLE
Fix jdk version for CI test secure cluster action

### DIFF
--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -20,7 +20,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Run Integration Tests on Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Remove jdk version < 21 for CI action "Test secure cluster" to adopt [change in security plugin](https://github.com/opensearch-project/security/pull/4457). For lower versions CI action is failing with error:
```
 Exception in thread "main" java.lang.IllegalStateException: opensearch-security requires Java 21:, your system: 17.0.11+9-LTS
```
https://github.com/opensearch-project/neural-search/actions/runs/9606643153/job/26496749470?pr=800#step:5:114

Dn't need to backport to 2.x for now as core PR is only for main without "backport" label

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] All tests pass
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
