### PR TITLE
Add triage.md based off of security

### DIFF
--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -1,0 +1,89 @@
+<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
+
+The maintainers of the k-NN/neural-search Repo's seek to promote an inclusive and engaged community of contributors. In 
+order to facilitate this, bi-weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to 
+contribute, discuss an issue, or learn more about the project. To learn more about contributing to the 
+k-NN/neural-search Repo visit the [Contributing](./CONTRIBUTING.md) documentation.
+
+### Do I need to attend for my issue to be addressed/triaged?
+
+Attendance is not required for your issue to be triaged or addressed. All new issues are triaged bi-weekly.
+
+### What happens if my issue does not get covered this time?
+
+Each meeting we seek to  address all new issues. However, should we run out of time before your issue is discussed, you 
+are always welcome to attend the next meeting or to follow up on the issue post itself.
+
+### How do I join the Backlog & Triage meeting?
+
+Meetings are hosted regularly at 5 PM Pacific Time on Tuesdays bi-weekly and can be joined via the links posted on the 
+[OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events. The event will be titled 
+`Development Backlog & Triage Meeting - k-NN/neural-search`.
+
+After joining the Chime meeting, you can enable your video / voice to join the discussion.  If you do not have a webcam 
+or microphone available, you can still join in via the text chat.
+
+If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to 
+everyone in the meeting.
+
+### Is there an agenda for each week?
+
+Meetings are 60 minutes and structured as follows:
+
+1. Initial Gathering: As we gather, feel free to turn on video and engage in informal and open-to-all conversation.  After a bit a volunteer will share their screen and proceed with the agenda.
+2. Announcements: If there are any announcements to be made they will happen at the start of the meeting.
+3. Review of New Issues: The meetings always start with reviewing all untriaged/recent issues for the k-NN and neural-search repositories.
+4. Member Requests: Opportunity for any meeting member to ask for consideration of an issue or pull request.
+5. Pull Request Discussion: Then, we review the status of outstanding pull requests from the k-NN and neural-search repositories.
+6. Open Discussion: Allow for members of the meeting to surface any topics without issues filed or pull request created.
+
+
+There is no specific ordering within each category.
+
+If you have an issue you would like to discuss but do not have the ability to attend the entire meeting please attend when is best for you and signal that you have an issue to discuss when you arrive.
+
+### Do I need to have already contributed to the project to attend a triage meeting?
+
+No, all are welcome and encouraged to attend. Attending the Backlog & Triage meetings is a great way for a new contributor to learn about the project as well as explore different avenues of contribution.
+
+### What if I have an issue that is almost a duplicate, should I open a new one to be triaged?
+
+You can always open an issue including one that you think may be a duplicate. However, in cases where you believe there 
+is an important distinction to be made between an existing issue and your newly created one, you are encouraged to 
+attend the triaging meeting to explain.
+
+### What if I have follow-up questions on an issue?
+
+If you have an existing issue you would like to discuss, you can always comment on the issue itself. Alternatively, you 
+are welcome to come to the triage meeting to discuss.
+
+### Is this meeting a good place to get help setting up k-NN/neural-search features on my OpenSearch instance?
+
+While we are always happy to help the community, the best resource for implementation questions is [the OpenSearch forum](https://forum.opensearch.org/c/plugins/k-nn/48).
+
+There you can find answers to many common questions as well as speak with implementation experts.
+
+### What are the issue labels associated with triaging?
+
+Yes, there are several labels that are used to identify the 'state' of issues filed in OpenSearch and the Security Plugin.
+
+| Label | When applied | Meaning |
+| ----- | ------------ | ------- |
+| Untriaged | When issues are created or re-opened. | Issues labeled as 'Untriaged' require the attention of the repository maintainers and may need to be prioritized for quicker resolution. It's crucial to keep the count of 'Untriaged' labels low to ensure all potential security issues are addressed in a timely manner. See [SECURITY.md](https://github.com/opensearch-project/security/blob/main/SECURITY.md) for more details on handling these issues. |
+| Triaged | During triage meetings. | Issues labeled as 'Triaged' have been reviewed and are deemed actionable. Opening a pull request for an issue with the 'Triaged' label has a higher likelihood of approval from the project maintainers, particularly in novel areas. |
+| Neither Label | During triage meetings. | This category is for issues that lack sufficient details to formulate a potential solution. Until more details are provided, it's difficult to ascertain if a proposed solution would be acceptable. When dealing with an 'Untriaged' issue that falls into this category, the triage team should provide further insights so the issue can be appropriately closed or labeled as 'Triaged'. Issues in this state are reviewed during every triage meeting. |
+| Help Wanted | Anytime. | Issues marked as 'Help Wanted' signal that they are actionable and not the current focus of the project maintainers. Community contributions are especially encouraged for these issues. |
+| Good First Issue | Anytime. | Issues labeled as 'Good First Issue' are small in scope and can be resolved with a single pull request. These are recommended starting points for newcomers looking to make their first contributions. |
+
+
+### What if my issue is critical to OpenSearch operations, do I have to wait for the bi-weekly meeting for it to be addressed?
+
+All new issues for the [k-NN](https://github.com/opensearch-project/k-NN/issues?q=is%3Aissue+is%3Aopen+label%3Auntriaged) repo and [neural-search](https://github.com/opensearch-project/neural-search/issues?q=is%3Aissue+is%3Aopen+-label%3Atriaged) repo are reviewed daily to check for critical issues which require immediate triaging. If an issue relates to a severe concern for OpenSearch operation, it will be triaged by a maintainer mid-week. You can still come to discuss an issue at the following meeting even if it has already been triaged during the week.
+
+### Is this where I should bring up potential security vulnerabilities?
+
+Due to the sensitive nature of security vulnerabilities, please report all potential vulnerabilities directly by following the steps outlined on the [SECURITY.md](https://github.com/opensearch-project/neural-search/blob/main/SECURITY.md) document.
+
+### Who should I contact if I have further questions?
+
+You can always file an issue for any question you have about the project.


### PR DESCRIPTION
### Description
Related to https://github.com/opensearch-project/k-NN/pull/1888 (markdown files are the same). We want to setup a bi-weekly traige meeting covering k-NN and neural search. We are proposing combining repos for now just because there is a lot of overlap between maintainers of projects. Feedback is welcome. Whatever process decided upon is not set in stone forever and can be adjusted as we go.

Highlights:
- Hosted by Amazon Chime
- ~8 am PST or 4 pm (16:00)~ 5 pm (17:00) pst bi-weekly on Tuesdays - would like feedback on this
- scope: neural-search and k-NN

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
