### PR TITLE
Address inconsistent scoring in hybrid query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+-  Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
@@ -108,11 +108,20 @@ public class HybridTopScoreDocCollector implements HybridSearchCollector {
                 }
                 // Increment total hit count which represents unique doc found on the shard
                 totalHits++;
+                hitsThresholdChecker.incrementHitCount();
                 for (int i = 0; i < subScoresByQuery.length; i++) {
                     float score = subScoresByQuery[i];
                     // if score is 0.0 there is no hits for that sub-query
                     if (score == 0) {
                         continue;
+                    }
+                    if (hitsThresholdChecker.isThresholdReached() && totalHitsRelation == TotalHits.Relation.EQUAL_TO) {
+                        log.info(
+                            "hit count threshold reached: total hits={}, threshold={}, action=updating_results",
+                            totalHits,
+                            hitsThresholdChecker.getTotalHitsThreshold()
+                        );
+                        totalHitsRelation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
                     }
                     collectedHitsPerSubQuery[i]++;
                     PriorityQueue<ScoreDoc> pq = compoundScores[i];

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerTests.java
@@ -7,19 +7,28 @@ package org.opensearch.neuralsearch.query;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.search.DisiWrapper;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
@@ -28,6 +37,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 import lombok.SneakyThrows;
+import org.opensearch.neuralsearch.search.HybridDisiWrapper;
 
 public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
 
@@ -91,7 +101,7 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
                 int idx = Arrays.binarySearch(docs2, doc);
                 expectedScore += scores2[idx];
             }
-            assertEquals(expectedScore, actualTotalScore, 0.001f);
+            assertEquals(expectedScore, actualTotalScore, DELTA_FOR_SCORE_ASSERTION);
             numOfActualDocs++;
         }
 
@@ -146,7 +156,7 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
             for (float score : hybridQueryScorer.hybridScores()) {
                 hybridScore += score;
             }
-            assertEquals(expectedScore, hybridScore, 0.001f);
+            assertEquals(expectedScore, hybridScore, DELTA_FOR_SCORE_ASSERTION);
             numOfActualDocs++;
         }
 
@@ -269,10 +279,384 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
                 assertEquals(DocIdSetIterator.NO_MORE_DOCS, doc);
             } else {
                 assertEquals(docs[idx], doc);
-                assertEquals(scores1[idx] + scores2[idx], queryScorer.score(), 0.001f);
+                assertEquals(scores1[idx] + scores2[idx], queryScorer.score(), DELTA_FOR_SCORE_ASSERTION);
             }
             idx++;
         }
+    }
+
+    @SneakyThrows
+    public void testScore_whenMultipleSubScorers_thenSumScores() {
+        // Create mock scorers with iterators
+        Scorer scorer1 = mock(Scorer.class);
+        DocIdSetIterator iterator1 = mock(DocIdSetIterator.class);
+        when(scorer1.iterator()).thenReturn(iterator1);
+        when(scorer1.docID()).thenReturn(1);
+        when(scorer1.score()).thenReturn(0.5f);
+
+        Scorer scorer2 = mock(Scorer.class);
+        DocIdSetIterator iterator2 = mock(DocIdSetIterator.class);
+        when(scorer2.iterator()).thenReturn(iterator2);
+        when(scorer2.docID()).thenReturn(1);
+        when(scorer2.score()).thenReturn(0.3f);
+
+        // Create DisiWrapper list
+        DisiWrapper wrapper1 = new DisiWrapper(scorer1);
+        wrapper1.next = new DisiWrapper(scorer2);
+
+        Weight weight = mock(Weight.class);
+        HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, Arrays.asList(scorer1, scorer2));
+        float score = hybridScorer.score(wrapper1);
+
+        assertEquals("Combined score should be sum of individual scores", 0.8f, score, DELTA_FOR_SCORE_ASSERTION);
+    }
+
+    @SneakyThrows
+    public void testScore_whenNoMoreDocs_thenReturnZero() {
+        // Create mock scorer
+        Scorer scorer = mock(Scorer.class);
+        DocIdSetIterator iterator = mock(DocIdSetIterator.class);
+        when(scorer.iterator()).thenReturn(iterator);
+
+        // Setup iterator behavior
+        when(iterator.docID()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(iterator.cost()).thenReturn(1L);
+
+        // Create TwoPhaseIterator if needed
+        TwoPhaseIterator twoPhase = mock(TwoPhaseIterator.class);
+        DocIdSetIterator approximation = mock(DocIdSetIterator.class);
+        when(approximation.docID()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(approximation.cost()).thenReturn(1L);
+        when(twoPhase.approximation()).thenReturn(approximation);
+        when(scorer.twoPhaseIterator()).thenReturn(twoPhase);
+
+        // Create wrapper
+        DisiWrapper wrapper = new DisiWrapper(scorer);
+
+        // Create weight mock
+        Weight weight = mock(Weight.class);
+
+        // Create HybridQueryScorer
+        HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, Collections.singletonList(scorer));
+
+        // Test score method
+        float score = hybridScorer.score(wrapper);
+
+        // Verify
+        assertEquals("Score should be 0.0 for NO_MORE_DOCS", 0.0f, score, DELTA_FOR_SCORE_ASSERTION);
+    }
+
+    @SneakyThrows
+    public void testGetSubMatches_whenNoScorers_thenReturnNull() {
+        Weight weight = mock(Weight.class);
+
+        // Create a scorer with a two-phase iterator that doesn't match
+        Scorer scorer = mock(Scorer.class);
+        DocIdSetIterator iterator = mock(DocIdSetIterator.class);
+        TwoPhaseIterator twoPhase = mock(TwoPhaseIterator.class);
+        when(twoPhase.matches()).thenReturn(false);
+        when(scorer.twoPhaseIterator()).thenReturn(twoPhase);
+        when(scorer.iterator()).thenReturn(iterator);
+        when(scorer.docID()).thenReturn(0);  // Set a valid docID
+
+        HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, Collections.singletonList(scorer), ScoreMode.TOP_SCORES);
+
+        DisiWrapper result = hybridScorer.getSubMatches();
+        assertNull("Should return null when no matches are available", result);
+    }
+
+    @SneakyThrows
+    public void testGetSubMatches_whenTwoPhaseIteratorPresent_thenReturnWrapper() {
+        // Create weight mock
+        Weight weight = mock(Weight.class);
+
+        // Create scorer with iterator
+        Scorer scorer = mock(Scorer.class);
+        DocIdSetIterator iterator = mock(DocIdSetIterator.class);
+
+        // Setup iterator behavior with AtomicInteger for state tracking
+        AtomicInteger currentDoc = new AtomicInteger(-1);
+
+        when(iterator.docID()).thenAnswer(inv -> currentDoc.get());
+        when(iterator.cost()).thenReturn(1L);
+        when(iterator.nextDoc()).thenAnswer(inv -> {
+            if (currentDoc.get() == -1) {
+                currentDoc.set(0);
+                return 0;
+            }
+            return DocIdSetIterator.NO_MORE_DOCS;
+        });
+
+        when(scorer.iterator()).thenReturn(iterator);
+        when(scorer.docID()).thenAnswer(inv -> currentDoc.get());
+
+        // Create and setup TwoPhaseIterator
+        TwoPhaseIterator twoPhase = mock(TwoPhaseIterator.class);
+        DocIdSetIterator approximation = mock(DocIdSetIterator.class);
+
+        // Setup approximation behavior
+        when(approximation.docID()).thenAnswer(inv -> currentDoc.get());
+        when(approximation.cost()).thenReturn(1L);
+        when(approximation.nextDoc()).thenAnswer(inv -> {
+            if (currentDoc.get() == -1) {
+                currentDoc.set(0);
+                return 0;
+            }
+            return DocIdSetIterator.NO_MORE_DOCS;
+        });
+
+        when(twoPhase.approximation()).thenReturn(approximation);
+        when(scorer.twoPhaseIterator()).thenReturn(twoPhase);
+        when(twoPhase.matches()).thenReturn(true);
+
+        // Create HybridQueryScorer
+        HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, Collections.singletonList(scorer), ScoreMode.TOP_SCORES);
+
+        // Initialize the scorer by moving to first doc
+        DocIdSetIterator scorerIterator = hybridScorer.iterator();
+        int firstDoc = scorerIterator.nextDoc();
+
+        // Verify initial state
+        assertEquals("First doc should be 0", 0, firstDoc);
+        assertEquals("Iterator should be at doc 0", 0, scorerIterator.docID());
+
+        // Get submatches
+        DisiWrapper result = hybridScorer.getSubMatches();
+
+        // Verify
+        assertNotNull("Should not be null when twoPhase is present", result);
+        assertTrue("Should be instance of HybridDisiWrapper", result instanceof HybridDisiWrapper);
+        assertNotNull("TwoPhaseView should not be null", result.twoPhaseView);
+        assertEquals("Should be at doc 0", 0, result.doc);
+
+        // Verify the two-phase iterator
+        TwoPhaseIterator resultTwoPhase = result.twoPhaseView;
+        assertNotNull("Two-phase iterator should not be null", resultTwoPhase);
+        assertTrue("Should match", resultTwoPhase.matches());
+    }
+
+    @SneakyThrows
+    public void testAdvanceShallow_whenTargetProvided_thenReturnTarget() {
+        Weight weight = mock(Weight.class);
+
+        // Create scorer
+        Scorer scorer = mock(Scorer.class);
+        DocIdSetIterator iterator = mock(DocIdSetIterator.class);
+        when(scorer.iterator()).thenReturn(iterator);
+
+        // Create and setup TwoPhaseIterator
+        TwoPhaseIterator twoPhase = mock(TwoPhaseIterator.class);
+        DocIdSetIterator approximation = mock(DocIdSetIterator.class);
+        when(twoPhase.approximation()).thenReturn(approximation);
+        when(scorer.twoPhaseIterator()).thenReturn(twoPhase);
+        when(twoPhase.matches()).thenReturn(true);
+
+        // Setup initial state
+        AtomicInteger currentDoc = new AtomicInteger(-1);
+
+        // Setup iterator behavior
+        when(iterator.docID()).thenAnswer(inv -> currentDoc.get());
+        when(approximation.docID()).thenAnswer(inv -> currentDoc.get());
+
+        // Setup nextDoc behavior
+        when(iterator.nextDoc()).thenAnswer(inv -> {
+            currentDoc.set(0);
+            return 0;
+        });
+
+        when(approximation.nextDoc()).thenAnswer(inv -> {
+            currentDoc.set(0);
+            return 0;
+        });
+
+        // Setup advance behavior
+        int target = 5;
+        when(approximation.advance(target)).thenAnswer(inv -> {
+            currentDoc.set(target);
+            return target;
+        });
+
+        when(iterator.advance(target)).thenAnswer(inv -> {
+            currentDoc.set(target);
+            return target;
+        });
+
+        // Setup costs
+        when(iterator.cost()).thenReturn(1L);
+        when(approximation.cost()).thenReturn(1L);
+
+        // Create hybrid scorer with custom advanceShallow implementation
+        HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, Collections.singletonList(scorer), ScoreMode.TOP_SCORES) {
+            @Override
+            public float score() throws IOException {
+                return 1.0f;
+            }
+
+            @Override
+            public int advanceShallow(int target) throws IOException {
+                DisiWrapper lead = getSubMatches();
+                if (lead != null && lead.twoPhaseView != null) {
+                    DocIdSetIterator approx = lead.twoPhaseView.approximation();
+                    int result = approx.advance(target);
+                    return result;
+                }
+                return 0;
+            }
+        };
+
+        // Initialize scorer
+        DocIdSetIterator scorerIterator = hybridScorer.iterator();
+
+        // Move to first doc
+        int firstDoc = scorerIterator.nextDoc();
+        assertEquals("Should be at first doc", 0, scorerIterator.docID());
+
+        // Test advanceShallow
+        int result = hybridScorer.advanceShallow(target);
+
+        // Verify
+        assertEquals("AdvanceShallow should return the target", target, result);
+        verify(approximation).advance(target);
+        assertEquals("Current doc should be at target", target, currentDoc.get());
+    }
+
+    @SneakyThrows
+    public void testScore_whenMultipleQueries_thenCombineScores() {
+        // Create mock scorers for different queries
+        Scorer boolScorer = mock(Scorer.class);
+        DocIdSetIterator boolIterator = mock(DocIdSetIterator.class);
+        when(boolScorer.iterator()).thenReturn(boolIterator);
+        when(boolScorer.docID()).thenReturn(1);
+        when(boolScorer.score()).thenReturn(0.7f);
+
+        Scorer neuralScorer = mock(Scorer.class);
+        DocIdSetIterator neuralIterator = mock(DocIdSetIterator.class);
+        when(neuralScorer.iterator()).thenReturn(neuralIterator);
+        when(neuralScorer.docID()).thenReturn(1);
+        when(neuralScorer.score()).thenReturn(0.9f);
+
+        // Create DisiWrapper chain
+        DisiWrapper boolWrapper = new DisiWrapper(boolScorer);
+        DisiWrapper neuralWrapper = new DisiWrapper(neuralScorer);
+        boolWrapper.next = neuralWrapper;
+
+        Weight weight = mock(Weight.class);
+        HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, Arrays.asList(boolScorer, neuralScorer), ScoreMode.COMPLETE);
+        float combinedScore = hybridScorer.score(boolWrapper);
+
+        assertEquals("Combined score should be sum of bool and neural scores", 1.6f, combinedScore, DELTA_FOR_SCORE_ASSERTION);
+    }
+
+    @SneakyThrows
+    public void testScore_whenEmptySubScorers_thenReturnZero() {
+        Weight weight = mock(Weight.class);
+        HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, Collections.emptyList());
+        float score = hybridScorer.score(null);
+
+        assertEquals("Score should be 0.0 for null wrapper", 0.0f, score, DELTA_FOR_SCORE_ASSERTION);
+    }
+
+    @SneakyThrows
+    public void testInitialization_whenValidScorer_thenSuccessful() {
+        // Create scorer with iterator
+        Scorer scorer = mock(Scorer.class);
+        DocIdSetIterator iterator = mock(DocIdSetIterator.class);
+
+        // Setup state tracking
+        AtomicInteger currentDoc = new AtomicInteger(-1);
+
+        // Setup iterator behavior
+        when(iterator.docID()).thenAnswer(inv -> currentDoc.get());
+        when(iterator.cost()).thenReturn(1L);
+        when(iterator.nextDoc()).thenAnswer(inv -> {
+            if (currentDoc.get() == -1) {
+                currentDoc.set(0);
+                return 0;
+            }
+            return DocIdSetIterator.NO_MORE_DOCS;
+        });
+
+        when(scorer.iterator()).thenReturn(iterator);
+        when(scorer.docID()).thenAnswer(inv -> currentDoc.get());
+
+        // Create wrapper
+        HybridDisiWrapper wrapper = new HybridDisiWrapper(scorer, 1);
+
+        // Verify
+        assertNotNull("Wrapper should not be null", wrapper);
+        assertEquals("Initial doc should be -1", -1, wrapper.doc);
+        assertNotNull("Iterator should not be null", wrapper.iterator);
+        assertEquals("Cost should be 1", 1L, wrapper.cost);
+    }
+
+    @SneakyThrows
+    public void testHybridScores_withTwoPhaseIterator() throws IOException {
+        // Create weight and scorers
+        Weight weight = mock(Weight.class);
+        Scorer scorer1 = mock(Scorer.class);
+        TwoPhaseIterator twoPhaseIterator = mock(TwoPhaseIterator.class);
+        DocIdSetIterator approximation = mock(DocIdSetIterator.class);
+
+        // Setup two-phase behavior
+        when(scorer1.twoPhaseIterator()).thenReturn(twoPhaseIterator);
+        when(twoPhaseIterator.approximation()).thenReturn(approximation);
+        when(scorer1.iterator()).thenReturn(approximation);
+        when(approximation.cost()).thenReturn(1L);
+
+        // Setup DocIdSetIterator behavior - use different docIDs
+        when(approximation.docID()).thenReturn(5);  // approximation at doc 5
+        when(scorer1.docID()).thenReturn(5);        // scorer at same doc
+        when(scorer1.score()).thenReturn(2.0f);
+
+        // matches() always returns false - document should never match
+        when(twoPhaseIterator.matches()).thenReturn(false);
+
+        // Create HybridQueryScorer with two-phase iterator
+        List<Scorer> subScorers = Collections.singletonList(scorer1);
+        HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, subScorers);
+
+        // Call matches() first to establish non-matching state
+        TwoPhaseIterator hybridTwoPhase = hybridScorer.twoPhaseIterator();
+        assertNotNull("Should have two phase iterator", hybridTwoPhase);
+        assertFalse("Document should not match", hybridTwoPhase.matches());
+
+        // Get scores - should be zero since document doesn't match
+        float[] scores = hybridScorer.hybridScores();
+        assertEquals("Should have one score entry", 1, scores.length);
+        assertEquals("Score should be 0 for non-matching document", 0.0f, scores[0], DELTA_FOR_SCORE_ASSERTION);
+
+        // Verify score() was never called since document didn't match
+        verify(scorer1, never()).score();
+        verify(twoPhaseIterator, times(1)).matches();
+    }
+
+    @SneakyThrows
+    public void testTwoPhaseIterator_withNestedTwoPhaseQuery() {
+        // Create a scorer that uses two-phase iteration
+        Scorer scorer = mock(Scorer.class);
+        TwoPhaseIterator twoPhaseIterator = mock(TwoPhaseIterator.class);
+        DocIdSetIterator approximation = mock(DocIdSetIterator.class);
+
+        // Setup the two-phase behavior
+        when(scorer.twoPhaseIterator()).thenReturn(twoPhaseIterator);
+        when(twoPhaseIterator.approximation()).thenReturn(approximation);
+        when(twoPhaseIterator.matches()).thenReturn(true);
+
+        // Mock iterator() method which is needed for cost calculation
+        when(scorer.iterator()).thenReturn(approximation);
+        // Mock cost to avoid NPE
+        when(approximation.cost()).thenReturn(1L);
+
+        // Create wrapper
+        HybridDisiWrapper wrapper = new HybridDisiWrapper(scorer, 1);
+
+        // This would return null before PR #998
+        TwoPhaseIterator wrapperTwoPhase = wrapper.twoPhaseView;
+        assertNotNull("Two-phase iterator should not be null", wrapperTwoPhase);
+
+        // Verify that the two-phase behavior is preserved
+        assertTrue("Should match", wrapperTwoPhase.matches());
+        assertSame("Should use same approximation", approximation, wrapperTwoPhase.approximation());
     }
 
     protected static Scorer scorerWithTwoPhaseIterator(final int[] docs, final float[] scores, Weight weight, int maxDoc) {


### PR DESCRIPTION
### Description
For hybrid query we are using `DocIdSetIterator` to iterate over doc ids to get the hybrid scores. That is a problem when sub-queries became complex and system switches to iterator with approximation and two phase approach (introduced in 2.13 in scope of https://github.com/opensearch-project/neural-search/pull/624). 

When both `two-phase` and `DocIdSetIterator` are in use there is a high chance they will go out of sync and point to different doc ids. This leads to `e_o_f_exception` described in the GH issue. 

Big thanks to @msfroh who pointed that out in https://github.com/opensearch-project/OpenSearch/pull/16660#discussion_r1847382120

I've added unit tests, but main verification is done manually, as per steps described [in here](https://github.com/opensearch-project/neural-search/issues/964#issuecomment-2498620874) as part of GH issue, mainly it's because some manual steps by installation of analyzer plugin.

Here are request/response after setting up things with `nori` analyser:

```
GET {{base_url}}/rag-chunk-500/_search?search_pipeline=nlp-search-pipeline 
{
    "_source": {
      "excludes": "body_chunk_embedding"
    },
    "query": {
        "hybrid": {
            "queries": [
                {
                    "multi_match": {
                        "query": "금융분야 클라우드컴퓨팅서비스 이용 가이드에 따르면, 중대한 변경이나 중요 계약사항 미이행 시 사후보고는 어떻게 해야 하며, 비중요업무의 경우 어떤 규정을 따라야 합니까?",
                        "fields": [
                            "body_chunk_default",
                            "summary",
                            "title"
                        ]
                    }
                },
                {
                  "neural": {
                    "body_chunk_embedding": {
                      "query_text": "금융분야 클라우드컴퓨팅서비스 이용 가이드에 따르면, 중대한 변경이나 중요 계약사항 미이행 시 사후보고는 어떻게 해야 하며, 비중요업무의 경우 어떤 규정을 따라야 합니까?",
                      "model_id": "UXo_ZJMB_dO27nZ9IKL8",
                      "k": 5
                    }
                }
              }
            ]
        }
    }
}
```
response
```
{
    "took": 89,
    "timed_out": false,
    "_shards": {
        "total": 5,
        "successful": 5,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 235,
            "relation": "eq"
        },
        "max_score": 0.5208311,
        "hits": [
            {
                "_index": "rag-chunk-500",
                "_id": "8HpAZJMB_dO27nZ9mqIq",
                "_score": 0.5208311,
                "_source": {
                    "summary": "이 내용은 금융회사가 보유한 정보에 대한 권한 문제를 다루고 있습니다. 금융회사는 언제든 해당 정보를 조회, 수정, 삭제할 수 있는 권한을 가지며, 클라우드 서비스 제공자는 이를 제한하거나 정보에 대한 권리를 주장할 수 없습니다. 또한 클라우드 서비스 제공자는 관련 법령에 따라 제3자에게 정보를 제공해야 하는 경우 사전에 금융회사에 알려야 하며, 정보 제공 사실을 금지하는 조항이 있을 경우에도 금융위원회 및 금융감독원에 통지해야 합니다.",
                    "body_chunk_default": "금융회사의 소유로서 금융회사는 이 정보에 대해 언제든지 조회 수정 삭제할 수 있는 권리를 가지며 클라우드서비스 제공자는 이를 제한하거나 정보에 대한 어떠한 권리도 주장할 수 없음 클라우드서비스 제공자는 금융회사가 처리를 위탁한 정보를 제3자 국외정부 수사기관 등 포함 에게 제공하도록 규정하는 관련 법령 에 대해 사전에 파악 하여 금융회사에 알려야 함 추가 변경사항 포함 정보 제공 사실을 알리는 것을 금지하는 조항이 있는 경우 해당 조항도 포함하여 금융회사에 알려아 하며 실제 정보제공이 요구되었으나 해당 조항에 따라 금융회사에 알리는 것이 불가한 경우에는 금융위 금감원에 별도 통지할 것 86 금융보안원 제7장 계약 체결 l 해당 법령에 따라 정보제공이 요구되는 경우 정보를 제공하기 전에 금융위 금감원 및 금융회사에 통지하고 관계국의 법령 국가간 상호협정 등에서 정한 적법한 절차에 따라 처리하여야 함 단 원칙적으로 정보주체의 동의를 받도록 하는 개인정보보호법 신용정보의 이용 및 보호에",
                    "auditor": "activate",
                    "title": "금융회사와 클라우드 서비스 제공자 간 정보 처리 및 제공 권한 명시"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "BnpAZJMB_dO27nZ9mqMq",
                "_score": 0.5199528,
                "_source": {
                    "summary": "금융 회사 또는 전자금융업자가 클라우드 컴퓨팅 서비스 제공자와 계약을 체결하고 클라우드 서비스를 이용할 때, 정보 보호 관련 업무를 재위탁할 수 있는 요건을 명시하고 있습니다. 재위탁 시 금융거래 정보의 안전한 관리와 유출 방지를 위해 준수해야 할 사항들을 설명하고 있습니다.",
                    "body_chunk_default": "있어 금융거래 정보의 변경이 필요한 경우 에는 위탁회사 또는 원수탁업자의 개별적 지시에 따라야 하며 위탁회사 또는 원수탁업자는 변경된 정보가 지시 내용에 부합하는지 여부를 확인하여야 함 위탁업무와 관련된 이용자의 금융거래정보는 위탁회사의 전산실 내에 두어야 함 다만 재수탁업자가 이용자의 정보를 어떠한 경우에도 알지 못하도록 위탁회사 또는 원수탁업자가 금융거래정보를 처리하여 제공한 경우에는 위탁회사의 관리 통제하에 재수탁회사 등 제3의 장소로 이전 가능함 법령해석 회신문 200036 20 5 4 클라우드와 관련하여 전자금융감독규정 제60조 제4항의 적용여부 및 해석 요청 질의 요지 전자금융거래법 상 금융회사 또는 전자금융업자가 클라우드컴퓨팅서비스 제공자와 계약을 맺고 클라 우드컴퓨팅서비스를 이용하면서 정보보호와 관련된 업무 역시 위탁한 때 전자금융감독규정 제60조 제4항의 요건을 갖춘 경우 금융회사의 정보보호와 관련된 업무를 재위탁하는 것이 가능한지 여부 특히 금융회사 등이",
                    "auditor": "activate",
                    "title": "금융거래 정보 보호를 위한 위탁 및 재위탁 규정"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "_XpAZJMB_dO27nZ9mqIq",
                "_score": 0.5,
                "_source": {
                    "summary": "금융회사는 클라우드 서비스 제공자와의 관계에서 고객정보 보호와 정보에 대한 통제권을 보장받아야 한다. 정보 암호화, 전용 네트워크 사용, 직원 보안 교육 등 클라우드 서비스 제공자가 준수해야 할 보안 조치들이 명시되어 있다.",
                    "body_chunk_default": "금융회사는 시정조치를 요구할 수 있어야 함 차 고객정보보호 및 비밀유지 규정 준수 시 고려사항 금융회사가 클라우드서비스를 이용하여 처리하는 모든 정보는 금융회사의 소유로서 금융회사는 이 정보에 대해 언제든지 조회 수정 삭제할 수 있는 권리를 가지며 클라우드서비스 제공자는 이를 제한하거나 정보에 대한 어떠한 권리도 주장할 수 없음 클라우드서비스 제공자는 모든 정보 전송 시 암호화 기술을 적용하여야 하며 정보의 비인가 접근 및 유출 등을 방지하기 위해 충분한 보호수단을 적용 하여야 함 클라우드서비스 제공자는 클라우드 서비스를 제공함에 있어 취득한 금융회사 데이터에 대한 비밀유지 서약을 준수하여야 함 클라우드서비스 제공자는 금융회사가 클라우드서비스 제공자와 네트워크 연결이 필요할 경우 전용회선 또는 전용회선과 동등한 보안수준을 갖춘 가상의 전용 회선을 이용할 수 있도록 지원하여야 함 클라우드서비스 제공자는 직원 보안 교육을 주기적으로 실시하고 금융회사가 요청할 경우 교육 계획 및 수행",
                    "auditor": "activate",
                    "title": "금융회사의 클라우드 서비스 이용 및 고객정보보호 규정"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "oHpAZJMB_dO27nZ9mqIq",
                "_score": 0.5,
                "_source": {
                    "summary": "본문은 전자금융감독규정에 따라 금융회사가 비중요 업무와 중요 업무에 대해 수립해야 하는 확보 조치에 대해 설명하고 있습니다. 비중요 업무의 경우 일부 필수사항만 수립하면 되지만, 중요 업무로 판단되는 경우에는 전자금융감독규정의 전체 요구사항을 준수해야 합니다. 또한 클라우드 컴퓨팅 서비스 이용 시에도 업무 연속성 계획 및 안전성 확보 조치를 취해야 합니다.",
                    "body_chunk_default": "확보조치의 수립 시행 단 제1호의 평가를 통해 비중요업무로 분류된 업무에 대해서는 별표 2의2 및 별표 2의4 의 필수사항만 수립 시행할수 있다 제4항에 따라 금융감독원장에게 보고할 경우 첨부해야 하는 서류는 다음 각 호와 같다 4 제1항제3호에 따른 업무 연속성 계획 및 안전성 확보조치에 관한 사항 6 별표 2의5 의 계약서 주요 기재사항을 포함한 클라우드 컴퓨팅서비스 이용계약서 금융회사는 클라우드서비스 이용 시에도 전자금융감독규정의 요구사항을 모두 준수 하여야 하며 업무 연속성 계획 및 안전성 확보조치 방안 마련 시 전자금융 감독규정 별표 2의3 별표 2의4 별표 2의5 와 같은 규제 준수가 필요한 사항을 반드시 고려하여야 함 감독규정 제14조의2 제8항에 따른 예외 사항 제외 더불어 클라우드컴퓨팅서비스 이용과 관련한 업무연속성 계획 및 안전성 확보 조치의 수립 시행 시 중요업무로 판단된 경우 전자금융감독규정 별표 2의3 별표 2의4 별표 2의5 에서 명시된 필수사항 및",
                    "auditor": "activate",
                    "title": "전자금융감독규정상 비중요 업무와 중요 업무에 대한 확보 조치"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "PnpAZJMB_dO27nZ9mqMq",
                "_score": 0.48165405,
                "_source": {
                    "summary": "이 텍스트는 금융기관이 클라우드 컴퓨팅 서비스를 이용하는 경우 관련된 보고 및 정보공개 의무사항을 설명하고 있습니다. 주요 내용으로는 i 중대한 변경사항 발생 시 3개월 이내 사후보고 의무, ii 계약 미이행 등 비중요 업무에 대한 반기현황 사후보고 의무, iii 금융보안원에서 발행한 금융분야 클라우드 컴퓨팅 서비스 이용 가이드라인 등이 있습니다.",
                    "body_chunk_default": "사후보고 23 6 1 CSP 합병 등 개정 감독규정 적용 중대변경 안전성 확보 중대한 변경 또는 중요 계약사항 미이행 시로부터 3개월 이내 사후보고 관련 계약미이행 등 비중요업무의 경우 개정 감독규정에 따르면 정보처리위탁규정 7 ii에 따른 반기현황 사후보고를 해야 하고 개정 감독규정에 따르면 감독규정 14의2 에 따른 사후보고를 해야 합니다 135 금융분야 클라우드컴퓨팅서비스 이용 가이드 발행일 2023 02월 발행인 김 철 웅 발행처 금융보안원 주 소 경기도 용인시 수지구 대지로 132 비매품 이 가이드 내용의 무단 전재를 금하며 가공 인용할 때에는 반드시 금융보안원 금융분야 클라우드컴퓨팅서비스 이용 가이드 라고 밝혀 주시기 바랍니다",
                    "auditor": "activate",
                    "title": "금융기관의 클라우드 서비스 이용 관련 보고 및 정보 가이드라인"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "CXpAZJMB_dO27nZ9mqMq",
                "_score": 0.416423,
                "_source": {
                    "summary": "이 문서는 금융 기관의 정보 보안 업무에 대해 설명합니다. 정보보호최고책임자(CISO가 인프라 운영, 취약점 분석평가, IT 내부통제 관리 등의 업무를 통솔해야 하며, 이 과정에서 정보 유출을 방지하는 것이 중요합니다. 일반적으로 재위탁이 제한되지만, 전자금융감독규정에 따라 일정한 조건을 준수하는 경우 제한적으로 재위탁을 허용하고 있습니다. 이에 따라 재수탁업자의 정보 변경 절차와 이용자 정보 관리 기준이 규정되어 있습니다.",
                    "body_chunk_default": "인프라 운영과 취약점 분석평가 IT내부통제 관리 등의 업무를 포괄하며 정보의 외부유출 방지 등을 위해 금융회사 등의 정보보호최고책임자 CISO 가 통솔해야 하는 업무 이므로 원칙적으로 재위탁을 제한하되 단서규정을 두어 일정한 조건을 준수하는 경우에 한하여 제한적으로 재위탁을 허용하였습니다 아울러 전자금융감독규정 제60조 제4항 각 호에서는 전자금융거래정보의 보호 목적 달성을 위해 다음과 같이 재위탁의 기준을 구체화하고 있으므로 해당 기준을 준수하는 경우에는 재위탁이 가능 합니다 전자금융감독규정 60 i 재수탁업자가 재위탁된 업무를 처리함에 있어 금융거래 정보의 변경이 필요한 경우에는 위탁회사 또는 원수탁업자의 개별적 지시에 따라야 하고 위탁회사 또는 원수탁업자는 변경된 정보가 지시 내용에 부합하는지 여부를 확인할 것 ii 위탁업무와 관련된 이용자의 금융거래정보는 위탁회사의 전산실 내에 둘 것 다만 재수탁업자가 이용자의 이용자 정보를 어떠한 경우에도 알지 못하도록 위탁회사 또는",
                    "auditor": "activate",
                    "title": "금융 정보 보안: CISO의 역할과 재위탁 규정"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "LnpAZJMB_dO27nZ9mqMq",
                "_score": 0.36809874,
                "_source": {
                    "summary": "해당 문서는 클라우드 아웃소싱 시 고려해야 할 주요 사항에 대해 다루고 있다. 중요 아웃소싱 기업의 경우 보안조치 강화가 필요하며, 중소 기업은 완화된 조치 적용이 가능하다. 클라우드 아웃소싱 계약 체결 시 데이터 처리 및 저장, API 보안, 비즈니스 연속성 관리, 규정 준수 모니터링 등의 요건을 포함해야 한다. 또한 서브 아웃소싱 허용 여부와 공급업체 의존 위험 최소화 방안을 고려해야 한다. 이를 통해 클라우드 투자 속도와 혁신의 이점을 극대화할 수 있다.",
                    "body_chunk_default": "따라 중요 아웃소싱인 경우 보안조치 등을 강화하고 규모 및 복잡성이 적은 기업은 완화된 조치를 적용 가능 집중위험이 확인될 경우 관할당국은 해당 위험을 모니터링하고 잠재적 영향을 평가 중요 클라우드 아웃소싱에 대한 요구사항 계약 관련 세부 정보 포함하여 아웃소싱 레지스터 등록 클라우드 아웃소싱 계약의 결과로 발생할 수 있는 위험 평가 동일한 CSP 사용으로 인한 집중 위험 발생 가능성 고려 CSP에 대한 평판 분석 등 적합성 평가 실시 데이터 처리 및 저장 위치 등을 포함한 서면 계약 요건 API 보안 비즈니스 연속성 관리 규정 준수 모니터링 수행 클라우드 아웃소싱 계약의 종료 가능 여부 평가 서브 아웃소싱 허용 여부를 고려한 아웃소싱 계약 체결 관할 당국에 클라우드 아웃소싱 계획 보고 공급업체 의존 위험 최소화 사례 자료제공 가트너 1 개요 미국의 금융회사인 AgCredit 은 SaaS 서비스 공급업체에 의존될 수 있는 위험을 사전에 해소하여 클라우드 투자 속도와 혁신의 이점을",
                    "auditor": "activate",
                    "title": "클라우드 아웃소싱 관리 및 위험 완화"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "XnpAZJMB_dO27nZ9mqIp",
                "_score": 0.36603695,
                "_source": {
                    "summary": "이 문장은 클라우드컴퓨팅서비스의 다양한 유형에 대해 설명하고 있습니다. 클라우드컴퓨팅서비스는 서비스의 운영 방식과 배치 모델에 따라 프라이빗, 퍼블릭, 커뮤니티, 하이브리드 등으로 나뉠 수 있으며, 상용으로 제공되는 클라우드컴퓨팅서비스는 주로 퍼블릭 방식입니다. 그러나 커뮤니티나 하이브리드 방식의 클라우드시스템도 서비스의 전부 또는 일부를 유상으로 제공한다면 이 법의 적용을 받을 수 있다고 설명하고 있습니다.",
                    "body_chunk_default": "아니합니다 예컨대 협회 단체 등이 전용으로 구축한 클라우드컴퓨팅서비스는 포함되지 않습니다 클라우드컴퓨팅서비스의 유형 클라우드컴퓨팅서비스는 서비스의 운영 방식 배치 모델 에 따라 일반적으로 1 프라이빗 클라우드 컴퓨팅서비스 2 퍼블릭 클라우드컴퓨팅서비스 3 커뮤니티 클라우드컴퓨팅서비스 4 하이브 리드 클라우드컴퓨팅서비스 등으로 나뉩니다 이 중에서 상용으로 제공되는 클라우드컴퓨팅서비스는 주로 퍼블릭 클라우드컴퓨팅서비스입니다 직접 개발 구축 운영 관리하는 경우에는 원칙적으로 이 법에서 규정하고 있는 클라우드컴퓨팅 서비스에 해당하지 않습니다 커뮤니티 클라우드컴퓨팅서비스나 하이브리드 클라우드컴퓨팅서비스도 서비스의 배치 및 운영 방식만 다를 뿐 상용으로 제공이 가능하므로 상용으로 제공 이용되고 있는 한 이 법에서 규정 하고 있는 클라우드컴퓨팅서비스에 포함될 수 있습니다 커뮤니티 하이브리드 등의 방식으로 구축된 클라우드시스템이라도 서비스의 전부 또는 일부를 클라우드컴퓨팅서비스 제공자가 유상으로",
                    "auditor": "activate",
                    "title": "클라우드컴퓨팅서비스의 유형과 범위"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "bnpAZJMB_dO27nZ9mqIq",
                "_score": 0.36191288,
                "_source": {
                    "summary": "금융회사 및 전자금융업자는 자사 클라우드 서비스 이용이 가능하지만, 전자금융감독규정에서 요구하는 절차를 준수해야 합니다. 상용 클라우드 이용 시 위탁계약서 등의 서류 제출은 필요하지 않으나, 상용 클라우드 이용과 관련된 서류를 제출해야 합니다. 또한 스타트업의 개발환경 지원 목적으로 클라우드를 이용할 경우에도 관련 규정을 따라야 합니다.",
                    "body_chunk_default": "따른 서류를 제출할 필요는 없으나 상용 클라우드 이용과 관련된 서류로 대체하여 제출해야 합니다 판단이유 전자금융감독규정 제14조의2에서 자사 클라우드 서비스 이용을 제한하고 있지 않으므로 금융회사 및 전자금융업자는 본인이 운영하는 상용 클라우드 서비스를 이용할 수 있습니다 9 FINANCIAL SECURITY INSTITUTE 적용 범위 관련 법령해석 회신문 및 비조치의견서 다만 이 경우에도 중요도 평가 등 동 규정에서 요구하고 있는 클라우드 이용 절차를 모두 준수해야 합니다 자사 클라우드 서비스 이용에 따른 사전보고시 위탁계약서 등 위탁관계에 따른 서류 제출할 필요는 없으나 상용 클라우드 이용과 관련된 서류로 대체 하여 제출해야 합니다 예 업무위수탁 운영 기준 상용 클라우드 이용에 따른 운영 기준 세부적인 제출서류 및 보고절차는 금융감독원 담당자 02 3145 7424 에게 문의하시기 바랍니다 비조치의견서 190011 19 5 27 스타트업 개발환경 지원 목적의 클라우드 이용시",
                    "auditor": "activate",
                    "title": "금융회사 및 전자금융업자의 상용 클라우드 서비스 이용 관련 규정"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "eXpAZJMB_dO27nZ9mqIq",
                "_score": 0.30663598,
                "_source": {
                    "summary": "이 문서는 금융회사가 클라우드 서비스를 이용할 때 필요한 업무 연속성 계획 및 안전성 확보조치 방안에 대해 설명하고 있습니다. 중요 업무 영역의 경우 필수 항목 전체를 평가해야 하지만, 지정된 클라우드 보안인증을 보유한 제공자를 이용하면 대체 항목을 생략할 수 있습니다. 비중요 업무 영역에서는 필수 항목만 평가하면 됩니다. 금융회사는 클라우드 서비스 이용에 따른 업무 연속성 계획과 안전성 확보조치 방안을 수립해야 합니다.",
                    "body_chunk_default": "또는 전자금융업자에서 자체적으로 수행 침해사고대응기관의 대표평가 결과를 공유받는 경우 활용 가능 중요 업무 이용영역에 대해 필수 대체 항목을 모두 평가해야 하나 지정된 클라우드 보안인증을 클라우드서비스 제공자가 보유 유지 하는 경우 대체 항목 생략 가능 필수 항목 생략 불가 비중요 업무 이용 영역에 대해 필수 항목 평가필요 대체 항목 생략 가능 다 업무 연속성 계획 및 안전성 확보조치 방안 수립 제5장 업무 연속성 계획 출구전략 포함 및 안전성 확보조치 방안 수립 l 금융회사는 클라우드서비스 이용에 따른 업무연속성 계획 안전성 확보조치 방안 등을 수립하여야 한다 17 FINANCIAL SECURITY INSTITUTE 중요 업무 감독규정 별표 2의3 클라우드컴퓨팅서비스 이용과 관련한 업무 연속성 계획 별표 2의4 클라우드컴퓨팅서비스 이용과 관련한 안전성 확보조치에서 필수 추가사항 모두 준수 필요 비중요 업무 업무 연속성 계획 안전성 확보조치에서 필수 사항 준수 필요 추가 사항 생략",
                    "auditor": "activate",
                    "title": "금융회사의 클라우드 서비스 이용을 위한 업무 연속성 계획 및 안전성 확보조치 방안"
                }
            }
        ]
    }
}
```

I also tested with concurrent segment search, got similar response which is expected

```
{
    "took": 84,
    "timed_out": false,
    "_shards": {
        "total": 5,
        "successful": 5,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 235,
            "relation": "eq"
        },
        "max_score": 0.5208311,
        "hits": [
            {
                "_index": "rag-chunk-500",
                "_id": "8HpAZJMB_dO27nZ9mqIq",
                "_score": 0.5208311,
                "_source": {
                    "summary": "이 내용은 금융회사가 보유한 정보에 대한 권한 문제를 다루고 있습니다. 금융회사는 언제든 해당 정보를 조회, 수정, 삭제할 수 있는 권한을 가지며, 클라우드 서비스 제공자는 이를 제한하거나 정보에 대한 권리를 주장할 수 없습니다. 또한 클라우드 서비스 제공자는 관련 법령에 따라 제3자에게 정보를 제공해야 하는 경우 사전에 금융회사에 알려야 하며, 정보 제공 사실을 금지하는 조항이 있을 경우에도 금융위원회 및 금융감독원에 통지해야 합니다.",
                    "body_chunk_default": "금융회사의 소유로서 금융회사는 이 정보에 대해 언제든지 조회 수정 삭제할 수 있는 권리를 가지며 클라우드서비스 제공자는 이를 제한하거나 정보에 대한 어떠한 권리도 주장할 수 없음 클라우드서비스 제공자는 금융회사가 처리를 위탁한 정보를 제3자 국외정부 수사기관 등 포함 에게 제공하도록 규정하는 관련 법령 에 대해 사전에 파악 하여 금융회사에 알려야 함 추가 변경사항 포함 정보 제공 사실을 알리는 것을 금지하는 조항이 있는 경우 해당 조항도 포함하여 금융회사에 알려아 하며 실제 정보제공이 요구되었으나 해당 조항에 따라 금융회사에 알리는 것이 불가한 경우에는 금융위 금감원에 별도 통지할 것 86 금융보안원 제7장 계약 체결 l 해당 법령에 따라 정보제공이 요구되는 경우 정보를 제공하기 전에 금융위 금감원 및 금융회사에 통지하고 관계국의 법령 국가간 상호협정 등에서 정한 적법한 절차에 따라 처리하여야 함 단 원칙적으로 정보주체의 동의를 받도록 하는 개인정보보호법 신용정보의 이용 및 보호에",
                    "auditor": "activate",
                    "title": "금융회사와 클라우드 서비스 제공자 간 정보 처리 및 제공 권한 명시"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "BnpAZJMB_dO27nZ9mqMq",
                "_score": 0.5199528,
                "_source": {
                    "summary": "금융 회사 또는 전자금융업자가 클라우드 컴퓨팅 서비스 제공자와 계약을 체결하고 클라우드 서비스를 이용할 때, 정보 보호 관련 업무를 재위탁할 수 있는 요건을 명시하고 있습니다. 재위탁 시 금융거래 정보의 안전한 관리와 유출 방지를 위해 준수해야 할 사항들을 설명하고 있습니다.",
                    "body_chunk_default": "있어 금융거래 정보의 변경이 필요한 경우 에는 위탁회사 또는 원수탁업자의 개별적 지시에 따라야 하며 위탁회사 또는 원수탁업자는 변경된 정보가 지시 내용에 부합하는지 여부를 확인하여야 함 위탁업무와 관련된 이용자의 금융거래정보는 위탁회사의 전산실 내에 두어야 함 다만 재수탁업자가 이용자의 정보를 어떠한 경우에도 알지 못하도록 위탁회사 또는 원수탁업자가 금융거래정보를 처리하여 제공한 경우에는 위탁회사의 관리 통제하에 재수탁회사 등 제3의 장소로 이전 가능함 법령해석 회신문 200036 20 5 4 클라우드와 관련하여 전자금융감독규정 제60조 제4항의 적용여부 및 해석 요청 질의 요지 전자금융거래법 상 금융회사 또는 전자금융업자가 클라우드컴퓨팅서비스 제공자와 계약을 맺고 클라 우드컴퓨팅서비스를 이용하면서 정보보호와 관련된 업무 역시 위탁한 때 전자금융감독규정 제60조 제4항의 요건을 갖춘 경우 금융회사의 정보보호와 관련된 업무를 재위탁하는 것이 가능한지 여부 특히 금융회사 등이",
                    "auditor": "activate",
                    "title": "금융거래 정보 보호를 위한 위탁 및 재위탁 규정"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "_XpAZJMB_dO27nZ9mqIq",
                "_score": 0.5,
                "_source": {
                    "summary": "금융회사는 클라우드 서비스 제공자와의 관계에서 고객정보 보호와 정보에 대한 통제권을 보장받아야 한다. 정보 암호화, 전용 네트워크 사용, 직원 보안 교육 등 클라우드 서비스 제공자가 준수해야 할 보안 조치들이 명시되어 있다.",
                    "body_chunk_default": "금융회사는 시정조치를 요구할 수 있어야 함 차 고객정보보호 및 비밀유지 규정 준수 시 고려사항 금융회사가 클라우드서비스를 이용하여 처리하는 모든 정보는 금융회사의 소유로서 금융회사는 이 정보에 대해 언제든지 조회 수정 삭제할 수 있는 권리를 가지며 클라우드서비스 제공자는 이를 제한하거나 정보에 대한 어떠한 권리도 주장할 수 없음 클라우드서비스 제공자는 모든 정보 전송 시 암호화 기술을 적용하여야 하며 정보의 비인가 접근 및 유출 등을 방지하기 위해 충분한 보호수단을 적용 하여야 함 클라우드서비스 제공자는 클라우드 서비스를 제공함에 있어 취득한 금융회사 데이터에 대한 비밀유지 서약을 준수하여야 함 클라우드서비스 제공자는 금융회사가 클라우드서비스 제공자와 네트워크 연결이 필요할 경우 전용회선 또는 전용회선과 동등한 보안수준을 갖춘 가상의 전용 회선을 이용할 수 있도록 지원하여야 함 클라우드서비스 제공자는 직원 보안 교육을 주기적으로 실시하고 금융회사가 요청할 경우 교육 계획 및 수행",
                    "auditor": "activate",
                    "title": "금융회사의 클라우드 서비스 이용 및 고객정보보호 규정"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "oHpAZJMB_dO27nZ9mqIq",
                "_score": 0.5,
                "_source": {
                    "summary": "본문은 전자금융감독규정에 따라 금융회사가 비중요 업무와 중요 업무에 대해 수립해야 하는 확보 조치에 대해 설명하고 있습니다. 비중요 업무의 경우 일부 필수사항만 수립하면 되지만, 중요 업무로 판단되는 경우에는 전자금융감독규정의 전체 요구사항을 준수해야 합니다. 또한 클라우드 컴퓨팅 서비스 이용 시에도 업무 연속성 계획 및 안전성 확보 조치를 취해야 합니다.",
                    "body_chunk_default": "확보조치의 수립 시행 단 제1호의 평가를 통해 비중요업무로 분류된 업무에 대해서는 별표 2의2 및 별표 2의4 의 필수사항만 수립 시행할수 있다 제4항에 따라 금융감독원장에게 보고할 경우 첨부해야 하는 서류는 다음 각 호와 같다 4 제1항제3호에 따른 업무 연속성 계획 및 안전성 확보조치에 관한 사항 6 별표 2의5 의 계약서 주요 기재사항을 포함한 클라우드 컴퓨팅서비스 이용계약서 금융회사는 클라우드서비스 이용 시에도 전자금융감독규정의 요구사항을 모두 준수 하여야 하며 업무 연속성 계획 및 안전성 확보조치 방안 마련 시 전자금융 감독규정 별표 2의3 별표 2의4 별표 2의5 와 같은 규제 준수가 필요한 사항을 반드시 고려하여야 함 감독규정 제14조의2 제8항에 따른 예외 사항 제외 더불어 클라우드컴퓨팅서비스 이용과 관련한 업무연속성 계획 및 안전성 확보 조치의 수립 시행 시 중요업무로 판단된 경우 전자금융감독규정 별표 2의3 별표 2의4 별표 2의5 에서 명시된 필수사항 및",
                    "auditor": "activate",
                    "title": "전자금융감독규정상 비중요 업무와 중요 업무에 대한 확보 조치"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "PnpAZJMB_dO27nZ9mqMq",
                "_score": 0.48165405,
                "_source": {
                    "summary": "이 텍스트는 금융기관이 클라우드 컴퓨팅 서비스를 이용하는 경우 관련된 보고 및 정보공개 의무사항을 설명하고 있습니다. 주요 내용으로는 i 중대한 변경사항 발생 시 3개월 이내 사후보고 의무, ii 계약 미이행 등 비중요 업무에 대한 반기현황 사후보고 의무, iii 금융보안원에서 발행한 금융분야 클라우드 컴퓨팅 서비스 이용 가이드라인 등이 있습니다.",
                    "body_chunk_default": "사후보고 23 6 1 CSP 합병 등 개정 감독규정 적용 중대변경 안전성 확보 중대한 변경 또는 중요 계약사항 미이행 시로부터 3개월 이내 사후보고 관련 계약미이행 등 비중요업무의 경우 개정 감독규정에 따르면 정보처리위탁규정 7 ii에 따른 반기현황 사후보고를 해야 하고 개정 감독규정에 따르면 감독규정 14의2 에 따른 사후보고를 해야 합니다 135 금융분야 클라우드컴퓨팅서비스 이용 가이드 발행일 2023 02월 발행인 김 철 웅 발행처 금융보안원 주 소 경기도 용인시 수지구 대지로 132 비매품 이 가이드 내용의 무단 전재를 금하며 가공 인용할 때에는 반드시 금융보안원 금융분야 클라우드컴퓨팅서비스 이용 가이드 라고 밝혀 주시기 바랍니다",
                    "auditor": "activate",
                    "title": "금융기관의 클라우드 서비스 이용 관련 보고 및 정보 가이드라인"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "CXpAZJMB_dO27nZ9mqMq",
                "_score": 0.416423,
                "_source": {
                    "summary": "이 문서는 금융 기관의 정보 보안 업무에 대해 설명합니다. 정보보호최고책임자(CISO가 인프라 운영, 취약점 분석평가, IT 내부통제 관리 등의 업무를 통솔해야 하며, 이 과정에서 정보 유출을 방지하는 것이 중요합니다. 일반적으로 재위탁이 제한되지만, 전자금융감독규정에 따라 일정한 조건을 준수하는 경우 제한적으로 재위탁을 허용하고 있습니다. 이에 따라 재수탁업자의 정보 변경 절차와 이용자 정보 관리 기준이 규정되어 있습니다.",
                    "body_chunk_default": "인프라 운영과 취약점 분석평가 IT내부통제 관리 등의 업무를 포괄하며 정보의 외부유출 방지 등을 위해 금융회사 등의 정보보호최고책임자 CISO 가 통솔해야 하는 업무 이므로 원칙적으로 재위탁을 제한하되 단서규정을 두어 일정한 조건을 준수하는 경우에 한하여 제한적으로 재위탁을 허용하였습니다 아울러 전자금융감독규정 제60조 제4항 각 호에서는 전자금융거래정보의 보호 목적 달성을 위해 다음과 같이 재위탁의 기준을 구체화하고 있으므로 해당 기준을 준수하는 경우에는 재위탁이 가능 합니다 전자금융감독규정 60 i 재수탁업자가 재위탁된 업무를 처리함에 있어 금융거래 정보의 변경이 필요한 경우에는 위탁회사 또는 원수탁업자의 개별적 지시에 따라야 하고 위탁회사 또는 원수탁업자는 변경된 정보가 지시 내용에 부합하는지 여부를 확인할 것 ii 위탁업무와 관련된 이용자의 금융거래정보는 위탁회사의 전산실 내에 둘 것 다만 재수탁업자가 이용자의 이용자 정보를 어떠한 경우에도 알지 못하도록 위탁회사 또는",
                    "auditor": "activate",
                    "title": "금융 정보 보안: CISO의 역할과 재위탁 규정"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "LnpAZJMB_dO27nZ9mqMq",
                "_score": 0.36809874,
                "_source": {
                    "summary": "해당 문서는 클라우드 아웃소싱 시 고려해야 할 주요 사항에 대해 다루고 있다. 중요 아웃소싱 기업의 경우 보안조치 강화가 필요하며, 중소 기업은 완화된 조치 적용이 가능하다. 클라우드 아웃소싱 계약 체결 시 데이터 처리 및 저장, API 보안, 비즈니스 연속성 관리, 규정 준수 모니터링 등의 요건을 포함해야 한다. 또한 서브 아웃소싱 허용 여부와 공급업체 의존 위험 최소화 방안을 고려해야 한다. 이를 통해 클라우드 투자 속도와 혁신의 이점을 극대화할 수 있다.",
                    "body_chunk_default": "따라 중요 아웃소싱인 경우 보안조치 등을 강화하고 규모 및 복잡성이 적은 기업은 완화된 조치를 적용 가능 집중위험이 확인될 경우 관할당국은 해당 위험을 모니터링하고 잠재적 영향을 평가 중요 클라우드 아웃소싱에 대한 요구사항 계약 관련 세부 정보 포함하여 아웃소싱 레지스터 등록 클라우드 아웃소싱 계약의 결과로 발생할 수 있는 위험 평가 동일한 CSP 사용으로 인한 집중 위험 발생 가능성 고려 CSP에 대한 평판 분석 등 적합성 평가 실시 데이터 처리 및 저장 위치 등을 포함한 서면 계약 요건 API 보안 비즈니스 연속성 관리 규정 준수 모니터링 수행 클라우드 아웃소싱 계약의 종료 가능 여부 평가 서브 아웃소싱 허용 여부를 고려한 아웃소싱 계약 체결 관할 당국에 클라우드 아웃소싱 계획 보고 공급업체 의존 위험 최소화 사례 자료제공 가트너 1 개요 미국의 금융회사인 AgCredit 은 SaaS 서비스 공급업체에 의존될 수 있는 위험을 사전에 해소하여 클라우드 투자 속도와 혁신의 이점을",
                    "auditor": "activate",
                    "title": "클라우드 아웃소싱 관리 및 위험 완화"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "XnpAZJMB_dO27nZ9mqIp",
                "_score": 0.36603695,
                "_source": {
                    "summary": "이 문장은 클라우드컴퓨팅서비스의 다양한 유형에 대해 설명하고 있습니다. 클라우드컴퓨팅서비스는 서비스의 운영 방식과 배치 모델에 따라 프라이빗, 퍼블릭, 커뮤니티, 하이브리드 등으로 나뉠 수 있으며, 상용으로 제공되는 클라우드컴퓨팅서비스는 주로 퍼블릭 방식입니다. 그러나 커뮤니티나 하이브리드 방식의 클라우드시스템도 서비스의 전부 또는 일부를 유상으로 제공한다면 이 법의 적용을 받을 수 있다고 설명하고 있습니다.",
                    "body_chunk_default": "아니합니다 예컨대 협회 단체 등이 전용으로 구축한 클라우드컴퓨팅서비스는 포함되지 않습니다 클라우드컴퓨팅서비스의 유형 클라우드컴퓨팅서비스는 서비스의 운영 방식 배치 모델 에 따라 일반적으로 1 프라이빗 클라우드 컴퓨팅서비스 2 퍼블릭 클라우드컴퓨팅서비스 3 커뮤니티 클라우드컴퓨팅서비스 4 하이브 리드 클라우드컴퓨팅서비스 등으로 나뉩니다 이 중에서 상용으로 제공되는 클라우드컴퓨팅서비스는 주로 퍼블릭 클라우드컴퓨팅서비스입니다 직접 개발 구축 운영 관리하는 경우에는 원칙적으로 이 법에서 규정하고 있는 클라우드컴퓨팅 서비스에 해당하지 않습니다 커뮤니티 클라우드컴퓨팅서비스나 하이브리드 클라우드컴퓨팅서비스도 서비스의 배치 및 운영 방식만 다를 뿐 상용으로 제공이 가능하므로 상용으로 제공 이용되고 있는 한 이 법에서 규정 하고 있는 클라우드컴퓨팅서비스에 포함될 수 있습니다 커뮤니티 하이브리드 등의 방식으로 구축된 클라우드시스템이라도 서비스의 전부 또는 일부를 클라우드컴퓨팅서비스 제공자가 유상으로",
                    "auditor": "activate",
                    "title": "클라우드컴퓨팅서비스의 유형과 범위"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "bnpAZJMB_dO27nZ9mqIq",
                "_score": 0.36191288,
                "_source": {
                    "summary": "금융회사 및 전자금융업자는 자사 클라우드 서비스 이용이 가능하지만, 전자금융감독규정에서 요구하는 절차를 준수해야 합니다. 상용 클라우드 이용 시 위탁계약서 등의 서류 제출은 필요하지 않으나, 상용 클라우드 이용과 관련된 서류를 제출해야 합니다. 또한 스타트업의 개발환경 지원 목적으로 클라우드를 이용할 경우에도 관련 규정을 따라야 합니다.",
                    "body_chunk_default": "따른 서류를 제출할 필요는 없으나 상용 클라우드 이용과 관련된 서류로 대체하여 제출해야 합니다 판단이유 전자금융감독규정 제14조의2에서 자사 클라우드 서비스 이용을 제한하고 있지 않으므로 금융회사 및 전자금융업자는 본인이 운영하는 상용 클라우드 서비스를 이용할 수 있습니다 9 FINANCIAL SECURITY INSTITUTE 적용 범위 관련 법령해석 회신문 및 비조치의견서 다만 이 경우에도 중요도 평가 등 동 규정에서 요구하고 있는 클라우드 이용 절차를 모두 준수해야 합니다 자사 클라우드 서비스 이용에 따른 사전보고시 위탁계약서 등 위탁관계에 따른 서류 제출할 필요는 없으나 상용 클라우드 이용과 관련된 서류로 대체 하여 제출해야 합니다 예 업무위수탁 운영 기준 상용 클라우드 이용에 따른 운영 기준 세부적인 제출서류 및 보고절차는 금융감독원 담당자 02 3145 7424 에게 문의하시기 바랍니다 비조치의견서 190011 19 5 27 스타트업 개발환경 지원 목적의 클라우드 이용시",
                    "auditor": "activate",
                    "title": "금융회사 및 전자금융업자의 상용 클라우드 서비스 이용 관련 규정"
                }
            },
            {
                "_index": "rag-chunk-500",
                "_id": "eXpAZJMB_dO27nZ9mqIq",
                "_score": 0.30663598,
                "_source": {
                    "summary": "이 문서는 금융회사가 클라우드 서비스를 이용할 때 필요한 업무 연속성 계획 및 안전성 확보조치 방안에 대해 설명하고 있습니다. 중요 업무 영역의 경우 필수 항목 전체를 평가해야 하지만, 지정된 클라우드 보안인증을 보유한 제공자를 이용하면 대체 항목을 생략할 수 있습니다. 비중요 업무 영역에서는 필수 항목만 평가하면 됩니다. 금융회사는 클라우드 서비스 이용에 따른 업무 연속성 계획과 안전성 확보조치 방안을 수립해야 합니다.",
                    "body_chunk_default": "또는 전자금융업자에서 자체적으로 수행 침해사고대응기관의 대표평가 결과를 공유받는 경우 활용 가능 중요 업무 이용영역에 대해 필수 대체 항목을 모두 평가해야 하나 지정된 클라우드 보안인증을 클라우드서비스 제공자가 보유 유지 하는 경우 대체 항목 생략 가능 필수 항목 생략 불가 비중요 업무 이용 영역에 대해 필수 항목 평가필요 대체 항목 생략 가능 다 업무 연속성 계획 및 안전성 확보조치 방안 수립 제5장 업무 연속성 계획 출구전략 포함 및 안전성 확보조치 방안 수립 l 금융회사는 클라우드서비스 이용에 따른 업무연속성 계획 안전성 확보조치 방안 등을 수립하여야 한다 17 FINANCIAL SECURITY INSTITUTE 중요 업무 감독규정 별표 2의3 클라우드컴퓨팅서비스 이용과 관련한 업무 연속성 계획 별표 2의4 클라우드컴퓨팅서비스 이용과 관련한 안전성 확보조치에서 필수 추가사항 모두 준수 필요 비중요 업무 업무 연속성 계획 안전성 확보조치에서 필수 사항 준수 필요 추가 사항 생략",
                    "auditor": "activate",
                    "title": "금융회사의 클라우드 서비스 이용을 위한 업무 연속성 계획 및 안전성 확보조치 방안"
                }
            }
        ]
    }
}
```

### Related Issues
https://github.com/opensearch-project/neural-search/issues/964 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
