### PR TITLE
Added rescorer in hybrid query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 - Implement `ignore_missing` field in text chunking processors ([#907](https://github.com/opensearch-project/neural-search/pull/907))
+- Added rescorer in hybrid query ([#917](https://github.com/opensearch-project/neural-search/pull/917))
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -66,7 +66,9 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
             }
             Query hybridQuery = extractHybridQuery(searchContext, query);
             QueryPhaseSearcher queryPhaseSearcher = getQueryPhaseSearcher(searchContext);
-            return queryPhaseSearcher.searchWith(searchContext, searcher, hybridQuery, collectors, hasFilterCollector, hasTimeout);
+            queryPhaseSearcher.searchWith(searchContext, searcher, hybridQuery, collectors, hasFilterCollector, hasTimeout);
+            // we decide on rescore later in collector manager
+            return false;
         }
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/search/query/exception/HybridSearchRescoreQueryException.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/exception/HybridSearchRescoreQueryException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.query.exception;
+
+import org.opensearch.OpenSearchException;
+
+/**
+ * Exception thrown when there is an issue with the hybrid search rescore query.
+ */
+public class HybridSearchRescoreQueryException extends OpenSearchException {
+
+    public HybridSearchRescoreQueryException(Throwable cause) {
+        super("rescore failed for hybrid query", cause);
+    }
+}


### PR DESCRIPTION
### Description
Enable rescore functionality in hybrid query. Currently `rescore` clause in ignored and plain results of hybrid query are returned. Following is example of query with rescore clause.

Logic will be similar to one for traditional queries: rescore query will be applied to search hits returned by sub-queries, based on match/no match scores and final order of documents will be adjusted. 

To implementing this we're using custom method to call the rescore. In QueryPhaseSearch we always return `rescore == false`, then we do actual check (rescore/not rescore) in the hybrid collector manager. We do the check for rescore clause at the shard level, before individual sub-query results are merged into a single object. That allows to minimize number of changes in existing logic for score normalization.

Following diagram shows flow that we introduced with the PR:

![Rescore - flow diagram new](https://github.com/user-attachments/assets/60547200-c8aa-4c94-acb9-31bbebe53e3d)

For comparison following diagram shows flow for today's implementation

![Rescore - flow diagram existing](https://github.com/user-attachments/assets/f7c9ac61-8c73-4dbf-9bb3-a4d5f008b687)

Example of rescore usage:

Query with rescore 

```
{
    "query": {
        "hybrid": {
            "queries": [
                {
                    "knn": {
                        "vector": {
                            "vector": [
                                4.2,
                                5.0,
                                8.5
                            ],
                            "k": 10
                        }
                    }
                },
                {
                    "range": {
                        "field1": {
                            "gte": 1,
                            "lte": 60
                        }
                    }
                }
            ]
        }
    },
    "rescore": [
        {
            "query": {
                "rescore_query": {
                    "range": {
                        "field1": {
                            "gte": 1,
                            "lte": 20
                        }
                    }
                },
                "score_mode": "total",
                "query_weight": 0.9,
                "rescore_query_weight": 1.2
            },
            "window_size": 10
        }
    ]
}
```

Response with implemented rescore from this PR, where documents with `field` in range of [1..20] are boosted

```
{
    "took": 4,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 3,
            "relation": "eq"
        },
        "max_score": 0.6695955,
        "hits": [
            {
                "_index": "index-test",
                "_id": "BhGESpIB67ctKZAvyp6_",
                "_score": 0.6695955,
                "_source": {
                    "field1": 2,
                    "vector": [
                        0.4,
                        0.5,
                        0.2
                    ],
                    "title": "basic"
                }
            },
            {
                "_index": "index-test",
                "_id": "BxGESpIB67ctKZAv057_",
                "_score": 0.6695361,
                "_source": {
                    "field1": 10,
                    "vector": [
                        0.2,
                        0.2,
                        0.3
                    ],
                    "title": "java"
                }
            },
            {
                "_index": "index-test",
                "_id": "CBGESpIB67ctKZAv3p5K",
                "_score": 0.3199462,
                "_source": {
                    "field1": 50,
                    "vector": [
                        4.2,
                        5.5,
                        8.9
                    ]
                }
            }
        ]
    }
}
```

same query before this PR or without rescore gives following response. Note the document with "field1" == 50, it has the highest score, which is the raw score after normalization.

```
{
    "took": 6,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 3,
            "relation": "eq"
        },
        "max_score": 0.7885865,
        "hits": [
            {
                "_index": "index-test",
                "_id": "CBGESpIB67ctKZAv3p5K",
                "_score": 0.7885865,
                "_source": {
                    "field1": 50,
                    "vector": [
                        4.2,
                        5.5,
                        8.9
                    ]
                }
            },
            {
                "_index": "index-test",
                "_id": "BhGESpIB67ctKZAvyp6_",
                "_score": 0.2954152,
                "_source": {
                    "field1": 2,
                    "vector": [
                        0.4,
                        0.5,
                        0.2
                    ],
                    "title": "basic"
                }
            },
            {
                "_index": "index-test",
                "_id": "BxGESpIB67ctKZAv057_",
                "_score": 0.29524556,
                "_source": {
                    "field1": 10,
                    "vector": [
                        0.2,
                        0.2,
                        0.3
                    ],
                    "title": "java"
                }
            }
        ]
    }
}
```

Few important notes regarding new logic: 
-  Scores will be scaled as per rules of normalization/combination techniques, typically in range [0, 1.0]. This is because  normalization process will still be executed after rescore logic is applied.

- Rescore doesn't work with sorting, this is in parity with same behavior for traditional query. 

### Related Issues
https://github.com/opensearch-project/neural-search/issues/914

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
