### PR TITLE
Fix neural search build & increment OS version to 2.17

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         java: [ 11, 17, 21 ]
         os: [ubuntu-latest,windows-latest]
-        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0"]
-        opensearch_version : [ "2.16.0-SNAPSHOT" ]
+        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0"]
+        opensearch_version : [ "2.17.0-SNAPSHOT" ]
 
     name: NeuralSearch Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -42,8 +42,8 @@ jobs:
       matrix:
         java: [ 11, 17, 21 ]
         os: [ubuntu-latest,windows-latest]
-        bwc_version: [ "2.11.0","2.12.0","2.13.0","2.14.0","2.15.0" ]
-        opensearch_version: [ "2.16.0-SNAPSHOT" ]
+        bwc_version: [ "2.11.0","2.12.0","2.13.0","2.14.0","2.15.0", "2.16.0" ]
+        opensearch_version: [ "2.17.0-SNAPSHOT" ]
 
     name: NeuralSearch Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -1,8 +1,8 @@
 <img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
 
-The maintainers of the k-NN/neural-search Repo's seek to promote an inclusive and engaged community of contributors. In 
-order to facilitate this, bi-weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to 
-contribute, discuss an issue, or learn more about the project. To learn more about contributing to the 
+The maintainers of the k-NN/neural-search Repo's seek to promote an inclusive and engaged community of contributors. In
+order to facilitate this, bi-weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to
+contribute, discuss an issue, or learn more about the project. To learn more about contributing to the
 k-NN/neural-search Repo visit the [Contributing](./CONTRIBUTING.md) documentation.
 
 ### Do I need to attend for my issue to be addressed/triaged?
@@ -11,19 +11,19 @@ Attendance is not required for your issue to be triaged or addressed. All new is
 
 ### What happens if my issue does not get covered this time?
 
-Each meeting we seek to  address all new issues. However, should we run out of time before your issue is discussed, you 
+Each meeting we seek to  address all new issues. However, should we run out of time before your issue is discussed, you
 are always welcome to attend the next meeting or to follow up on the issue post itself.
 
 ### How do I join the Backlog & Triage meeting?
 
-Meetings are hosted regularly at 5 PM Pacific Time on Tuesdays bi-weekly and can be joined via the links posted on the 
-[OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events. The event will be titled 
+Meetings are hosted regularly at 5 PM Pacific Time on Tuesdays bi-weekly and can be joined via the links posted on the
+[OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events. The event will be titled
 `Development Backlog & Triage Meeting - k-NN/neural-search`.
 
-After joining the Chime meeting, you can enable your video / voice to join the discussion.  If you do not have a webcam 
+After joining the Chime meeting, you can enable your video / voice to join the discussion.  If you do not have a webcam
 or microphone available, you can still join in via the text chat.
 
-If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to 
+If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to
 everyone in the meeting.
 
 ### Is there an agenda for each week?
@@ -48,13 +48,13 @@ No, all are welcome and encouraged to attend. Attending the Backlog & Triage mee
 
 ### What if I have an issue that is almost a duplicate, should I open a new one to be triaged?
 
-You can always open an issue including one that you think may be a duplicate. However, in cases where you believe there 
-is an important distinction to be made between an existing issue and your newly created one, you are encouraged to 
+You can always open an issue including one that you think may be a duplicate. However, in cases where you believe there
+is an important distinction to be made between an existing issue and your newly created one, you are encouraged to
 attend the triaging meeting to explain.
 
 ### What if I have follow-up questions on an issue?
 
-If you have an existing issue you would like to discuss, you can always comment on the issue itself. Alternatively, you 
+If you have an existing issue you would like to discuss, you can always comment on the issue itself. Alternatively, you
 are welcome to come to the triage meeting to discuss.
 
 ### Is this meeting a good place to get help setting up k-NN/neural-search features on my OpenSearch instance?

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ import java.util.concurrent.Callable
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.16.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.17.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         version_tokens = opensearch_version.tokenize('-')

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=2.16.0-SNAPSHOT
-systemProp.bwc.bundle.version=2.15.0
+systemProp.bwc.version=2.17.0-SNAPSHOT
+systemProp.bwc.bundle.version=2.16.0
 
 # For fixing Spotless check with Java 17
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.apache.logging.log4j.util.Strings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -237,7 +236,7 @@ public class MLCommonsClientAccessor {
             final List<ModelTensor> tensorsList = tensors.getMlModelTensors();
             for (final ModelTensor tensor : tensorsList) {
                 if (Objects.isNull(tensor.getData())) {
-                    if (Objects.nonNull(tensor.getDataAsMap()) && Strings.isNotBlank((String) tensor.getDataAsMap().get("message"))) {
+                    if (Objects.nonNull(tensor.getDataAsMap()) && checkIfStringIsNotBlank((String) tensor.getDataAsMap().get("message"))) {
                         String errorFromModel = (String) tensor.getDataAsMap().get("message");
                         throw new IllegalStateException(
                             String.format(Locale.ROOT, "%s: %s", EXCEPTION_MESSAGE_PREFIX_MODEL_PREDICT_FAILED, errorFromModel)
@@ -310,5 +309,19 @@ public class MLCommonsClientAccessor {
         final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         final MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
         return new MLInput(FunctionName.TEXT_EMBEDDING, null, inputDataset);
+    }
+
+    private boolean checkIfStringIsNotBlank(String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        // returns true when the String even contain a single character which is not a white space.
+        for (int i = 0; i < value.length(); ++i) {
+            char c = value.charAt(i);
+            if (!Character.isWhitespace(c)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.FunctionName;
@@ -236,7 +237,7 @@ public class MLCommonsClientAccessor {
             final List<ModelTensor> tensorsList = tensors.getMlModelTensors();
             for (final ModelTensor tensor : tensorsList) {
                 if (Objects.isNull(tensor.getData())) {
-                    if (Objects.nonNull(tensor.getDataAsMap()) && checkIfStringIsNotBlank((String) tensor.getDataAsMap().get("message"))) {
+                    if (Objects.nonNull(tensor.getDataAsMap()) && Strings.hasText((String) tensor.getDataAsMap().get("message"))) {
                         String errorFromModel = (String) tensor.getDataAsMap().get("message");
                         throw new IllegalStateException(
                             String.format(Locale.ROOT, "%s: %s", EXCEPTION_MESSAGE_PREFIX_MODEL_PREDICT_FAILED, errorFromModel)
@@ -309,19 +310,5 @@ public class MLCommonsClientAccessor {
         final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         final MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
         return new MLInput(FunctionName.TEXT_EMBEDDING, null, inputDataset);
-    }
-
-    private boolean checkIfStringIsNotBlank(String value) {
-        if (value == null || value.isEmpty()) {
-            return false;
-        }
-        // returns true when the String even contain a single character which is not a white space.
-        for (int i = 0; i < value.length(); ++i) {
-            char c = value.charAt(i);
-            if (!Character.isWhitespace(c)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/ValidateDependentPluginInstallationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/ValidateDependentPluginInstallationIT.java
@@ -75,7 +75,8 @@ public class ValidateDependentPluginInstallationIT extends OpenSearchSecureRestT
             .endObject()
             .toString();
         mapping = mapping.substring(1, mapping.length() - 1);
-        createIndex(KNN_INDEX_NAME, Settings.EMPTY, mapping);
+        Settings settings = Settings.builder().put("index.knn", true).build();
+        createIndex(KNN_INDEX_NAME, settings, mapping);
     }
 
     private Set<String> getAllInstalledPlugins() throws IOException {

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -62,6 +62,8 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.SearchOperationListener;
+import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
@@ -93,8 +95,10 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         HybridQueryPhaseSearcher hybridQueryPhaseSearcher = spy(new HybridQueryPhaseSearcher());
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+        KNNMappingConfig mockKNNMappingConfig = mock(KNNMappingConfig.class);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(mockKNNMappingConfig);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
-        when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockKNNVectorField.getKnnMappingConfig().getDimension()).thenReturn(4);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
         MapperService mapperService = createMapperService();
         TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) mapperService.fieldType(TEXT_FIELD_NAME);
@@ -138,6 +142,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         when(searchContext.mapperService()).thenReturn(mapperService);
@@ -209,6 +214,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.queryResult()).thenReturn(new QuerySearchResult());
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
@@ -280,6 +286,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         QuerySearchResult querySearchResult = new QuerySearchResult();
         when(searchContext.queryResult()).thenReturn(querySearchResult);
@@ -366,6 +373,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         when(searchContext.mapperService()).thenReturn(mapperService);
@@ -452,6 +460,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         when(searchContext.mapperService()).thenReturn(mapperService);
@@ -676,6 +685,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         when(searchContext.mapperService()).thenReturn(mapperService);
@@ -766,6 +776,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         when(searchContext.mapperService()).thenReturn(mapperService);
@@ -816,8 +827,10 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         HybridQueryPhaseSearcher hybridQueryPhaseSearcher = spy(new HybridQueryPhaseSearcher());
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+        KNNMappingConfig mockKNNMappingConfig = mock(KNNMappingConfig.class);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(mockKNNMappingConfig);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
-        when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockKNNVectorField.getKnnMappingConfig().getDimension()).thenReturn(4);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
         MapperService mapperService = createMapperService();
         TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) mapperService.fieldType(TEXT_FIELD_NAME);
@@ -861,6 +874,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         when(searchContext.mapperService()).thenReturn(mapperService);
@@ -954,6 +968,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(searchContext.searcher()).thenReturn(contextIndexSearcher);
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
         when(searchContext.indexShard()).thenReturn(indexShard);
         when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
         when(searchContext.mapperService()).thenReturn(mapperService);


### PR DESCRIPTION
### Description
The PR is  backporting changes made in the following PR https://github.com/opensearch-project/neural-search/pull/868. 
Moreover, this PR also contains changes to increment OS version to 2.17 on branch 2.x. Additionally, it also updates BWC version to 2.17 in github workflows.

Also we have removed org.apache.logging.log4j.util.Strings from MLCommonsClientAccessor.java due to following campaign made in opensearch core. https://github.com/opensearch-project/OpenSearch/pull/15238
