### PR TITLE
Enhance syntax for nested mapping in destination fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - InferenceProcessor inherits from AbstractBatchingProcessor to support sub batching in processor [#820](https://github.com/opensearch-project/neural-search/pull/820)
 - Adds dynamic knn query parameters efsearch and nprobes [#814](https://github.com/opensearch-project/neural-search/pull/814/)
 - Enable '.' for nested field in text embedding processor ([#811](https://github.com/opensearch-project/neural-search/pull/811))
+- Enhance syntax for nested mapping in destination fields([#841](https://github.com/opensearch-project/neural-search/pull/841))
 ### Bug Fixes
 - Fix for missing HybridQuery results when concurrent segment search is enabled ([#800](https://github.com/opensearch-project/neural-search/pull/800))
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -52,7 +52,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
 
     public static final String MODEL_ID_FIELD = "model_id";
     public static final String FIELD_MAP_FIELD = "field_map";
-    protected static final BiFunction<Object, Object, Object> REMAPPING_FUNCTION = (v1, v2) -> {
+    private static final BiFunction<Object, Object, Object> REMAPPING_FUNCTION = (v1, v2) -> {
         if (v1 instanceof Collection && v2 instanceof Collection) {
             ((Collection) v1).addAll((Collection) v2);
             return v1;

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -29,6 +30,7 @@ import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
 import org.opensearch.index.mapper.IndexFieldMapper;
+
 import org.opensearch.ingest.AbstractBatchingProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
@@ -50,6 +52,17 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
 
     public static final String MODEL_ID_FIELD = "model_id";
     public static final String FIELD_MAP_FIELD = "field_map";
+    protected static final BiFunction<Object, Object, Object> REMAPPING_FUNCTION = (v1, v2) -> {
+        if (v1 instanceof Collection && v2 instanceof Collection) {
+            ((Collection) v1).addAll((Collection) v2);
+            return v1;
+        } else if (v1 instanceof Map && v2 instanceof Map) {
+            ((Map) v1).putAll((Map) v2);
+            return v1;
+        } else {
+            return v2;
+        }
+    };
 
     private final String type;
 
@@ -325,17 +338,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
                     buildNestedMap(nestedFieldMapEntry.getKey(), nestedFieldMapEntry.getValue(), map, next);
                 }
             }
-            treeRes.merge(parentKey, next, (v1, v2) -> {
-                if (v1 instanceof Collection && v2 instanceof Collection) {
-                    ((Collection) v1).addAll((Collection) v2);
-                    return v1;
-                } else if (v1 instanceof Map && v2 instanceof Map) {
-                    ((Map) v1).putAll((Map) v2);
-                    return v1;
-                } else {
-                    return v2;
-                }
-            });
+            treeRes.merge(parentKey, next, REMAPPING_FUNCTION);
         } else {
             String key = String.valueOf(processorKey);
             treeRes.put(key, sourceAndMetadataMap.get(parentKey));
@@ -389,8 +392,9 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         IndexWrapper indexWrapper = new IndexWrapper(0);
         Map<String, Object> result = new LinkedHashMap<>();
         for (Map.Entry<String, Object> knnMapEntry : processorMap.entrySet()) {
-            String knnKey = knnMapEntry.getKey();
-            Object sourceValue = knnMapEntry.getValue();
+            Pair<String, Object> processedNestedKey = processNestedKey(knnMapEntry);
+            String knnKey = processedNestedKey.getKey();
+            Object sourceValue = processedNestedKey.getValue();
             if (sourceValue instanceof String) {
                 result.put(knnKey, results.get(indexWrapper.index++));
             } else if (sourceValue instanceof List) {
@@ -419,19 +423,31 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
                         nestedElement.put(inputNestedMapEntry.getKey(), results.get(indexWrapper.index++));
                     }
                 } else {
+                    Pair<String, Object> processedNestedKey = processNestedKey(inputNestedMapEntry);
+                    Map<String, Object> sourceMap;
+                    if (sourceAndMetadataMap.get(processorKey) == null) {
+                        sourceMap = new HashMap<>();
+                        sourceAndMetadataMap.put(processorKey, sourceMap);
+                    } else {
+                        sourceMap = (Map<String, Object>) sourceAndMetadataMap.get(processorKey);
+                    }
                     putNLPResultToSourceMapForMapType(
-                        inputNestedMapEntry.getKey(),
-                        inputNestedMapEntry.getValue(),
+                        processedNestedKey.getKey(),
+                        processedNestedKey.getValue(),
                         results,
                         indexWrapper,
-                        (Map<String, Object>) sourceAndMetadataMap.get(processorKey)
+                        sourceMap
                     );
                 }
             }
         } else if (sourceValue instanceof String) {
-            sourceAndMetadataMap.put(processorKey, results.get(indexWrapper.index++));
+            sourceAndMetadataMap.merge(processorKey, results.get(indexWrapper.index++), REMAPPING_FUNCTION);
         } else if (sourceValue instanceof List) {
-            sourceAndMetadataMap.put(processorKey, buildNLPResultForListType((List<String>) sourceValue, results, indexWrapper));
+            sourceAndMetadataMap.merge(
+                processorKey,
+                buildNLPResultForListType((List<String>) sourceValue, results, indexWrapper),
+                REMAPPING_FUNCTION
+            );
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -41,10 +42,15 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
     protected static final String LEVEL_1_FIELD = "nested_passages";
     protected static final String LEVEL_2_FIELD = "level_2";
     protected static final String LEVEL_3_FIELD_TEXT = "level_3_text";
+    protected static final String LEVEL_3_FIELD_CONTAINER = "level_3_container";
     protected static final String LEVEL_3_FIELD_EMBEDDING = "level_3_embedding";
+    protected static final String TEXT_FIELD_VALUE_1 = "hello";
+    protected static final String TEXT_FIELD_VALUE_2 = "clown";
+    protected static final String TEXT_FIELD_VALUE_3 = "abc";
     private final String INGEST_DOC1 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc1.json").toURI()));
     private final String INGEST_DOC2 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc2.json").toURI()));
     private final String INGEST_DOC3 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc3.json").toURI()));
+    private final String INGEST_DOC4 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc4.json").toURI()));
     private final String BULK_ITEM_TEMPLATE = Files.readString(
         Path.of(classLoader.getResource("processor/bulk_item_template.json").toURI())
     );
@@ -99,23 +105,17 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_EMBEDDING_WITH_NESTED_FIELDS_MAPPING);
             createTextEmbeddingIndex();
             ingestDocument(INGEST_DOC3, "3");
+            ingestDocument(INGEST_DOC4, "4");
 
-            Map<String, Object> sourceMap = (Map<String, Object>) getDocById(INDEX_NAME, "3").get("_source");
-            assertNotNull(sourceMap);
-            assertTrue(sourceMap.containsKey(LEVEL_1_FIELD));
-            Map<String, Object> nestedPassages = (Map<String, Object>) sourceMap.get(LEVEL_1_FIELD);
-            assertTrue(nestedPassages.containsKey(LEVEL_2_FIELD));
-            Map<String, Object> level2 = (Map<String, Object>) nestedPassages.get(LEVEL_2_FIELD);
-            assertEquals(QUERY_TEXT, level2.get(LEVEL_3_FIELD_TEXT));
-            assertTrue(level2.containsKey(LEVEL_3_FIELD_EMBEDDING));
-            List<Double> embeddings = (List<Double>) level2.get(LEVEL_3_FIELD_EMBEDDING);
-            assertEquals(768, embeddings.size());
-            for (Double embedding : embeddings) {
-                assertTrue(embedding >= 0.0 && embedding <= 1.0);
-            }
+            assertDoc(
+                (Map<String, Object>) getDocById(INDEX_NAME, "3").get("_source"),
+                TEXT_FIELD_VALUE_1,
+                Optional.of(TEXT_FIELD_VALUE_3)
+            );
+            assertDoc((Map<String, Object>) getDocById(INDEX_NAME, "4").get("_source"), TEXT_FIELD_VALUE_2, Optional.empty());
 
             NeuralQueryBuilder neuralQueryBuilderQuery = new NeuralQueryBuilder(
-                LEVEL_1_FIELD + "." + LEVEL_2_FIELD + "." + LEVEL_3_FIELD_EMBEDDING,
+                LEVEL_1_FIELD + "." + LEVEL_2_FIELD + "." + LEVEL_3_FIELD_CONTAINER + "." + LEVEL_3_FIELD_EMBEDDING,
                 QUERY_TEXT,
                 "",
                 modelId,
@@ -133,7 +133,7 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             );
             QueryBuilder queryNestedHighLevel = QueryBuilders.nestedQuery(LEVEL_1_FIELD, queryNestedLowerLevel, ScoreMode.Total);
 
-            Map<String, Object> searchResponseAsMap = search(INDEX_NAME, queryNestedHighLevel, 1);
+            Map<String, Object> searchResponseAsMap = search(INDEX_NAME, queryNestedHighLevel, 2);
             assertNotNull(searchResponseAsMap);
 
             Map<String, Object> hits = (Map<String, Object>) searchResponseAsMap.get("hits");
@@ -142,12 +142,35 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             assertEquals(1.0, hits.get("max_score"));
             List<Map<String, Object>> listOfHits = (List<Map<String, Object>>) hits.get("hits");
             assertNotNull(listOfHits);
-            assertEquals(1, listOfHits.size());
-            Map<String, Object> hitsInner = listOfHits.get(0);
-            assertEquals("3", hitsInner.get("_id"));
-            assertEquals(1.0, hitsInner.get("_score"));
+            assertEquals(2, listOfHits.size());
+
+            Map<String, Object> innerHitDetails = listOfHits.get(0);
+            assertEquals("3", innerHitDetails.get("_id"));
+            assertEquals(1.0, innerHitDetails.get("_score"));
+
+            innerHitDetails = listOfHits.get(1);
+            assertEquals("4", innerHitDetails.get("_id"));
+            assertTrue((double) innerHitDetails.get("_score") <= 1.0);
         } finally {
             wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
+        }
+    }
+
+    private void assertDoc(Map<String, Object> sourceMap, String textFieldValue, Optional<String> level3ExpectedValue) {
+        assertNotNull(sourceMap);
+        assertTrue(sourceMap.containsKey(LEVEL_1_FIELD));
+        Map<String, Object> nestedPassages = (Map<String, Object>) sourceMap.get(LEVEL_1_FIELD);
+        assertTrue(nestedPassages.containsKey(LEVEL_2_FIELD));
+        Map<String, Object> level2 = (Map<String, Object>) nestedPassages.get(LEVEL_2_FIELD);
+        assertEquals(textFieldValue, level2.get(LEVEL_3_FIELD_TEXT));
+        Map<String, Object> level3 = (Map<String, Object>) level2.get(LEVEL_3_FIELD_CONTAINER);
+        List<Double> embeddings = (List<Double>) level3.get(LEVEL_3_FIELD_EMBEDDING);
+        assertEquals(768, embeddings.size());
+        for (Double embedding : embeddings) {
+            assertTrue(embedding >= 0.0 && embedding <= 1.0);
+        }
+        if (level3ExpectedValue.isPresent()) {
+            assertEquals(level3ExpectedValue.get(), level3.get("level_4_text_field"));
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
@@ -39,6 +39,7 @@ import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 
@@ -119,6 +120,7 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
         when(mockKNNVectorField.getDimension()).thenReturn(4);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
         when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.L2);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(VECTOR_FIELD_NAME, VECTOR_QUERY, K);
         Query knnQuery = knnQueryBuilder.toQuery(mockQueryShardContext);
 

--- a/src/test/resources/processor/IndexMappings.json
+++ b/src/test/resources/processor/IndexMappings.json
@@ -109,16 +109,23 @@
               "level_3_text": {
                 "type": "text"
               },
-              "level_3_embedding": {
-                "type": "knn_vector",
-                "dimension": 768,
-                "method": {
-                  "name": "hnsw",
-                  "space_type": "l2",
-                  "engine": "lucene",
-                  "parameters": {
-                    "ef_construction": 128,
-                    "m": 24
+              "level_3_container": {
+                "properties": {
+                  "level_3_embedding": {
+                    "type": "knn_vector",
+                    "dimension": 768,
+                    "method": {
+                      "name": "hnsw",
+                      "space_type": "l2",
+                      "engine": "lucene",
+                      "parameters": {
+                        "ef_construction": 128,
+                        "m": 24
+                      }
+                    }
+                  },
+                  "random_field1": {
+                    "type": "text"
                   }
                 }
               }

--- a/src/test/resources/processor/PipelineConfigurationWithNestedFieldsMapping.json
+++ b/src/test/resources/processor/PipelineConfigurationWithNestedFieldsMapping.json
@@ -11,7 +11,7 @@
             "game": "game_knn",
             "movie": "movie_knn"
           },
-          "nested_passages.level_2.level_3_text": "level_3_embedding"
+          "nested_passages.level_2.level_3_text": "level_3_container.level_3_embedding"
         }
       }
     }

--- a/src/test/resources/processor/ingest_doc3.json
+++ b/src/test/resources/processor/ingest_doc3.json
@@ -14,7 +14,10 @@
     {
       "level_2":
           {
-            "level_3_text": "hello"
+            "level_3_text": "hello",
+            "level_3_container": {
+              "level_4_text_field": "abc"
+            }
           }
     }
 }

--- a/src/test/resources/processor/ingest_doc4.json
+++ b/src/test/resources/processor/ingest_doc4.json
@@ -1,0 +1,20 @@
+{
+  "title": "This is a good day",
+  "description": "daily logging",
+  "favor_list": [
+    "key",
+    "hey",
+    "click"
+  ],
+  "favorites": {
+    "game": "cossacks",
+    "movie": "matrix"
+  },
+  "nested_passages":
+    {
+      "level_2":
+          {
+            "level_3_text": "clown"
+          }
+    }
+}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -867,7 +867,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final String queryText
     ) {
         float[] queryVector = runInference(modelId, queryText);
-        return spaceType.getVectorSimilarityFunction().compare(queryVector, indexVector);
+        return spaceType.getKnnVectorSimilarityFunction().compare(queryVector, indexVector);
     }
 
     protected Map<String, Object> getTaskQueryResponse(final String taskId) throws Exception {


### PR DESCRIPTION
### Description
This is continuation of enabling comma based syntax for nested fields in mapping definition for embedding processors. This PR is focused on adding new syntax for the destination field.

Example of the new format we going to support:

```
"a.b": "c.vector_field"
```

final ingest document will look like:

```
a : {
    b: some_text
    c : {
        vector_field: [float numbers]
```

with today's code ingest document will look like:

```
a : {
    b: some_text
    c.vector_field: [float numbers]
}
```

 
Previous PR for source part of the mapping: https://github.com/opensearch-project/neural-search/pull/811  

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/110

### Check List
- [X] New functionality includes testing.
    - [x] All tests pass
- [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
