### PR TITLE
Nominate Minal Shah (minalsha) as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @sean-zheng-amazon @model-collapse @zane-neo @ylwu-amzn @jngz-es @vibrantvarun @zhichao-aws @yuye-aws
+*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @sean-zheng-amazon @model-collapse @zane-neo @vibrantvarun @zhichao-aws @yuye-aws @minalsha

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,8 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Varun Jain              | [vibrantvarun](https://github.com/vibrantvarun)           | Amazon      |
 | Zhichao Geng            | [zhichao-aws](https://github.com/zhichao-aws)             | Amazon      |
 | Yuye Zhu                | [yuye-aws](https://github.com/yuye-aws)                   | Amazon      |
+| Minal Shah              | [minalsha](https://github.com/minalsha)                   | Amazon      |
+
 
 ## Emeritus
 


### PR DESCRIPTION
Nominating [minalsha](https://github.com/minalsha)  as maintainer of neural-search.
We have followed the OpenSearch process of becoming a maintainer and got an approval for minalsha from other maintainers.