### PR TITLE
Use AbstractBatchingProcessor for InferenceProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 - Enable sorting and search_after features in Hybrid Search [#827](https://github.com/opensearch-project/neural-search/pull/827)
 ### Enhancements
+- InferenceProcessor inherits from AbstractBatchingProcessor to support sub batching in processor [#820](https://github.com/opensearch-project/neural-search/pull/820)
 - Adds dynamic knn query parameters efsearch and nprobes [#814](https://github.com/opensearch-project/neural-search/pull/814/)
 - Enable '.' for nested field in text embedding processor ([#811](https://github.com/opensearch-project/neural-search/pull/811))
 ### Bug Fixes

--- a/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
@@ -31,13 +31,14 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
     public SparseEncodingProcessor(
         String tag,
         String description,
+        int batchSize,
         String modelId,
         Map<String, Object> fieldMap,
         MLCommonsClientAccessor clientAccessor,
         Environment environment,
         ClusterService clusterService
     ) {
-        super(tag, description, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
+        super(tag, description, batchSize, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -30,13 +30,14 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
     public TextEmbeddingProcessor(
         String tag,
         String description,
+        int batchSize,
         String modelId,
         Map<String, Object> fieldMap,
         MLCommonsClientAccessor clientAccessor,
         Environment environment,
         ClusterService clusterService
     ) {
-        super(tag, description, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
+        super(tag, description, batchSize, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/SparseEncodingProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/SparseEncodingProcessorFactory.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
-import org.opensearch.ingest.Processor;
+import org.opensearch.ingest.AbstractBatchingProcessor;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.SparseEncodingProcessor;
 
@@ -24,27 +24,23 @@ import lombok.extern.log4j.Log4j2;
  * Factory for sparse encoding ingest processor for ingestion pipeline. Instantiates processor based on user provided input.
  */
 @Log4j2
-public class SparseEncodingProcessorFactory implements Processor.Factory {
+public class SparseEncodingProcessorFactory extends AbstractBatchingProcessor.Factory {
     private final MLCommonsClientAccessor clientAccessor;
     private final Environment environment;
     private final ClusterService clusterService;
 
     public SparseEncodingProcessorFactory(MLCommonsClientAccessor clientAccessor, Environment environment, ClusterService clusterService) {
+        super(TYPE);
         this.clientAccessor = clientAccessor;
         this.environment = environment;
         this.clusterService = clusterService;
     }
 
     @Override
-    public SparseEncodingProcessor create(
-        Map<String, Processor.Factory> registry,
-        String processorTag,
-        String description,
-        Map<String, Object> config
-    ) throws Exception {
-        String modelId = readStringProperty(TYPE, processorTag, config, MODEL_ID_FIELD);
-        Map<String, Object> fieldMap = readMap(TYPE, processorTag, config, FIELD_MAP_FIELD);
+    protected AbstractBatchingProcessor newProcessor(String tag, String description, int batchSize, Map<String, Object> config) {
+        String modelId = readStringProperty(TYPE, tag, config, MODEL_ID_FIELD);
+        Map<String, Object> fieldMap = readMap(TYPE, tag, config, FIELD_MAP_FIELD);
 
-        return new SparseEncodingProcessor(processorTag, description, modelId, fieldMap, clientAccessor, environment, clusterService);
+        return new SparseEncodingProcessor(tag, description, batchSize, modelId, fieldMap, clientAccessor, environment, clusterService);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/TextEmbeddingProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/TextEmbeddingProcessorFactory.java
@@ -14,14 +14,14 @@ import java.util.Map;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
-import org.opensearch.ingest.Processor;
+import org.opensearch.ingest.AbstractBatchingProcessor;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.TextEmbeddingProcessor;
 
 /**
  * Factory for text embedding ingest processor for ingestion pipeline. Instantiates processor based on user provided input.
  */
-public class TextEmbeddingProcessorFactory implements Processor.Factory {
+public final class TextEmbeddingProcessorFactory extends AbstractBatchingProcessor.Factory {
 
     private final MLCommonsClientAccessor clientAccessor;
 
@@ -34,20 +34,16 @@ public class TextEmbeddingProcessorFactory implements Processor.Factory {
         final Environment environment,
         final ClusterService clusterService
     ) {
+        super(TYPE);
         this.clientAccessor = clientAccessor;
         this.environment = environment;
         this.clusterService = clusterService;
     }
 
     @Override
-    public TextEmbeddingProcessor create(
-        final Map<String, Processor.Factory> registry,
-        final String processorTag,
-        final String description,
-        final Map<String, Object> config
-    ) throws Exception {
-        String modelId = readStringProperty(TYPE, processorTag, config, MODEL_ID_FIELD);
-        Map<String, Object> filedMap = readMap(TYPE, processorTag, config, FIELD_MAP_FIELD);
-        return new TextEmbeddingProcessor(processorTag, description, modelId, filedMap, clientAccessor, environment, clusterService);
+    protected AbstractBatchingProcessor newProcessor(String tag, String description, int batchSize, Map<String, Object> config) {
+        String modelId = readStringProperty(TYPE, tag, config, MODEL_ID_FIELD);
+        Map<String, Object> filedMap = readMap(TYPE, tag, config, FIELD_MAP_FIELD);
+        return new TextEmbeddingProcessor(tag, description, batchSize, modelId, filedMap, clientAccessor, environment, clusterService);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/TextImageEmbeddingProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/TextImageEmbeddingProcessorFactory.java
@@ -6,7 +6,6 @@ package org.opensearch.neuralsearch.processor.factory;
 
 import static org.opensearch.ingest.ConfigurationUtils.readMap;
 import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
-import static org.opensearch.neuralsearch.processor.TextEmbeddingProcessor.Factory;
 import static org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessor.EMBEDDING_FIELD;
 import static org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessor.FIELD_MAP_FIELD;
 import static org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessor.MODEL_ID_FIELD;
@@ -16,6 +15,7 @@ import java.util.Map;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
+import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessor;
 
@@ -25,31 +25,18 @@ import lombok.AllArgsConstructor;
  * Factory for text_image embedding ingest processor for ingestion pipeline. Instantiates processor based on user provided input.
  */
 @AllArgsConstructor
-public class TextImageEmbeddingProcessorFactory implements Factory {
+public class TextImageEmbeddingProcessorFactory implements Processor.Factory {
 
     private final MLCommonsClientAccessor clientAccessor;
     private final Environment environment;
     private final ClusterService clusterService;
 
     @Override
-    public TextImageEmbeddingProcessor create(
-        final Map<String, Factory> registry,
-        final String processorTag,
-        final String description,
-        final Map<String, Object> config
-    ) throws Exception {
-        String modelId = readStringProperty(TYPE, processorTag, config, MODEL_ID_FIELD);
-        String embedding = readStringProperty(TYPE, processorTag, config, EMBEDDING_FIELD);
-        Map<String, String> filedMap = readMap(TYPE, processorTag, config, FIELD_MAP_FIELD);
-        return new TextImageEmbeddingProcessor(
-            processorTag,
-            description,
-            modelId,
-            embedding,
-            filedMap,
-            clientAccessor,
-            environment,
-            clusterService
-        );
+    public Processor create(Map<String, Processor.Factory> processorFactories, String tag, String description, Map<String, Object> config)
+        throws Exception {
+        String modelId = readStringProperty(TYPE, tag, config, MODEL_ID_FIELD);
+        String embedding = readStringProperty(TYPE, tag, config, EMBEDDING_FIELD);
+        Map<String, String> filedMap = readMap(TYPE, tag, config, FIELD_MAP_FIELD);
+        return new TextImageEmbeddingProcessor(tag, description, modelId, embedding, filedMap, clientAccessor, environment, clusterService);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -6,11 +6,15 @@ package org.opensearch.neuralsearch.processor;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -74,11 +78,11 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             loadModel(modelId);
             createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_EMBEDDING);
             createTextEmbeddingIndex();
-            ingestBatchDocumentWithBulk("batch_");
+            ingestBatchDocumentWithBulk("batch_", 2, 2, Collections.emptySet(), Collections.emptySet());
             assertEquals(2, getDocCount(INDEX_NAME));
 
-            ingestDocument(INGEST_DOC1, "1");
-            ingestDocument(INGEST_DOC2, "2");
+            ingestDocument(String.format(LOCALE, INGEST_DOC1, "success"), "1");
+            ingestDocument(String.format(LOCALE, INGEST_DOC2, "success"), "2");
 
             assertEquals(getDocById(INDEX_NAME, "1").get("_source"), getDocById(INDEX_NAME, "batch_1").get("_source"));
             assertEquals(getDocById(INDEX_NAME, "2").get("_source"), getDocById(INDEX_NAME, "batch_2").get("_source"));
@@ -147,6 +151,70 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
         }
     }
 
+    public void testTextEmbeddingProcessor_withBatchSizeInProcessor() throws Exception {
+        String modelId = null;
+        try {
+            modelId = uploadTextEmbeddingModel();
+            loadModel(modelId);
+            URL pipelineURLPath = classLoader.getResource("processor/PipelineConfigurationWithBatchSize.json");
+            Objects.requireNonNull(pipelineURLPath);
+            String requestBody = Files.readString(Path.of(pipelineURLPath.toURI()));
+            createPipelineProcessor(requestBody, PIPELINE_NAME, modelId);
+            createTextEmbeddingIndex();
+            int docCount = 5;
+            ingestBatchDocumentWithBulk("batch_", docCount, docCount, Collections.emptySet(), Collections.emptySet());
+            assertEquals(5, getDocCount(INDEX_NAME));
+
+            for (int i = 0; i < docCount; ++i) {
+                String template = List.of(INGEST_DOC1, INGEST_DOC2).get(i % 2);
+                String payload = String.format(LOCALE, template, "success");
+                ingestDocument(payload, String.valueOf(i + 1));
+            }
+
+            for (int i = 0; i < docCount; ++i) {
+                assertEquals(
+                    getDocById(INDEX_NAME, String.valueOf(i + 1)).get("_source"),
+                    getDocById(INDEX_NAME, "batch_" + (i + 1)).get("_source")
+                );
+
+            }
+        } finally {
+            wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
+        }
+    }
+
+    public void testTextEmbeddingProcessor_withFailureAndSkip() throws Exception {
+        String modelId = null;
+        try {
+            modelId = uploadTextEmbeddingModel();
+            loadModel(modelId);
+            URL pipelineURLPath = classLoader.getResource("processor/PipelineConfigurationWithBatchSize.json");
+            Objects.requireNonNull(pipelineURLPath);
+            String requestBody = Files.readString(Path.of(pipelineURLPath.toURI()));
+            createPipelineProcessor(requestBody, PIPELINE_NAME, modelId);
+            createTextEmbeddingIndex();
+            int docCount = 5;
+            ingestBatchDocumentWithBulk("batch_", docCount, docCount, Set.of(0), Set.of(1));
+            assertEquals(3, getDocCount(INDEX_NAME));
+
+            for (int i = 2; i < docCount; ++i) {
+                String template = List.of(INGEST_DOC1, INGEST_DOC2).get(i % 2);
+                String payload = String.format(LOCALE, template, "success");
+                ingestDocument(payload, String.valueOf(i + 1));
+            }
+
+            for (int i = 2; i < docCount; ++i) {
+                assertEquals(
+                    getDocById(INDEX_NAME, String.valueOf(i + 1)).get("_source"),
+                    getDocById(INDEX_NAME, "batch_" + (i + 1)).get("_source")
+                );
+
+            }
+        } finally {
+            wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
+        }
+    }
+
     private String uploadTextEmbeddingModel() throws Exception {
         String requestBody = Files.readString(Path.of(classLoader.getResource("processor/UploadModelRequestBody.json").toURI()));
         return registerModelGroupAndUploadModel(requestBody);
@@ -183,23 +251,27 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
         assertEquals("created", map.get("result"));
     }
 
-    private void ingestBatchDocumentWithBulk(String idPrefix) throws Exception {
-        String doc1 = INGEST_DOC1.replace("\n", "");
-        String doc2 = INGEST_DOC2.replace("\n", "");
-        final String id1 = idPrefix + "1";
-        final String id2 = idPrefix + "2";
-        String item1 = BULK_ITEM_TEMPLATE.replace("{{index}}", INDEX_NAME)
-            .replace("{{id}}", id1)
-            .replace("{{doc}}", doc1)
-            .replace("{{comma}}", ",");
-        String item2 = BULK_ITEM_TEMPLATE.replace("{{index}}", INDEX_NAME)
-            .replace("{{id}}", id2)
-            .replace("{{doc}}", doc2)
-            .replace("{{comma}}", "\n");
-        final String payload = item1 + item2;
+    private void ingestBatchDocumentWithBulk(String idPrefix, int docCount, int batchSize, Set<Integer> failedIds, Set<Integer> droppedIds)
+        throws Exception {
+        StringBuilder payloadBuilder = new StringBuilder();
+        for (int i = 0; i < docCount; ++i) {
+            String docTemplate = List.of(INGEST_DOC1, INGEST_DOC2).get(i % 2);
+            if (failedIds.contains(i)) {
+                docTemplate = String.format(LOCALE, docTemplate, "fail");
+            } else if (droppedIds.contains(i)) {
+                docTemplate = String.format(LOCALE, docTemplate, "drop");
+            } else {
+                docTemplate = String.format(LOCALE, docTemplate, "success");
+            }
+            String doc = docTemplate.replace("\n", "");
+            final String id = idPrefix + (i + 1);
+            String item = BULK_ITEM_TEMPLATE.replace("{{index}}", INDEX_NAME).replace("{{id}}", id).replace("{{doc}}", doc);
+            payloadBuilder.append(item).append("\n");
+        }
+        final String payload = payloadBuilder.toString();
         Map<String, String> params = new HashMap<>();
         params.put("refresh", "true");
-        params.put("batch_size", "2");
+        params.put("batch_size", String.valueOf(batchSize));
         Response response = makeRequest(
             client(),
             "POST",
@@ -213,7 +285,7 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             EntityUtils.toString(response.getEntity()),
             false
         );
-        assertEquals(false, map.get("errors"));
-        assertEquals(2, ((List) map.get("items")).size());
+        assertEquals(!failedIds.isEmpty(), map.get("errors"));
+        assertEquals(docCount, ((List) map.get("items")).size());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
@@ -89,7 +89,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
             TextImageEmbeddingProcessor.FIELD_MAP_FIELD,
             ImmutableMap.of(TEXT_FIELD_NAME, "my_text_field", IMAGE_FIELD_NAME, "image_field")
         );
-        return textImageEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
+        return (TextImageEmbeddingProcessor) textImageEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
     }
 
     @SneakyThrows
@@ -223,7 +223,12 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
             TextImageEmbeddingProcessor.FIELD_MAP_FIELD,
             ImmutableMap.of(TEXT_FIELD_NAME, "my_text_field", IMAGE_FIELD_NAME, "image_field")
         );
-        TextImageEmbeddingProcessor processor = textImageEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
+        TextImageEmbeddingProcessor processor = (TextImageEmbeddingProcessor) textImageEmbeddingProcessorFactory.create(
+            registry,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            config
+        );
         doThrow(new RuntimeException()).when(accessor).inferenceSentences(anyString(), anyMap(), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/TextImageEmbeddingProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/TextImageEmbeddingProcessorFactoryTests.java
@@ -42,7 +42,7 @@ public class TextImageEmbeddingProcessorFactoryTests extends OpenSearchTestCase 
         config.put(MODEL_ID_FIELD, "1234567678");
         config.put(EMBEDDING_FIELD, "embedding_field");
         config.put(FIELD_MAP_FIELD, Map.of(TEXT_FIELD_NAME, "my_text_field", IMAGE_FIELD_NAME, "my_image_field"));
-        TextImageEmbeddingProcessor inferenceProcessor = textImageEmbeddingProcessorFactory.create(
+        TextImageEmbeddingProcessor inferenceProcessor = (TextImageEmbeddingProcessor) textImageEmbeddingProcessorFactory.create(
             processorFactories,
             tag,
             description,
@@ -68,7 +68,7 @@ public class TextImageEmbeddingProcessorFactoryTests extends OpenSearchTestCase 
         configOnlyTextField.put(MODEL_ID_FIELD, "1234567678");
         configOnlyTextField.put(EMBEDDING_FIELD, "embedding_field");
         configOnlyTextField.put(FIELD_MAP_FIELD, Map.of(TEXT_FIELD_NAME, "my_text_field"));
-        TextImageEmbeddingProcessor processor = textImageEmbeddingProcessorFactory.create(
+        TextImageEmbeddingProcessor processor = (TextImageEmbeddingProcessor) textImageEmbeddingProcessorFactory.create(
             processorFactories,
             tag,
             description,
@@ -81,7 +81,12 @@ public class TextImageEmbeddingProcessorFactoryTests extends OpenSearchTestCase 
         configOnlyImageField.put(MODEL_ID_FIELD, "1234567678");
         configOnlyImageField.put(EMBEDDING_FIELD, "embedding_field");
         configOnlyImageField.put(FIELD_MAP_FIELD, Map.of(TEXT_FIELD_NAME, "my_text_field"));
-        processor = textImageEmbeddingProcessorFactory.create(processorFactories, tag, description, configOnlyImageField);
+        processor = (TextImageEmbeddingProcessor) textImageEmbeddingProcessorFactory.create(
+            processorFactories,
+            tag,
+            description,
+            configOnlyImageField
+        );
         assertNotNull(processor);
         assertEquals("text_image_embedding", processor.getType());
     }

--- a/src/test/resources/processor/PipelineConfigurationWithBatchSize.json
+++ b/src/test/resources/processor/PipelineConfigurationWithBatchSize.json
@@ -1,0 +1,33 @@
+{
+  "description": "text embedding pipeline for hybrid",
+  "processors": [
+    {
+      "drop": {
+        "if": "ctx.text.contains('drop')"
+      }
+    },
+    {
+      "fail": {
+        "if": "ctx.text.contains('fail')",
+        "message": "fail"
+      }
+    },
+    {
+      "text_embedding": {
+        "model_id": "%s",
+        "batch_size": 2,
+        "field_map": {
+          "title": "title_knn",
+          "favor_list": "favor_list_knn",
+          "favorites": {
+            "game": "game_knn",
+            "movie": "movie_knn"
+          },
+          "nested_passages": {
+            "text": "embedding"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/processor/bulk_item_template.json
+++ b/src/test/resources/processor/bulk_item_template.json
@@ -1,2 +1,2 @@
 { "index": { "_index": "{{index}}", "_id": "{{id}}" } },
-{{doc}}{{comma}}
+{{doc}}

--- a/src/test/resources/processor/ingest_doc1.json
+++ b/src/test/resources/processor/ingest_doc1.json
@@ -1,5 +1,6 @@
 {
   "title": "This is a good day",
+  "text": "%s",
   "description": "daily logging",
   "favor_list": [
     "test",

--- a/src/test/resources/processor/ingest_doc2.json
+++ b/src/test/resources/processor/ingest_doc2.json
@@ -1,5 +1,6 @@
 {
   "title": "this is a second doc",
+  "text": "%s",
   "description": "the description is not very long",
   "favor_list": [
     "favor"


### PR DESCRIPTION
### Description
Based on [discussion](https://github.com/opensearch-project/OpenSearch/issues/14283), it's strongly recommended to move sub batching logic from `_bulk` API to each processor. 

So for two batch supporting processors: text_embedding, sparse_encoding, based on [discussion](https://github.com/opensearch-project/OpenSearch/issues/14283), we make them inherit from a newly introduced `AbstractBatchingProcessing` so that these two processors supports a new optional parameter `batch_size` and this parameter can control the cutting sub batches logic. The default of this parameter is 1 to be consistent with existing behavior.

Add more integration tests.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/14283

### Check List
- [x] New functionality includes testing.
    - [x] All tests pass
- [x] New functionality has been documented.
    - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
