### PR TITLE
Support empty string for fields in text embedding processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Explainability in hybrid query ([#970](https://github.com/opensearch-project/neural-search/pull/970))
 - Support new knn query parameter expand_nested ([#1013](https://github.com/opensearch-project/neural-search/pull/1013))
 - Implement pruning for neural sparse ingestion pipeline and two phase search processor ([#988](https://github.com/opensearch-project/neural-search/pull/988))
-- Allow empty string for field in field map ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
+- Support empty string for fields in text embedding processor ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
 ### Bug Fixes
 -  Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Explainability in hybrid query ([#970](https://github.com/opensearch-project/neural-search/pull/970))
 - Support new knn query parameter expand_nested ([#1013](https://github.com/opensearch-project/neural-search/pull/1013))
 - Implement pruning for neural sparse ingestion pipeline and two phase search processor ([#988](https://github.com/opensearch-project/neural-search/pull/988))
+- Allow empty string for field in field map ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
 ### Bug Fixes
 -  Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -391,7 +391,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
             indexName,
             clusterService,
             environment,
-            false
+            true
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -307,7 +307,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
                 buildNestedMap(originalKey, targetKey, sourceAndMetadataMap, treeRes);
                 mapWithProcessorKeys.put(originalKey, treeRes.get(originalKey));
             } else {
-                mapWithProcessorKeys.put(String.valueOf(targetKey), sourceAndMetadataMap.get(originalKey));
+                mapWithProcessorKeys.put(String.valueOf(targetKey), normalizeSourceValue(sourceAndMetadataMap.get(originalKey)));
             }
         }
         return mapWithProcessorKeys;
@@ -333,7 +333,10 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
             } else if (sourceAndMetadataMap.get(parentKey) instanceof List) {
                 for (Map.Entry<String, Object> nestedFieldMapEntry : ((Map<String, Object>) processorKey).entrySet()) {
                     List<Map<String, Object>> list = (List<Map<String, Object>>) sourceAndMetadataMap.get(parentKey);
-                    List<Object> listOfStrings = list.stream().map(x -> x.get(nestedFieldMapEntry.getKey())).collect(Collectors.toList());
+                    List<Object> listOfStrings = list.stream().map(x -> {
+                        Object nestedSourceValue = x.get(nestedFieldMapEntry.getKey());
+                        return normalizeSourceValue(nestedSourceValue);
+                    }).collect(Collectors.toList());
                     Map<String, Object> map = new LinkedHashMap<>();
                     map.put(nestedFieldMapEntry.getKey(), listOfStrings);
                     buildNestedMap(nestedFieldMapEntry.getKey(), nestedFieldMapEntry.getValue(), map, next);
@@ -341,9 +344,21 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
             }
             treeRes.merge(parentKey, next, REMAPPING_FUNCTION);
         } else {
+            Object parentValue = sourceAndMetadataMap.get(parentKey);
             String key = String.valueOf(processorKey);
-            treeRes.put(key, sourceAndMetadataMap.get(parentKey));
+            treeRes.put(key, normalizeSourceValue(parentValue));
         }
+    }
+
+    private boolean isBlankString(Object object) {
+        return object instanceof String && StringUtils.isBlank((String) object);
+    }
+
+    private Object normalizeSourceValue(Object value) {
+        if (isBlankString(value)) {
+            return null;
+        }
+        return value;
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
@@ -66,28 +66,6 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
         verify(clientAccessor, never()).inferenceSentences(anyString(), anyList(), any());
     }
 
-    public void test_batchExecuteWithEmpty_allFailedValidation() {
-        final int docCount = 2;
-        TestInferenceProcessor processor = new TestInferenceProcessor(createMockVectorResult(), BATCH_SIZE, null);
-        List<IngestDocumentWrapper> wrapperList = createIngestDocumentWrappers(docCount);
-        wrapperList.get(0).getIngestDocument().setFieldValue("key1", Arrays.asList("", "value1"));
-        wrapperList.get(1).getIngestDocument().setFieldValue("key1", Arrays.asList("", "value1"));
-        Consumer resultHandler = mock(Consumer.class);
-        processor.batchExecute(wrapperList, resultHandler);
-        ArgumentCaptor<List<IngestDocumentWrapper>> captor = ArgumentCaptor.forClass(List.class);
-        verify(resultHandler).accept(captor.capture());
-        assertEquals(docCount, captor.getValue().size());
-        for (int i = 0; i < docCount; ++i) {
-            assertNotNull(captor.getValue().get(i).getException());
-            assertEquals(
-                "list type field [key1] has empty string, cannot process it",
-                captor.getValue().get(i).getException().getMessage()
-            );
-            assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
-        }
-        verify(clientAccessor, never()).inferenceSentences(anyString(), anyList(), any());
-    }
-
     public void test_batchExecuteWithNull_allFailedValidation() {
         final int docCount = 2;
         TestInferenceProcessor processor = new TestInferenceProcessor(createMockVectorResult(), BATCH_SIZE, null);
@@ -105,27 +83,6 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
         verify(clientAccessor, never()).inferenceSentences(anyString(), anyList(), any());
-    }
-
-    public void test_batchExecute_partialFailedValidation() {
-        final int docCount = 2;
-        TestInferenceProcessor processor = new TestInferenceProcessor(createMockVectorResult(), BATCH_SIZE, null);
-        List<IngestDocumentWrapper> wrapperList = createIngestDocumentWrappers(docCount);
-        wrapperList.get(0).getIngestDocument().setFieldValue("key1", Arrays.asList("", "value1"));
-        wrapperList.get(1).getIngestDocument().setFieldValue("key1", Arrays.asList("value3", "value4"));
-        Consumer resultHandler = mock(Consumer.class);
-        processor.batchExecute(wrapperList, resultHandler);
-        ArgumentCaptor<List<IngestDocumentWrapper>> captor = ArgumentCaptor.forClass(List.class);
-        verify(resultHandler).accept(captor.capture());
-        assertEquals(docCount, captor.getValue().size());
-        assertNotNull(captor.getValue().get(0).getException());
-        assertNull(captor.getValue().get(1).getException());
-        for (int i = 0; i < docCount; ++i) {
-            assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
-        }
-        ArgumentCaptor<List<String>> inferenceTextCaptor = ArgumentCaptor.forClass(List.class);
-        verify(clientAccessor).inferenceSentences(anyString(), inferenceTextCaptor.capture(), any());
-        assertEquals(2, inferenceTextCaptor.getValue().size());
     }
 
     public void test_batchExecute_happyCase() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -241,31 +241,6 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         verify(handler).accept(any(IngestDocument.class), isNull());
     }
 
-    public void testExecute_SimpleTypeWithEmptyStringValue_throwIllegalArgumentException() {
-        Map<String, Object> sourceAndMetadata = new HashMap<>();
-        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
-        sourceAndMetadata.put("key1", "    ");
-        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
-
-        BiConsumer handler = mock(BiConsumer.class);
-        processor.execute(ingestDocument, handler);
-        verify(handler).accept(isNull(), any(IllegalArgumentException.class));
-    }
-
-    public void testExecute_listHasEmptyStringValue_throwIllegalArgumentException() {
-        List<String> list1 = ImmutableList.of("", "test2", "test3");
-        Map<String, Object> sourceAndMetadata = new HashMap<>();
-        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
-        sourceAndMetadata.put("key1", list1);
-        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
-
-        BiConsumer handler = mock(BiConsumer.class);
-        processor.execute(ingestDocument, handler);
-        verify(handler).accept(isNull(), any(IllegalArgumentException.class));
-    }
-
     public void testExecute_listHasNonStringValue_throwIllegalArgumentException() {
         List<Integer> list2 = ImmutableList.of(1, 2, 3);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
@@ -539,20 +514,6 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     public void testExecute_mapHasNonStringValue_throwIllegalArgumentException() {
         Map<String, String> map1 = ImmutableMap.of("test1", "test2");
         Map<String, Double> map2 = ImmutableMap.of("test3", 209.3D);
-        Map<String, Object> sourceAndMetadata = new HashMap<>();
-        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
-        sourceAndMetadata.put("key1", map1);
-        sourceAndMetadata.put("key2", map2);
-        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstanceWithLevel2MapConfig();
-        BiConsumer handler = mock(BiConsumer.class);
-        processor.execute(ingestDocument, handler);
-        verify(handler).accept(isNull(), any(IllegalArgumentException.class));
-    }
-
-    public void testExecute_mapHasEmptyStringValue_throwIllegalArgumentException() {
-        Map<String, String> map1 = ImmutableMap.of("test1", "test2");
-        Map<String, String> map2 = ImmutableMap.of("test3", "   ");
         Map<String, Object> sourceAndMetadata = new HashMap<>();
         sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", map1);


### PR DESCRIPTION
### Description
Allow empty string for field in field map.

The basic idea is to mark field with empty string as `null`, so that empty value for such field won't be taken into account.

### Related Issues
Resolves #774 

#### What is the current experience
For current text_embedding processor, it does not allow empty field of fieldMap due to validation [here](https://github.com/opensearch-project/neural-search/blob/main/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java#L107-L110)

Given such fieldMap
```
{
  "description": "text embedding pipeline for hybrid",
  "processors": [
    {
      "text_embedding": {
        "model_id": "L34TCpQBkpdyEl29cLe8",
        "field_map": {
           "title": "embedding_tns_title",
	  "description": "embedding_tns_description",
	  "body": "embedding_tns_body"
        }
      }
    }
  ]
}

```

if below document is being ingested, ingestion will fail
```
POST http://localhost:9200/_ingest/pipeline/nlp-ingest-pipeline-nested-allow-empty/_simulate

{
	"docs": [
		{
			"_index": "neural-search-index-v2",
			"_id": "1",
			"_source": {
				"title": "this is title",
				"body": "this is body",
				"description": " "
			}
		}
	]
}
```
Result:

```
{
	"docs": [
		{
			"error": {
				"root_cause": [
					{
						"type": "illegal_argument_exception",
						"reason": "map type field [description] has empty string value, cannot process it"
					}
				],
				"type": "illegal_argument_exception",
				"reason": "map type field [description] has empty string value, cannot process it"
			}
		}
	]
}
```
#### After the PR how will the experience look like
Given same fieldMap and request as above, with this PR, the result looks like below
```
{
	"docs": [
		{
			"doc": {
				"_index": "neural-search-index-v2",
				"_id": "1",
				"_source": {
				    "title": "this is title",
                                      "embedding_tns_title": [~768~]
				    "body": "this is body",
                                      "embedding_tns_body": [~768~]
				    "description": " "
                                 },
				"_ingest": {
					"timestamp": "2024-12-27T21:15:37.530145Z"
				}
			}
		}
	]
}
```
#### What are the use cases of this fix
The use case we want to support is: we still allow document ingestion even if it has some fields in fieldMap with empty/null value

As mentioned in #774 , because not all document have valid values for field in fieldMap. Also, 
```
One of the key concepts in OpenSearch/Lucene is that not all documents must follow the same 'data schema'. This is also valid for search, where only documents with matching fields will be returned.

So, in terms of consistency and robustness please allow fields inside "field_map" that don't have to appear in all documents.
```

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
