### PR TITLE
Setting source and target levels Java 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,12 +155,12 @@ ext {
 allprojects {
     group = opensearch_group
     version = "${opensearch_build}"
-    targetCompatibility = JavaVersion.VERSION_11
-    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
 
     apply from: rootProject.file('repositories.gradle').absoluteFile
     plugins.withId('java') {
-        sourceCompatibility = targetCompatibility = "11"
+        sourceCompatibility = targetCompatibility = "21"
     }
 
     afterEvaluate {


### PR DESCRIPTION
### Description
Addressing items from global opensearch campaign of switching to jdk 21. 

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/775

### Check List
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
