### PR TITLE
Fix linux build CI error due to action runner env upgrade node 20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - "*"
       - "feature/**"
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:

--- a/.github/workflows/test_aggregations.yml
+++ b/.github/workflows/test_aggregations.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - "*"
       - "feature/**"
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - "*"
       - "feature/**"
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:


### PR DESCRIPTION
### Description
The gradle check on linux is failing with below error.
```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```
Therefore created a similar PR like KNN [https://github.com/opensearch-project/k-NN/pull/1795](https://github.com/opensearch-project/k-NN/pull/1795) on neural search to fix it.

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
