### PR TITLE
Fix: nested neural_sparse search throws error if model_id not supplied and default_model_id is configured

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -376,13 +376,21 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
     }
 
     private static void validateForRewrite(String queryText, String modelId) {
-        if (StringUtils.isBlank(queryText) || StringUtils.isBlank(modelId)) {
+        if (StringUtils.isBlank(modelId) && !isClusterOnOrAfterMinReqVersionForDefaultModelIdSupport()) {
             throw new IllegalArgumentException(
                 String.format(
                     Locale.ROOT,
-                    "%s and %s cannot be null",
-                    QUERY_TEXT_FIELD.getPreferredName(),
+                    "%s cannot be null",
                     MODEL_ID_FIELD.getPreferredName()
+                )
+            );
+        }
+        if (StringUtils.isBlank(queryText)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "%s cannot be null",
+                    QUERY_TEXT_FIELD.getPreferredName()
                 )
             );
         }


### PR DESCRIPTION
### Description
Adds a conditional for default model id support when validating model id presence in NeuralSparseQueryBuilder. This will prevent the `query_text and model_id cannot be null` error. Also splits up the errors to make it more clear which is null.

### Related Issues
Resolves #871 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
