### PR TITLE
[Backport] manually backport 1013 to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 - Explainability in hybrid query ([#970](https://github.com/opensearch-project/neural-search/pull/970))
+- Support new knn query parameter expand_nested ([#1013](https://github.com/opensearch-project/neural-search/pull/1013))
 ### Bug Fixes
 -  Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 ### Infrastructure

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
@@ -132,9 +132,6 @@ public class HybridSearchIT extends AbstractRestartUpgradeRestTestCase {
         if (expandNestedDocs != null) {
             neuralQueryBuilder.expandNested(expandNestedDocs);
         }
-        if (isClusterOnOrAfterMinReqVersion(EXPAND_NESTED_FIELD.getPreferredName()) && expandNestedDocs != null) {
-            neuralQueryBuilder.expandNested(expandNestedDocs);
-        }
         if (methodParameters != null) {
             neuralQueryBuilder.methodParameters(methodParameters);
         }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -62,6 +62,7 @@ public class KnnRadialSearchIT extends AbstractRestartUpgradeRestTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         Map<String, Object> responseWithMinScoreQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
@@ -74,6 +75,7 @@ public class KnnRadialSearchIT extends AbstractRestartUpgradeRestTestCase {
             modelId,
             null,
             100000f,
+            null,
             null,
             null,
             null,

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -64,6 +64,7 @@ public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
@@ -9,6 +9,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import org.opensearch.index.query.MatchQueryBuilder;
 import static org.opensearch.neuralsearch.util.TestUtils.NODES_BWC_CLUSTER;
 import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_WEIGHTS;
@@ -17,6 +19,8 @@ import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_NORMALIZATION_M
 import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_COMBINATION_METHOD;
 import static org.opensearch.neuralsearch.util.TestUtils.getModelId;
 
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
@@ -31,6 +35,8 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
     private static final String TEXT_UPGRADED = "Hi earth";
     private static final String QUERY = "Hi world";
     private static final int NUM_DOCS_PER_ROUND = 1;
+    private static final String VECTOR_EMBEDDING_FIELD = "passage_embedding";
+    protected static final String RESCORE_QUERY = "hi";
     private static String modelId = "";
 
     // Test rolling-upgrade normalization processor when index with multiple shards
@@ -61,13 +67,14 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
                 int totalDocsCountMixed;
                 if (isFirstMixedRound()) {
                     totalDocsCountMixed = NUM_DOCS_PER_ROUND;
-                    HybridQueryBuilder hybridQueryBuilder = getQueryBuilder(modelId, null, null);
-                    validateTestIndexOnUpgrade(totalDocsCountMixed, modelId, hybridQueryBuilder);
+                    HybridQueryBuilder hybridQueryBuilder = getQueryBuilder(modelId, null, null, null);
+                    QueryBuilder rescorer = QueryBuilders.matchQuery(TEST_FIELD, RESCORE_QUERY).boost(0.3f);
+                    validateTestIndexOnUpgrade(totalDocsCountMixed, modelId, hybridQueryBuilder, rescorer);
                     addDocument(getIndexNameForTest(), "1", TEST_FIELD, TEXT_MIXED, null, null);
                 } else {
                     totalDocsCountMixed = 2 * NUM_DOCS_PER_ROUND;
-                    HybridQueryBuilder hybridQueryBuilder = getQueryBuilder(modelId, null, null);
-                    validateTestIndexOnUpgrade(totalDocsCountMixed, modelId, hybridQueryBuilder);
+                    HybridQueryBuilder hybridQueryBuilder = getQueryBuilder(modelId, null, null, null);
+                    validateTestIndexOnUpgrade(totalDocsCountMixed, modelId, hybridQueryBuilder, null);
                 }
                 break;
             case UPGRADED:
@@ -76,10 +83,11 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
                     int totalDocsCountUpgraded = 3 * NUM_DOCS_PER_ROUND;
                     loadModel(modelId);
                     addDocument(getIndexNameForTest(), "2", TEST_FIELD, TEXT_UPGRADED, null, null);
-                    HybridQueryBuilder hybridQueryBuilder = getQueryBuilder(modelId, null, null);
-                    validateTestIndexOnUpgrade(totalDocsCountUpgraded, modelId, hybridQueryBuilder);
-                    hybridQueryBuilder = getQueryBuilder(modelId, Map.of("ef_search", 100), RescoreContext.getDefault());
-                    validateTestIndexOnUpgrade(totalDocsCountUpgraded, modelId, hybridQueryBuilder);
+                    HybridQueryBuilder hybridQueryBuilder = getQueryBuilder(modelId, null, null, null);
+                    QueryBuilder rescorer = QueryBuilders.matchQuery(TEST_FIELD, RESCORE_QUERY).boost(0.3f);
+                    validateTestIndexOnUpgrade(totalDocsCountUpgraded, modelId, hybridQueryBuilder, rescorer);
+                    hybridQueryBuilder = getQueryBuilder(modelId, Boolean.FALSE, Map.of("ef_search", 100), RescoreContext.getDefault());
+                    validateTestIndexOnUpgrade(totalDocsCountUpgraded, modelId, hybridQueryBuilder, rescorer);
                 } finally {
                     wipeOfTestResources(getIndexNameForTest(), PIPELINE_NAME, modelId, SEARCH_PIPELINE_NAME);
                 }
@@ -89,15 +97,19 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
         }
     }
 
-    private void validateTestIndexOnUpgrade(final int numberOfDocs, final String modelId, HybridQueryBuilder hybridQueryBuilder)
-        throws Exception {
+    private void validateTestIndexOnUpgrade(
+        final int numberOfDocs,
+        final String modelId,
+        HybridQueryBuilder hybridQueryBuilder,
+        QueryBuilder rescorer
+    ) throws Exception {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
         Map<String, Object> searchResponseAsMap = search(
             getIndexNameForTest(),
             hybridQueryBuilder,
-            null,
+            rescorer,
             1,
             Map.of("search_pipeline", SEARCH_PIPELINE_NAME)
         );
@@ -112,19 +124,23 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
 
     private HybridQueryBuilder getQueryBuilder(
         final String modelId,
+        final Boolean expandNestedDocs,
         final Map<String, ?> methodParameters,
-        final RescoreContext rescoreContext
+        final RescoreContext rescoreContextForNeuralQuery
     ) {
         NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_embedding");
+        neuralQueryBuilder.fieldName(VECTOR_EMBEDDING_FIELD);
         neuralQueryBuilder.modelId(modelId);
         neuralQueryBuilder.queryText(QUERY);
         neuralQueryBuilder.k(5);
+        if (expandNestedDocs != null) {
+            neuralQueryBuilder.expandNested(expandNestedDocs);
+        }
         if (methodParameters != null) {
             neuralQueryBuilder.methodParameters(methodParameters);
         }
-        if (rescoreContext != null) {
-            neuralQueryBuilder.rescoreContext(rescoreContext);
+        if (Objects.nonNull(rescoreContextForNeuralQuery)) {
+            neuralQueryBuilder.rescoreContext(rescoreContextForNeuralQuery);
         }
 
         MatchQueryBuilder matchQueryBuilder = new MatchQueryBuilder("text", QUERY);

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -88,6 +88,7 @@ public class KnnRadialSearchIT extends AbstractRollingUpgradeTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         Map<String, Object> responseWithMinScore = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
@@ -100,6 +101,7 @@ public class KnnRadialSearchIT extends AbstractRollingUpgradeTestCase {
             modelId,
             null,
             100000f,
+            null,
             null,
             null,
             null,

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -87,6 +87,7 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         Map<String, Object> responseWithKQuery = search(getIndexNameForTest(), neuralQueryBuilderWithKQuery, 1);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -98,6 +98,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 null,
                 null,
                 null,
+                null,
                 null
             );
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
@@ -150,6 +151,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 null,
                 null,
                 null,
+                null,
                 null
             );
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
@@ -186,6 +188,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 6,
+                null,
                 null,
                 null,
                 null,

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
@@ -224,7 +224,20 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
             hybridQueryBuilderDefaultNorm.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -249,7 +262,20 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
             hybridQueryBuilderL2Norm.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -299,7 +325,20 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
             hybridQueryBuilderDefaultNorm.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -324,7 +363,20 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
             hybridQueryBuilderL2Norm.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
@@ -85,7 +85,20 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
             hybridQueryBuilderArithmeticMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -110,7 +123,20 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
             hybridQueryBuilderHarmonicMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -135,7 +161,20 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
             hybridQueryBuilderGeometricMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -185,7 +224,20 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
             hybridQueryBuilderArithmeticMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -210,7 +262,20 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
             hybridQueryBuilderHarmonicMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -235,7 +300,20 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
             hybridQueryBuilderGeometricMean.add(
-                new NeuralQueryBuilder(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DOC_TEXT1, "", modelId, 5, null, null, null, null, null, null)
+                new NeuralQueryBuilder(
+                    TEST_KNN_VECTOR_FIELD_NAME_1,
+                    TEST_DOC_TEXT1,
+                    "",
+                    modelId,
+                    5,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
             );
             hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -125,6 +125,7 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
                 null,
                 null,
                 null,
+                null,
                 null
             );
             QueryBuilder queryNestedLowerLevel = QueryBuilders.nestedQuery(

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
 import static org.opensearch.index.query.AbstractQueryBuilder.NAME_FIELD;
+import static org.opensearch.knn.index.query.KNNQueryBuilder.EXPAND_NESTED_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.FILTER_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.MAX_DISTANCE_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.MIN_SCORE_FIELD;
@@ -202,6 +203,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
                 "k": int,
                 "boost": 10.0,
                 "_name": "something",
+                "expandNestedDocs": true
               }
           }
         */
@@ -215,6 +217,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .field(K_FIELD.getPreferredName(), K)
             .field(BOOST_FIELD.getPreferredName(), BOOST)
             .field(NAME_FIELD.getPreferredName(), QUERY_NAME)
+            .field(EXPAND_NESTED_FIELD.getPreferredName(), Boolean.TRUE)
             .endObject()
             .endObject();
 
@@ -229,6 +232,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         assertEquals(K, neuralQueryBuilder.k());
         assertEquals(BOOST, neuralQueryBuilder.boost(), 0.0);
         assertEquals(QUERY_NAME, neuralQueryBuilder.queryName());
+        assertEquals(Boolean.TRUE, neuralQueryBuilder.expandNested());
     }
 
     @SneakyThrows
@@ -428,6 +432,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .modelId(MODEL_ID)
             .queryText(QUERY_TEXT)
             .k(K)
+            .expandNested(Boolean.TRUE)
             .filter(TEST_FILTER);
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
@@ -454,6 +459,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         assertEquals(MODEL_ID, secondInnerMap.get(MODEL_ID_FIELD.getPreferredName()));
         assertEquals(QUERY_TEXT, secondInnerMap.get(QUERY_TEXT_FIELD.getPreferredName()));
         assertEquals(K, secondInnerMap.get(K_FIELD.getPreferredName()));
+        assertEquals(Boolean.TRUE, secondInnerMap.get(EXPAND_NESTED_FIELD.getPreferredName()));
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
         assertEquals(
             xContentBuilderToMap(TEST_FILTER.toXContent(xContentBuilder, EMPTY_PARAMS)),
@@ -718,6 +724,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .queryImage(IMAGE_TEXT)
             .modelId(MODEL_ID)
             .k(K)
+            .expandNested(Boolean.TRUE)
             .vectorSupplier(nullSupplier);
         QueryBuilder queryBuilder = neuralQueryBuilder.doRewrite(null);
         assertEquals(neuralQueryBuilder, queryBuilder);
@@ -729,6 +736,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .queryImage(IMAGE_TEXT)
             .modelId(MODEL_ID)
             .k(K)
+            .expandNested(Boolean.TRUE)
             .methodParameters(Map.of("ef_search", 100))
             .rescoreContext(RescoreContext.getDefault())
             .vectorSupplier(TEST_VECTOR_SUPPLIER);
@@ -739,6 +747,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .methodParameters(neuralQueryBuilder.methodParameters())
             .rescoreContext(neuralQueryBuilder.rescoreContext())
             .vector(TEST_VECTOR_SUPPLIER.get())
+            .expandNested(Boolean.TRUE)
             .build();
 
         QueryBuilder queryBuilder = neuralQueryBuilder.doRewrite(null);

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
@@ -113,6 +113,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 null,
                 null,
                 null,
+                null,
                 null
             );
 
@@ -131,6 +132,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 TEST_IMAGE_TEXT,
                 modelId,
                 1,
+                null,
                 null,
                 null,
                 null,
@@ -164,6 +166,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 null,
                 null,
                 null,
+                null,
                 null
             );
 
@@ -191,6 +194,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 null,
                 null,
                 0.01f,
+                null,
                 null,
                 null,
                 null,
@@ -245,6 +249,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 1,
+                null,
                 null,
                 null,
                 null,
@@ -329,6 +334,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 null,
                 null,
                 null,
+                null,
                 null
             );
             NeuralQueryBuilder neuralQueryBuilder2 = new NeuralQueryBuilder(
@@ -337,6 +343,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 1,
+                null,
                 null,
                 null,
                 null,
@@ -366,6 +373,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 1,
+                null,
                 null,
                 null,
                 null,
@@ -428,6 +436,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 null,
                 null,
                 null,
+                null,
                 null
             );
 
@@ -475,6 +484,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
                 "",
                 modelId,
                 1,
+                null,
                 null,
                 null,
                 null,


### PR DESCRIPTION
Signed-off-by: Bo Zhang <bzhangam@amazon.com>
(cherry picked from commit fa149d43f98ae170b25d489c1639de6c00e0d606)

### Description
Support new knn query parameter `expand_nested_docs`.

### Related Issues
Resolves [#1008](https://github.com/opensearch-project/neural-search/issues/1008)

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
