### PR TITLE
Integrate explainability for hybrid query into RRF processor

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/AbstractScoreHybridizationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/AbstractScoreHybridizationProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchPhaseResults;
+import org.opensearch.search.SearchPhaseResult;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.pipeline.PipelineProcessingContext;
+import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
+
+import java.util.Optional;
+
+/**
+ * Base class for all score hybridization processors. This class is responsible for executing the score hybridization process.
+ * It is a pipeline processor that is executed after the query phase and before the fetch phase.
+ */
+public abstract class AbstractScoreHybridizationProcessor implements SearchPhaseResultsProcessor {
+    /**
+     * Method abstracts functional aspect of score normalization and score combination. Exact methods for each processing stage
+     * are set as part of class constructor. This method is called when there is no pipeline context
+     * @param searchPhaseResult {@link SearchPhaseResults} DTO that has query search results. Results will be mutated as part of this method execution
+     * @param searchPhaseContext {@link SearchContext}
+     */
+    @Override
+    public <Result extends SearchPhaseResult> void process(
+        final SearchPhaseResults<Result> searchPhaseResult,
+        final SearchPhaseContext searchPhaseContext
+    ) {
+        hybridizeScores(searchPhaseResult, searchPhaseContext, Optional.empty());
+    }
+
+    /**
+     * Method abstracts functional aspect of score normalization and score combination. Exact methods for each processing stage
+     * are set as part of class constructor. This method is called when there is pipeline context
+     * @param searchPhaseResult {@link SearchPhaseResults} DTO that has query search results. Results will be mutated as part of this method execution
+     * @param searchPhaseContext {@link SearchContext}
+     * @param requestContext {@link PipelineProcessingContext} processing context of search pipeline
+     * @param <Result>
+     */
+    @Override
+    public <Result extends SearchPhaseResult> void process(
+        final SearchPhaseResults<Result> searchPhaseResult,
+        final SearchPhaseContext searchPhaseContext,
+        final PipelineProcessingContext requestContext
+    ) {
+        hybridizeScores(searchPhaseResult, searchPhaseContext, Optional.ofNullable(requestContext));
+    }
+
+    /**
+     * Method abstracts functional aspect of score normalization and score combination. Exact methods for each processing stage
+     * are set as part of class constructor
+     * @param searchPhaseResult
+     * @param searchPhaseContext
+     * @param requestContextOptional
+     * @param <Result>
+     */
+    abstract <Result extends SearchPhaseResult> void hybridizeScores(
+        SearchPhaseResults<Result> searchPhaseResult,
+        SearchPhaseContext searchPhaseContext,
+        Optional<PipelineProcessingContext> requestContextOptional
+    );
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessor.java
@@ -111,8 +111,9 @@ public class ExplanationResponseProcessor implements SearchResponseProcessor {
                         );
                     }
                     // Create and set final explanation combining all components
+                    Float finalScore = Float.isNaN(searchHit.getScore()) ? 0.0f : searchHit.getScore();
                     Explanation finalExplanation = Explanation.match(
-                        searchHit.getScore(),
+                        finalScore,
                         // combination level explanation is always a single detail
                         combinationExplanation.getScoreDetails().get(0).getValue(),
                         normalizedExplanation

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessor.java
@@ -19,9 +19,7 @@ import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechniq
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
 import org.opensearch.search.SearchPhaseResult;
 import org.opensearch.search.fetch.FetchSearchResult;
-import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
-import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
 import org.opensearch.search.query.QuerySearchResult;
 
 import lombok.AllArgsConstructor;
@@ -33,7 +31,7 @@ import lombok.extern.log4j.Log4j2;
  */
 @Log4j2
 @AllArgsConstructor
-public class NormalizationProcessor implements SearchPhaseResultsProcessor {
+public class NormalizationProcessor extends AbstractScoreHybridizationProcessor {
     public static final String TYPE = "normalization-processor";
 
     private final String tag;
@@ -42,38 +40,8 @@ public class NormalizationProcessor implements SearchPhaseResultsProcessor {
     private final ScoreCombinationTechnique combinationTechnique;
     private final NormalizationProcessorWorkflow normalizationWorkflow;
 
-    /**
-     * Method abstracts functional aspect of score normalization and score combination. Exact methods for each processing stage
-     * are set as part of class constructor. This method is called when there is no pipeline context
-     * @param searchPhaseResult {@link SearchPhaseResults} DTO that has query search results. Results will be mutated as part of this method execution
-     * @param searchPhaseContext {@link SearchContext}
-     */
     @Override
-    public <Result extends SearchPhaseResult> void process(
-        final SearchPhaseResults<Result> searchPhaseResult,
-        final SearchPhaseContext searchPhaseContext
-    ) {
-        prepareAndExecuteNormalizationWorkflow(searchPhaseResult, searchPhaseContext, Optional.empty());
-    }
-
-    /**
-     * Method abstracts functional aspect of score normalization and score combination. Exact methods for each processing stage
-     * are set as part of class constructor
-     * @param searchPhaseResult {@link SearchPhaseResults} DTO that has query search results. Results will be mutated as part of this method execution
-     * @param searchPhaseContext {@link SearchContext}
-     * @param requestContext {@link PipelineProcessingContext} processing context of search pipeline
-     * @param <Result>
-     */
-    @Override
-    public <Result extends SearchPhaseResult> void process(
-        final SearchPhaseResults<Result> searchPhaseResult,
-        final SearchPhaseContext searchPhaseContext,
-        final PipelineProcessingContext requestContext
-    ) {
-        prepareAndExecuteNormalizationWorkflow(searchPhaseResult, searchPhaseContext, Optional.ofNullable(requestContext));
-    }
-
-    private <Result extends SearchPhaseResult> void prepareAndExecuteNormalizationWorkflow(
+    <Result extends SearchPhaseResult> void hybridizeScores(
         SearchPhaseResults<Result> searchPhaseResult,
         SearchPhaseContext searchPhaseContext,
         Optional<PipelineProcessingContext> requestContextOptional

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/RRFScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/RRFScoreCombinationTechnique.java
@@ -6,27 +6,39 @@ package org.opensearch.neuralsearch.processor.combination;
 
 import lombok.ToString;
 import lombok.extern.log4j.Log4j2;
+import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
 
-import java.util.Map;
+import java.util.List;
+import java.util.Objects;
+
+import static org.opensearch.neuralsearch.processor.explain.ExplanationUtils.describeCombinationTechnique;
 
 @Log4j2
 /**
  * Abstracts combination of scores based on reciprocal rank fusion algorithm
  */
 @ToString(onlyExplicitlyIncluded = true)
-public class RRFScoreCombinationTechnique implements ScoreCombinationTechnique {
+public class RRFScoreCombinationTechnique implements ScoreCombinationTechnique, ExplainableTechnique {
     @ToString.Include
     public static final String TECHNIQUE_NAME = "rrf";
 
     // Not currently using weights for RRF, no need to modify or verify these params
-    public RRFScoreCombinationTechnique(final Map<String, Object> params, final ScoreCombinationUtil combinationUtil) {}
+    public RRFScoreCombinationTechnique() {}
 
     @Override
     public float combine(final float[] scores) {
+        if (Objects.isNull(scores)) {
+            throw new IllegalArgumentException("scores array cannot be null");
+        }
         float sumScores = 0.0f;
         for (float score : scores) {
             sumScores += score;
         }
         return sumScores;
+    }
+
+    @Override
+    public String describe() {
+        return describeCombinationTechnique(TECHNIQUE_NAME, List.of());
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationFactory.java
@@ -27,7 +27,7 @@ public class ScoreCombinationFactory {
         GeometricMeanScoreCombinationTechnique.TECHNIQUE_NAME,
         params -> new GeometricMeanScoreCombinationTechnique(params, scoreCombinationUtil),
         RRFScoreCombinationTechnique.TECHNIQUE_NAME,
-        params -> new RRFScoreCombinationTechnique(params, scoreCombinationUtil)
+        params -> new RRFScoreCombinationTechnique()
     );
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
@@ -71,7 +71,7 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
 
     @Override
     public String describe() {
-        return String.format(Locale.ROOT, "%s, rank_constant %s", TECHNIQUE_NAME, rankConstant);
+        return String.format(Locale.ROOT, "%s, rank_constant [%s]", TECHNIQUE_NAME, rankConstant);
     }
 
     @Override

--- a/src/test/java/org/opensearch/neuralsearch/processor/AbstractScoreHybridizationProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/AbstractScoreHybridizationProcessorTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.opensearch.action.OriginalIndices;
+import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchPhaseName;
+import org.opensearch.action.search.SearchPhaseResults;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+import org.opensearch.common.util.concurrent.AtomicArray;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.SearchPhaseResult;
+import org.opensearch.search.SearchShardTarget;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.internal.ShardSearchContextId;
+import org.opensearch.search.pipeline.PipelineProcessingContext;
+import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AbstractScoreHybridizationProcessorTests extends OpenSearchTestCase {
+    private static final String TEST_TAG = "test_processor";
+    private static final String TEST_DESCRIPTION = "Test Processor";
+
+    private TestScoreHybridizationProcessor processor;
+    private NormalizationProcessorWorkflow normalizationWorkflow;
+
+    private static class TestScoreHybridizationProcessor extends AbstractScoreHybridizationProcessor {
+        private final String tag;
+        private final String description;
+        private final NormalizationProcessorWorkflow normalizationWorkflow1;
+
+        TestScoreHybridizationProcessor(String tag, String description, NormalizationProcessorWorkflow normalizationWorkflow) {
+            this.tag = tag;
+            this.description = description;
+            normalizationWorkflow1 = normalizationWorkflow;
+        }
+
+        @Override
+        <Result extends SearchPhaseResult> void hybridizeScores(
+            SearchPhaseResults<Result> searchPhaseResult,
+            SearchPhaseContext searchPhaseContext,
+            Optional<PipelineProcessingContext> requestContextOptional
+        ) {
+            NormalizationProcessorWorkflowExecuteRequest normalizationExecuteDTO = NormalizationProcessorWorkflowExecuteRequest.builder()
+                .pipelineProcessingContext(requestContextOptional.orElse(null))
+                .build();
+            normalizationWorkflow1.execute(normalizationExecuteDTO);
+        }
+
+        @Override
+        public SearchPhaseName getBeforePhase() {
+            return SearchPhaseName.FETCH;
+        }
+
+        @Override
+        public SearchPhaseName getAfterPhase() {
+            return SearchPhaseName.QUERY;
+        }
+
+        @Override
+        public String getType() {
+            return "my_processor";
+        }
+
+        @Override
+        public String getTag() {
+            return tag;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public boolean isIgnoreFailure() {
+            return false;
+        }
+    }
+
+    @Before
+    public void setup() {
+        normalizationWorkflow = mock(NormalizationProcessorWorkflow.class);
+
+        processor = new TestScoreHybridizationProcessor(TEST_TAG, TEST_DESCRIPTION, normalizationWorkflow);
+    }
+
+    public void testProcessorMetadata() {
+        assertEquals(TEST_TAG, processor.getTag());
+        assertEquals(TEST_DESCRIPTION, processor.getDescription());
+    }
+
+    public void testProcessWithExplanations() {
+        SearchRequest searchRequest = new SearchRequest();
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        SearchPhaseContext context = mock(SearchPhaseContext.class);
+        SearchPhaseResults<SearchPhaseResult> results = mock(SearchPhaseResults.class);
+
+        sourceBuilder.explain(true);
+        searchRequest.source(sourceBuilder);
+        when(context.getRequest()).thenReturn(searchRequest);
+
+        AtomicArray<SearchPhaseResult> resultsArray = new AtomicArray<>(1);
+        QuerySearchResult queryResult = createQuerySearchResult();
+        resultsArray.set(0, queryResult);
+        when(results.getAtomicArray()).thenReturn(resultsArray);
+
+        TestScoreHybridizationProcessor spyProcessor = spy(processor);
+        spyProcessor.process(results, context);
+
+        verify(spyProcessor).hybridizeScores(any(SearchPhaseResults.class), any(SearchPhaseContext.class), any(Optional.class));
+        verify(normalizationWorkflow).execute(any());
+    }
+
+    public void testProcess() {
+        SearchPhaseResults<SearchPhaseResult> searchPhaseResult = mock(SearchPhaseResults.class);
+        SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
+        PipelineProcessingContext requestContext = mock(PipelineProcessingContext.class);
+
+        TestScoreHybridizationProcessor spyProcessor = spy(processor);
+        spyProcessor.process(searchPhaseResult, searchPhaseContext, requestContext);
+
+        verify(spyProcessor).hybridizeScores(any(SearchPhaseResults.class), any(SearchPhaseContext.class), any(Optional.class));
+    }
+
+    private QuerySearchResult createQuerySearchResult() {
+        QuerySearchResult result = new QuerySearchResult(
+            new ShardSearchContextId("test", 1),
+            new SearchShardTarget("node1", new ShardId("index", "uuid", 0), null, OriginalIndices.NONE),
+            null
+        );
+        TopDocs topDocs = new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(0, 1.0f) });
+        result.topDocs(new TopDocsAndMaxScore(topDocs, 1.0f), new DocValueFormat[0]);
+        return result;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/combination/RRFScoreCombinationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/combination/RRFScoreCombinationTechniqueTests.java
@@ -5,24 +5,60 @@
 package org.opensearch.neuralsearch.processor.combination;
 
 import java.util.List;
-import java.util.Map;
 
 public class RRFScoreCombinationTechniqueTests extends BaseScoreCombinationTechniqueTests {
 
-    private ScoreCombinationUtil scoreCombinationUtil = new ScoreCombinationUtil();
+    private static final int RANK_CONSTANT = 60;
+    private RRFScoreCombinationTechnique combinationTechnique;
 
     public RRFScoreCombinationTechniqueTests() {
         this.expectedScoreFunction = (scores, weights) -> RRF(scores, weights);
+        combinationTechnique = new RRFScoreCombinationTechnique();
     }
 
     public void testLogic_whenAllScoresPresentAndNoWeights_thenCorrectScores() {
-        ScoreCombinationTechnique technique = new RRFScoreCombinationTechnique(Map.of(), scoreCombinationUtil);
+        ScoreCombinationTechnique technique = new RRFScoreCombinationTechnique();
         testLogic_whenAllScoresPresentAndNoWeights_thenCorrectScores(technique);
     }
 
     public void testLogic_whenNotAllScoresPresentAndNoWeights_thenCorrectScores() {
-        ScoreCombinationTechnique technique = new RRFScoreCombinationTechnique(Map.of(), scoreCombinationUtil);
+        ScoreCombinationTechnique technique = new RRFScoreCombinationTechnique();
         testLogic_whenNotAllScoresPresentAndNoWeights_thenCorrectScores(technique);
+    }
+
+    public void testDescribe() {
+        String description = combinationTechnique.describe();
+        assertEquals("rrf", description);
+    }
+
+    public void testCombineWithEmptyInput() {
+        float[] scores = new float[0];
+        float result = combinationTechnique.combine(scores);
+        assertEquals(0.0f, result, 0.001f);
+    }
+
+    public void testCombineWithSingleScore() {
+        float[] scores = new float[] { 0.5f };
+        float result = combinationTechnique.combine(scores);
+        assertEquals(0.5f, result, 0.001f);
+    }
+
+    public void testCombineWithMultipleScores() {
+        float[] scores = new float[] { 0.8f, 0.6f, 0.4f };
+        float result = combinationTechnique.combine(scores);
+        float expected = 0.8f + 0.6f + 0.4f;
+        assertEquals(expected, result, 0.001f);
+    }
+
+    public void testCombineWithZeroScores() {
+        float[] scores = new float[] { 0.0f, 0.0f };
+        float result = combinationTechnique.combine(scores);
+        assertEquals(0.0f, result, 0.001f);
+    }
+
+    public void testCombineWithNullInput() {
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> combinationTechnique.combine(null));
+        assertEquals("scores array cannot be null", exception.getMessage());
     }
 
     private float RRF(List<Float> scores, List<Double> weights) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -30,8 +30,13 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     private static final SearchShard SEARCH_SHARD = new SearchShard("my_index", 0, "12345678");
 
     public void testDescribe() {
+        // verify with default values for parameters
         RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
-        assertEquals("rrf, rank_constant 60", normalizationTechnique.describe());
+        assertEquals("rrf, rank_constant [60]", normalizationTechnique.describe());
+
+        // verify when parameter values are set
+        normalizationTechnique = new RRFNormalizationTechnique(Map.of("rank_constant", 25), scoreNormalizationUtil);
+        assertEquals("rrf, rank_constant [25]", normalizationTechnique.describe());
     }
 
     public void testNormalization_whenResultFromOneShardOneSubQuery_thenSuccessful() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -10,10 +10,14 @@ import org.apache.lucene.search.TotalHits;
 import org.opensearch.neuralsearch.processor.CompoundTopDocs;
 import org.opensearch.neuralsearch.processor.NormalizeScoresDTO;
 import org.opensearch.neuralsearch.processor.SearchShard;
+import org.opensearch.neuralsearch.processor.explain.DocIdAtSearchShard;
+import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -24,6 +28,11 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     static final int RANK_CONSTANT = 60;
     private ScoreNormalizationUtil scoreNormalizationUtil = new ScoreNormalizationUtil();
     private static final SearchShard SEARCH_SHARD = new SearchShard("my_index", 0, "12345678");
+
+    public void testDescribe() {
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        assertEquals("rrf, rank_constant 60", normalizationTechnique.describe());
+    }
 
     public void testNormalization_whenResultFromOneShardOneSubQuery_thenSuccessful() {
         RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
@@ -224,6 +233,27 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
         }
     }
 
+    public void testExplainWithEmptyAndNullList() {
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        normalizationTechnique.explain(List.of());
+
+        List<CompoundTopDocs> compoundTopDocs = new ArrayList<>();
+        compoundTopDocs.add(null);
+        normalizationTechnique.explain(compoundTopDocs);
+    }
+
+    public void testExplainWithSingleTopDocs() {
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        CompoundTopDocs topDocs = createCompoundTopDocs(new float[] { 0.8f }, 1);
+        List<CompoundTopDocs> queryTopDocs = Collections.singletonList(topDocs);
+
+        Map<DocIdAtSearchShard, ExplanationDetails> explanation = normalizationTechnique.explain(queryTopDocs);
+
+        assertNotNull(explanation);
+        assertEquals(1, explanation.size());
+        assertTrue(explanation.containsKey(new DocIdAtSearchShard(0, new SearchShard("test_index", 0, "uuid"))));
+    }
+
     private float rrfNorm(int rank) {
         // 1.0f / (float) (rank + RANK_CONSTANT + 1);
         return BigDecimal.ONE.divide(BigDecimal.valueOf(rank + RANK_CONSTANT + 1), 10, RoundingMode.HALF_UP).floatValue();
@@ -238,5 +268,24 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             assertEquals(expected.scoreDocs[i].doc, actual.scoreDocs[i].doc);
             assertEquals(expected.scoreDocs[i].shardIndex, actual.scoreDocs[i].shardIndex);
         }
+    }
+
+    private CompoundTopDocs createCompoundTopDocs(float[] scores, int size) {
+        ScoreDoc[] scoreDocs = new ScoreDoc[size];
+        for (int i = 0; i < size; i++) {
+            scoreDocs[i] = new ScoreDoc(i, scores[i]);
+        }
+        TopDocs singleTopDocs = new TopDocs(new TotalHits(size, TotalHits.Relation.EQUAL_TO), scoreDocs);
+
+        List<TopDocs> topDocsList = Collections.singletonList(singleTopDocs);
+        TopDocs topDocs = new TopDocs(new TotalHits(size, TotalHits.Relation.EQUAL_TO), scoreDocs);
+        SearchShard searchShard = new SearchShard("test_index", 0, "uuid");
+
+        return new CompoundTopDocs(
+            new TotalHits(size, TotalHits.Relation.EQUAL_TO),
+            topDocsList,
+            false, // isSortEnabled
+            searchShard
+        );
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -633,7 +633,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             // two sub-queries meaning we do have two detail objects with separate query level details
             Map<String, Object> hit1DetailsForHit1 = hit1Details.get(0);
             assertTrue((double) hit1DetailsForHit1.get("value") > DELTA_FOR_SCORE_ASSERTION);
-            assertEquals("rrf, rank_constant 60 normalization of:", hit1DetailsForHit1.get("description"));
+            assertEquals("rrf, rank_constant [60] normalization of:", hit1DetailsForHit1.get("description"));
             assertEquals(1, ((List) hit1DetailsForHit1.get("details")).size());
 
             Map<String, Object> explanationsHit1 = getListOfValues(hit1DetailsForHit1, "details").get(0);
@@ -643,7 +643,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
 
             Map<String, Object> hit1DetailsForHit2 = hit1Details.get(1);
             assertTrue((double) hit1DetailsForHit2.get("value") > 0.0f);
-            assertEquals("rrf, rank_constant 60 normalization of:", hit1DetailsForHit2.get("description"));
+            assertEquals("rrf, rank_constant [60] normalization of:", hit1DetailsForHit2.get("description"));
             assertEquals(1, ((List) hit1DetailsForHit2.get("details")).size());
 
             Map<String, Object> explanationsHit2 = getListOfValues(hit1DetailsForHit2, "details").get(0);
@@ -663,12 +663,12 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
 
             Map<String, Object> hit2DetailsForHit1 = hit2Details.get(0);
             assertTrue((double) hit2DetailsForHit1.get("value") > DELTA_FOR_SCORE_ASSERTION);
-            assertEquals("rrf, rank_constant 60 normalization of:", hit2DetailsForHit1.get("description"));
+            assertEquals("rrf, rank_constant [60] normalization of:", hit2DetailsForHit1.get("description"));
             assertEquals(1, ((List) hit2DetailsForHit1.get("details")).size());
 
             Map<String, Object> hit2DetailsForHit2 = hit2Details.get(1);
             assertTrue((double) hit2DetailsForHit2.get("value") > DELTA_FOR_SCORE_ASSERTION);
-            assertEquals("rrf, rank_constant 60 normalization of:", hit2DetailsForHit2.get("description"));
+            assertEquals("rrf, rank_constant [60] normalization of:", hit2DetailsForHit2.get("description"));
             assertEquals(1, ((List) hit2DetailsForHit2.get("details")).size());
 
             // hit 3
@@ -683,7 +683,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
 
             Map<String, Object> hit3DetailsForHit1 = hit3Details.get(0);
             assertTrue((double) hit3DetailsForHit1.get("value") > .0f);
-            assertEquals("rrf, rank_constant 60 normalization of:", hit3DetailsForHit1.get("description"));
+            assertEquals("rrf, rank_constant [60] normalization of:", hit3DetailsForHit1.get("description"));
             assertEquals(1, ((List) hit3DetailsForHit1.get("details")).size());
 
             Map<String, Object> explanationsHit3 = getListOfValues(hit3DetailsForHit1, "details").get(0);
@@ -703,7 +703,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
 
             Map<String, Object> hit4DetailsForHit1 = hit4Details.get(0);
             assertTrue((double) hit4DetailsForHit1.get("value") > DELTA_FOR_SCORE_ASSERTION);
-            assertEquals("rrf, rank_constant 60 normalization of:", hit4DetailsForHit1.get("description"));
+            assertEquals("rrf, rank_constant [60] normalization of:", hit4DetailsForHit1.get("description"));
             assertEquals(1, ((List) hit4DetailsForHit1.get("details")).size());
 
             Map<String, Object> explanationsHit4 = getListOfValues(hit4DetailsForHit1, "details").get(0);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -58,7 +58,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
     private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
-    private static final String SEARCH_PIPELINE = "phase-results-hybrid-pipeline";
+    private static final String NORMALIZATION_SEARCH_PIPELINE = "normalization-search-pipeline";
+    private static final String RRF_SEARCH_PIPELINE = "rrf-search-pipeline";
 
     static final Supplier<float[]> TEST_VECTOR_SUPPLIER = () -> new float[768];
 
@@ -78,7 +79,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
             // create search pipeline with both normalization processor and explain response processor
-            createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
+            createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
 
             TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
             TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4);
@@ -95,7 +96,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
                 hybridQueryBuilderNeuralThenTerm,
                 null,
                 10,
-                Map.of("search_pipeline", SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
+                Map.of("search_pipeline", NORMALIZATION_SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
             );
             // Assert
             // search hits
@@ -187,7 +188,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit3Details.get("description"));
             assertEquals(3, getListOfValues(explanationsHit3Details, "details").size());
         } finally {
-            wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, null, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, null, NORMALIZATION_SEARCH_PIPELINE);
         }
     }
 
@@ -196,7 +197,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_NAME);
             createSearchPipeline(
-                SEARCH_PIPELINE,
+                NORMALIZATION_SEARCH_PIPELINE,
                 NORMALIZATION_TECHNIQUE_L2,
                 DEFAULT_COMBINATION_METHOD,
                 Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
@@ -217,7 +218,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
                 hybridQueryBuilder,
                 null,
                 10,
-                Map.of("search_pipeline", SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
+                Map.of("search_pipeline", NORMALIZATION_SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
             );
             // Assert
             // basic sanity check for search hits
@@ -322,7 +323,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             assertEquals(0, getListOfValues(explanationsHit4, "details").size());
             assertTrue((double) explanationsHit4.get("value") > 0.0f);
         } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME, null, null, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME, null, null, NORMALIZATION_SEARCH_PIPELINE);
         }
     }
 
@@ -331,7 +332,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
             // create search pipeline with normalization processor, no explanation response processor
-            createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), false);
+            createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), false);
 
             TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
             TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4);
@@ -348,7 +349,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
                 hybridQueryBuilderNeuralThenTerm,
                 null,
                 10,
-                Map.of("search_pipeline", SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
+                Map.of("search_pipeline", NORMALIZATION_SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
             );
             // Assert
             // search hits
@@ -463,7 +464,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             assertEquals("boost", explanationsHit3Details.get("description"));
             assertEquals(0, getListOfValues(explanationsHit3Details, "details").size());
         } finally {
-            wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, null, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, null, NORMALIZATION_SEARCH_PIPELINE);
         }
     }
 
@@ -472,7 +473,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_LARGE_DOCS_INDEX_NAME);
             // create search pipeline with both normalization processor and explain response processor
-            createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
+            createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
 
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -483,7 +484,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
                 hybridQueryBuilder,
                 null,
                 MAX_NUMBER_OF_DOCS_IN_LARGE_INDEX,
-                Map.of("search_pipeline", SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
+                Map.of("search_pipeline", NORMALIZATION_SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
             );
 
             List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
@@ -521,7 +522,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             }
             assertTrue(IntStream.range(0, scores.size() - 1).noneMatch(i -> scores.get(i) < scores.get(i + 1)));
         } finally {
-            wipeOfTestResources(TEST_LARGE_DOCS_INDEX_NAME, null, null, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_LARGE_DOCS_INDEX_NAME, null, null, NORMALIZATION_SEARCH_PIPELINE);
         }
     }
 
@@ -530,7 +531,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_LARGE_DOCS_INDEX_NAME);
             // create search pipeline with both normalization processor and explain response processor
-            createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
+            createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
             hybridQueryBuilder.add(QueryBuilders.multiMatchQuery(TEST_QUERY_TEXT3, TEST_TEXT_FIELD_NAME_1, TEST_TEXT_FIELD_NAME_2));
@@ -543,7 +544,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
                 hybridQueryBuilder,
                 null,
                 MAX_NUMBER_OF_DOCS_IN_LARGE_INDEX,
-                Map.of("search_pipeline", SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
+                Map.of("search_pipeline", NORMALIZATION_SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
             );
 
             List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
@@ -581,7 +582,136 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             }
             assertTrue(IntStream.range(0, scores.size() - 1).noneMatch(i -> scores.get(i) < scores.get(i + 1)));
         } finally {
-            wipeOfTestResources(TEST_LARGE_DOCS_INDEX_NAME, null, null, SEARCH_PIPELINE);
+            wipeOfTestResources(TEST_LARGE_DOCS_INDEX_NAME, null, null, NORMALIZATION_SEARCH_PIPELINE);
+        }
+    }
+
+    @SneakyThrows
+    public void testExplain_whenRRFProcessor_thenSuccessful() {
+        try {
+            initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_NAME);
+            createRRFSearchPipeline(RRF_SEARCH_PIPELINE, true);
+
+            HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+            KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .vector(createRandomVector(TEST_DIMENSION))
+                .k(10)
+                .build();
+            hybridQueryBuilder.add(QueryBuilders.existsQuery(TEST_TEXT_FIELD_NAME_1));
+            hybridQueryBuilder.add(knnQueryBuilder);
+
+            Map<String, Object> searchResponseAsMap = search(
+                TEST_MULTI_DOC_INDEX_NAME,
+                hybridQueryBuilder,
+                null,
+                10,
+                Map.of("search_pipeline", RRF_SEARCH_PIPELINE, "explain", Boolean.TRUE.toString())
+            );
+            // Assert
+            // basic sanity check for search hits
+            assertEquals(4, getHitCount(searchResponseAsMap));
+            assertTrue(getMaxScore(searchResponseAsMap).isPresent());
+            float actualMaxScore = getMaxScore(searchResponseAsMap).get();
+            assertTrue(actualMaxScore > 0);
+            Map<String, Object> total = getTotalHits(searchResponseAsMap);
+            assertNotNull(total.get("value"));
+            assertEquals(4, total.get("value"));
+            assertNotNull(total.get("relation"));
+            assertEquals(RELATION_EQUAL_TO, total.get("relation"));
+
+            // explain, hit 1
+            List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
+            Map<String, Object> searchHit1 = hitsNestedList.get(0);
+            Map<String, Object> explanationForHit1 = getValueByKey(searchHit1, "_explanation");
+            assertNotNull(explanationForHit1);
+            assertEquals((double) searchHit1.get("_score"), (double) explanationForHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+            String expectedTopLevelDescription = "rrf combination of:";
+            assertEquals(expectedTopLevelDescription, explanationForHit1.get("description"));
+            List<Map<String, Object>> hit1Details = getListOfValues(explanationForHit1, "details");
+            assertEquals(2, hit1Details.size());
+            // two sub-queries meaning we do have two detail objects with separate query level details
+            Map<String, Object> hit1DetailsForHit1 = hit1Details.get(0);
+            assertTrue((double) hit1DetailsForHit1.get("value") > DELTA_FOR_SCORE_ASSERTION);
+            assertEquals("rrf, rank_constant 60 normalization of:", hit1DetailsForHit1.get("description"));
+            assertEquals(1, ((List) hit1DetailsForHit1.get("details")).size());
+
+            Map<String, Object> explanationsHit1 = getListOfValues(hit1DetailsForHit1, "details").get(0);
+            assertEquals("ConstantScore(FieldExistsQuery [field=test-text-field-1])", explanationsHit1.get("description"));
+            assertTrue((double) explanationsHit1.get("value") > 0.5f);
+            assertEquals(0, ((List) explanationsHit1.get("details")).size());
+
+            Map<String, Object> hit1DetailsForHit2 = hit1Details.get(1);
+            assertTrue((double) hit1DetailsForHit2.get("value") > 0.0f);
+            assertEquals("rrf, rank_constant 60 normalization of:", hit1DetailsForHit2.get("description"));
+            assertEquals(1, ((List) hit1DetailsForHit2.get("details")).size());
+
+            Map<String, Object> explanationsHit2 = getListOfValues(hit1DetailsForHit2, "details").get(0);
+            assertEquals("within top 10", explanationsHit2.get("description"));
+            assertTrue((double) explanationsHit2.get("value") > 0.0f);
+            assertEquals(0, ((List) explanationsHit2.get("details")).size());
+
+            // hit 2
+            Map<String, Object> searchHit2 = hitsNestedList.get(1);
+            Map<String, Object> explanationForHit2 = getValueByKey(searchHit2, "_explanation");
+            assertNotNull(explanationForHit2);
+            assertEquals((double) searchHit2.get("_score"), (double) explanationForHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
+
+            assertEquals(expectedTopLevelDescription, explanationForHit2.get("description"));
+            List<Map<String, Object>> hit2Details = getListOfValues(explanationForHit2, "details");
+            assertEquals(2, hit2Details.size());
+
+            Map<String, Object> hit2DetailsForHit1 = hit2Details.get(0);
+            assertTrue((double) hit2DetailsForHit1.get("value") > DELTA_FOR_SCORE_ASSERTION);
+            assertEquals("rrf, rank_constant 60 normalization of:", hit2DetailsForHit1.get("description"));
+            assertEquals(1, ((List) hit2DetailsForHit1.get("details")).size());
+
+            Map<String, Object> hit2DetailsForHit2 = hit2Details.get(1);
+            assertTrue((double) hit2DetailsForHit2.get("value") > DELTA_FOR_SCORE_ASSERTION);
+            assertEquals("rrf, rank_constant 60 normalization of:", hit2DetailsForHit2.get("description"));
+            assertEquals(1, ((List) hit2DetailsForHit2.get("details")).size());
+
+            // hit 3
+            Map<String, Object> searchHit3 = hitsNestedList.get(2);
+            Map<String, Object> explanationForHit3 = getValueByKey(searchHit3, "_explanation");
+            assertNotNull(explanationForHit3);
+            assertEquals((double) searchHit3.get("_score"), (double) explanationForHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
+
+            assertEquals(expectedTopLevelDescription, explanationForHit3.get("description"));
+            List<Map<String, Object>> hit3Details = getListOfValues(explanationForHit3, "details");
+            assertEquals(1, hit3Details.size());
+
+            Map<String, Object> hit3DetailsForHit1 = hit3Details.get(0);
+            assertTrue((double) hit3DetailsForHit1.get("value") > .0f);
+            assertEquals("rrf, rank_constant 60 normalization of:", hit3DetailsForHit1.get("description"));
+            assertEquals(1, ((List) hit3DetailsForHit1.get("details")).size());
+
+            Map<String, Object> explanationsHit3 = getListOfValues(hit3DetailsForHit1, "details").get(0);
+            assertEquals("within top 10", explanationsHit3.get("description"));
+            assertEquals(0, getListOfValues(explanationsHit3, "details").size());
+            assertTrue((double) explanationsHit3.get("value") > 0.0f);
+
+            // hit 4
+            Map<String, Object> searchHit4 = hitsNestedList.get(3);
+            Map<String, Object> explanationForHit4 = getValueByKey(searchHit4, "_explanation");
+            assertNotNull(explanationForHit4);
+            assertEquals((double) searchHit4.get("_score"), (double) explanationForHit4.get("value"), DELTA_FOR_SCORE_ASSERTION);
+
+            assertEquals(expectedTopLevelDescription, explanationForHit4.get("description"));
+            List<Map<String, Object>> hit4Details = getListOfValues(explanationForHit4, "details");
+            assertEquals(1, hit4Details.size());
+
+            Map<String, Object> hit4DetailsForHit1 = hit4Details.get(0);
+            assertTrue((double) hit4DetailsForHit1.get("value") > DELTA_FOR_SCORE_ASSERTION);
+            assertEquals("rrf, rank_constant 60 normalization of:", hit4DetailsForHit1.get("description"));
+            assertEquals(1, ((List) hit4DetailsForHit1.get("details")).size());
+
+            Map<String, Object> explanationsHit4 = getListOfValues(hit4DetailsForHit1, "details").get(0);
+            assertEquals("ConstantScore(FieldExistsQuery [field=test-text-field-1])", explanationsHit4.get("description"));
+            assertEquals(0, getListOfValues(explanationsHit4, "details").size());
+            assertTrue((double) explanationsHit4.get("value") > 0.0f);
+        } finally {
+            wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME, null, null, RRF_SEARCH_PIPELINE);
         }
     }
 

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1472,7 +1472,12 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
     @SneakyThrows
     protected void createDefaultRRFSearchPipeline() {
-        String requestBody = XContentFactory.jsonBuilder()
+        createRRFSearchPipeline(RRF_SEARCH_PIPELINE, false);
+    }
+
+    @SneakyThrows
+    protected void createRRFSearchPipeline(final String pipelineName, boolean addExplainResponseProcessor) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .field("description", "Post processor for hybrid search")
             .startArray("phase_results_processors")
@@ -1483,14 +1488,23 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             .endObject()
             .endObject()
             .endObject()
-            .endArray()
-            .endObject()
-            .toString();
+            .endArray();
+
+        if (addExplainResponseProcessor) {
+            builder.startArray("response_processors")
+                .startObject()
+                .startObject("explanation_response_processor")
+                .endObject()
+                .endObject()
+                .endArray();
+        }
+
+        String requestBody = builder.endObject().toString();
 
         makeRequest(
             client(),
             "PUT",
-            String.format(LOCALE, "/_search/pipeline/%s", RRF_SEARCH_PIPELINE),
+            String.format(LOCALE, "/_search/pipeline/%s", pipelineName),
             null,
             toHttpEntity(String.format(LOCALE, requestBody)),
             ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))


### PR DESCRIPTION
### Description
Adding explainability support to RRF processor

This PR adds explainability functionality to the RRF (Reciprocal Rank Fusion) processor. It's being submitted to the feature branch while the application security review for the RRF feature is in progress.

Key changes:
- Implemented explainability support for RRF
- Changed explanation details for case when sorting is enabled by field other then `score`, we return `0.0` as the score in explanation
- Minor refactoring and more unit tests

PR for explainability feature https://github.com/opensearch-project/neural-search/pull/1014

Example response when RRF is part of the search pipeline and the 'explain' flag is set:
```
"hits": {
        "total": {
            "value": 5,
            "relation": "eq"
        },
        "max_score": 0.032522473,
        "hits": [
            {
                "_shard": "[index-test][0]",
                "_node": "oEdoEKSrReuk_oX9PJilBg",
                "_index": "index-test",
                "_id": "LJS935MBlqE6ecphe2i6",
                "_score": 0.032522473,
                "_source": {
                    "field1": 50,
                    "vector": [
                        4.2,
                        5.5,
                        8.9
                    ],
                    "name": "Why would he go to all that effort for a free pack of ranch dressing?",
                    "category": "story",
                    "price": 10
                },
                "_explanation": {
                    "value": 0.032522473,
                    "description": "rrf combination of:",
                    "details": [
                        {
                            "value": 0.016393442,
                            "description": "rrf, rank_constant [60] normalization of:",
                            "details": [
                                {
                                    "value": 1.0,
                                    "description": "field1:[20 TO 150]",
                                    "details": []
                                }
                            ]
                        },
                        {
                            "value": 0.016129032,
                            "description": "rrf, rank_constant [60] normalization of:",
                            "details": [
                                {
                                    "value": 0.019948136,
                                    "description": "within top 12",
                                    "details": []
                                }
                            ]
                        }
                    ]
                }
            },
```

### Check List
- [X] New functionality includes testing.
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [X] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
