### PR TITLE
Fixed incorrect document order for nested aggregations in hybrid query

### DIFF
--- a/release-notes/opensearch-neural-search.release-notes-2.18.0.0.md
+++ b/release-notes/opensearch-neural-search.release-notes-2.18.0.0.md
@@ -5,7 +5,8 @@ Compatible with OpenSearch 2.18.0
 
 ### Features
 - Introduces ByFieldRerankProcessor for second level reranking on documents ([#932](https://github.com/opensearch-project/neural-search/pull/932))
-
+### Bug Fixes
+- Fixed incorrect document order for nested aggregations in hybrid query ([#956](https://github.com/opensearch-project/neural-search/pull/956))
 ### Enhancements
 - Implement `ignore_missing` field in text chunking processors ([#907](https://github.com/opensearch-project/neural-search/pull/907))
 - Added rescorer in hybrid query ([#917](https://github.com/opensearch-project/neural-search/pull/917))

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
@@ -97,8 +97,13 @@ public final class HybridQueryScorer extends Scorer {
      */
     @Override
     public float score() throws IOException {
+        return score(getSubMatches());
+    }
+
+    private float score(DisiWrapper topList) throws IOException {
         float totalScore = 0.0f;
-        for (DisiWrapper disiWrapper : subScorersPQ) {
+        for (DisiWrapper disiWrapper = topList; disiWrapper != null; disiWrapper = disiWrapper.next) {
+            // check if this doc has match in the subQuery. If not, add score as 0.0 and continue
             if (disiWrapper.scorer.docID() == DocIdSetIterator.NO_MORE_DOCS) {
                 continue;
             }

--- a/src/test/resources/processor/ingest_bulk.json
+++ b/src/test/resources/processor/ingest_bulk.json
@@ -1,0 +1,184 @@
+{"index": {"_index": "{indexname}"}}
+{"id": "s9", "passage_text": "Stenocarpus mynpachtbrief", "imdb": 7.7, "actor": "jackie"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s10", "passage_text": "weirangle meritorious", "imdb": 2.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s11", "passage_text": "clotbur plagiostome", "imdb": 2.5, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s12", "passage_text": "guider perityphlic", "imdb": 8.0, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s13", "passage_text": "amidoazobenzene bibliopegy nymphosis", "imdb": 2.5, "actor": "sanjay"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s14", "passage_text": "sepiarian antipode unpadded", "imdb": 9.8, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s15", "passage_text": "portraiture hemihyperidrosis mongery", "imdb": 8.0, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s16", "passage_text": "pseudoasymmetrical glucolipide nonangling", "imdb": 6.6, "actor": "abhishek"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s17", "passage_text": "supraseptal snitch", "imdb": 9.9, "actor": "ranveer"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s18", "passage_text": "ultragaseous factious", "imdb": 9.9, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s19", "passage_text": "shrewstruck redemptor uninquisitive", "imdb": 9.8, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s20", "passage_text": "superindifferent wet chontawood", "imdb": 9.9, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s21", "passage_text": "corporational harebrain", "imdb": 9.8, "actor": "ranveer"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s22", "passage_text": "aecial proscriptiveness pantometrical", "imdb": 9.8, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s23", "passage_text": "goodlike derived sorriness", "imdb": 6.6, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s24", "passage_text": "precognizant Albertina", "imdb": 9.9, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s25", "passage_text": "defoliated nominatively", "imdb": 9.8, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s26", "passage_text": "orthographist pseudoevangelical strideways", "imdb": 2.5, "actor": "jackie"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s27", "passage_text": "delayingly outbleat", "imdb": 8.0, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s28", "passage_text": "precongratulation phytovitellin", "imdb": 3.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s29", "passage_text": "turtledom illogic interchanger", "imdb": 7.7, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s30", "passage_text": "penetratingly Pyrrhonean pioneership", "imdb": 4.5, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s31", "passage_text": "uneuphemistical acclimatize unpinked", "imdb": 10.0, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s32", "passage_text": "supercentrifuge sheetflood fairyhood", "imdb": 9.9, "actor": "jackie"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s33", "passage_text": "uninheritable weetbird", "imdb": 9.8, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s34", "passage_text": "anelectrotonic Lewanna arsonium", "imdb": 6.6, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s35", "passage_text": "killeen laggen", "imdb": 9.9, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s36", "passage_text": "cyberneticist diffusate", "imdb": 2.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s37", "passage_text": "neuronal adephagia", "imdb": 9.8, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s38", "passage_text": "target crumby pipped", "imdb": 2.5, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s39", "passage_text": "Armoracia Dedanim walking", "imdb": 2.5, "actor": "jackie"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s40", "passage_text": "incrash untrainable", "imdb": 6.6, "actor": "ranveer"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s41", "passage_text": "scientician sweetfish trithiocarbonic", "imdb": 10.0, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s42", "passage_text": "gnarly studentlike notchwing", "imdb": 2.5, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s43", "passage_text": "Juha ambassage", "imdb": 9.8, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s44", "passage_text": "Skodaic shinbone", "imdb": 7.7, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s45", "passage_text": "parison Meibomia naturopathic", "imdb": 9.9, "actor": "sanjay"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s46", "passage_text": "rheologist heartener", "imdb": 2.5, "actor": "ranveer"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s47", "passage_text": "ungloved telford enfasten", "imdb": 8.0, "actor": "abhishek"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s48", "passage_text": "averruncation blotchy schreinerize", "imdb": 8.0, "actor": "abhishek"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s49", "passage_text": "graftdom joug unreared", "imdb": 6.6, "actor": "sanjay"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s50", "passage_text": "forfeit quercite Typhoean", "imdb": 10.0, "actor": "abhishek"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s51", "passage_text": "dimanganous sipunculoid", "imdb": 2.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s52", "passage_text": "subtotem aogiri", "imdb": 9.8, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s53", "passage_text": "stull outfast", "imdb": 7.7, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s54", "passage_text": "peership Marcionist", "imdb": 3.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s55", "passage_text": "blackish geissospermin phylarchical", "imdb": 2.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s56", "passage_text": "soapfish skinning stree", "imdb": 7.7, "actor": "sanjay"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s57", "passage_text": "agamogony aeonist protractive", "imdb": 9.9, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s58", "passage_text": "descriptory labral", "imdb": 4.5, "actor": "abhishek"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s59", "passage_text": "coincline phagedenic", "imdb": 2.5, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s60", "passage_text": "perform meadowsweet outlighten", "imdb": 9.8, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s61", "passage_text": "sublevel subcommended", "imdb": 8.0, "actor": "jackie"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s62", "passage_text": "sundra hernanesell interspersal", "imdb": 7.7, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s63", "passage_text": "Buphthalmum Pitcairnia", "imdb": 6.6, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s64", "passage_text": "rheumatismal sporoblast", "imdb": 9.9, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s65", "passage_text": "spahi arteriectopia suburbican", "imdb": 2.5, "actor": "abhishek"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s66", "passage_text": "municipalization unsympathy", "imdb": 8.0, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s67", "passage_text": "pyromucyl breislakite", "imdb": 2.5, "actor": "sanjay"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s68", "passage_text": "grandfer kimberlite coattail", "imdb": 10.0, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s69", "passage_text": "Almohades unchancellor cubitopalmar", "imdb": 2.5, "actor": "ranveer"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s70", "passage_text": "pierine outswift", "imdb": 9.8, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s71", "passage_text": "precompiler zirconic", "imdb": 3.0, "actor": "jackie"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s72", "passage_text": "idiotical endomesoderm", "imdb": 4.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s73", "passage_text": "unnonsensical chamois vanadous", "imdb": 3.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s74", "passage_text": "Myrmidon semiflashproof", "imdb": 8.0, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s75", "passage_text": "unapprehendable archheretic", "imdb": 6.6, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s76", "passage_text": "Christmasberry preactive", "imdb": 9.9, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s77", "passage_text": "naphthol Melanthium", "imdb": 7.7, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s78", "passage_text": "unifarious spodomantic birdberry", "imdb": 2.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s79", "passage_text": "saltativeness sammer", "imdb": 2.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s80", "passage_text": "nova hypophyseoprivous", "imdb": 7.7, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s81", "passage_text": "hysterogen warmheartedly preflagellate", "imdb": 10.0, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s82", "passage_text": "thruster Johannist", "imdb": 9.8, "actor": "jackie"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s83", "passage_text": "penetrably borsholder", "imdb": 6.6, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s84", "passage_text": "Anomalurus nihility forevermore", "imdb": 9.9, "actor": "abhishek"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s85", "passage_text": "nonsystematic nonimmigrant nonburnable", "imdb": 2.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s86", "passage_text": "valeraldehyde interpermeate", "imdb": 8.0, "actor": "sanjay"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s87", "passage_text": "noncretaceous Archegosaurus umbelliflorous", "imdb": 9.9, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s88", "passage_text": "chrysochlorous hobbledehoyism pycnite", "imdb": 7.7, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s89", "passage_text": "Puritanize egad unlanguaged", "imdb": 9.8, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s90", "passage_text": "tumasha ingulfment fensive", "imdb": 10.0, "actor": "jackie"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s91", "passage_text": "headmost nonability noreaster", "imdb": 4.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s92", "passage_text": "spikily sketchy", "imdb": 3.0, "actor": "ranveer"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s93", "passage_text": "bespecked pushmobile Melanconiales", "imdb": 3.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s94", "passage_text": "Tashnakist equimolar convincingness", "imdb": 9.8, "actor": "salman"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s95", "passage_text": "mountainy gausterer", "imdb": 4.5, "actor": "anil"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s96", "passage_text": "dorsoepitrochlear multimarble spheniscomorphic", "imdb": 8.0, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s97", "passage_text": "Fourierism frenum", "imdb": 6.6, "actor": "abhishek"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s98", "passage_text": "meroblastic gymnoceratous eventognathous", "imdb": 7.7, "actor": "ranbir"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s99", "passage_text": "purree operatee segregable", "imdb": 8.0, "actor": "sanjay"}
+{"index": {"_index": "{indexname}"}}
+{"id": "s100", "passage_text": "Garibaldian quickset", "imdb": 9.8, "actor": "jackie"}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -785,6 +786,39 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
     }
 
+    @SneakyThrows
+    protected void bulkIngest(final String ingestBulkPayload, final String pipeline) {
+        Map<String, String> params = new HashMap<>();
+        params.put("refresh", "true");
+        if (Objects.nonNull(pipeline)) {
+            params.put("pipeline", pipeline);
+        }
+        Response response = makeRequest(
+            client(),
+            "POST",
+            "_bulk",
+            params,
+            toHttpEntity(ingestBulkPayload),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+        );
+        Map<String, Object> map = XContentHelper.convertToMap(
+            XContentType.JSON.xContent(),
+            EntityUtils.toString(response.getEntity()),
+            false
+        );
+
+        int failedDocCount = 0;
+        for (Object item : ((List) map.get("items"))) {
+            Map<String, Map<String, Object>> itemMap = (Map<String, Map<String, Object>>) item;
+            if (itemMap.get("index").get("error") != null) {
+                failedDocCount++;
+            }
+        }
+        assertEquals(0, failedDocCount);
+
+        assertEquals("_bulk failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
     /**
      * Parse the first returned hit from a search response as a map
      *
@@ -925,6 +959,27 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final List<String> dateFields,
         final int numberOfShards
     ) {
+        return buildIndexConfiguration(
+            knnFieldConfigs,
+            nestedFields,
+            intFields,
+            Collections.emptyList(),
+            keywordFields,
+            dateFields,
+            numberOfShards
+        );
+    }
+
+    @SneakyThrows
+    protected String buildIndexConfiguration(
+        final List<KNNFieldConfig> knnFieldConfigs,
+        final List<String> nestedFields,
+        final List<String> intFields,
+        final List<String> floatFields,
+        final List<String> keywordFields,
+        final List<String> dateFields,
+        final int numberOfShards
+    ) {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("settings")
@@ -962,6 +1017,10 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
         for (String intField : intFields) {
             xContentBuilder.startObject(intField).field("type", "integer").endObject();
+        }
+
+        for (String floatField : floatFields) {
+            xContentBuilder.startObject(floatField).field("type", "float").endObject();
         }
 
         for (String keywordField : keywordFields) {

--- a/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
@@ -304,6 +304,10 @@ public class TestUtils {
     }
 
     public static void assertHitResultsFromQuery(int expected, Map<String, Object> searchResponseAsMap) {
+        assertHitResultsFromQuery(expected, expected, searchResponseAsMap);
+    }
+
+    public static void assertHitResultsFromQuery(int expected, int expectedTotal, Map<String, Object> searchResponseAsMap) {
         assertEquals(expected, getHitCount(searchResponseAsMap));
 
         List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
@@ -321,7 +325,7 @@ public class TestUtils {
 
         Map<String, Object> total = getTotalHits(searchResponseAsMap);
         assertNotNull(total.get("value"));
-        assertEquals(expected, total.get("value"));
+        assertEquals(expectedTotal, total.get("value"));
         assertNotNull(total.get("relation"));
         assertEquals(RELATION_EQUAL_TO, total.get("relation"));
     }


### PR DESCRIPTION
### Description
Fixed logic for getting scorers for sub-queries of hybrid query. Today we're getting document ids and scorers from a pre-sorted collection of doc iterators, but that does not work for deeply nested aggregations because that order can change dynamically.

I have added an integ test for this scenario, it will for 2.15.

### Related Issues
https://github.com/opensearch-project/neural-search/issues/955

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
