### PR TITLE
[Backport 2.x] Increment BWC version to 2.18.0-SNAPSHOT

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         java: [ 11, 17, 21 ]
         os: [ubuntu-latest,windows-latest]
-        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0"]
-        opensearch_version : [ "2.17.0-SNAPSHOT" ]
+        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0"]
+        opensearch_version : [ "2.18.0-SNAPSHOT" ]
 
     name: NeuralSearch Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -42,8 +42,8 @@ jobs:
       matrix:
         java: [ 11, 17, 21 ]
         os: [ubuntu-latest,windows-latest]
-        bwc_version: [ "2.11.0","2.12.0","2.13.0","2.14.0","2.15.0", "2.16.0" ]
-        opensearch_version: [ "2.17.0-SNAPSHOT" ]
+        bwc_version: [ "2.11.0","2.12.0","2.13.0","2.14.0","2.15.0", "2.16.0", "2.17.0" ]
+        opensearch_version: [ "2.18.0-SNAPSHOT" ]
 
     name: NeuralSearch Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ import java.util.concurrent.Callable
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.17.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.18.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         version_tokens = opensearch_version.tokenize('-')

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=2.17.0-SNAPSHOT
-systemProp.bwc.bundle.version=2.16.0
+systemProp.bwc.version=2.18.0-SNAPSHOT
+systemProp.bwc.bundle.version=2.17.0
 
 # For fixing Spotless check with Java 17
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION
Manually backport https://github.com/opensearch-project/neural-search/commit/d03e69bb0210b864cbac7da4956e72330a5a359a from https://github.com/opensearch-project/neural-search/pull/916
