### PR TITLE
Fixed document source and score field mismatch in sorted hybrid queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement pruning for neural sparse ingestion pipeline and two phase search processor ([#988](https://github.com/opensearch-project/neural-search/pull/988))
 - Support empty string for fields in text embedding processor ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
 ### Bug Fixes
--  Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
--  Fix bug where ingested document has list of nested objects ([#1040](https://github.com/opensearch-project/neural-search/pull/1040))
+- Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
+- Fix bug where ingested document has list of nested objects ([#1040](https://github.com/opensearch-project/neural-search/pull/1040))
+- Fixed document source and score field mismatch in sorted hybrid queries ([#1043](https://github.com/opensearch-project/neural-search/pull/1043))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollectorTests.java
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.opensearch.neuralsearch.search;
+package org.opensearch.neuralsearch.search.collector;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +24,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.FieldValueHitQueue;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
@@ -35,14 +36,13 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.neuralsearch.query.HybridQueryScorer;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
-import org.opensearch.neuralsearch.search.collector.HybridTopFieldDocSortCollector;
-import org.opensearch.neuralsearch.search.collector.PagingFieldCollector;
-import org.opensearch.neuralsearch.search.collector.SimpleFieldCollector;
+import org.opensearch.neuralsearch.search.HitsThresholdChecker;
 
 public class HybridTopFieldDocSortCollectorTests extends OpenSearchQueryTestCase {
     static final String TEXT_FIELD_NAME = "field";
@@ -127,8 +127,13 @@ public class HybridTopFieldDocSortCollectorTests extends OpenSearchQueryTestCase
         DocIdSetIterator iterator = hybridQueryScorer.iterator();
 
         int doc = iterator.nextDoc();
+        assertNull(hybridTopFieldDocSortCollector.getFieldValueLeafTrackers());
         while (doc != DocIdSetIterator.NO_MORE_DOCS) {
             leafCollector.collect(doc);
+            FieldValueHitQueue.Entry[] fieldValueLeafTrackers = hybridTopFieldDocSortCollector.getFieldValueLeafTrackers();
+            assertNotNull(fieldValueLeafTrackers);
+            assertEquals(1, fieldValueLeafTrackers.length);
+            assertEquals(doc, fieldValueLeafTrackers[0].doc);
             doc = iterator.nextDoc();
         }
 

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollectorTests.java
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.opensearch.neuralsearch.search;
+package org.opensearch.neuralsearch.search.collector;
 
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
@@ -46,7 +46,7 @@ import org.opensearch.neuralsearch.query.HybridQueryScorer;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 
 import lombok.SneakyThrows;
-import org.opensearch.neuralsearch.search.collector.HybridTopScoreDocCollector;
+import org.opensearch.neuralsearch.search.HitsThresholdChecker;
 
 public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
 


### PR DESCRIPTION
Fixed document source and score field mismatch in sorted hybrid queries. 
Returned search hits identified with the help of min heap, it's used by sorting functionality to get top X docs. We do keep track of the heap leaf element and updating it when collecting doc ids. In current code we use only one element for this, but in case of hybrid query we do need separate element for each sub-query. With a single element our updates are incorrectly propagated to a results of different sub-queries, cause different types of inconsistency: doc id, score fields, score can be incorrect in final search result.

In this PR I'm changing the min heap leaf element from a single object to an array of objects, one for each sub-query.

Tested on the data set referred in the issue, got correct response where all field have consistent values in `_source` and `sort` sections:

```
{
    "took": 455,
    "timed_out": false,
    "_shards": {
        "total": 5,
        "successful": 5,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 397,
            "relation": "eq"
        },
        "max_score": 0.8442519,
        "hits": [
            {
                "_index": "templates_prod",
                "_id": "bk2m5np8h467r92kmalxdcvft",
                "_score": null,
                "_source": {
                    "trendingScore": 303.125,
                    "name": "Summer Breeze Design"
                },
                "sort": [
                    303.125
                ]
            },
            {
                "_index": "templates_prod",
                "_id": "bk2m6w28201xn8m3vb6mmdebn",
                "_score": null,
                "_source": {
                    "trendingScore": 303.125,
                    "name": "Winterfrost"
                },
                "sort": [
                    303.125
                ]
            },
            {
                "_index": "templates_prod",
                "_id": "ak2nhbsz900lwxe0xcpir0duc",
                "_score": null,
                "_source": {
                    "trendingScore": 19,
                    "name": "Sunshine Days - Nature Greeting"
                },
                "sort": [
                    19.0
                ]
            },
            {
                "_index": "templates_prod",
                "_id": "ak2n8y4h900csue0x7ij8rwuj",
                "_score": null,
                "_source": {
                    "trendingScore": 13,
                    "name": "Mountain Vista Wedding Suite - Save the Date"
                },
                "sort": [
                    13.0
                ]
            },
            {
                "_index": "templates_prod",
                "_id": "ak2nau2a900e7ue0x2h3nheb9",
                "_score": null,
                "_source": {
                    "trendingScore": 10,
                    "name": "Ocean Waves Thank You"
                },
                "sort": [
                    10.0
                ]
            },
            {
                "_index": "templates_prod",
                "_id": "ak305ic900fr3xe0xjuiin2nt",
                "_score": null,
                "_source": {
                    "trendingScore": 10,
                    "name": "Midnight Dreams - Elegant Celebration"
                },
                "sort": [
                    10.0
                ]
            },
            {
                "_index": "templates_prod",
                "_id": "ak2n2r1t007au00xsn82pvg1",
                "_score": null,
                "_source": {
                    "trendingScore": 6,
                    "name": "Forest Pine - Rustic Wedding Invitation"
                },
                "sort": [
                    6.0
                ]
            },
            {
                "_index": "templates_prod",
                "_id": "ak2n0pxe0060u00xxz0afuaa",
                "_score": null,
                "_source": {
                    "trendingScore": 3.0,
                    "name": "Modern Romance - Classic Black Wedding Invitation"
                },
                "sort": [
                    3.0
                ]
            }
        ]
    }
}
```

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1044

### Check List
- [X] New functionality includes testing.
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [X] Commits are signed per the DCO using `--signoff`.~~
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
