### PR TITLE
[Part 3] Concurrent segment search bug in Sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fix for missing HybridQuery results when concurrent segment search is enabled ([#800](https://github.com/opensearch-project/neural-search/pull/800))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
-- Fix for missing HybridQuery results when concurrent segment search is enabled ([#800](https://github.com/opensearch-project/neural-search/pull/800))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -292,15 +292,14 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
             if (vectorSupplier().get() == null) {
                 return this;
             }
-            KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(fieldName(), vectorSupplier.get()).filter(filter());
-            if (maxDistance != null) {
-                knnQueryBuilder.maxDistance(maxDistance);
-            } else if (minScore != null) {
-                knnQueryBuilder.minScore(minScore);
-            } else {
-                knnQueryBuilder.k(k);
-            }
-            return knnQueryBuilder;
+            return KNNQueryBuilder.builder()
+                .fieldName(fieldName())
+                .vector(vectorSupplier.get())
+                .filter(filter())
+                .maxDistance(maxDistance)
+                .minScore(minScore)
+                .k(k)
+                .build();
         }
 
         SetOnce<float[]> vectorSetOnce = new SetOnce<>();

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridSearchCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridSearchCollector.java
@@ -8,10 +8,22 @@ import java.util.List;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.TopDocs;
 
+/**
+ * Common interface class for Hybrid search collectors
+ */
 public interface HybridSearchCollector extends Collector {
+    /**
+     * @return List of topDocs which contains topDocs of individual subqueries.
+     */
     List<? extends TopDocs> topDocs();
 
+    /**
+     * @return count of total hits per shard
+     */
     int getTotalHits();
 
+    /**
+     * @return maxScore found on a shard
+     */
     float getMaxScore();
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridSearchCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridSearchCollector.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.collector;
+
+import java.util.List;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.TopDocs;
+
+public interface HybridSearchCollector extends Collector {
+    List<? extends TopDocs> topDocs();
+
+    int getTotalHits();
+
+    float getMaxScore();
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollector.java
@@ -13,7 +13,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.FieldValueHitQueue;
 import org.apache.lucene.search.ScoreDoc;
@@ -38,7 +37,7 @@ import org.opensearch.neuralsearch.search.lucene.MultiLeafFieldComparator;
  The individual query results are sorted as per the sort criteria sent in the search request.
  */
 @Log4j2
-public abstract class HybridTopFieldDocSortCollector implements Collector {
+public abstract class HybridTopFieldDocSortCollector implements HybridSearchCollector {
     private final int numHits;
     private final HitsThresholdChecker hitsThresholdChecker;
     private final Sort sort;

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 
 import lombok.Getter;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.HitQueue;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
@@ -30,7 +29,7 @@ import org.opensearch.neuralsearch.search.HitsThresholdChecker;
  * Collects the TopDocs after executing hybrid query. Uses HybridQueryTopDocs as DTO to handle each sub query results
  */
 @Log4j2
-public class HybridTopScoreDocCollector implements Collector {
+public class HybridTopScoreDocCollector implements HybridSearchCollector {
     private static final TopDocs EMPTY_TOPDOCS = new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
     private int docBase;
     private final HitsThresholdChecker hitsThresholdChecker;

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -62,7 +62,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
     private final SortAndFormats sortAndFormats;
     @Nullable
     private final Weight filterWeight;
-    private static final float boost_factor = 1f;
+    private static final float boostFactor = 1f;
     private final TopDocsMerger topDocsMerger;
     @Nullable
     private final FieldDoc after;
@@ -92,7 +92,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
             // Boost factor 1f is taken because if boost is multiplicative of 1 then it means "no boost"
             // Previously this code in OpenSearch looked like
             // https://github.com/opensearch-project/OpenSearch/commit/36a5cf8f35e5cbaa1ff857b5a5db8c02edc1a187
-            filteringWeight = searcher.createWeight(searcher.rewrite(filterQuery), ScoreMode.COMPLETE_NO_SCORES, boost_factor);
+            filteringWeight = searcher.createWeight(searcher.rewrite(filterQuery), ScoreMode.COMPLETE_NO_SCORES, boostFactor);
         }
 
         return searchContext.shouldUseConcurrentSearch()
@@ -151,7 +151,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
     public ReduceableSearchResult reduce(Collection<Collector> collectors) {
         final List<HybridSearchCollector> hybridSearchCollectors = getHybridSearchCollectors(collectors);
         if (hybridSearchCollectors.isEmpty()) {
-            throw new IllegalStateException("cannot collect results of hybrid search query, there are no proper score collectors");
+            throw new IllegalStateException("cannot collect results of hybrid search query, there are no proper collectors");
         }
         return reduceSearchResults(getSearchResults(hybridSearchCollectors));
     }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -388,18 +388,8 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
         }
         // we need to do actual merge because query result and current collector both have some score hits
         TopDocsAndMaxScore originalTotalDocsAndHits = result.topDocs();
-        result.topDocs(getMergeTopDocsAndMaxScores(originalTotalDocsAndHits, topDocsAndMaxScore), docValueFormats);
-    }
-
-    private TopDocsAndMaxScore getMergeTopDocsAndMaxScores(
-        final TopDocsAndMaxScore originalTotalDocsAndHits,
-        final TopDocsAndMaxScore topDocsAndMaxScore
-    ) {
-        if (sortAndFormats != null) {
-            return topDocsMerger.mergeFieldDocs(originalTotalDocsAndHits, topDocsAndMaxScore, sortAndFormats);
-        } else {
-            return topDocsMerger.merge(originalTotalDocsAndHits, topDocsAndMaxScore);
-        }
+        TopDocsAndMaxScore mergeTopDocsAndMaxScores = topDocsMerger.merge(originalTotalDocsAndHits, topDocsAndMaxScore);
+        result.topDocs(mergeTopDocsAndMaxScores, docValueFormats);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -171,18 +171,15 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
         final DocValueFormat[] docValueFormats
     ) {
         TopDocs newTopDocs;
-        List<? extends TopDocs> topDocs = hybridSearchCollector.topDocs();
+        List topDocs = hybridSearchCollector.topDocs();
         if (docValueFormats != null) {
             newTopDocs = getNewTopFieldDocs(
                 getTotalHits(this.trackTotalHitsUpTo, topDocs, hybridSearchCollector.getTotalHits()),
-                (List<TopFieldDocs>) topDocs,
+                topDocs,
                 sortAndFormats.sort.getSort()
             );
         } else {
-            newTopDocs = getNewTopDocs(
-                getTotalHits(this.trackTotalHitsUpTo, topDocs, hybridSearchCollector.getTotalHits()),
-                (List<TopDocs>) topDocs
-            );
+            newTopDocs = getNewTopDocs(getTotalHits(this.trackTotalHitsUpTo, topDocs, hybridSearchCollector.getTotalHits()), topDocs);
         }
         return new TopDocsAndMaxScore(newTopDocs, hybridSearchCollector.getMaxScore());
     }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryFieldDocComparator.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryFieldDocComparator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.query;
+
+import java.util.Comparator;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.Pruning;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.SortField;
+
+/**
+ * Comparator class that compares two field docs as per the sorting criteria
+ */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+class HybridQueryFieldDocComparator implements Comparator<FieldDoc> {
+    final SortField[] sortFields;
+    final FieldComparator<?>[] comparators;
+    final int[] reverseMul;
+    final Comparator<ScoreDoc> tieBreaker;
+
+    public HybridQueryFieldDocComparator(SortField[] sortFields, Comparator<ScoreDoc> tieBreaker) {
+        this.sortFields = sortFields;
+        this.tieBreaker = tieBreaker;
+        comparators = new FieldComparator[sortFields.length];
+        reverseMul = new int[sortFields.length];
+        for (int compIDX = 0; compIDX < sortFields.length; compIDX++) {
+            final SortField sortField = sortFields[compIDX];
+            comparators[compIDX] = sortField.getComparator(1, Pruning.NONE);
+            reverseMul[compIDX] = sortField.getReverse() ? -1 : 1;
+        }
+    }
+
+    @Override
+    public int compare(final FieldDoc firstFD, final FieldDoc secondFD) {
+        for (int compIDX = 0; compIDX < comparators.length; compIDX++) {
+            final FieldComparator comp = comparators[compIDX];
+
+            final int cmp = reverseMul[compIDX] * comp.compareValues(firstFD.fields[compIDX], secondFD.fields[compIDX]);
+
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return tieBreakCompare(firstFD, secondFD, tieBreaker);
+    }
+
+    private int tieBreakCompare(ScoreDoc firstDoc, ScoreDoc secondDoc, Comparator<ScoreDoc> tieBreaker) {
+        assert tieBreaker != null;
+        int value = tieBreaker.compare(firstDoc, secondDoc);
+        return value;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.query;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.lucene.search.ScoreDoc;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryScoreDocElement;
+
+/**
+ * Merges two ScoreDoc arrays into one
+ */
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+class HybridQueryScoreDocsMerger<T extends ScoreDoc> {
+
+    private static final int MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC = 3;
+
+    /**
+     * Merge two score docs objects, result ScoreDocs[] object will have all hits per sub-query from both original objects.
+     * Input and output ScoreDocs are in format that is specific to Hybrid Query. This method should not be used for ScoreDocs from
+     * other query types.
+     * Logic is based on assumption that hits of every sub-query are sorted by score.
+     * Method returns new object and doesn't mutate original ScoreDocs arrays.
+     * @param sourceScoreDocs original score docs from query result
+     * @param newScoreDocs new score docs that we need to merge into existing scores
+     * @return merged array of ScoreDocs objects
+     */
+    public T[] merge(final T[] sourceScoreDocs, final T[] newScoreDocs, final Comparator<T> comparator) {
+        if (Objects.requireNonNull(sourceScoreDocs, "score docs cannot be null").length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC
+            || Objects.requireNonNull(newScoreDocs, "score docs cannot be null").length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC) {
+            throw new IllegalArgumentException("cannot merge top docs because it does not have enough elements");
+        }
+        // we overshoot and preallocate more than we need - length of both top docs combined.
+        // we will take only portion of the array at the end
+        List<T> mergedScoreDocs = new ArrayList<>(sourceScoreDocs.length + newScoreDocs.length);
+        int sourcePointer = 0;
+        // mark beginning of hybrid query results by start element
+        mergedScoreDocs.add(sourceScoreDocs[sourcePointer]);
+        sourcePointer++;
+        // new pointer is set to 1 as we don't care about it start-stop element
+        int newPointer = 1;
+
+        while (sourcePointer < sourceScoreDocs.length - 1 && newPointer < newScoreDocs.length - 1) {
+            // every iteration is for results of one sub-query
+            mergedScoreDocs.add(sourceScoreDocs[sourcePointer]);
+            sourcePointer++;
+            newPointer++;
+            // simplest case when both arrays have results for sub-query
+            while (sourcePointer < sourceScoreDocs.length
+                && isHybridQueryScoreDocElement(sourceScoreDocs[sourcePointer])
+                && newPointer < newScoreDocs.length
+                && isHybridQueryScoreDocElement(newScoreDocs[newPointer])) {
+                if (comparator.compare(sourceScoreDocs[sourcePointer], newScoreDocs[newPointer]) >= 0) {
+                    mergedScoreDocs.add(sourceScoreDocs[sourcePointer]);
+                    sourcePointer++;
+                } else {
+                    mergedScoreDocs.add(newScoreDocs[newPointer]);
+                    newPointer++;
+                }
+            }
+            // at least one object got exhausted at this point, now merge all elements from object that's left
+            while (sourcePointer < sourceScoreDocs.length && isHybridQueryScoreDocElement(sourceScoreDocs[sourcePointer])) {
+                mergedScoreDocs.add(sourceScoreDocs[sourcePointer]);
+                sourcePointer++;
+            }
+            while (newPointer < newScoreDocs.length && isHybridQueryScoreDocElement(newScoreDocs[newPointer])) {
+                mergedScoreDocs.add(newScoreDocs[newPointer]);
+                newPointer++;
+            }
+        }
+        // mark end of hybrid query results by end element
+        mergedScoreDocs.add(sourceScoreDocs[sourceScoreDocs.length - 1]);
+        return mergedScoreDocs.toArray((T[]) new ScoreDoc[0]);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
@@ -32,6 +32,8 @@ class HybridQueryScoreDocsMerger<T extends ScoreDoc> {
      * Method returns new object and doesn't mutate original ScoreDocs arrays.
      * @param sourceScoreDocs original score docs from query result
      * @param newScoreDocs new score docs that we need to merge into existing scores
+     * @param comparator comparator to compare the score docs
+     * @param isSortEnabled flag that show if sort is enabled or disabled
      * @return merged array of ScoreDocs objects
      */
     public T[] merge(final T[] sourceScoreDocs, final T[] newScoreDocs, final Comparator<T> comparator, final boolean isSortEnabled) {

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.search.query;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
 
 import java.util.ArrayList;
@@ -33,7 +34,7 @@ class HybridQueryScoreDocsMerger<T extends ScoreDoc> {
      * @param newScoreDocs new score docs that we need to merge into existing scores
      * @return merged array of ScoreDocs objects
      */
-    public T[] merge(final T[] sourceScoreDocs, final T[] newScoreDocs, final Comparator<T> comparator) {
+    public T[] merge(final T[] sourceScoreDocs, final T[] newScoreDocs, final Comparator<T> comparator, final boolean isSortEnabled) {
         if (Objects.requireNonNull(sourceScoreDocs, "score docs cannot be null").length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC
             || Objects.requireNonNull(newScoreDocs, "score docs cannot be null").length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC) {
             throw new IllegalArgumentException("cannot merge top docs because it does not have enough elements");
@@ -58,7 +59,7 @@ class HybridQueryScoreDocsMerger<T extends ScoreDoc> {
                 && isHybridQueryScoreDocElement(sourceScoreDocs[sourcePointer])
                 && newPointer < newScoreDocs.length
                 && isHybridQueryScoreDocElement(newScoreDocs[newPointer])) {
-                if (comparator.compare(sourceScoreDocs[sourcePointer], newScoreDocs[newPointer]) >= 0) {
+                if (compareCondition(sourceScoreDocs[sourcePointer], newScoreDocs[newPointer], comparator, isSortEnabled)) {
                     mergedScoreDocs.add(sourceScoreDocs[sourcePointer]);
                     sourcePointer++;
                 } else {
@@ -78,6 +79,23 @@ class HybridQueryScoreDocsMerger<T extends ScoreDoc> {
         }
         // mark end of hybrid query results by end element
         mergedScoreDocs.add(sourceScoreDocs[sourceScoreDocs.length - 1]);
+        if (isSortEnabled) {
+            return mergedScoreDocs.toArray((T[]) new FieldDoc[0]);
+        }
         return mergedScoreDocs.toArray((T[]) new ScoreDoc[0]);
+    }
+
+    private boolean compareCondition(
+        final ScoreDoc oldScoreDoc,
+        final ScoreDoc secondScoreDoc,
+        final Comparator<T> comparator,
+        final boolean isSortEnabled
+    ) {
+        // If sorting is enabled then compare condition will be different then normal HybridQuery
+        if (isSortEnabled) {
+            return comparator.compare((T) oldScoreDoc, (T) secondScoreDoc) < 0;
+        } else {
+            return comparator.compare((T) oldScoreDoc, (T) secondScoreDoc) >= 0;
+        }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
@@ -7,13 +7,16 @@ package org.opensearch.neuralsearch.search.query;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 
 import java.util.Comparator;
 import java.util.Objects;
+import org.opensearch.search.sort.SortAndFormats;
 
 /**
  * Utility class for merging TopDocs and MaxScore across multiple search queries
@@ -21,13 +24,29 @@ import java.util.Objects;
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 class TopDocsMerger {
 
-    private final HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger;
+    private HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger;
+    private HybridQueryScoreDocsMerger<FieldDoc> fieldDocsMerger;
     @VisibleForTesting
-    protected static final Comparator<ScoreDoc> SCORE_DOC_BY_SCORE_COMPARATOR = Comparator.comparing((scoreDoc) -> scoreDoc.score);
+    protected static Comparator<ScoreDoc> SCORE_DOC_BY_SCORE_COMPARATOR;
+    @VisibleForTesting
+    protected static HybridQueryFieldDocComparator FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR;
+    private final Comparator<ScoreDoc> MERGING_TIE_BREAKER = (o1, o2) -> {
+        int docIdComparison = Integer.compare(o1.doc, o2.doc);
+        return docIdComparison;
+    };
+
     /**
      * Uses hybrid query score docs merger to merge internal score docs
      */
-    static final TopDocsMerger TOP_DOCS_MERGER_TOP_SCORES = new TopDocsMerger(new HybridQueryScoreDocsMerger<>());
+    TopDocsMerger(final SortAndFormats sortAndFormats) {
+        if (sortAndFormats != null) {
+            fieldDocsMerger = new HybridQueryScoreDocsMerger<>();
+            FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR = new HybridQueryFieldDocComparator(sortAndFormats.sort.getSort(), MERGING_TIE_BREAKER);
+        } else {
+            scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+            SCORE_DOC_BY_SCORE_COMPARATOR = Comparator.comparing((scoreDoc) -> scoreDoc.score);
+        }
+    }
 
     /**
      * Merge TopDocs and MaxScore from multiple search queries into a single TopDocsAndMaxScore object.
@@ -35,7 +54,7 @@ class TopDocsMerger {
      * @param newTopDocs TopDocsAndMaxScore for the new query
      * @return merged TopDocsAndMaxScore object
      */
-    public TopDocsAndMaxScore merge(TopDocsAndMaxScore source, TopDocsAndMaxScore newTopDocs) {
+    public TopDocsAndMaxScore merge(final TopDocsAndMaxScore source, final TopDocsAndMaxScore newTopDocs) {
         if (Objects.isNull(newTopDocs) || Objects.isNull(newTopDocs.topDocs) || newTopDocs.topDocs.totalHits.value == 0) {
             return source;
         }
@@ -52,7 +71,8 @@ class TopDocsMerger {
         ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(
             source.topDocs.scoreDocs,
             newTopDocs.topDocs.scoreDocs,
-            SCORE_DOC_BY_SCORE_COMPARATOR
+            SCORE_DOC_BY_SCORE_COMPARATOR,
+            false
         );
         TotalHits mergedTotalHits = getMergedTotalHits(source, newTopDocs);
         TopDocsAndMaxScore result = new TopDocsAndMaxScore(
@@ -62,7 +82,45 @@ class TopDocsMerger {
         return result;
     }
 
-    private TotalHits getMergedTotalHits(TopDocsAndMaxScore source, TopDocsAndMaxScore newTopDocs) {
+    /**
+     * Merge TopFieldDocs and MaxScore from multiple search queries into a single TopDocsAndMaxScore object.
+     * @param source TopDocsAndMaxScore for the original query
+     * @param newTopDocs TopDocsAndMaxScore for the new query
+     * @return merged TopDocsAndMaxScore object
+     */
+    public TopDocsAndMaxScore mergeFieldDocs(
+        final TopDocsAndMaxScore source,
+        final TopDocsAndMaxScore newTopDocs,
+        final SortAndFormats sortAndFormats
+    ) {
+        if (Objects.isNull(newTopDocs) || Objects.isNull(newTopDocs.topDocs) || newTopDocs.topDocs.totalHits.value == 0) {
+            return source;
+        }
+        // we need to merge hits per individual sub-query
+        // format of results in both new and source TopDocs is following
+        // doc_id | magic_number_1 | [1]
+        // doc_id | magic_number_2 | [1]
+        // ...
+        // doc_id | magic_number_2 | [1]
+        // ...
+        // doc_id | magic_number_2 | [1]
+        // ...
+        // doc_id | magic_number_1 | [1]
+        FieldDoc[] mergedScoreDocs = fieldDocsMerger.merge(
+            (FieldDoc[]) source.topDocs.scoreDocs,
+            (FieldDoc[]) newTopDocs.topDocs.scoreDocs,
+            FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR,
+            true
+        );
+        TotalHits mergedTotalHits = getMergedTotalHits(source, newTopDocs);
+        TopDocsAndMaxScore result = new TopDocsAndMaxScore(
+            new TopFieldDocs(mergedTotalHits, mergedScoreDocs, sortAndFormats.sort.getSort()),
+            Math.max(source.maxScore, newTopDocs.maxScore)
+        );
+        return result;
+    }
+
+    private TotalHits getMergedTotalHits(final TopDocsAndMaxScore source, final TopDocsAndMaxScore newTopDocs) {
         // merged value is a lower bound - if both are equal_to than merged will also be equal_to,
         // otherwise assign greater_than_or_equal
         TotalHits.Relation mergedHitsRelation = source.topDocs.totalHits.relation == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO

--- a/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.query;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Utility class for merging TopDocs and MaxScore across multiple search queries
+ */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+class TopDocsMerger {
+
+    private final HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger;
+    @VisibleForTesting
+    protected static final Comparator<ScoreDoc> SCORE_DOC_BY_SCORE_COMPARATOR = Comparator.comparing((scoreDoc) -> scoreDoc.score);
+    /**
+     * Uses hybrid query score docs merger to merge internal score docs
+     */
+    static final TopDocsMerger TOP_DOCS_MERGER_TOP_SCORES = new TopDocsMerger(new HybridQueryScoreDocsMerger<>());
+
+    /**
+     * Merge TopDocs and MaxScore from multiple search queries into a single TopDocsAndMaxScore object.
+     * @param source TopDocsAndMaxScore for the original query
+     * @param newTopDocs TopDocsAndMaxScore for the new query
+     * @return merged TopDocsAndMaxScore object
+     */
+    public TopDocsAndMaxScore merge(TopDocsAndMaxScore source, TopDocsAndMaxScore newTopDocs) {
+        if (Objects.isNull(newTopDocs) || Objects.isNull(newTopDocs.topDocs) || newTopDocs.topDocs.totalHits.value == 0) {
+            return source;
+        }
+        // we need to merge hits per individual sub-query
+        // format of results in both new and source TopDocs is following
+        // doc_id | magic_number_1
+        // doc_id | magic_number_2
+        // ...
+        // doc_id | magic_number_2
+        // ...
+        // doc_id | magic_number_2
+        // ...
+        // doc_id | magic_number_1
+        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(
+            source.topDocs.scoreDocs,
+            newTopDocs.topDocs.scoreDocs,
+            SCORE_DOC_BY_SCORE_COMPARATOR
+        );
+        TotalHits mergedTotalHits = getMergedTotalHits(source, newTopDocs);
+        TopDocsAndMaxScore result = new TopDocsAndMaxScore(
+            new TopDocs(mergedTotalHits, mergedScoreDocs),
+            Math.max(source.maxScore, newTopDocs.maxScore)
+        );
+        return result;
+    }
+
+    private TotalHits getMergedTotalHits(TopDocsAndMaxScore source, TopDocsAndMaxScore newTopDocs) {
+        // merged value is a lower bound - if both are equal_to than merged will also be equal_to,
+        // otherwise assign greater_than_or_equal
+        TotalHits.Relation mergedHitsRelation = source.topDocs.totalHits.relation == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+            || newTopDocs.topDocs.totalHits.relation == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+                ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+                : TotalHits.Relation.EQUAL_TO;
+        return new TotalHits(source.topDocs.totalHits.value + newTopDocs.topDocs.totalHits.value, mergedHitsRelation);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
@@ -78,7 +78,7 @@ class TopDocsMerger {
     }
 
     private TopDocs getTopDocs(ScoreDoc[] mergedScoreDocs, TotalHits mergedTotalHits) {
-        if (sortAndFormats != null) {
+        if (isSortingEnabled()) {
             return new TopFieldDocs(mergedTotalHits, mergedScoreDocs, sortAndFormats.sort.getSort());
         }
         return new TopDocs(mergedTotalHits, mergedScoreDocs);

--- a/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
@@ -68,44 +68,6 @@ class TopDocsMerger {
         return result;
     }
 
-    // /**
-    // * Merge TopFieldDocs and MaxScore from multiple search queries into a single TopDocsAndMaxScore object.
-    // * @param source TopDocsAndMaxScore for the original query
-    // * @param newTopDocs TopDocsAndMaxScore for the new query
-    // * @return merged TopDocsAndMaxScore object
-    // */
-    // public TopDocsAndMaxScore mergeFieldDocs(
-    // final TopDocsAndMaxScore source,
-    // final TopDocsAndMaxScore newTopDocs,
-    // final SortAndFormats sortAndFormats
-    // ) {
-    // if (Objects.isNull(newTopDocs) || Objects.isNull(newTopDocs.topDocs) || newTopDocs.topDocs.totalHits.value == 0) {
-    // return source;
-    // }
-    // // we need to merge hits per individual sub-query
-    // // format of results in both new and source TopDocs is following
-    // // doc_id | magic_number_1 | [1]
-    // // doc_id | magic_number_2 | [1]
-    // // ...
-    // // doc_id | magic_number_2 | [1]
-    // // ...
-    // // doc_id | magic_number_2 | [1]
-    // // ...
-    // // doc_id | magic_number_1 | [1]
-    // FieldDoc[] mergedScoreDocs = fieldDocsMerger.merge(
-    // (FieldDoc[]) source.topDocs.scoreDocs,
-    // (FieldDoc[]) newTopDocs.topDocs.scoreDocs,
-    // FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR,
-    // true
-    // );
-    // TotalHits mergedTotalHits = getMergedTotalHits(source, newTopDocs);
-    // TopDocsAndMaxScore result = new TopDocsAndMaxScore(
-    // new TopFieldDocs(mergedTotalHits, mergedScoreDocs, sortAndFormats.sort.getSort()),
-    // Math.max(source.maxScore, newTopDocs.maxScore)
-    // );
-    // return result;
-    // }
-
     private TotalHits getMergedTotalHits(final TopDocsAndMaxScore source, final TopDocsAndMaxScore newTopDocs) {
         // merged value is a lower bound - if both are equal_to than merged will also be equal_to,
         // otherwise assign greater_than_or_equal

--- a/src/main/java/org/opensearch/neuralsearch/search/util/HybridSearchResultFormatUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/util/HybridSearchResultFormatUtil.java
@@ -71,6 +71,30 @@ public class HybridSearchResultFormatUtil {
     }
 
     /**
+     * Checking if passed scoreDocs object is a special element (start/stop or delimiter) in the list of hybrid query result scores
+     * @param scoreDoc score doc object to check on
+     * @return true if it is a special element
+     */
+    public static boolean isHybridQuerySpecialElement(final ScoreDoc scoreDoc) {
+        if (Objects.isNull(scoreDoc)) {
+            return false;
+        }
+        return isHybridQueryStartStopElement(scoreDoc) || isHybridQueryDelimiterElement(scoreDoc);
+    }
+
+    /**
+     * Checking if passed scoreDocs object is a document score element
+     * @param scoreDoc score doc object to check on
+     * @return true if element has score
+     */
+    public static boolean isHybridQueryScoreDocElement(final ScoreDoc scoreDoc) {
+        if (Objects.isNull(scoreDoc)) {
+            return false;
+        }
+        return !isHybridQuerySpecialElement(scoreDoc);
+    }
+
+    /**
      * This method is for creating dummy sort object for the field docs having magic number scores which acts as delimiters.
      *  The sort object should be in the same type of the field on which sorting criteria is applied.
      * @param fields contains the information about the object type of the field on which sorting criteria is applied

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
@@ -100,43 +100,43 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
 
     @SneakyThrows
     public void testPipelineAggs_whenConcurrentSearchEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testAvgSumMinMaxAggs();
     }
 
     @SneakyThrows
     public void testPipelineAggs_whenConcurrentSearchDisabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testAvgSumMinMaxAggs();
     }
 
     @SneakyThrows
     public void testMetricAggsOnSingleShard_whenMaxAggsAndConcurrentSearchEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testMaxAggsOnSingleShardCluster();
     }
 
     @SneakyThrows
     public void testMetricAggsOnSingleShard_whenMaxAggsAndConcurrentSearchDisabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testMaxAggsOnSingleShardCluster();
     }
 
     @SneakyThrows
     public void testBucketAndNestedAggs_whenConcurrentSearchDisabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateRange();
     }
 
     @SneakyThrows
     public void testBucketAndNestedAggs_whenConcurrentSearchEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testDateRange();
     }
 
     @SneakyThrows
     public void testAggregationNotSupportedConcurrentSearch_whenUseSamplerAgg_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
 
         try {
             prepareResources(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SEARCH_PIPELINE);
@@ -177,14 +177,14 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
 
     @SneakyThrows
     public void testPostFilterOnIndexWithMultipleShards_WhenConcurrentSearchNotEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testPostFilterWithSimpleHybridQuery(false, true);
         testPostFilterWithComplexHybridQuery(false, true);
     }
 
     @SneakyThrows
     public void testPostFilterOnIndexWithMultipleShards_WhenConcurrentSearchEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testPostFilterWithSimpleHybridQuery(false, true);
         testPostFilterWithComplexHybridQuery(false, true);
     }
@@ -420,14 +420,14 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
 
     @SneakyThrows
     public void testPostFilterOnIndexWithSingleShards_WhenConcurrentSearchNotEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testPostFilterWithSimpleHybridQuery(true, true);
         testPostFilterWithComplexHybridQuery(true, true);
     }
 
     @SneakyThrows
     public void testPostFilterOnIndexWithSingleShards_WhenConcurrentSearchEnabled_thenSuccessful() {
-        updateClusterSettings("search.concurrent_segment_search.enabled", true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testPostFilterWithSimpleHybridQuery(true, true);
         testPostFilterWithComplexHybridQuery(true, true);
     }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryPostFilterIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryPostFilterIT.java
@@ -68,7 +68,7 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
     @SneakyThrows
     public void testPostFilterOnIndexWithSingleShard_whenConcurrentSearchEnabled_thenSuccessful() {
         try {
-            updateClusterSettings("search.concurrent_segment_search.enabled", true);
+            updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
             prepareResourcesBeforeTestExecution(SHARDS_COUNT_IN_SINGLE_NODE_CLUSTER);
             testPostFilterRangeQuery(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD);
             testPostFilterBoolQuery(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD);
@@ -81,7 +81,7 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
     @SneakyThrows
     public void testPostFilterOnIndexWithSingleShard_whenConcurrentSearchDisabled_thenSuccessful() {
         try {
-            updateClusterSettings("search.concurrent_segment_search.enabled", false);
+            updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
             prepareResourcesBeforeTestExecution(SHARDS_COUNT_IN_SINGLE_NODE_CLUSTER);
             testPostFilterRangeQuery(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD);
             testPostFilterBoolQuery(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD);
@@ -94,7 +94,7 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
     @SneakyThrows
     public void testPostFilterOnIndexWithMultipleShards_whenConcurrentSearchEnabled_thenSuccessful() {
         try {
-            updateClusterSettings("search.concurrent_segment_search.enabled", true);
+            updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
             prepareResourcesBeforeTestExecution(SHARDS_COUNT_IN_MULTI_NODE_CLUSTER);
             testPostFilterRangeQuery(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS);
             testPostFilterBoolQuery(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS);
@@ -107,7 +107,7 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
     @SneakyThrows
     public void testPostFilterOnIndexWithMultipleShards_whenConcurrentSearchDisabled_thenSuccessful() {
         try {
-            updateClusterSettings("search.concurrent_segment_search.enabled", false);
+            updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
             prepareResourcesBeforeTestExecution(SHARDS_COUNT_IN_MULTI_NODE_CLUSTER);
             testPostFilterRangeQuery(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS);
             testPostFilterBoolQuery(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS);

--- a/src/test/java/org/opensearch/neuralsearch/query/aggregation/BaseAggregationsWithHybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/aggregation/BaseAggregationsWithHybridQueryIT.java
@@ -77,7 +77,6 @@ public class BaseAggregationsWithHybridQueryIT extends BaseNeuralSearchIT {
     protected static final String AVG_AGGREGATION_NAME = "avg_field";
     protected static final String GENERIC_AGGREGATION_NAME = "my_aggregation";
     protected static final String DATE_AGGREGATION_NAME = "date_aggregation";
-    protected static final String CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH = "search.concurrent_segment_search.enabled";
 
     @BeforeClass
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/query/aggregation/BucketAggregationsWithHybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/aggregation/BucketAggregationsWithHybridQueryIT.java
@@ -68,165 +68,165 @@ public class BucketAggregationsWithHybridQueryIT extends BaseAggregationsWithHyb
 
     @SneakyThrows
     public void testBucketAndNestedAggs_whenAdjacencyMatrix_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testAdjacencyMatrixAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenAdjacencyMatrix_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testAdjacencyMatrixAggs();
     }
 
     @SneakyThrows
     public void testBucketAndNestedAggs_whenDiversifiedSampler_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDiversifiedSampler();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenDiversifiedSampler_thenFail() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
 
         testDiversifiedSampler();
     }
 
     @SneakyThrows
     public void testBucketAndNestedAggs_whenAvgNestedIntoFilter_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testAvgNestedIntoFilter();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenAvgNestedIntoFilter_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testAvgNestedIntoFilter();
     }
 
     @SneakyThrows
     public void testBucketAndNestedAggs_whenSumNestedIntoFilters_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testSumNestedIntoFilters();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenSumNestedIntoFilters_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testSumNestedIntoFilters();
     }
 
     @SneakyThrows
     public void testBucketAggs_whenGlobalAggUsedWithQuery_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testGlobalAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenGlobalAggUsedWithQuery_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testGlobalAggs();
     }
 
     @SneakyThrows
     public void testBucketAggs_whenHistogramAgg_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testHistogramAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenHistogramAgg_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testHistogramAggs();
     }
 
     @SneakyThrows
     public void testBucketAggs_whenNestedAgg_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testNestedAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenNestedAgg_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testNestedAggs();
     }
 
     @SneakyThrows
     public void testBucketAggs_whenSamplerAgg_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testSampler();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenSamplerAgg_thenFail() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
 
         testSampler();
     }
 
     @SneakyThrows
     public void testPipelineSiblingAggs_whenDateBucketedSumsPipelinedToBucketMinMaxSumAvgAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateBucketedSumsPipelinedToBucketMinMaxSumAvgAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenDateBucketedSumsPipelinedToBucketMinMaxSumAvgAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testDateBucketedSumsPipelinedToBucketMinMaxSumAvgAggs();
     }
 
     @SneakyThrows
     public void testPipelineSiblingAggs_whenDateBucketedSumsPipelinedToBucketStatsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateBucketedSumsPipelinedToBucketStatsAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenDateBucketedSumsPipelinedToBucketStatsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testDateBucketedSumsPipelinedToBucketStatsAggs();
     }
 
     @SneakyThrows
     public void testPipelineSiblingAggs_whenDateBucketedSumsPipelinedToBucketScriptAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateBucketedSumsPipelinedToBucketScriptedAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenDateBucketedSumsPipelinedToBucketScriptedAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testDateBucketedSumsPipelinedToBucketScriptedAggs();
     }
 
     @SneakyThrows
     public void testPipelineParentAggs_whenDateBucketedSumsPipelinedToBucketScriptedAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateBucketedSumsPipelinedToBucketScriptedAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenTermsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testTermsAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenTermsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testTermsAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenSignificantTermsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testSignificantTermsAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenSignificantTermsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testSignificantTermsAggs();
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/aggregation/MetricAggregationsWithHybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/aggregation/MetricAggregationsWithHybridQueryIT.java
@@ -81,103 +81,103 @@ public class MetricAggregationsWithHybridQueryIT extends BaseAggregationsWithHyb
      */
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenAvgAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testAvgAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenCardinalityAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testCardinalityAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenCardinalityAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testCardinalityAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenExtendedStatsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testExtendedStatsAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenExtendedStatsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testExtendedStatsAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenTopHitsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testTopHitsAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenTopHitsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testTopHitsAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenPercentileRank_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testPercentileRankAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenPercentileRank_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testPercentileRankAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenPercentile_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testPercentileAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenPercentile_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testPercentileAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenScriptedMetrics_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testScriptedMetricsAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenScriptedMetrics_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testScriptedMetricsAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenSumAgg_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testSumAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenSumAgg_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testSumAggs();
     }
 
     @SneakyThrows
     public void testMetricAggs_whenValueCount_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testValueCountAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenValueCount_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testValueCountAggs();
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/aggregation/PipelineAggregationsWithHybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/aggregation/PipelineAggregationsWithHybridQueryIT.java
@@ -53,49 +53,49 @@ public class PipelineAggregationsWithHybridQueryIT extends BaseAggregationsWithH
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenDateBucketedSumsPipelinedToBucketStatsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testDateBucketedSumsPipelinedToBucketStatsAggs();
     }
 
     @SneakyThrows
     public void testPipelineSiblingAggs_whenDateBucketedSumsPipelinedToBucketStatsAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateBucketedSumsPipelinedToBucketStatsAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenDateBucketedSumsPipelinedToBucketScriptedAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testDateBucketedSumsPipelinedToBucketScriptedAggs();
     }
 
     @SneakyThrows
     public void testPipelineParentAggs_whenDateBucketedSumsPipelinedToBucketScriptedAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateBucketedSumsPipelinedToBucketScriptedAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenDateBucketedSumsPipelinedToBucketSortAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testDateBucketedSumsPipelinedToBucketSortAggs();
     }
 
     @SneakyThrows
     public void testPipelineParentAggs_whenDateBucketedSumsPipelinedToBucketSortAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateBucketedSumsPipelinedToBucketSortAggs();
     }
 
     @SneakyThrows
     public void testWithConcurrentSegmentSearch_whenDateBucketedSumsPipelinedToCumulativeSumAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, true);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, true);
         testDateBucketedSumsPipelinedToCumulativeSumAggs();
     }
 
     @SneakyThrows
     public void testPipelineParentAggs_whenDateBucketedSumsPipelinedToCumulativeSumAggs_thenSuccessful() {
-        updateClusterSettings(CLUSTER_SETTING_CONCURRENT_SEGMENT_SEARCH, false);
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
         testDateBucketedSumsPipelinedToCumulativeSumAggs();
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -67,6 +67,7 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
     private static final String TEST_DOC_TEXT2 = "Hi to this place";
     private static final String TEST_DOC_TEXT3 = "We would like to welcome everyone";
     private static final String QUERY1 = "hello";
+    private static final String QUERY2 = "hi";
     private static final float DELTA_FOR_ASSERTION = 0.001f;
 
     @SneakyThrows
@@ -480,5 +481,131 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         w.close();
         reader.close();
         directory.close();
+    }
+
+    @SneakyThrows
+    public void testReduceWithConcurrentSegmentSearch_whenMultipleCollectorsMatchedDocs_thenSuccessful() {
+        SearchContext searchContext = mock(SearchContext.class);
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        HybridQuery hybridQueryWithTerm = new HybridQuery(
+            List.of(
+                QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY1).toQuery(mockQueryShardContext),
+                QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY2).toQuery(mockQueryShardContext)
+            )
+        );
+        when(searchContext.query()).thenReturn(hybridQueryWithTerm);
+        ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
+        IndexReader indexReader = mock(IndexReader.class);
+        when(indexReader.numDocs()).thenReturn(2);
+        when(indexSearcher.getIndexReader()).thenReturn(indexReader);
+        when(searchContext.searcher()).thenReturn(indexSearcher);
+        when(searchContext.size()).thenReturn(1);
+
+        Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> classCollectorManagerMap = new HashMap<>();
+        when(searchContext.queryCollectorManagers()).thenReturn(classCollectorManagerMap);
+        when(searchContext.shouldUseConcurrentSearch()).thenReturn(true);
+
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        Directory directory = newDirectory();
+        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+
+        int docId1 = RandomizedTest.randomInt();
+        int docId2 = RandomizedTest.randomInt();
+        int docId3 = RandomizedTest.randomInt();
+
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId1, TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
+        w.flush();
+        w.commit();
+
+        SearchContext searchContext2 = mock(SearchContext.class);
+
+        ContextIndexSearcher indexSearcher2 = mock(ContextIndexSearcher.class);
+        IndexReader indexReader2 = mock(IndexReader.class);
+        when(indexReader2.numDocs()).thenReturn(1);
+        when(indexSearcher2.getIndexReader()).thenReturn(indexReader);
+        when(searchContext2.searcher()).thenReturn(indexSearcher2);
+        when(searchContext2.size()).thenReturn(1);
+
+        when(searchContext2.queryCollectorManagers()).thenReturn(new HashMap<>());
+        when(searchContext2.shouldUseConcurrentSearch()).thenReturn(true);
+
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        Directory directory2 = newDirectory();
+        final IndexWriter w2 = new IndexWriter(directory2, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft2 = new FieldType(TextField.TYPE_NOT_STORED);
+        ft2.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft2.setOmitNorms(random().nextBoolean());
+        ft2.freeze();
+
+        w2.addDocument(getDocument(TEXT_FIELD_NAME, docId2, TEST_DOC_TEXT2, ft));
+        w2.flush();
+        w2.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+        IndexSearcher searcher = newSearcher(reader);
+        IndexReader reader2 = DirectoryReader.open(w2);
+        IndexSearcher searcher2 = newSearcher(reader2);
+
+        CollectorManager hybridCollectorManager = HybridCollectorManager.createHybridCollectorManager(searchContext);
+        HybridTopScoreDocCollector collector1 = (HybridTopScoreDocCollector) hybridCollectorManager.newCollector();
+        HybridTopScoreDocCollector collector2 = (HybridTopScoreDocCollector) hybridCollectorManager.newCollector();
+
+        Weight weight1 = new HybridQueryWeight(hybridQueryWithTerm, searcher, ScoreMode.TOP_SCORES, BoostingQueryBuilder.DEFAULT_BOOST);
+        Weight weight2 = new HybridQueryWeight(hybridQueryWithTerm, searcher2, ScoreMode.TOP_SCORES, BoostingQueryBuilder.DEFAULT_BOOST);
+        collector1.setWeight(weight1);
+        collector2.setWeight(weight2);
+        LeafReaderContext leafReaderContext = searcher.getIndexReader().leaves().get(0);
+        LeafCollector leafCollector1 = collector1.getLeafCollector(leafReaderContext);
+
+        LeafReaderContext leafReaderContext2 = searcher2.getIndexReader().leaves().get(0);
+        LeafCollector leafCollector2 = collector2.getLeafCollector(leafReaderContext2);
+        BulkScorer scorer = weight1.bulkScorer(leafReaderContext);
+        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs());
+        leafCollector1.finish();
+        BulkScorer scorer2 = weight2.bulkScorer(leafReaderContext2);
+        scorer2.score(leafCollector2, leafReaderContext2.reader().getLiveDocs());
+        leafCollector2.finish();
+
+        Object results = hybridCollectorManager.reduce(List.of(collector1, collector2));
+
+        assertNotNull(results);
+        ReduceableSearchResult reduceableSearchResult = ((ReduceableSearchResult) results);
+        QuerySearchResult querySearchResult = new QuerySearchResult();
+        reduceableSearchResult.reduce(querySearchResult);
+        TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
+
+        assertNotNull(topDocsAndMaxScore);
+        assertEquals(2, topDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation);
+        float maxScore = topDocsAndMaxScore.maxScore;
+        assertTrue(maxScore > 0);
+        ScoreDoc[] scoreDocs = topDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(6, scoreDocs.length);
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[0].score, DELTA_FOR_ASSERTION);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[1].score, DELTA_FOR_ASSERTION);
+        assertTrue(scoreDocs[2].score > 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[3].score, DELTA_FOR_ASSERTION);
+        assertTrue(scoreDocs[4].score > 0);
+
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[5].score, DELTA_FOR_ASSERTION);
+        // we have to assert that one of hits is max score because scores are generated for each run and order is not guaranteed
+        assertTrue(Float.compare(scoreDocs[2].score, maxScore) == 0 || Float.compare(scoreDocs[4].score, maxScore) == 0);
+
+        w.close();
+        reader.close();
+        directory.close();
+        w2.close();
+        reader2.close();
+        directory2.close();
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMergerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMergerTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.query;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+
+import static org.opensearch.neuralsearch.search.query.TopDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createStartStopElementForHybridSearchResults;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createDelimiterElementForHybridSearchResults;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_START_STOP;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_DELIMITER;
+
+public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
+
+    private static final float DELTA_FOR_ASSERTION = 0.001f;
+
+    public void testIncorrectInput_whenScoreDocsAreNullOrNotEnoughElements_thenFail() {
+        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+
+        ScoreDoc[] scores = new ScoreDoc[] {
+            createStartStopElementForHybridSearchResults(2),
+            createDelimiterElementForHybridSearchResults(2),
+            new ScoreDoc(1, 0.7f),
+            createStartStopElementForHybridSearchResults(2) };
+
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> scoreDocsMerger.merge(scores, null, SCORE_DOC_BY_SCORE_COMPARATOR)
+        );
+        assertEquals("score docs cannot be null", exception.getMessage());
+
+        exception = assertThrows(NullPointerException.class, () -> scoreDocsMerger.merge(scores, null, SCORE_DOC_BY_SCORE_COMPARATOR));
+        assertEquals("score docs cannot be null", exception.getMessage());
+
+        ScoreDoc[] lessElementsScoreDocs = new ScoreDoc[] { createStartStopElementForHybridSearchResults(2), new ScoreDoc(1, 0.7f) };
+
+        IllegalArgumentException notEnoughException = assertThrows(
+            IllegalArgumentException.class,
+            () -> scoreDocsMerger.merge(lessElementsScoreDocs, scores, SCORE_DOC_BY_SCORE_COMPARATOR)
+        );
+        assertEquals("cannot merge top docs because it does not have enough elements", notEnoughException.getMessage());
+
+        notEnoughException = assertThrows(
+            IllegalArgumentException.class,
+            () -> scoreDocsMerger.merge(scores, lessElementsScoreDocs, SCORE_DOC_BY_SCORE_COMPARATOR)
+        );
+        assertEquals("cannot merge top docs because it does not have enough elements", notEnoughException.getMessage());
+    }
+
+    public void testMergeScoreDocs_whenBothTopDocsHasHits_thenSuccessful() {
+        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+
+        ScoreDoc[] scoreDocsOriginal = new ScoreDoc[] {
+            createStartStopElementForHybridSearchResults(0),
+            createDelimiterElementForHybridSearchResults(0),
+            new ScoreDoc(0, 0.5f),
+            new ScoreDoc(2, 0.3f),
+            createDelimiterElementForHybridSearchResults(0),
+            createStartStopElementForHybridSearchResults(0) };
+
+        ScoreDoc[] scoreDocsNew = new ScoreDoc[] {
+            createStartStopElementForHybridSearchResults(2),
+            createDelimiterElementForHybridSearchResults(2),
+            new ScoreDoc(1, 0.7f),
+            new ScoreDoc(4, 0.3f),
+            new ScoreDoc(5, 0.05f),
+            createDelimiterElementForHybridSearchResults(2),
+            new ScoreDoc(4, 0.6f),
+            createStartStopElementForHybridSearchResults(2) };
+
+        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(scoreDocsOriginal, scoreDocsNew, SCORE_DOC_BY_SCORE_COMPARATOR);
+
+        assertNotNull(mergedScoreDocs);
+        assertEquals(10, mergedScoreDocs.length);
+
+        // check format, all elements one by one
+        assertEquals(MAGIC_NUMBER_START_STOP, mergedScoreDocs[0].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, mergedScoreDocs[1].score, 0);
+        assertScoreDoc(mergedScoreDocs[2], 1, 0.7f);
+        assertScoreDoc(mergedScoreDocs[3], 0, 0.5f);
+        assertScoreDoc(mergedScoreDocs[4], 2, 0.3f);
+        assertScoreDoc(mergedScoreDocs[5], 4, 0.3f);
+        assertScoreDoc(mergedScoreDocs[6], 5, 0.05f);
+        assertEquals(MAGIC_NUMBER_DELIMITER, mergedScoreDocs[7].score, 0);
+        assertScoreDoc(mergedScoreDocs[8], 4, 0.6f);
+        assertEquals(MAGIC_NUMBER_START_STOP, mergedScoreDocs[9].score, 0);
+    }
+
+    public void testMergeScoreDocs_whenOneTopDocsHasHitsAndOtherIsEmpty_thenSuccessful() {
+        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+
+        ScoreDoc[] scoreDocsOriginal = new ScoreDoc[] {
+            createStartStopElementForHybridSearchResults(0),
+            createDelimiterElementForHybridSearchResults(0),
+            createDelimiterElementForHybridSearchResults(0),
+            createStartStopElementForHybridSearchResults(0) };
+        ScoreDoc[] scoreDocsNew = new ScoreDoc[] {
+            createStartStopElementForHybridSearchResults(2),
+            createDelimiterElementForHybridSearchResults(2),
+            new ScoreDoc(1, 0.7f),
+            new ScoreDoc(4, 0.3f),
+            new ScoreDoc(5, 0.05f),
+            createDelimiterElementForHybridSearchResults(2),
+            new ScoreDoc(4, 0.6f),
+            createStartStopElementForHybridSearchResults(2) };
+
+        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(scoreDocsOriginal, scoreDocsNew, SCORE_DOC_BY_SCORE_COMPARATOR);
+
+        assertNotNull(mergedScoreDocs);
+        assertEquals(8, mergedScoreDocs.length);
+
+        assertEquals(MAGIC_NUMBER_START_STOP, mergedScoreDocs[0].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, mergedScoreDocs[1].score, 0);
+        assertScoreDoc(mergedScoreDocs[2], 1, 0.7f);
+        assertScoreDoc(mergedScoreDocs[3], 4, 0.3f);
+        assertScoreDoc(mergedScoreDocs[4], 5, 0.05f);
+        assertEquals(MAGIC_NUMBER_DELIMITER, mergedScoreDocs[5].score, 0);
+        assertScoreDoc(mergedScoreDocs[6], 4, 0.6f);
+        assertEquals(MAGIC_NUMBER_START_STOP, mergedScoreDocs[7].score, 0);
+    }
+
+    public void testMergeScoreDocs_whenBothTopDocsHasNoHits_thenSuccessful() {
+        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+
+        ScoreDoc[] scoreDocsOriginal = new ScoreDoc[] {
+            createStartStopElementForHybridSearchResults(0),
+            createDelimiterElementForHybridSearchResults(0),
+            createDelimiterElementForHybridSearchResults(0),
+            createStartStopElementForHybridSearchResults(0) };
+        ScoreDoc[] scoreDocsNew = new ScoreDoc[] {
+            createStartStopElementForHybridSearchResults(2),
+            createDelimiterElementForHybridSearchResults(2),
+            createDelimiterElementForHybridSearchResults(2),
+            createStartStopElementForHybridSearchResults(2) };
+
+        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(scoreDocsOriginal, scoreDocsNew, SCORE_DOC_BY_SCORE_COMPARATOR);
+
+        assertNotNull(mergedScoreDocs);
+        assertEquals(4, mergedScoreDocs.length);
+        // check format, all elements one by one
+        assertEquals(MAGIC_NUMBER_START_STOP, mergedScoreDocs[0].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, mergedScoreDocs[1].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, mergedScoreDocs[2].score, 0);
+        assertEquals(MAGIC_NUMBER_START_STOP, mergedScoreDocs[3].score, 0);
+    }
+
+    private void assertScoreDoc(ScoreDoc scoreDoc, int expectedDocId, float expectedScore) {
+        assertEquals(expectedDocId, scoreDoc.doc);
+        assertEquals(expectedScore, scoreDoc.score, DELTA_FOR_ASSERTION);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMergerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMergerTests.java
@@ -4,14 +4,20 @@
  */
 package org.opensearch.neuralsearch.search.query;
 
+import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 
-import static org.opensearch.neuralsearch.search.query.TopDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createFieldDocDelimiterElementForHybridSearchResults;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createFieldDocStartStopElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createStartStopElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createDelimiterElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_START_STOP;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_DELIMITER;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.sort.SortAndFormats;
 
 public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
 
@@ -19,7 +25,7 @@ public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
 
     public void testIncorrectInput_whenScoreDocsAreNullOrNotEnoughElements_thenFail() {
         HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
-
+        TopDocsMerger topDocsMerger = new TopDocsMerger(null);
         ScoreDoc[] scores = new ScoreDoc[] {
             createStartStopElementForHybridSearchResults(2),
             createDelimiterElementForHybridSearchResults(2),
@@ -28,24 +34,27 @@ public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
 
         NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> scoreDocsMerger.merge(scores, null, SCORE_DOC_BY_SCORE_COMPARATOR)
+            () -> scoreDocsMerger.merge(scores, null, topDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR, false)
         );
         assertEquals("score docs cannot be null", exception.getMessage());
 
-        exception = assertThrows(NullPointerException.class, () -> scoreDocsMerger.merge(scores, null, SCORE_DOC_BY_SCORE_COMPARATOR));
+        exception = assertThrows(
+            NullPointerException.class,
+            () -> scoreDocsMerger.merge(scores, null, topDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR, false)
+        );
         assertEquals("score docs cannot be null", exception.getMessage());
 
         ScoreDoc[] lessElementsScoreDocs = new ScoreDoc[] { createStartStopElementForHybridSearchResults(2), new ScoreDoc(1, 0.7f) };
 
         IllegalArgumentException notEnoughException = assertThrows(
             IllegalArgumentException.class,
-            () -> scoreDocsMerger.merge(lessElementsScoreDocs, scores, SCORE_DOC_BY_SCORE_COMPARATOR)
+            () -> scoreDocsMerger.merge(lessElementsScoreDocs, scores, topDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR, false)
         );
         assertEquals("cannot merge top docs because it does not have enough elements", notEnoughException.getMessage());
 
         notEnoughException = assertThrows(
             IllegalArgumentException.class,
-            () -> scoreDocsMerger.merge(scores, lessElementsScoreDocs, SCORE_DOC_BY_SCORE_COMPARATOR)
+            () -> scoreDocsMerger.merge(scores, lessElementsScoreDocs, topDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR, false)
         );
         assertEquals("cannot merge top docs because it does not have enough elements", notEnoughException.getMessage());
     }
@@ -71,7 +80,13 @@ public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
             new ScoreDoc(4, 0.6f),
             createStartStopElementForHybridSearchResults(2) };
 
-        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(scoreDocsOriginal, scoreDocsNew, SCORE_DOC_BY_SCORE_COMPARATOR);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(null);
+        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(
+            scoreDocsOriginal,
+            scoreDocsNew,
+            topDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR,
+            false
+        );
 
         assertNotNull(mergedScoreDocs);
         assertEquals(10, mergedScoreDocs.length);
@@ -91,6 +106,7 @@ public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
 
     public void testMergeScoreDocs_whenOneTopDocsHasHitsAndOtherIsEmpty_thenSuccessful() {
         HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+        TopDocsMerger topDocsMerger = new TopDocsMerger(null);
 
         ScoreDoc[] scoreDocsOriginal = new ScoreDoc[] {
             createStartStopElementForHybridSearchResults(0),
@@ -107,7 +123,12 @@ public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
             new ScoreDoc(4, 0.6f),
             createStartStopElementForHybridSearchResults(2) };
 
-        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(scoreDocsOriginal, scoreDocsNew, SCORE_DOC_BY_SCORE_COMPARATOR);
+        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(
+            scoreDocsOriginal,
+            scoreDocsNew,
+            topDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR,
+            false
+        );
 
         assertNotNull(mergedScoreDocs);
         assertEquals(8, mergedScoreDocs.length);
@@ -124,6 +145,7 @@ public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
 
     public void testMergeScoreDocs_whenBothTopDocsHasNoHits_thenSuccessful() {
         HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+        TopDocsMerger topDocsMerger = new TopDocsMerger(null);
 
         ScoreDoc[] scoreDocsOriginal = new ScoreDoc[] {
             createStartStopElementForHybridSearchResults(0),
@@ -136,7 +158,12 @@ public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
             createDelimiterElementForHybridSearchResults(2),
             createStartStopElementForHybridSearchResults(2) };
 
-        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(scoreDocsOriginal, scoreDocsNew, SCORE_DOC_BY_SCORE_COMPARATOR);
+        ScoreDoc[] mergedScoreDocs = scoreDocsMerger.merge(
+            scoreDocsOriginal,
+            scoreDocsNew,
+            topDocsMerger.SCORE_DOC_BY_SCORE_COMPARATOR,
+            false
+        );
 
         assertNotNull(mergedScoreDocs);
         assertEquals(4, mergedScoreDocs.length);
@@ -147,8 +174,184 @@ public class HybridQueryScoreDocsMergerTests extends OpenSearchQueryTestCase {
         assertEquals(MAGIC_NUMBER_START_STOP, mergedScoreDocs[3].score, 0);
     }
 
+    public void testIncorrectInput_whenFieldDocsAreNullOrNotEnoughElements_thenFail() {
+        HybridQueryScoreDocsMerger<FieldDoc> fieldDocsMerger = new HybridQueryScoreDocsMerger<>();
+        DocValueFormat docValueFormat[] = new DocValueFormat[] { DocValueFormat.RAW };
+        SortField sortField = new SortField("stock", SortField.Type.INT, true);
+        Sort sort = new Sort(sortField);
+        SortAndFormats sortAndFormats = new SortAndFormats(sort, docValueFormat);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(sortAndFormats);
+
+        FieldDoc[] scores = new FieldDoc[] {
+            createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+            new FieldDoc(1, 0.7f, new Object[] { 100 }),
+            createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }) };
+
+        NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> fieldDocsMerger.merge(scores, null, topDocsMerger.FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR, true)
+        );
+        assertEquals("score docs cannot be null", exception.getMessage());
+
+        exception = assertThrows(
+            NullPointerException.class,
+            () -> fieldDocsMerger.merge(scores, null, topDocsMerger.FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR, true)
+        );
+        assertEquals("score docs cannot be null", exception.getMessage());
+
+        FieldDoc[] lessElementsScoreDocs = new FieldDoc[] {
+            createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }),
+            new FieldDoc(1, 0.7f, new Object[] { 100 }) };
+
+        IllegalArgumentException notEnoughException = assertThrows(
+            IllegalArgumentException.class,
+            () -> fieldDocsMerger.merge(lessElementsScoreDocs, scores, topDocsMerger.FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR, true)
+        );
+        assertEquals("cannot merge top docs because it does not have enough elements", notEnoughException.getMessage());
+
+        notEnoughException = assertThrows(
+            IllegalArgumentException.class,
+            () -> fieldDocsMerger.merge(scores, lessElementsScoreDocs, topDocsMerger.FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR, true)
+        );
+        assertEquals("cannot merge top docs because it does not have enough elements", notEnoughException.getMessage());
+    }
+
+    public void testMergeFieldDocs_whenBothTopDocsHasHits_thenSuccessful() {
+        HybridQueryScoreDocsMerger<FieldDoc> fieldDocsMerger = new HybridQueryScoreDocsMerger<>();
+
+        FieldDoc[] fieldDocsOriginal = new FieldDoc[] {
+            createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+            new FieldDoc(0, 0.5f, new Object[] { 100 }),
+            new FieldDoc(2, 0.3f, new Object[] { 80 }),
+            createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+            createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }) };
+
+        FieldDoc[] fieldDocsNew = new FieldDoc[] {
+            createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+            new FieldDoc(1, 0.7f, new Object[] { 10 }),
+            new FieldDoc(4, 0.3f, new Object[] { 5 }),
+            new FieldDoc(5, 0.05f, new Object[] { 2 }),
+            createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+            new FieldDoc(4, 0.6f, new Object[] { 5 }),
+            createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }) };
+
+        DocValueFormat docValueFormat[] = new DocValueFormat[] { DocValueFormat.RAW };
+        SortField sortField = new SortField("stock", SortField.Type.INT, true);
+        Sort sort = new Sort(sortField);
+        SortAndFormats sortAndFormats = new SortAndFormats(sort, docValueFormat);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(sortAndFormats);
+
+        FieldDoc[] mergedFieldDocs = fieldDocsMerger.merge(
+            fieldDocsOriginal,
+            fieldDocsNew,
+            topDocsMerger.FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR,
+            true
+        );
+
+        assertNotNull(mergedFieldDocs);
+        assertEquals(10, mergedFieldDocs.length);
+
+        // check format, all elements one by one
+        assertEquals(1, mergedFieldDocs[0].fields[0]);
+        assertEquals(1, mergedFieldDocs[1].fields[0]);
+        assertFieldDoc(mergedFieldDocs[2], 0, 100);
+        assertFieldDoc(mergedFieldDocs[3], 2, 80);
+        assertFieldDoc(mergedFieldDocs[4], 1, 10);
+        assertFieldDoc(mergedFieldDocs[5], 4, 5);
+        assertFieldDoc(mergedFieldDocs[6], 5, 2);
+        assertEquals(1, mergedFieldDocs[7].fields[0]);
+        assertFieldDoc(mergedFieldDocs[8], 4, 5);
+        assertEquals(1, mergedFieldDocs[9].fields[0]);
+    }
+
+    public void testMergeFieldDocs_whenOneTopDocsHasHitsAndOtherIsEmpty_thenSuccessful() {
+        HybridQueryScoreDocsMerger<FieldDoc> fieldDocsMerger = new HybridQueryScoreDocsMerger<>();
+        DocValueFormat docValueFormat[] = new DocValueFormat[] { DocValueFormat.RAW };
+        SortField sortField = new SortField("stock", SortField.Type.INT, true);
+        Sort sort = new Sort(sortField);
+        SortAndFormats sortAndFormats = new SortAndFormats(sort, docValueFormat);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(sortAndFormats);
+
+        FieldDoc[] fieldDocsOriginal = new FieldDoc[] {
+            createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+            createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }) };
+        FieldDoc[] fieldDocsNew = new FieldDoc[] {
+            createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+            new FieldDoc(1, 0.7f, new Object[] { 100 }),
+            new FieldDoc(4, 0.3f, new Object[] { 80 }),
+            new FieldDoc(5, 0.05f, new Object[] { 20 }),
+            createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+            new FieldDoc(4, 0.6f, new Object[] { 50 }),
+            createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }) };
+
+        FieldDoc[] mergedFieldDocs = fieldDocsMerger.merge(
+            fieldDocsOriginal,
+            fieldDocsNew,
+            topDocsMerger.FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR,
+            true
+        );
+
+        assertNotNull(mergedFieldDocs);
+        assertEquals(8, mergedFieldDocs.length);
+
+        assertEquals(1, mergedFieldDocs[0].fields[0]);
+        assertEquals(1, mergedFieldDocs[1].fields[0]);
+        assertFieldDoc(mergedFieldDocs[2], 1, 100);
+        assertFieldDoc(mergedFieldDocs[3], 4, 80);
+        assertFieldDoc(mergedFieldDocs[4], 5, 20);
+        assertEquals(1, mergedFieldDocs[5].fields[0]);
+        assertFieldDoc(mergedFieldDocs[6], 4, 50);
+        assertEquals(1, mergedFieldDocs[7].fields[0]);
+    }
+
+    public void testMergeFieldDocs_whenBothTopDocsHasNoHits_thenSuccessful() {
+        HybridQueryScoreDocsMerger<FieldDoc> fieldDocsMerger = new HybridQueryScoreDocsMerger<>();
+        DocValueFormat docValueFormat[] = new DocValueFormat[] { DocValueFormat.RAW };
+        SortField sortField = new SortField("stock", SortField.Type.INT, true);
+        Sort sort = new Sort(sortField);
+        SortAndFormats sortAndFormats = new SortAndFormats(sort, docValueFormat);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(sortAndFormats);
+
+        FieldDoc[] fieldDocsOriginal = new FieldDoc[] {
+            createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+            createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }) };
+        FieldDoc[] fieldDocsNew = new FieldDoc[] {
+            createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+            createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+            createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }) };
+
+        FieldDoc[] mergedFieldDocs = fieldDocsMerger.merge(
+            fieldDocsOriginal,
+            fieldDocsNew,
+            topDocsMerger.FIELD_DOC_BY_SORT_CRITERIA_COMPARATOR,
+            true
+        );
+
+        assertNotNull(mergedFieldDocs);
+        assertEquals(4, mergedFieldDocs.length);
+        // check format, all elements one by one
+        assertEquals(1, mergedFieldDocs[0].fields[0]);
+        assertEquals(1, mergedFieldDocs[1].fields[0]);
+        assertEquals(1, mergedFieldDocs[2].fields[0]);
+        assertEquals(1, mergedFieldDocs[3].fields[0]);
+    }
+
     private void assertScoreDoc(ScoreDoc scoreDoc, int expectedDocId, float expectedScore) {
         assertEquals(expectedDocId, scoreDoc.doc);
         assertEquals(expectedScore, scoreDoc.score, DELTA_FOR_ASSERTION);
+    }
+
+    private void assertFieldDoc(FieldDoc fieldDoc, int expectedDocId, int expectedSortValue) {
+        assertEquals(expectedDocId, fieldDoc.doc);
+        assertEquals(expectedSortValue, fieldDoc.fields[0]);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/query/TopDocsMergerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/TopDocsMergerTests.java
@@ -5,8 +5,12 @@
 package org.opensearch.neuralsearch.search.query;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
@@ -15,6 +19,11 @@ import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUt
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createDelimiterElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_START_STOP;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_DELIMITER;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createFieldDocStartStopElementForHybridSearchResults;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createFieldDocDelimiterElementForHybridSearchResults;
+
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.sort.SortAndFormats;
 
 public class TopDocsMergerTests extends OpenSearchQueryTestCase {
 
@@ -22,8 +31,7 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
 
     @SneakyThrows
     public void testMergeScoreDocs_whenBothTopDocsHasHits_thenSuccessful() {
-        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
-        TopDocsMerger topDocsMerger = new TopDocsMerger(scoreDocsMerger);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(null);
 
         TopDocs topDocsOriginal = new TopDocs(
             new TotalHits(2, TotalHits.Relation.EQUAL_TO),
@@ -78,8 +86,7 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
 
     @SneakyThrows
     public void testMergeScoreDocs_whenOneTopDocsHasHitsAndOtherIsEmpty_thenSuccessful() {
-        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
-        TopDocsMerger topDocsMerger = new TopDocsMerger(scoreDocsMerger);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(null);
 
         TopDocs topDocsOriginal = new TopDocs(
             new TotalHits(0, TotalHits.Relation.EQUAL_TO),
@@ -130,8 +137,7 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
 
     @SneakyThrows
     public void testMergeScoreDocs_whenBothTopDocsHasNoHits_thenSuccessful() {
-        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
-        TopDocsMerger topDocsMerger = new TopDocsMerger(scoreDocsMerger);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(null);
 
         TopDocs topDocsOriginal = new TopDocs(
             new TotalHits(0, TotalHits.Relation.EQUAL_TO),
@@ -172,8 +178,7 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
 
     @SneakyThrows
     public void testThreeSequentialMerges_whenAllTopDocsHasHits_thenSuccessful() {
-        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
-        TopDocsMerger topDocsMerger = new TopDocsMerger(scoreDocsMerger);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(null);
 
         TopDocs topDocsOriginal = new TopDocs(
             new TotalHits(2, TotalHits.Relation.EQUAL_TO),
@@ -248,8 +253,277 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[12].score, 0);
     }
 
+    @SneakyThrows
+    public void testMergeFieldDocs_whenBothTopDocsHasHits_thenSuccessful() {
+        DocValueFormat docValueFormat[] = new DocValueFormat[] { DocValueFormat.RAW };
+        SortField sortField = new SortField("stock", SortField.Type.INT, true);
+        Sort sort = new Sort(sortField);
+        SortAndFormats sortAndFormats = new SortAndFormats(sort, docValueFormat);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(sortAndFormats);
+
+        TopDocs topDocsOriginal = new TopFieldDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+                new FieldDoc(0, 0.5f, new Object[] { 100 }),
+                new FieldDoc(2, 0.3f, new Object[] { 80 }),
+                createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreOriginal = new TopDocsAndMaxScore(topDocsOriginal, 0.5f);
+        TopDocs topDocsNew = new TopFieldDocs(
+            new TotalHits(4, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(1, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(1, new Object[] { 1 }),
+                new FieldDoc(1, 0.7f, new Object[] { 70 }),
+                new FieldDoc(4, 0.3f, new Object[] { 60 }),
+                new FieldDoc(5, 0.05f, new Object[] { 30 }),
+                createFieldDocDelimiterElementForHybridSearchResults(1, new Object[] { 1 }),
+                new FieldDoc(4, 0.6f, new Object[] { 40 }),
+                createFieldDocStartStopElementForHybridSearchResults(1, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
+            topDocsAndMaxScoreOriginal,
+            topDocsAndMaxScoreNew,
+            sortAndFormats
+        );
+
+        assertNotNull(mergedTopDocsAndMaxScore);
+
+        assertEquals(0.7f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
+        assertEquals(6, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        // expected number of rows is 5 from sub-query1 and 1 from sub-query2, plus 2 start-stop elements + 2 delimiters
+        // 5 + 1 + 2 + 2 = 10
+        assertEquals(10, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
+        // check format, all elements one by one
+        FieldDoc[] fieldDocs = (FieldDoc[]) mergedTopDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(1, fieldDocs[0].fields[0]);
+        assertEquals(1, fieldDocs[1].fields[0]);
+        assertFieldDoc(fieldDocs[2], 0, 100);
+        assertFieldDoc(fieldDocs[3], 2, 80);
+        assertFieldDoc(fieldDocs[4], 1, 70);
+        assertFieldDoc(fieldDocs[5], 4, 60);
+        assertFieldDoc(fieldDocs[6], 5, 30);
+        assertEquals(1, fieldDocs[7].fields[0]);
+        assertFieldDoc(fieldDocs[8], 4, 40);
+        assertEquals(1, fieldDocs[9].fields[0]);
+    }
+
+    @SneakyThrows
+    public void testMergeFieldDocs_whenOneTopDocsHasHitsAndOtherIsEmpty_thenSuccessful() {
+        DocValueFormat docValueFormat[] = new DocValueFormat[] { DocValueFormat.RAW };
+        SortField sortField = new SortField("stock", SortField.Type.INT, true);
+        Sort sort = new Sort(sortField);
+        SortAndFormats sortAndFormats = new SortAndFormats(sort, docValueFormat);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(sortAndFormats);
+
+        TopDocs topDocsOriginal = new TopFieldDocs(
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreOriginal = new TopDocsAndMaxScore(topDocsOriginal, 0.5f);
+        TopDocs topDocsNew = new TopFieldDocs(
+            new TotalHits(4, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+                new FieldDoc(1, 0.7f, new Object[] { 100 }),
+                new FieldDoc(4, 0.3f, new Object[] { 60 }),
+                new FieldDoc(5, 0.05f, new Object[] { 30 }),
+                createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+                new FieldDoc(4, 0.6f, new Object[] { 80 }),
+                createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
+            topDocsAndMaxScoreOriginal,
+            topDocsAndMaxScoreNew,
+            sortAndFormats
+        );
+
+        assertNotNull(mergedTopDocsAndMaxScore);
+
+        assertEquals(0.7f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
+        assertEquals(4, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        // expected number of rows is 3 from sub-query1 and 1 from sub-query2, plus 2 start-stop elements + 2 delimiters
+        // 3 + 1 + 2 + 2 = 8
+        assertEquals(8, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
+        // check format, all elements one by one
+        FieldDoc[] fieldDocs = (FieldDoc[]) mergedTopDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(1, fieldDocs[0].fields[0]);
+        assertEquals(1, fieldDocs[1].fields[0]);
+        assertFieldDoc(fieldDocs[2], 1, 100);
+        assertFieldDoc(fieldDocs[3], 4, 60);
+        assertFieldDoc(fieldDocs[4], 5, 30);
+        assertEquals(1, fieldDocs[5].fields[0]);
+        assertFieldDoc(fieldDocs[6], 4, 80);
+        assertEquals(1, fieldDocs[7].fields[0]);
+    }
+
+    @SneakyThrows
+    public void testMergeFieldDocs_whenBothTopDocsHasNoHits_thenSuccessful() {
+        DocValueFormat docValueFormat[] = new DocValueFormat[] { DocValueFormat.RAW };
+        SortField sortField = new SortField("stock", SortField.Type.INT, true);
+        Sort sort = new Sort(sortField);
+        SortAndFormats sortAndFormats = new SortAndFormats(sort, docValueFormat);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(sortAndFormats);
+
+        TopDocs topDocsOriginal = new TopFieldDocs(
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreOriginal = new TopDocsAndMaxScore(topDocsOriginal, 0);
+        TopDocs topDocsNew = new TopFieldDocs(
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+                createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0);
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
+            topDocsAndMaxScoreOriginal,
+            topDocsAndMaxScoreNew,
+            sortAndFormats
+        );
+
+        assertNotNull(mergedTopDocsAndMaxScore);
+
+        assertEquals(0f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
+        assertEquals(0, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(4, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
+        // check format, all elements one by one
+        FieldDoc[] fieldDocs = (FieldDoc[]) mergedTopDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(1, fieldDocs[0].fields[0]);
+        assertEquals(1, fieldDocs[1].fields[0]);
+        assertEquals(1, fieldDocs[2].fields[0]);
+        assertEquals(1, fieldDocs[3].fields[0]);
+    }
+
+    @SneakyThrows
+    public void testThreeSequentialMergesWithFieldDocs_whenAllTopDocsHasHits_thenSuccessful() {
+        DocValueFormat docValueFormat[] = new DocValueFormat[] { DocValueFormat.RAW };
+        SortField sortField = new SortField("stock", SortField.Type.INT, true);
+        Sort sort = new Sort(sortField);
+        SortAndFormats sortAndFormats = new SortAndFormats(sort, docValueFormat);
+        TopDocsMerger topDocsMerger = new TopDocsMerger(sortAndFormats);
+
+        TopDocs topDocsOriginal = new TopFieldDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+                new FieldDoc(0, 0.5f, new Object[] { 100 }),
+                new FieldDoc(2, 0.3f, new Object[] { 20 }),
+                createFieldDocDelimiterElementForHybridSearchResults(0, new Object[] { 1 }),
+                createFieldDocStartStopElementForHybridSearchResults(0, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreOriginal = new TopDocsAndMaxScore(topDocsOriginal, 0.5f);
+        TopDocs topDocsNew = new TopFieldDocs(
+            new TotalHits(4, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+                new FieldDoc(1, 0.7f, new Object[] { 80 }),
+                new FieldDoc(4, 0.3f, new Object[] { 30 }),
+                new FieldDoc(5, 0.05f, new Object[] { 10 }),
+                createFieldDocDelimiterElementForHybridSearchResults(2, new Object[] { 1 }),
+                new FieldDoc(4, 0.6f, new Object[] { 30 }),
+                createFieldDocStartStopElementForHybridSearchResults(2, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
+        TopDocsAndMaxScore firstMergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
+            topDocsAndMaxScoreOriginal,
+            topDocsAndMaxScoreNew,
+            sortAndFormats
+        );
+
+        assertNotNull(firstMergedTopDocsAndMaxScore);
+
+        // merge results from collector 3
+        TopDocs topDocsThirdCollector = new TopFieldDocs(
+            new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+
+            new FieldDoc[] {
+                createFieldDocStartStopElementForHybridSearchResults(3, new Object[] { 1 }),
+                createFieldDocDelimiterElementForHybridSearchResults(3, new Object[] { 1 }),
+                new FieldDoc(3, 0.4f, new Object[] { 90 }),
+                createFieldDocDelimiterElementForHybridSearchResults(3, new Object[] { 1 }),
+                new FieldDoc(7, 0.85f, new Object[] { 60 }),
+                new FieldDoc(9, 0.2f, new Object[] { 50 }),
+                createFieldDocStartStopElementForHybridSearchResults(3, new Object[] { 1 }) },
+            sortAndFormats.sort.getSort()
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreThirdCollector = new TopDocsAndMaxScore(topDocsThirdCollector, 0.85f);
+        TopDocsAndMaxScore finalMergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
+            firstMergedTopDocsAndMaxScore,
+            topDocsAndMaxScoreThirdCollector,
+            sortAndFormats
+        );
+
+        assertEquals(0.85f, finalMergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
+        assertEquals(9, finalMergedTopDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, finalMergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        // expected number of rows is 6 from sub-query1 and 3 from sub-query2, plus 2 start-stop elements + 2 delimiters
+        // 6 + 3 + 2 + 2 = 13
+        assertEquals(13, finalMergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
+        // check format, all elements one by one
+        FieldDoc[] fieldDocs = (FieldDoc[]) finalMergedTopDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(1, fieldDocs[0].fields[0]);
+        assertEquals(1, fieldDocs[1].fields[0]);
+        assertFieldDoc(fieldDocs[2], 0, 100);
+        assertFieldDoc(fieldDocs[3], 3, 90);
+        assertFieldDoc(fieldDocs[4], 1, 80);
+        assertFieldDoc(fieldDocs[5], 4, 30);
+        assertFieldDoc(fieldDocs[6], 2, 20);
+        assertFieldDoc(fieldDocs[7], 5, 10);
+        assertEquals(1, fieldDocs[8].fields[0]);
+        assertFieldDoc(fieldDocs[9], 7, 60);
+        assertFieldDoc(fieldDocs[10], 9, 50);
+        assertFieldDoc(fieldDocs[11], 4, 30);
+        assertEquals(1, fieldDocs[12].fields[0]);
+    }
+
     private void assertScoreDoc(ScoreDoc scoreDoc, int expectedDocId, float expectedScore) {
         assertEquals(expectedDocId, scoreDoc.doc);
         assertEquals(expectedScore, scoreDoc.score, DELTA_FOR_ASSERTION);
+    }
+
+    private void assertFieldDoc(FieldDoc fieldDoc, int expectedDocId, int expectedSortValue) {
+        assertEquals(expectedDocId, fieldDoc.doc);
+        assertEquals(expectedSortValue, fieldDoc.fields[0]);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/query/TopDocsMergerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/TopDocsMergerTests.java
@@ -289,11 +289,7 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
             sortAndFormats.sort.getSort()
         );
         TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
-        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
-            topDocsAndMaxScoreOriginal,
-            topDocsAndMaxScoreNew,
-            sortAndFormats
-        );
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.merge(topDocsAndMaxScoreOriginal, topDocsAndMaxScoreNew);
 
         assertNotNull(mergedTopDocsAndMaxScore);
 
@@ -352,11 +348,7 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
             sortAndFormats.sort.getSort()
         );
         TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
-        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
-            topDocsAndMaxScoreOriginal,
-            topDocsAndMaxScoreNew,
-            sortAndFormats
-        );
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.merge(topDocsAndMaxScoreOriginal, topDocsAndMaxScoreNew);
 
         assertNotNull(mergedTopDocsAndMaxScore);
 
@@ -409,11 +401,7 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
             sortAndFormats.sort.getSort()
         );
         TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0);
-        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
-            topDocsAndMaxScoreOriginal,
-            topDocsAndMaxScoreNew,
-            sortAndFormats
-        );
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.merge(topDocsAndMaxScoreOriginal, topDocsAndMaxScoreNew);
 
         assertNotNull(mergedTopDocsAndMaxScore);
 
@@ -465,11 +453,7 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
             sortAndFormats.sort.getSort()
         );
         TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
-        TopDocsAndMaxScore firstMergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
-            topDocsAndMaxScoreOriginal,
-            topDocsAndMaxScoreNew,
-            sortAndFormats
-        );
+        TopDocsAndMaxScore firstMergedTopDocsAndMaxScore = topDocsMerger.merge(topDocsAndMaxScoreOriginal, topDocsAndMaxScoreNew);
 
         assertNotNull(firstMergedTopDocsAndMaxScore);
 
@@ -488,10 +472,9 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
             sortAndFormats.sort.getSort()
         );
         TopDocsAndMaxScore topDocsAndMaxScoreThirdCollector = new TopDocsAndMaxScore(topDocsThirdCollector, 0.85f);
-        TopDocsAndMaxScore finalMergedTopDocsAndMaxScore = topDocsMerger.mergeFieldDocs(
+        TopDocsAndMaxScore finalMergedTopDocsAndMaxScore = topDocsMerger.merge(
             firstMergedTopDocsAndMaxScore,
-            topDocsAndMaxScoreThirdCollector,
-            sortAndFormats
+            topDocsAndMaxScoreThirdCollector
         );
 
         assertEquals(0.85f, finalMergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);

--- a/src/test/java/org/opensearch/neuralsearch/search/query/TopDocsMergerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/TopDocsMergerTests.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.query;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createStartStopElementForHybridSearchResults;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createDelimiterElementForHybridSearchResults;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_START_STOP;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_DELIMITER;
+
+public class TopDocsMergerTests extends OpenSearchQueryTestCase {
+
+    private static final float DELTA_FOR_ASSERTION = 0.001f;
+
+    @SneakyThrows
+    public void testMergeScoreDocs_whenBothTopDocsHasHits_thenSuccessful() {
+        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+        TopDocsMerger topDocsMerger = new TopDocsMerger(scoreDocsMerger);
+
+        TopDocs topDocsOriginal = new TopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(0),
+                createDelimiterElementForHybridSearchResults(0),
+                new ScoreDoc(0, 0.5f),
+                new ScoreDoc(2, 0.3f),
+                createDelimiterElementForHybridSearchResults(0),
+                createStartStopElementForHybridSearchResults(0) }
+
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreOriginal = new TopDocsAndMaxScore(topDocsOriginal, 0.5f);
+        TopDocs topDocsNew = new TopDocs(
+            new TotalHits(4, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(2),
+                createDelimiterElementForHybridSearchResults(2),
+                new ScoreDoc(1, 0.7f),
+                new ScoreDoc(4, 0.3f),
+                new ScoreDoc(5, 0.05f),
+                createDelimiterElementForHybridSearchResults(2),
+                new ScoreDoc(4, 0.6f),
+                createStartStopElementForHybridSearchResults(2) }
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.merge(topDocsAndMaxScoreOriginal, topDocsAndMaxScoreNew);
+
+        assertNotNull(mergedTopDocsAndMaxScore);
+
+        assertEquals(0.7f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
+        assertEquals(6, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        // expected number of rows is 5 from sub-query1 and 1 from sub-query2, plus 2 start-stop elements + 2 delimiters
+        // 5 + 1 + 2 + 2 = 10
+        assertEquals(10, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
+        // check format, all elements one by one
+        ScoreDoc[] scoreDocs = mergedTopDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[0].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[1].score, 0);
+        assertScoreDoc(scoreDocs[2], 1, 0.7f);
+        assertScoreDoc(scoreDocs[3], 0, 0.5f);
+        assertScoreDoc(scoreDocs[4], 2, 0.3f);
+        assertScoreDoc(scoreDocs[5], 4, 0.3f);
+        assertScoreDoc(scoreDocs[6], 5, 0.05f);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[7].score, 0);
+        assertScoreDoc(scoreDocs[8], 4, 0.6f);
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[9].score, 0);
+    }
+
+    @SneakyThrows
+    public void testMergeScoreDocs_whenOneTopDocsHasHitsAndOtherIsEmpty_thenSuccessful() {
+        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+        TopDocsMerger topDocsMerger = new TopDocsMerger(scoreDocsMerger);
+
+        TopDocs topDocsOriginal = new TopDocs(
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(0),
+                createDelimiterElementForHybridSearchResults(0),
+                createDelimiterElementForHybridSearchResults(0),
+                createStartStopElementForHybridSearchResults(0) }
+
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreOriginal = new TopDocsAndMaxScore(topDocsOriginal, 0.5f);
+        TopDocs topDocsNew = new TopDocs(
+            new TotalHits(4, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(2),
+                createDelimiterElementForHybridSearchResults(2),
+                new ScoreDoc(1, 0.7f),
+                new ScoreDoc(4, 0.3f),
+                new ScoreDoc(5, 0.05f),
+                createDelimiterElementForHybridSearchResults(2),
+                new ScoreDoc(4, 0.6f),
+                createStartStopElementForHybridSearchResults(2) }
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.merge(topDocsAndMaxScoreOriginal, topDocsAndMaxScoreNew);
+
+        assertNotNull(mergedTopDocsAndMaxScore);
+
+        assertEquals(0.7f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
+        assertEquals(4, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        // expected number of rows is 3 from sub-query1 and 1 from sub-query2, plus 2 start-stop elements + 2 delimiters
+        // 3 + 1 + 2 + 2 = 8
+        assertEquals(8, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
+        // check format, all elements one by one
+        ScoreDoc[] scoreDocs = mergedTopDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[0].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[1].score, 0);
+        assertScoreDoc(scoreDocs[2], 1, 0.7f);
+        assertScoreDoc(scoreDocs[3], 4, 0.3f);
+        assertScoreDoc(scoreDocs[4], 5, 0.05f);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[5].score, 0);
+        assertScoreDoc(scoreDocs[6], 4, 0.6f);
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[7].score, 0);
+    }
+
+    @SneakyThrows
+    public void testMergeScoreDocs_whenBothTopDocsHasNoHits_thenSuccessful() {
+        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+        TopDocsMerger topDocsMerger = new TopDocsMerger(scoreDocsMerger);
+
+        TopDocs topDocsOriginal = new TopDocs(
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(0),
+                createDelimiterElementForHybridSearchResults(0),
+                createDelimiterElementForHybridSearchResults(0),
+                createStartStopElementForHybridSearchResults(0) }
+
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreOriginal = new TopDocsAndMaxScore(topDocsOriginal, 0);
+        TopDocs topDocsNew = new TopDocs(
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(2),
+                createDelimiterElementForHybridSearchResults(2),
+                createDelimiterElementForHybridSearchResults(2),
+                createStartStopElementForHybridSearchResults(2) }
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0);
+        TopDocsAndMaxScore mergedTopDocsAndMaxScore = topDocsMerger.merge(topDocsAndMaxScoreOriginal, topDocsAndMaxScoreNew);
+
+        assertNotNull(mergedTopDocsAndMaxScore);
+
+        assertEquals(0f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
+        assertEquals(0, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(4, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
+        // check format, all elements one by one
+        ScoreDoc[] scoreDocs = mergedTopDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[0].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[1].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[2].score, 0);
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[3].score, 0);
+    }
+
+    @SneakyThrows
+    public void testThreeSequentialMerges_whenAllTopDocsHasHits_thenSuccessful() {
+        HybridQueryScoreDocsMerger<ScoreDoc> scoreDocsMerger = new HybridQueryScoreDocsMerger<>();
+        TopDocsMerger topDocsMerger = new TopDocsMerger(scoreDocsMerger);
+
+        TopDocs topDocsOriginal = new TopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(0),
+                createDelimiterElementForHybridSearchResults(0),
+                new ScoreDoc(0, 0.5f),
+                new ScoreDoc(2, 0.3f),
+                createDelimiterElementForHybridSearchResults(0),
+                createStartStopElementForHybridSearchResults(0) }
+
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreOriginal = new TopDocsAndMaxScore(topDocsOriginal, 0.5f);
+        TopDocs topDocsNew = new TopDocs(
+            new TotalHits(4, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(2),
+                createDelimiterElementForHybridSearchResults(2),
+                new ScoreDoc(1, 0.7f),
+                new ScoreDoc(4, 0.3f),
+                new ScoreDoc(5, 0.05f),
+                createDelimiterElementForHybridSearchResults(2),
+                new ScoreDoc(4, 0.6f),
+                createStartStopElementForHybridSearchResults(2) }
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreNew = new TopDocsAndMaxScore(topDocsNew, 0.7f);
+        TopDocsAndMaxScore firstMergedTopDocsAndMaxScore = topDocsMerger.merge(topDocsAndMaxScoreOriginal, topDocsAndMaxScoreNew);
+
+        assertNotNull(firstMergedTopDocsAndMaxScore);
+
+        // merge results from collector 3
+        TopDocs topDocsThirdCollector = new TopDocs(
+            new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+
+            new ScoreDoc[] {
+                createStartStopElementForHybridSearchResults(3),
+                createDelimiterElementForHybridSearchResults(3),
+                new ScoreDoc(3, 0.4f),
+                createDelimiterElementForHybridSearchResults(3),
+                new ScoreDoc(7, 0.85f),
+                new ScoreDoc(9, 0.2f),
+                createStartStopElementForHybridSearchResults(3) }
+        );
+        TopDocsAndMaxScore topDocsAndMaxScoreThirdCollector = new TopDocsAndMaxScore(topDocsThirdCollector, 0.85f);
+        TopDocsAndMaxScore finalMergedTopDocsAndMaxScore = topDocsMerger.merge(
+            firstMergedTopDocsAndMaxScore,
+            topDocsAndMaxScoreThirdCollector
+        );
+
+        assertEquals(0.85f, finalMergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
+        assertEquals(9, finalMergedTopDocsAndMaxScore.topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, finalMergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        // expected number of rows is 6 from sub-query1 and 3 from sub-query2, plus 2 start-stop elements + 2 delimiters
+        // 6 + 3 + 2 + 2 = 13
+        assertEquals(13, finalMergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
+        // check format, all elements one by one
+        ScoreDoc[] scoreDocs = finalMergedTopDocsAndMaxScore.topDocs.scoreDocs;
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[0].score, 0);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[1].score, 0);
+        assertScoreDoc(scoreDocs[2], 1, 0.7f);
+        assertScoreDoc(scoreDocs[3], 0, 0.5f);
+        assertScoreDoc(scoreDocs[4], 3, 0.4f);
+        assertScoreDoc(scoreDocs[5], 2, 0.3f);
+        assertScoreDoc(scoreDocs[6], 4, 0.3f);
+        assertScoreDoc(scoreDocs[7], 5, 0.05f);
+        assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[8].score, 0);
+        assertScoreDoc(scoreDocs[9], 7, 0.85f);
+        assertScoreDoc(scoreDocs[10], 4, 0.6f);
+        assertScoreDoc(scoreDocs[11], 9, 0.2f);
+        assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[12].score, 0);
+    }
+
+    private void assertScoreDoc(ScoreDoc scoreDoc, int expectedDocId, float expectedScore) {
+        assertEquals(expectedDocId, scoreDoc.doc);
+        assertEquals(expectedScore, scoreDoc.score, DELTA_FOR_ASSERTION);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/search/util/HybridSearchResultFormatUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/util/HybridSearchResultFormatUtilTests.java
@@ -4,16 +4,14 @@
  */
 package org.opensearch.neuralsearch.search.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_DELIMITER;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_START_STOP;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createDelimiterElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createStartStopElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryDelimiterElement;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryScoreDocElement;
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQuerySpecialElement;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.opensearch.common.Randomness;
@@ -56,5 +54,24 @@ public class HybridSearchResultFormatUtilTests extends OpenSearchQueryTestCase {
         assertNotNull(delimiterElement);
         assertEquals(docId, delimiterElement.doc);
         assertEquals(MAGIC_NUMBER_DELIMITER, delimiterElement.score, 0.0f);
+    }
+
+    public void testSpecialElementCheck_whenElementIsSpecialAndIsNotSpecial_thenSuccessful() {
+        int docId = 1;
+        ScoreDoc startStopElement = new ScoreDoc(docId, MAGIC_NUMBER_START_STOP);
+        assertTrue(isHybridQuerySpecialElement(startStopElement));
+        assertFalse(isHybridQueryScoreDocElement(startStopElement));
+
+        ScoreDoc delimiterElement = new ScoreDoc(docId, MAGIC_NUMBER_DELIMITER);
+        assertTrue(isHybridQuerySpecialElement(delimiterElement));
+        assertFalse(isHybridQueryScoreDocElement(delimiterElement));
+    }
+
+    public void testScoreElementCheck_whenElementIsSpecialAndIsNotSpecial_thenSuccessful() {
+        int docId = 1;
+        float score = Randomness.get().nextFloat();
+        ScoreDoc startStopElement = new ScoreDoc(docId, score);
+        assertFalse(isHybridQuerySpecialElement(startStopElement));
+        assertTrue(isHybridQueryScoreDocElement(startStopElement));
     }
 }

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -83,6 +83,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         "processor/PipelineForTextImageEmbeddingProcessorConfiguration.json"
     );
     private static final Set<RestStatus> SUCCESS_STATUSES = Set.of(RestStatus.CREATED, RestStatus.OK);
+    protected static final String CONCURRENT_SEGMENT_SEARCH_ENABLED = "search.concurrent_segment_search.enabled";
 
     protected final ClassLoader classLoader = this.getClass().getClassLoader();
 


### PR DESCRIPTION
### Description
Cater the fix for [https://github.com/opensearch-project/neural-search/issues/799](https://github.com/opensearch-project/neural-search/issues/799) in Sorting.

This PR contains some cherry pick changes from commit 
[https://github.com/opensearch-project/neural-search/pull/800](https://github.com/opensearch-project/neural-search/pull/800)
Therefore Classes to review are
1. HybridCollectorManager
2. HybridTopFieldDocComparator
3. HybridScoreDocsMerger
4. TopDocsMerger
5. TopDocsMergerTests
6. HybridScoreDocsMergerTests
7. HybridQuerySortIT

Rest all class are cherry picked from the commit so please ignore them.

### Issues Resolved
[https://github.com/opensearch-project/neural-search/issues/799](https://github.com/opensearch-project/neural-search/issues/799)
[https://github.com/opensearch-project/neural-search/issues/507](https://github.com/opensearch-project/neural-search/issues/507)

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
