### PR TITLE
Fixed failed test after knn added multiple inner hits feature

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -67,6 +67,7 @@ import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterTestUtils;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 
@@ -141,8 +142,8 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertNotNull(queryOnlyNeural);
         assertTrue(queryOnlyNeural instanceof HybridQuery);
         assertEquals(1, ((HybridQuery) queryOnlyNeural).getSubQueries().size());
-        assertTrue(((HybridQuery) queryOnlyNeural).getSubQueries().iterator().next() instanceof KNNQuery);
-        KNNQuery knnQuery = (KNNQuery) ((HybridQuery) queryOnlyNeural).getSubQueries().iterator().next();
+        assertTrue(((HybridQuery) queryOnlyNeural).getSubQueries().iterator().next() instanceof NativeEngineKnnVectorQuery);
+        KNNQuery knnQuery = ((NativeEngineKnnVectorQuery) ((HybridQuery) queryOnlyNeural).getSubQueries().iterator().next()).getKnnQuery();
         assertEquals(VECTOR_FIELD_NAME, knnQuery.getField());
         assertEquals(K, knnQuery.getK());
         assertNotNull(knnQuery.getQueryVector());
@@ -183,8 +184,8 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         // verify knn vector query
         Iterator<Query> queryIterator = ((HybridQuery) queryTwoSubQueries).getSubQueries().iterator();
         Query firstQuery = queryIterator.next();
-        assertTrue(firstQuery instanceof KNNQuery);
-        KNNQuery knnQuery = (KNNQuery) firstQuery;
+        assertTrue(firstQuery instanceof NativeEngineKnnVectorQuery);
+        KNNQuery knnQuery = ((NativeEngineKnnVectorQuery) firstQuery).getKnnQuery();
         assertEquals(VECTOR_FIELD_NAME, knnQuery.getField());
         assertEquals(K, knnQuery.getK());
         assertNotNull(knnQuery.getQueryVector());


### PR DESCRIPTION
### Description
Need to fix some unit tests after recent k-NN feature "Support for Multi Values in innerHit for Nested k-NN Fields in Lucene and FAISS" https://github.com/opensearch-project/k-NN/pull/2283

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [X] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
