### PR TITLE
Update maintainers.md by adding @ylwu-amzn and @jngz-es to emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,8 +12,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Charlie Yang            | [model-collapse](https://github.com/model-collapse)       | Amazon      |
 | Navneet Verma           | [navneet1v](https://github.com/navneet1v)                 | Amazon      |
 | Zan Niu                 | [zane-neo](https://github.com/zane-neo)                   | Amazon      |
-| Yaliang Wu              | [ylwu-amzn](https://github.com/ylwu-amzn)                 | Amazon      |
-| Jing Zhang              | [jngz-es](https://github.com/jngz-es)                     | Amazon      |
 | Heemin Kim              | [heemin32](https://github.com/heemin32)                   | Amazon      |
 | Junqiu Lei              | [junqiu-lei](https://github.com/junqiu-lei)               | Amazon      |
 | Martin Gaievski         | [martin-gaievski](https://github.com/martin-gaievski)     | Amazon      |
@@ -28,3 +26,5 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer              | GitHub ID                                   | Affiliation |
 |-------------------------|---------------------------------------------|-------------|
 | Junshen Wu              | [wujunshen](https://github.com/wujunshen)   | Independent |
+| Yaliang Wu              | [ylwu-amzn](https://github.com/ylwu-amzn)                 | Amazon      |
+| Jing Zhang              | [jngz-es](https://github.com/jngz-es)                     | Amazon      |


### PR DESCRIPTION
### Description
As per the issue [870](https://github.com/opensearch-project/neural-search/issues/870) updating permissions for @ylwu-amzn and @jngz-es. 
**Reference** 
https://github.com/opensearch-project/neural-search/issues/870#issuecomment-2384132555
https://github.com/opensearch-project/neural-search/issues/870#issuecomment-2438834808

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
[870](https://github.com/opensearch-project/neural-search/issues/870)
