### PR TITLE
Change CI to use pull_request

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/f
+      - uses: actions/checkout@v4
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,12 +38,6 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - uses: actions/checkout@v4
-        if: github.event_name == 'push' || github.event_name == 'schedule'
-
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -73,12 +67,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name == 'push' || github.event_name == 'schedule'
-
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -111,12 +99,6 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - uses: actions/checkout@v4
-        if: github.event_name == 'push' || github.event_name == 'schedule'
-
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -145,13 +127,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
-        if: github.event_name == 'push' || github.event_name == 'schedule'
-
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/f
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,8 +6,7 @@ on:
     branches:
       - "*"
       - "feature/**"
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
     branches:
       - "*"
       - "feature/**"
@@ -42,7 +41,7 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'schedule'
 
       - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -77,7 +76,7 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'schedule'
 
       - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -115,7 +114,7 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'schedule'
 
       - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -150,7 +149,7 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'schedule'
 
       - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
### Description
Changes the CI to use pull_request instead of pull_request_target.  This will result in codecov only running a few times per day then running out of quota

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
