### PR TITLE
Fix KNN SpaceType.getVectorSimilarityFunction renamed issue

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
@@ -39,6 +39,7 @@ import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 
@@ -119,6 +120,7 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
         when(mockKNNVectorField.getDimension()).thenReturn(4);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
         when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.L2);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(VECTOR_FIELD_NAME, VECTOR_QUERY, K);
         Query knnQuery = knnQueryBuilder.toQuery(mockQueryShardContext);
 

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -867,7 +867,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final String queryText
     ) {
         float[] queryVector = runInference(modelId, queryText);
-        return spaceType.getVectorSimilarityFunction().compare(queryVector, indexVector);
+        return spaceType.getKnnVectorSimilarityFunction().compare(queryVector, indexVector);
     }
 
     protected Map<String, Object> getTaskQueryResponse(final String taskId) throws Exception {


### PR DESCRIPTION
### Description
Knn repo `SpaceType.getVectorSimilarityFunction` has been rename to `SpaceType.getKnnVectorSimilarityFunction` by this [PR](https://github.com/opensearch-project/k-NN/pull/1781/) which caused :compileTestFixturesJava failure  https://github.com/opensearch-project/neural-search/actions/runs/9904116192/job/27602462802?pr=832

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
