### PR TITLE
Fix: update jdk version to 21 in maven publish workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add BWC for batch ingestion ([#769](https://github.com/opensearch-project/neural-search/pull/769))
 - Add backward test cases for neural sparse two phase processor ([#777](https://github.com/opensearch-project/neural-search/pull/777))
 - Fix CI for JDK upgrade towards 21 ([#835](https://github.com/opensearch-project/neural-search/pull/835))
+- Maven publishing workflow by upgrade jdk to 21 ([#837](https://github.com/opensearch-project/neural-search/pull/837))
 ### Documentation
 ### Maintenance
 ### Refactoring


### PR DESCRIPTION
### Description
Update jdk version to 21 in maven publish workflow to fix test: https://github.com/opensearch-project/neural-search/actions/runs/10005385653/job/27655990133

### Issues Resolved
Update jdk version to 21 in maven publish workflow to fix test: https://github.com/opensearch-project/neural-search/actions/runs/10005385653/job/27655990133

### Check List
- [ ] New functionality includes testing.
    - [ ] All tests pass
- [ ] New functionality has been documented.
    - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
