### PR TITLE
Increase timeout for cluster status call in BWC

### DIFF
--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1194,6 +1194,8 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         Request waitForGreen = new Request("GET", "/_cluster/health");
         waitForGreen.addParameter("wait_for_nodes", numOfNodes);
         waitForGreen.addParameter("wait_for_status", "green");
+        waitForGreen.addParameter("cluster_manager_timeout", "60s");
+        waitForGreen.addParameter("timeout", "60s");
         client().performRequest(waitForGreen);
     }
 


### PR DESCRIPTION
### Description
Increase timeout for wait_for_green_status call for BWC rolling upgrade tests. Increase from default 30s to 60s.

### Related Issues
Flaky BWC tests in CI. Caused errors like here: https://github.com/opensearch-project/neural-search/actions/runs/10713784342/job/29706410196?pr=886

```
org.opensearch.client.ResponseException: method [GET], host [http://127.0.0.1:32775/], URI [/_cluster/health?wait_for_nodes=3&wait_for_status=green], status line [HTTP/1.1 408 Request Timeout]
    {"cluster_name":"neuralSearchBwcCluster-rolling","status":"yellow","timed_out":true,"number_of_nodes":3,"number_of_data_nodes":3,"discovered_master":true,"discovered_cluster_manager":true,"active_primary_shards":25,"active_shards":49,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":1,"delayed_unassigned_shards":1,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":98.0}
        at __randomizedtesting.SeedInfo.seed([12431F7E983230AD:BBF02D70ED1EF549]:0)
        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:479)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:371)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:346)
        at app//org.opensearch.neuralsearch.BaseNeuralSearchIT.waitForClusterHealthGreen(BaseNeuralSearchIT.java:1197)
        at app//org.opensearch.neuralsearch.bwc.HybridSearchIT.testNormalizationProcessor_whenIndexWithMultipleShards_E2EFlow(HybridSearchIT.java:40)
``` 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
