### PR TITLE
Fixed unit test for neural query after recent knn change in rescore context

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -16,6 +16,7 @@ import static org.opensearch.knn.index.query.KNNQueryBuilder.MAX_DISTANCE_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.MIN_SCORE_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.RESCORE_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.RESCORE_OVERSAMPLE_FIELD;
+import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_FLOATS_ASSERTION;
 import static org.opensearch.neuralsearch.util.TestUtils.xContentBuilderToMap;
 import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.K_FIELD;
 import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.MODEL_ID_FIELD;
@@ -183,7 +184,11 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
         assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
         assertEquals(K, neuralQueryBuilder.k());
-        assertEquals(RescoreContext.getDefault(), neuralQueryBuilder.rescoreContext());
+        assertEquals(
+            RescoreContext.getDefault().getOversampleFactor(),
+            neuralQueryBuilder.rescoreContext().getOversampleFactor(),
+            DELTA_FOR_FLOATS_ASSERTION
+        );
         assertNull(neuralQueryBuilder.methodParameters());
     }
 

--- a/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
@@ -39,6 +39,7 @@ public class TestUtils {
 
     public static final String RELATION_EQUAL_TO = "eq";
     public static final float DELTA_FOR_SCORE_ASSERTION = 0.001f;
+    public static final float DELTA_FOR_FLOATS_ASSERTION = 0.001f;
     public static final String RESTART_UPGRADE_OLD_CLUSTER = "tests.is_old_cluster";
     public static final String BWC_VERSION = "tests.plugin_bwc_version";
     public static final String NEURAL_SEARCH_BWC_PREFIX = "neuralsearch-bwc-";


### PR DESCRIPTION
Fixed unit test for neural query after recent push in k-NN https://github.com/opensearch-project/k-NN/pull/2183. In that PR k-NN team has added a field `userProvided` to RescoreContext, and by default it's `false`, but anything user provided is `true`. Because of this the `equals` check in RescoreContext class start failing, and we need to compare only on certain fields.

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
