### PR TITLE
Enable '.' for nested field in text embedding processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.15...2.x)
 ### Features
 ### Enhancements
-* Adds dynamic knn query parameters efsearch and nprobes [#814](https://github.com/opensearch-project/neural-search/pull/814/)
+- Adds dynamic knn query parameters efsearch and nprobes [#814](https://github.com/opensearch-project/neural-search/pull/814/)
+- Enable '.' for nested field in text embedding processor ([#811](https://github.com/opensearch-project/neural-search/pull/811))
 ### Bug Fixes
 - Fix for missing HybridQuery results when concurrent segment search is enabled ([#800](https://github.com/opensearch-project/neural-search/pull/800))
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -65,7 +65,6 @@ public abstract class InferenceProcessor extends AbstractProcessor {
 
     private final Environment environment;
     private final ClusterService clusterService;
-    List<Pair<String, Object>> mappingForNestedFields;
 
     public InferenceProcessor(
         String tag,
@@ -88,7 +87,6 @@ public abstract class InferenceProcessor extends AbstractProcessor {
         this.mlCommonsClientAccessor = clientAccessor;
         this.environment = environment;
         this.clusterService = clusterService;
-        mappingForNestedFields = fieldMap.entrySet().stream().map(this::processNestedKey).collect(Collectors.toList());
     }
 
     private void validateEmbeddingConfiguration(Map<String, Object> fieldMap) {
@@ -284,7 +282,8 @@ public abstract class InferenceProcessor extends AbstractProcessor {
     Map<String, Object> buildMapWithTargetKeys(IngestDocument ingestDocument) {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
         Map<String, Object> mapWithProcessorKeys = new LinkedHashMap<>();
-        for (Pair<String, Object> processedNestedKey : mappingForNestedFields) {
+        for (Map.Entry<String, Object> fieldMapEntry : fieldMap.entrySet()) {
+            Pair<String, Object> processedNestedKey = processNestedKey(fieldMapEntry);
             String originalKey = processedNestedKey.getKey();
             Object targetKey = processedNestedKey.getValue();
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -299,12 +299,8 @@ public abstract class InferenceProcessor extends AbstractProcessor {
         return mapWithProcessorKeys;
     }
 
-    private void buildNestedMap(
-        String parentKey,
-        Object processorKey,
-        Map<String, Object> sourceAndMetadataMap,
-        Map<String, Object> treeRes
-    ) {
+    @VisibleForTesting
+    void buildNestedMap(String parentKey, Object processorKey, Map<String, Object> sourceAndMetadataMap, Map<String, Object> treeRes) {
         if (Objects.isNull(processorKey) || Objects.isNull(sourceAndMetadataMap)) {
             return;
         }
@@ -351,7 +347,8 @@ public abstract class InferenceProcessor extends AbstractProcessor {
      * @param nestedFieldMapEntry
      * @return A pair of the original key and the target key
      */
-    private Pair<String, Object> processNestedKey(final Map.Entry<String, Object> nestedFieldMapEntry) {
+    @VisibleForTesting
+    protected Pair<String, Object> processNestedKey(final Map.Entry<String, Object> nestedFieldMapEntry) {
         String originalKey = nestedFieldMapEntry.getKey();
         Object targetKey = nestedFieldMapEntry.getValue();
         int nestedDotIndex = originalKey.indexOf('.');

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -65,6 +65,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
 
     private final Environment environment;
     private final ClusterService clusterService;
+    List<Pair<String, Object>> mappingForNestedFields;
 
     public InferenceProcessor(
         String tag,
@@ -87,6 +88,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
         this.mlCommonsClientAccessor = clientAccessor;
         this.environment = environment;
         this.clusterService = clusterService;
+        mappingForNestedFields = fieldMap.entrySet().stream().map(this::processNestedKey).collect(Collectors.toList());
     }
 
     private void validateEmbeddingConfiguration(Map<String, Object> fieldMap) {
@@ -282,8 +284,7 @@ public abstract class InferenceProcessor extends AbstractProcessor {
     Map<String, Object> buildMapWithTargetKeys(IngestDocument ingestDocument) {
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
         Map<String, Object> mapWithProcessorKeys = new LinkedHashMap<>();
-        for (Map.Entry<String, Object> fieldMapEntry : fieldMap.entrySet()) {
-            Pair<String, Object> processedNestedKey = processNestedKey(fieldMapEntry);
+        for (Pair<String, Object> processedNestedKey : mappingForNestedFields) {
             String originalKey = processedNestedKey.getKey();
             Object targetKey = processedNestedKey.getValue();
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTestCase.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.processor;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.math.RandomUtils;
 import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
@@ -57,5 +58,18 @@ public class InferenceProcessorTestCase extends OpenSearchTestCase {
         modelTensorList.add(number6);
         modelTensorList.add(number7);
         return modelTensorList;
+    }
+
+    protected List<List<Float>> createRandomOneDimensionalMockVector(int numOfVectors, int vectorDimension, float min, float max) {
+        List<List<Float>> result = new ArrayList<>();
+        for (int i = 0; i < numOfVectors; i++) {
+            List<Float> numbers = new ArrayList<>();
+            for (int j = 0; j < vectorDimension; j++) {
+                Float nextFloat = RandomUtils.nextFloat() * (max - min) + min;
+                numbers.add(nextFloat);
+            }
+            result.add(numbers);
+        }
+        return result;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -16,21 +16,31 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.lucene.search.join.ScoreMode;
 import org.junit.Before;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
 
 import com.google.common.collect.ImmutableList;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
 
 public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
 
     private static final String INDEX_NAME = "text_embedding_index";
 
     private static final String PIPELINE_NAME = "pipeline-hybrid";
+    protected static final String QUERY_TEXT = "hello";
+    protected static final String LEVEL_1_FIELD = "nested_passages";
+    protected static final String LEVEL_2_FIELD = "level_2";
+    protected static final String LEVEL_3_FIELD_TEXT = "level_3_text";
+    protected static final String LEVEL_3_FIELD_EMBEDDING = "level_3_embedding";
     private final String INGEST_DOC1 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc1.json").toURI()));
     private final String INGEST_DOC2 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc2.json").toURI()));
+    private final String INGEST_DOC3 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc3.json").toURI()));
     private final String BULK_ITEM_TEMPLATE = Files.readString(
         Path.of(classLoader.getResource("processor/bulk_item_template.json").toURI())
     );
@@ -72,6 +82,66 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
 
             assertEquals(getDocById(INDEX_NAME, "1").get("_source"), getDocById(INDEX_NAME, "batch_1").get("_source"));
             assertEquals(getDocById(INDEX_NAME, "2").get("_source"), getDocById(INDEX_NAME, "batch_2").get("_source"));
+        } finally {
+            wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
+        }
+    }
+
+    public void testNestedFieldMapping_whenDocumentsIngested_thenSuccessful() throws Exception {
+        String modelId = null;
+        try {
+            modelId = uploadTextEmbeddingModel();
+            loadModel(modelId);
+            createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_EMBEDDING_WITH_NESTED_FIELDS_MAPPING);
+            createTextEmbeddingIndex();
+            ingestDocument(INGEST_DOC3, "3");
+
+            Map<String, Object> sourceMap = (Map<String, Object>) getDocById(INDEX_NAME, "3").get("_source");
+            assertNotNull(sourceMap);
+            assertTrue(sourceMap.containsKey(LEVEL_1_FIELD));
+            Map<String, Object> nestedPassages = (Map<String, Object>) sourceMap.get(LEVEL_1_FIELD);
+            assertTrue(nestedPassages.containsKey(LEVEL_2_FIELD));
+            Map<String, Object> level2 = (Map<String, Object>) nestedPassages.get(LEVEL_2_FIELD);
+            assertEquals(QUERY_TEXT, level2.get(LEVEL_3_FIELD_TEXT));
+            assertTrue(level2.containsKey(LEVEL_3_FIELD_EMBEDDING));
+            List<Double> embeddings = (List<Double>) level2.get(LEVEL_3_FIELD_EMBEDDING);
+            assertEquals(768, embeddings.size());
+            for (Double embedding : embeddings) {
+                assertTrue(embedding >= 0.0 && embedding <= 1.0);
+            }
+
+            NeuralQueryBuilder neuralQueryBuilderQuery = new NeuralQueryBuilder(
+                LEVEL_1_FIELD + "." + LEVEL_2_FIELD + "." + LEVEL_3_FIELD_EMBEDDING,
+                QUERY_TEXT,
+                "",
+                modelId,
+                10,
+                null,
+                null,
+                null,
+                null,
+                null
+            );
+            QueryBuilder queryNestedLowerLevel = QueryBuilders.nestedQuery(
+                LEVEL_1_FIELD + "." + LEVEL_2_FIELD,
+                neuralQueryBuilderQuery,
+                ScoreMode.Total
+            );
+            QueryBuilder queryNestedHighLevel = QueryBuilders.nestedQuery(LEVEL_1_FIELD, queryNestedLowerLevel, ScoreMode.Total);
+
+            Map<String, Object> searchResponseAsMap = search(INDEX_NAME, queryNestedHighLevel, 1);
+            assertNotNull(searchResponseAsMap);
+
+            Map<String, Object> hits = (Map<String, Object>) searchResponseAsMap.get("hits");
+            assertNotNull(hits);
+
+            assertEquals(1.0, hits.get("max_score"));
+            List<Map<String, Object>> listOfHits = (List<Map<String, Object>>) hits.get("hits");
+            assertNotNull(listOfHits);
+            assertEquals(1, listOfHits.size());
+            Map<String, Object> hitsInner = listOfHits.get(0);
+            assertEquals("3", hitsInner.get("_id"));
+            assertEquals(1.0, hitsInner.get("_score"));
         } finally {
             wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
         }

--- a/src/test/resources/processor/IndexMappings.json
+++ b/src/test/resources/processor/IndexMappings.json
@@ -102,6 +102,27 @@
                 "m": 24
               }
             }
+          },
+          "level_2": {
+            "type": "nested",
+            "properties": {
+              "level_3_text": {
+                "type": "text"
+              },
+              "level_3_embedding": {
+                "type": "knn_vector",
+                "dimension": 768,
+                "method": {
+                  "name": "hnsw",
+                  "space_type": "l2",
+                  "engine": "lucene",
+                  "parameters": {
+                    "ef_construction": 128,
+                    "m": 24
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/src/test/resources/processor/PipelineConfigurationWithNestedFieldsMapping.json
+++ b/src/test/resources/processor/PipelineConfigurationWithNestedFieldsMapping.json
@@ -1,0 +1,19 @@
+{
+  "description": "text embedding pipeline for hybrid",
+  "processors": [
+    {
+      "text_embedding": {
+        "model_id": "%s",
+        "field_map": {
+          "title": "title_knn",
+          "favor_list": "favor_list_knn",
+          "favorites": {
+            "game": "game_knn",
+            "movie": "movie_knn"
+          },
+          "nested_passages.level_2.level_3_text": "level_3_embedding"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/processor/ingest_doc3.json
+++ b/src/test/resources/processor/ingest_doc3.json
@@ -1,0 +1,20 @@
+{
+  "title": "This is a good day",
+  "description": "daily logging",
+  "favor_list": [
+    "test",
+    "hello",
+    "mock"
+  ],
+  "favorites": {
+    "game": "overwatch",
+    "movie": null
+  },
+  "nested_passages":
+    {
+      "level_2":
+          {
+            "level_3_text": "hello"
+          }
+    }
+}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -81,7 +81,9 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         ProcessorType.SPARSE_ENCODING,
         "processor/SparseEncodingPipelineConfiguration.json",
         ProcessorType.TEXT_IMAGE_EMBEDDING,
-        "processor/PipelineForTextImageEmbeddingProcessorConfiguration.json"
+        "processor/PipelineForTextImageEmbeddingProcessorConfiguration.json",
+        ProcessorType.TEXT_EMBEDDING_WITH_NESTED_FIELDS_MAPPING,
+        "processor/PipelineConfigurationWithNestedFieldsMapping.json"
     );
     private static final Set<RestStatus> SUCCESS_STATUSES = Set.of(RestStatus.CREATED, RestStatus.OK);
     protected static final String CONCURRENT_SEGMENT_SEARCH_ENABLED = "search.concurrent_segment_search.enabled";
@@ -1344,6 +1346,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
      */
     protected enum ProcessorType {
         TEXT_EMBEDDING,
+        TEXT_EMBEDDING_WITH_NESTED_FIELDS_MAPPING,
         TEXT_IMAGE_EMBEDDING,
         SPARSE_ENCODING
     }


### PR DESCRIPTION
### Description
Adding support for complex structures in inference processor definition. Main purpose is to improve user experience for cases when object has complex hierarchical structure, so users can apply easier syntax in processor definition.

Example of such new format:

```
"a.b.c.d": "field"
```
or

```
"a.b" : {
   "c.d": "field"
}
```

in this case we will try to look for structure like this in the ingest document:

```
"a" : {
   "b": {
     "c" : {
       "d" : "field"
```

Today we do support only hierarchical type of definition in mapping. It must look exactly like it is in the document:

```
"a" : {
   "b": {
     "c" : {
       "d" : "field"
```  

**Note**: this change affects only source field (left part of the mapping, one that holds value that is a basis for embedding generation). Today logic for the destination field (right part in mapping, field that will store generated embeddings) will be unchanged. As per today's logic that destination field is expected at the same level with the final source field. Example: `"a.b.c: d"` in this case embeddings are inserted in following structure: 
```
"a" : {
   "b" : {
     "d" : [0.1, 0.2 ....]
```

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/110

### Check List
- [X] New functionality includes testing.
    - [x] All tests pass
- [X] New functionality has been documented.
    - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
