### PR TITLE
Support empty string for fields in text embedding processor (#1041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Explainability in hybrid query ([#970](https://github.com/opensearch-project/neural-search/pull/970))
 - Implement pruning for neural sparse ingestion pipeline and two phase search processor ([#988](https://github.com/opensearch-project/neural-search/pull/988))
 - Support new knn query parameter expand_nested ([#1013](https://github.com/opensearch-project/neural-search/pull/1013))
+- Support empty string for fields in text embedding processor ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
 ### Bug Fixes
 -  Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 ### Infrastructure

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
@@ -66,28 +66,6 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
         verify(clientAccessor, never()).inferenceSentences(anyString(), anyList(), any());
     }
 
-    public void test_batchExecuteWithEmpty_allFailedValidation() {
-        final int docCount = 2;
-        TestInferenceProcessor processor = new TestInferenceProcessor(createMockVectorResult(), BATCH_SIZE, null);
-        List<IngestDocumentWrapper> wrapperList = createIngestDocumentWrappers(docCount);
-        wrapperList.get(0).getIngestDocument().setFieldValue("key1", Arrays.asList("", "value1"));
-        wrapperList.get(1).getIngestDocument().setFieldValue("key1", Arrays.asList("", "value1"));
-        Consumer resultHandler = mock(Consumer.class);
-        processor.batchExecute(wrapperList, resultHandler);
-        ArgumentCaptor<List<IngestDocumentWrapper>> captor = ArgumentCaptor.forClass(List.class);
-        verify(resultHandler).accept(captor.capture());
-        assertEquals(docCount, captor.getValue().size());
-        for (int i = 0; i < docCount; ++i) {
-            assertNotNull(captor.getValue().get(i).getException());
-            assertEquals(
-                "list type field [key1] has empty string, cannot process it",
-                captor.getValue().get(i).getException().getMessage()
-            );
-            assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
-        }
-        verify(clientAccessor, never()).inferenceSentences(anyString(), anyList(), any());
-    }
-
     public void test_batchExecuteWithNull_allFailedValidation() {
         final int docCount = 2;
         TestInferenceProcessor processor = new TestInferenceProcessor(createMockVectorResult(), BATCH_SIZE, null);
@@ -105,27 +83,6 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
         verify(clientAccessor, never()).inferenceSentences(anyString(), anyList(), any());
-    }
-
-    public void test_batchExecute_partialFailedValidation() {
-        final int docCount = 2;
-        TestInferenceProcessor processor = new TestInferenceProcessor(createMockVectorResult(), BATCH_SIZE, null);
-        List<IngestDocumentWrapper> wrapperList = createIngestDocumentWrappers(docCount);
-        wrapperList.get(0).getIngestDocument().setFieldValue("key1", Arrays.asList("", "value1"));
-        wrapperList.get(1).getIngestDocument().setFieldValue("key1", Arrays.asList("value3", "value4"));
-        Consumer resultHandler = mock(Consumer.class);
-        processor.batchExecute(wrapperList, resultHandler);
-        ArgumentCaptor<List<IngestDocumentWrapper>> captor = ArgumentCaptor.forClass(List.class);
-        verify(resultHandler).accept(captor.capture());
-        assertEquals(docCount, captor.getValue().size());
-        assertNotNull(captor.getValue().get(0).getException());
-        assertNull(captor.getValue().get(1).getException());
-        for (int i = 0; i < docCount; ++i) {
-            assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
-        }
-        ArgumentCaptor<List<String>> inferenceTextCaptor = ArgumentCaptor.forClass(List.class);
-        verify(clientAccessor).inferenceSentences(anyString(), inferenceTextCaptor.capture(), any());
-        assertEquals(2, inferenceTextCaptor.getValue().size());
     }
 
     public void test_batchExecute_happyCase() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -28,6 +28,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -238,31 +239,6 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(any(IngestDocument.class), isNull());
-    }
-
-    public void testExecute_SimpleTypeWithEmptyStringValue_throwIllegalArgumentException() {
-        Map<String, Object> sourceAndMetadata = new HashMap<>();
-        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
-        sourceAndMetadata.put("key1", "    ");
-        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
-
-        BiConsumer handler = mock(BiConsumer.class);
-        processor.execute(ingestDocument, handler);
-        verify(handler).accept(isNull(), any(IllegalArgumentException.class));
-    }
-
-    public void testExecute_listHasEmptyStringValue_throwIllegalArgumentException() {
-        List<String> list1 = ImmutableList.of("", "test2", "test3");
-        Map<String, Object> sourceAndMetadata = new HashMap<>();
-        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
-        sourceAndMetadata.put("key1", list1);
-        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
-
-        BiConsumer handler = mock(BiConsumer.class);
-        processor.execute(ingestDocument, handler);
-        verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
     public void testExecute_listHasNonStringValue_throwIllegalArgumentException() {
@@ -549,20 +525,6 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         verify(handler).accept(isNull(), any(IllegalArgumentException.class));
     }
 
-    public void testExecute_mapHasEmptyStringValue_throwIllegalArgumentException() {
-        Map<String, String> map1 = ImmutableMap.of("test1", "test2");
-        Map<String, String> map2 = ImmutableMap.of("test3", "   ");
-        Map<String, Object> sourceAndMetadata = new HashMap<>();
-        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
-        sourceAndMetadata.put("key1", map1);
-        sourceAndMetadata.put("key2", map2);
-        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        TextEmbeddingProcessor processor = createInstanceWithLevel2MapConfig();
-        BiConsumer handler = mock(BiConsumer.class);
-        processor.execute(ingestDocument, handler);
-        verify(handler).accept(isNull(), any(IllegalArgumentException.class));
-    }
-
     public void testExecute_mapDepthReachLimit_throwIllegalArgumentException() {
         Map<String, Object> ret = createMaxDepthLimitExceedMap(() -> 1);
         Map<String, Object> sourceAndMetadata = new HashMap<>();
@@ -783,6 +745,79 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         assertTrue(nestedObj.get(0).containsKey("textFieldNotForEmbedding"));
         assertTrue(nestedObj.get(1).containsKey("vectorField"));
         assertNotNull(nestedObj.get(1).get("vectorField"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testBuildVectorOutput_withPlainString_EmptyString_skipped() {
+        Map<String, Object> config = createPlainStringConfiguration();
+        IngestDocument ingestDocument = createPlainIngestDocument();
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        sourceAndMetadata.put("oriKey1", StringUtils.EMPTY);
+
+        TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
+        Map<String, Object> knnMap = processor.buildMapWithTargetKeys(ingestDocument);
+        List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(6, 100, 0.0f, 1.0f);
+        processor.setVectorFieldsToDocument(ingestDocument, knnMap, modelTensorList);
+
+        /** IngestDocument
+         * "oriKey1": "",
+         * "oriKey2": "oriValue2",
+         * "oriKey3": "oriValue3",
+         * "oriKey4": "oriValue4",
+         * "oriKey5": "oriValue5",
+         * "oriKey6": [
+         *     "oriValue6",
+         *     "oriValue7"
+         * ]
+         *
+         */
+        assertEquals(11, sourceAndMetadata.size());
+        assertFalse(sourceAndMetadata.containsKey("oriKey1_knn"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testBuildVectorOutput_withNestedField_EmptyString_skipped() {
+        Map<String, Object> config = createNestedMapConfiguration();
+        IngestDocument ingestDocument = createNestedMapIngestDocument();
+        Map<String, Object> favorites = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("favorites");
+        Map<String, Object> favorite = (Map<String, Object>) favorites.get("favorite");
+        favorite.put("movie", StringUtils.EMPTY);
+
+        TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
+        Map<String, Object> knnMap = processor.buildMapWithTargetKeys(ingestDocument);
+        List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(1, 100, 0.0f, 1.0f);
+        processor.buildNLPResult(knnMap, modelTensorList, ingestDocument.getSourceAndMetadata());
+
+        /**
+         * "favorites": {
+         *      "favorite": {
+         *          "movie": "",
+         *          "actor": "Charlie Chaplin",
+         *          "games" : {
+         *              "adventure": {
+         *                  "action": "overwatch",
+         *                  "rpg": "elden ring"
+         *              }
+         *          }
+         *      }
+         * }
+         */
+        Map<String, Object> favoritesMap = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("favorites");
+        assertNotNull(favoritesMap);
+        Map<String, Object> favoriteMap = (Map<String, Object>) favoritesMap.get("favorite");
+        assertNotNull(favoriteMap);
+
+        Map<String, Object> favoriteGames = (Map<String, Object>) favoriteMap.get("games");
+        assertNotNull(favoriteGames);
+        Map<String, Object> adventure = (Map<String, Object>) favoriteGames.get("adventure");
+        List<Float> adventureKnnVector = (List<Float>) adventure.get("with_action_knn");
+        assertNotNull(adventureKnnVector);
+        assertEquals(100, adventureKnnVector.size());
+        for (float vector : adventureKnnVector) {
+            assertTrue(vector >= 0.0f && vector <= 1.0f);
+        }
+
+        assertFalse(favoriteMap.containsKey("favorite_movie_knn"));
     }
 
     public void test_updateDocument_appendVectorFieldsToDocument_successful() {


### PR DESCRIPTION
### Description
Support empty string for fields in text embedding processor (#1041)

### Related Issues
Resolves PR #1041 


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
