### PR TITLE
Fixed flaky hybrid collector test

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -498,7 +498,7 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
     }
 
     @SneakyThrows
-    public void testReduceWithConcurrentSegmentSearch_whenMultipleCollectorsMatchedDocs_thenSuccessful() {
+    public void testReduceWithConcurrentSegmentSearch_whenMultipleCollectorsMatchedDocs_thenSuccessful() throws IOException {
         SearchContext searchContext = mock(SearchContext.class);
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
@@ -513,81 +513,48 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         when(searchContext.query()).thenReturn(hybridQueryWithTerm);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
         IndexReader indexReader = mock(IndexReader.class);
-        when(indexReader.numDocs()).thenReturn(2);
+        when(indexReader.numDocs()).thenReturn(3);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
-        when(searchContext.size()).thenReturn(1);
+        when(searchContext.size()).thenReturn(10);
 
         Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> classCollectorManagerMap = new HashMap<>();
         when(searchContext.queryCollectorManagers()).thenReturn(classCollectorManagerMap);
         when(searchContext.shouldUseConcurrentSearch()).thenReturn(true);
 
-        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
-
         Directory directory = newDirectory();
-        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
-        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
-        ft.setOmitNorms(random().nextBoolean());
+        ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(false);
         ft.freeze();
 
-        int docId1 = RandomizedTest.randomInt();
-        int docId2 = RandomizedTest.randomInt();
-        int docId3 = RandomizedTest.randomInt();
-
-        w.addDocument(getDocument(TEXT_FIELD_NAME, docId1, TEST_DOC_TEXT1, ft));
-        w.addDocument(getDocument(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, 1, TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, 2, TEST_DOC_TEXT2, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, 3, TEST_DOC_TEXT3, ft));
         w.flush();
         w.commit();
 
-        SearchContext searchContext2 = mock(SearchContext.class);
-
-        ContextIndexSearcher indexSearcher2 = mock(ContextIndexSearcher.class);
-        IndexReader indexReader2 = mock(IndexReader.class);
-        when(indexReader2.numDocs()).thenReturn(1);
-        when(indexSearcher2.getIndexReader()).thenReturn(indexReader);
-        when(searchContext2.searcher()).thenReturn(indexSearcher2);
-        when(searchContext2.size()).thenReturn(1);
-
-        when(searchContext2.queryCollectorManagers()).thenReturn(new HashMap<>());
-        when(searchContext2.shouldUseConcurrentSearch()).thenReturn(true);
-
-        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
-
-        Directory directory2 = newDirectory();
-        final IndexWriter w2 = new IndexWriter(directory2, newIndexWriterConfig(new MockAnalyzer(random())));
-        FieldType ft2 = new FieldType(TextField.TYPE_NOT_STORED);
-        ft2.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
-        ft2.setOmitNorms(random().nextBoolean());
-        ft2.freeze();
-
-        w2.addDocument(getDocument(TEXT_FIELD_NAME, docId2, TEST_DOC_TEXT2, ft));
-        w2.flush();
-        w2.commit();
-
         IndexReader reader = DirectoryReader.open(w);
         IndexSearcher searcher = newSearcher(reader);
-        IndexReader reader2 = DirectoryReader.open(w2);
-        IndexSearcher searcher2 = newSearcher(reader2);
 
         CollectorManager hybridCollectorManager = HybridCollectorManager.createHybridCollectorManager(searchContext);
         HybridTopScoreDocCollector collector1 = (HybridTopScoreDocCollector) hybridCollectorManager.newCollector();
         HybridTopScoreDocCollector collector2 = (HybridTopScoreDocCollector) hybridCollectorManager.newCollector();
 
-        Weight weight1 = new HybridQueryWeight(hybridQueryWithTerm, searcher, ScoreMode.TOP_SCORES, BoostingQueryBuilder.DEFAULT_BOOST);
-        Weight weight2 = new HybridQueryWeight(hybridQueryWithTerm, searcher2, ScoreMode.TOP_SCORES, BoostingQueryBuilder.DEFAULT_BOOST);
-        collector1.setWeight(weight1);
-        collector2.setWeight(weight2);
+        Weight weight = new HybridQueryWeight(hybridQueryWithTerm, searcher, ScoreMode.TOP_SCORES, BoostingQueryBuilder.DEFAULT_BOOST);
+        collector1.setWeight(weight);
+        collector2.setWeight(weight);
+
         LeafReaderContext leafReaderContext = searcher.getIndexReader().leaves().get(0);
         LeafCollector leafCollector1 = collector1.getLeafCollector(leafReaderContext);
+        LeafCollector leafCollector2 = collector2.getLeafCollector(leafReaderContext);
 
-        LeafReaderContext leafReaderContext2 = searcher2.getIndexReader().leaves().get(0);
-        LeafCollector leafCollector2 = collector2.getLeafCollector(leafReaderContext2);
-        BulkScorer scorer = weight1.bulkScorer(leafReaderContext);
+        BulkScorer scorer = weight.bulkScorer(leafReaderContext);
         scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector2, leafReaderContext.reader().getLiveDocs());
+
         leafCollector1.finish();
-        BulkScorer scorer2 = weight2.bulkScorer(leafReaderContext2);
-        scorer2.score(leafCollector2, leafReaderContext2.reader().getLiveDocs());
         leafCollector2.finish();
 
         Object results = hybridCollectorManager.reduce(List.of(collector1, collector2));
@@ -603,6 +570,7 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation);
         float maxScore = topDocsAndMaxScore.maxScore;
         assertTrue(maxScore > 0);
+
         ScoreDoc[] scoreDocs = topDocsAndMaxScore.topDocs.scoreDocs;
         assertEquals(6, scoreDocs.length);
         assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[0].score, DELTA_FOR_ASSERTION);
@@ -610,7 +578,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         assertTrue(scoreDocs[2].score > 0);
         assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[3].score, DELTA_FOR_ASSERTION);
         assertTrue(scoreDocs[4].score > 0);
-
         assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[5].score, DELTA_FOR_ASSERTION);
         // we have to assert that one of hits is max score because scores are generated for each run and order is not guaranteed
         assertTrue(Float.compare(scoreDocs[2].score, maxScore) == 0 || Float.compare(scoreDocs[4].score, maxScore) == 0);
@@ -618,9 +585,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         w.close();
         reader.close();
         directory.close();
-        w2.close();
-        reader2.close();
-        directory2.close();
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
Fixed flakiness of `testReduceWithConcurrentSegmentSearch_whenMultipleCollectorsMatchedDocs_thenSuccessful`

Ran test 100 times, worked fine with the change
```
 ./gradlew ':test' --tests "org.opensearch.neuralsearch.search.query.HybridCollectorManagerTests.testReduceWithConcurrentSegmentSearch_whenMultipleCollectorsMatchedDocs_thenSuccessful" -Dtests.seed=8305B866B5D072CE -Dtests.security.manager=false -Dtests.locale=af-ZA -Dtests.timezone=Europe/Uzhgorod -Dtests.iters=100
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.9
  OS Info               : Mac OS X 14.7 (aarch64)
  JDK Version           : 21 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home
  Random Testing Seed   : 8305B866B5D072CE
  In FIPS 140 mode      : false
=======================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.9/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1s

```
### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/819

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
