### PR TITLE
Fixed merge logic in hybrid query for multiple shards case

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
@@ -55,8 +55,11 @@ class TopDocsMerger {
      * @return merged TopDocsAndMaxScore object
      */
     public TopDocsAndMaxScore merge(final TopDocsAndMaxScore source, final TopDocsAndMaxScore newTopDocs) {
-        if (Objects.isNull(newTopDocs) || Objects.isNull(newTopDocs.topDocs) || newTopDocs.topDocs.totalHits.value == 0) {
+        if (isEmpty(newTopDocs)) {
             return source;
+        }
+        if (isEmpty(source)) {
+            return newTopDocs;
         }
         TotalHits mergedTotalHits = getMergedTotalHits(source, newTopDocs);
         TopDocsAndMaxScore result = new TopDocsAndMaxScore(
@@ -64,6 +67,20 @@ class TopDocsMerger {
             Math.max(source.maxScore, newTopDocs.maxScore)
         );
         return result;
+    }
+
+    /**
+     * Checks if TopDocsAndMaxScore is null, has no top docs or zero total hits
+     * @param topDocsAndMaxScore
+     * @return
+     */
+    private static boolean isEmpty(final TopDocsAndMaxScore topDocsAndMaxScore) {
+        if (Objects.isNull(topDocsAndMaxScore)
+            || Objects.isNull(topDocsAndMaxScore.topDocs)
+            || topDocsAndMaxScore.topDocs.totalHits.value == 0) {
+            return true;
+        }
+        return false;
     }
 
     private TotalHits getMergedTotalHits(final TopDocsAndMaxScore source, final TopDocsAndMaxScore newTopDocs) {


### PR DESCRIPTION
### Description
Fix for scenario in hybrid query search when:
- concurrent segment search is enabled
- one of the shards does not have any results
- such shard appeared first in the sequence of multiple "merge shards results" calls

It's a gap in existing code, we only handle scenarios when merged result object is not empty and we're merging it with an empty result object.

The issue isn't trivial to repro because the sequence in which segment/shard results are passed to a merger isn't guaranteed, and we need to ingest documents and run search multiple times. Credit for providing a tool to replicate the issue goes to @eemmiirr, I used his script https://github.com/eemmiirr/opensearch-concurrent-segment-search-bug. 

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/875

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
