### PR TITLE
Removing code to cut search results of hybrid search in the priority queue

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
@@ -172,11 +172,6 @@ public class HybridTopScoreDocCollector implements HybridSearchCollector {
 
         int size = howMany - start;
         ScoreDoc[] results = new ScoreDoc[size];
-        // pq's pop() returns the 'least' element in the queue, therefore need
-        // to discard the first ones, until we reach the requested range.
-        for (int i = pq.size() - start - size; i > 0; i--) {
-            pq.pop();
-        }
 
         // Get the requested results from pq.
         populateResults(results, size, pq);

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridAggregationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridAggregationProcessor.java
@@ -32,10 +32,6 @@ public class HybridAggregationProcessor implements AggregationProcessor {
         delegateAggsProcessor.preProcess(context);
 
         if (isHybridQuery(context.query(), context)) {
-            // TODO remove this check after following issue https://github.com/opensearch-project/neural-search/issues/280 gets resolved.
-            if (context.from() != 0) {
-                throw new IllegalArgumentException("In the current OpenSearch version pagination is not supported with hybrid query");
-            }
             // adding collector manager for hybrid query
             CollectorManager collectorManager;
             try {

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridAggregationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridAggregationProcessor.java
@@ -32,6 +32,9 @@ public class HybridAggregationProcessor implements AggregationProcessor {
         delegateAggsProcessor.preProcess(context);
 
         if (isHybridQuery(context.query(), context)) {
+            if (context.from() != 0) {
+                throw new IllegalArgumentException("In the current OpenSearch version pagination is not supported with hybrid query");
+            }
             // adding collector manager for hybrid query
             CollectorManager collectorManager;
             try {

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridAggregationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridAggregationProcessor.java
@@ -32,6 +32,7 @@ public class HybridAggregationProcessor implements AggregationProcessor {
         delegateAggsProcessor.preProcess(context);
 
         if (isHybridQuery(context.query(), context)) {
+            // TODO remove this check after following issue https://github.com/opensearch-project/neural-search/issues/280 gets resolved.
             if (context.from() != 0) {
                 throw new IllegalArgumentException("In the current OpenSearch version pagination is not supported with hybrid query");
             }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -60,6 +60,10 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
             validateQuery(searchContext, query);
             return super.searchWith(searchContext, searcher, query, collectors, hasFilterCollector, hasTimeout);
         } else {
+            // TODO remove this check after following issue https://github.com/opensearch-project/neural-search/issues/280 gets resolved.
+            if (searchContext.from() != 0) {
+                throw new IllegalArgumentException("In the current OpenSearch version pagination is not supported with hybrid query");
+            }
             Query hybridQuery = extractHybridQuery(searchContext, query);
             QueryPhaseSearcher queryPhaseSearcher = getQueryPhaseSearcher(searchContext);
             return queryPhaseSearcher.searchWith(searchContext, searcher, hybridQuery, collectors, hasFilterCollector, hasTimeout);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
@@ -215,7 +215,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                     rangeFilterQuery,
                     null,
                     false,
-                    null
+                    null,
+                    0
                 );
 
                 assertHitResultsFromQuery(1, searchResponseAsMap);
@@ -230,7 +231,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                     null,
                     null,
                     false,
-                    null
+                    null,
+                    0
                 );
                 assertHitResultsFromQuery(2, searchResponseAsMap);
             } else if (!isSingleShard && hasPostFilterQuery) {
@@ -244,7 +246,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                     rangeFilterQuery,
                     null,
                     false,
-                    null
+                    null,
+                    0
                 );
                 assertHitResultsFromQuery(2, searchResponseAsMap);
             } else {
@@ -258,7 +261,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                     null,
                     null,
                     false,
-                    null
+                    null,
+                    0
                 );
                 assertHitResultsFromQuery(3, searchResponseAsMap);
             }
@@ -319,7 +323,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                     rangeFilterQuery,
                     null,
                     false,
-                    null
+                    null,
+                    0
                 );
 
                 assertHitResultsFromQuery(1, searchResponseAsMap);
@@ -334,7 +339,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                     null,
                     null,
                     false,
-                    null
+                    null,
+                    0
                 );
                 assertHitResultsFromQuery(2, searchResponseAsMap);
             } else if (!isSingleShard && hasPostFilterQuery) {
@@ -348,7 +354,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                     rangeFilterQuery,
                     null,
                     false,
-                    null
+                    null,
+                    0
                 );
                 assertHitResultsFromQuery(4, searchResponseAsMap);
             } else {
@@ -362,7 +369,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                     null,
                     null,
                     false,
-                    null
+                    null,
+                    0
                 );
                 assertHitResultsFromQuery(3, searchResponseAsMap);
             }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryPostFilterIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryPostFilterIT.java
@@ -177,7 +177,8 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
             postFilterQuery,
             null,
             false,
-            null
+            null,
+            0
         );
         assertHybridQueryResults(searchResponseAsMap, 1, 0, GTE_OF_RANGE_IN_POST_FILTER_QUERY, LTE_OF_RANGE_IN_POST_FILTER_QUERY);
     }
@@ -262,7 +263,8 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
             postFilterQuery,
             null,
             false,
-            null
+            null,
+            0
         );
         assertHybridQueryResults(searchResponseAsMap, 2, 1, GTE_OF_RANGE_IN_POST_FILTER_QUERY, LTE_OF_RANGE_IN_POST_FILTER_QUERY);
         // Case 2 A Query with a combination of hybrid query (Match Query, Term Query, Range Query), aggregation (Average stock price
@@ -278,7 +280,8 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
             postFilterQuery,
             null,
             false,
-            null
+            null,
+            0
         );
         assertHybridQueryResults(searchResponseAsMap, 2, 1, GTE_OF_RANGE_IN_POST_FILTER_QUERY, LTE_OF_RANGE_IN_POST_FILTER_QUERY);
         Map<String, Object> aggregations = getAggregations(searchResponseAsMap);
@@ -303,7 +306,8 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
             postFilterQuery,
             null,
             false,
-            null
+            null,
+            0
         );
         assertHybridQueryResults(searchResponseAsMap, 0, 0, GTE_OF_RANGE_IN_POST_FILTER_QUERY, LTE_OF_RANGE_IN_POST_FILTER_QUERY);
         // Case 4 A Query with a combination of hybrid query (Match Query, Range Query) and a post filter query (Bool Query with a should
@@ -324,7 +328,8 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
             postFilterQuery,
             null,
             false,
-            null
+            null,
+            0
         );
         assertHybridQueryResults(searchResponseAsMap, 0, 0, GTE_OF_RANGE_IN_POST_FILTER_QUERY, LTE_OF_RANGE_IN_POST_FILTER_QUERY);
     }
@@ -382,7 +387,8 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
             postFilterQuery,
             null,
             false,
-            null
+            null,
+            0
         );
         assertHybridQueryResults(searchResponseAsMap, 4, 3, GTE_OF_RANGE_IN_POST_FILTER_QUERY, LTE_OF_RANGE_IN_POST_FILTER_QUERY);
 
@@ -399,7 +405,8 @@ public class HybridQueryPostFilterIT extends BaseNeuralSearchIT {
             postFilterQuery,
             null,
             false,
-            null
+            null,
+            0
         );
         assertHybridQueryResults(searchResponseAsMap, 0, 0, GTE_OF_RANGE_IN_POST_FILTER_QUERY, LTE_OF_RANGE_IN_POST_FILTER_QUERY);
     }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
@@ -139,7 +139,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
             null,
             createSortBuilders(fieldSortOrderMap, false),
             false,
-            null
+            null,
+            0
         );
         List<Map<String, Object>> nestedHits = validateHitsCountAndFetchNestedHits(searchResponseAsMap, 6, 6);
         assertStockValueWithSortOrderInHybridQueryResults(nestedHits, SortOrder.DESC, LARGEST_STOCK_VALUE_IN_QUERY_RESULT, true, true);
@@ -168,7 +169,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
             null,
             createSortBuilders(fieldSortOrderMap, false),
             false,
-            null
+            null,
+            0
         );
         List<Map<String, Object>> nestedHits = validateHitsCountAndFetchNestedHits(searchResponseAsMap, 6, 6);
         assertStockValueWithSortOrderInHybridQueryResults(nestedHits, SortOrder.DESC, LARGEST_STOCK_VALUE_IN_QUERY_RESULT, true, false);
@@ -200,7 +202,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
                     null,
                     createSortBuilders(fieldSortOrderMap, false),
                     true,
-                    null
+                    null,
+                    0
                 )
             );
         } finally {
@@ -234,7 +237,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
                     null,
                     createSortBuilders(fieldSortOrderMap, false),
                     true,
-                    null
+                    null,
+                    0
                 )
             );
         } finally {
@@ -312,7 +316,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
             null,
             createSortBuilders(fieldSortOrderMap, false),
             false,
-            searchAfter
+            searchAfter,
+            0
         );
         List<Map<String, Object>> nestedHits = validateHitsCountAndFetchNestedHits(searchResponseAsMap, 3, 6);
         assertStockValueWithSortOrderInHybridQueryResults(
@@ -348,7 +353,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
             null,
             createSortBuilders(fieldSortOrderMap, false),
             false,
-            searchAfter
+            searchAfter,
+            0
         );
         List<Map<String, Object>> nestedHits = validateHitsCountAndFetchNestedHits(searchResponseAsMap, 5, 6);
         assertStockValueWithSortOrderInHybridQueryResults(
@@ -381,7 +387,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
             null,
             createSortBuilders(fieldSortOrderMap, false),
             false,
-            null
+            null,
+            0
         );
         List<Map<String, Object>> nestedHits = validateHitsCountAndFetchNestedHits(searchResponseAsMap, 6, 6);
         assertScoreWithSortOrderInHybridQueryResults(nestedHits, SortOrder.DESC, 1.0);
@@ -415,7 +422,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
                     null,
                     createSortBuilders(fieldSortOrderMap, false),
                     true,
-                    searchAfter
+                    searchAfter,
+                    0
                 )
             );
         } finally {
@@ -450,7 +458,8 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
                     null,
                     createSortBuilders(fieldSortOrderMap, false),
                     true,
-                    searchAfter
+                    searchAfter,
+                    0
                 )
             );
         } finally {

--- a/src/test/java/org/opensearch/neuralsearch/query/aggregation/MetricAggregationsWithHybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/aggregation/MetricAggregationsWithHybridQueryIT.java
@@ -424,7 +424,8 @@ public class MetricAggregationsWithHybridQueryIT extends BaseAggregationsWithHyb
                 rangeFilterQuery,
                 null,
                 false,
-                null
+                null,
+                0
             );
 
             Map<String, Object> aggregations = getAggregations(searchResponseAsMap);

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -528,7 +528,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         Map<String, String> requestParams,
         List<Object> aggs
     ) {
-        return search(index, queryBuilder, rescorer, resultSize, requestParams, aggs, null, null, false, null);
+        return search(index, queryBuilder, rescorer, resultSize, requestParams, aggs, null, null, false, null, 0);
     }
 
     @SneakyThrows
@@ -542,10 +542,11 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         QueryBuilder postFilterBuilder,
         List<SortBuilder<?>> sortBuilders,
         boolean trackScores,
-        List<Object> searchAfter
+        List<Object> searchAfter,
+        int from
     ) {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-
+        builder.field("from", from);
         if (queryBuilder != null) {
             builder.field("query");
             queryBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);


### PR DESCRIPTION
### Description
This PR removes the code where we cut the results of hybrid search while fetching topDocs(). Due to this piece of code the user gets a perception that pagination works in hybrid search however it does not. Therefore, to make cx experience better I am removing it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
