### PR TITLE
Fix random total hits range for ExplanationPayloadProcessorTests.

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/ExplanationPayloadProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ExplanationPayloadProcessorTests.java
@@ -125,7 +125,7 @@ public class ExplanationPayloadProcessorTests extends OpenSearchTestCase {
             searchHit.explanation(explanation);
         }
         TotalHits.Relation totalHitsRelation = randomFrom(TotalHits.Relation.values());
-        TotalHits totalHits = new TotalHits(randomLongBetween(0, 1000), totalHitsRelation);
+        TotalHits totalHits = new TotalHits(randomLongBetween(1, 1000), totalHitsRelation);
         final SortField[] sortFields = new SortField[] {
             new SortField("random-text-field-1", SortField.Type.INT, randomBoolean()),
             new SortField("random-text-field-2", SortField.Type.STRING, randomBoolean()) };
@@ -203,7 +203,7 @@ public class ExplanationPayloadProcessorTests extends OpenSearchTestCase {
         int requestedSize = 2;
         PriorityQueue<SearchHit> priorityQueue = new PriorityQueue<>(new SearchHitComparator(null));
         TotalHits.Relation totalHitsRelation = randomFrom(TotalHits.Relation.values());
-        TotalHits totalHits = new TotalHits(randomLongBetween(0, 1000), totalHitsRelation);
+        TotalHits totalHits = new TotalHits(randomLongBetween(1, 1000), totalHitsRelation);
 
         final int numDocs = totalHits.value >= requestedSize ? requestedSize : (int) totalHits.value;
         int scoreFactor = randomIntBetween(1, numResponses);


### PR DESCRIPTION
### Description
Fix random total hits range for ExplanationPayloadProcessorTests. In tests we don't expect 0 total hit and 0 total hit will cause Index 0 out of bounds for length 0 error because we assume it should not be 0.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
