### PR TITLE
add support for builder constructor in neural query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support new knn query parameter expand_nested ([#1013](https://github.com/opensearch-project/neural-search/pull/1013))
 - Implement pruning for neural sparse ingestion pipeline and two phase search processor ([#988](https://github.com/opensearch-project/neural-search/pull/988))
 - Support empty string for fields in text embedding processor ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
+- Support for builder constructor in Neural Query Builder ([#1047](https://github.com/opensearch-project/neural-search/pull/1047))
 ### Bug Fixes
 -  Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 ### Infrastructure

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
@@ -13,8 +13,6 @@ import java.util.Map;
 
 import org.opensearch.index.query.MatchQueryBuilder;
 
-import static org.opensearch.knn.index.query.KNNQueryBuilder.EXPAND_NESTED_FIELD;
-import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isClusterOnOrAfterMinReqVersion;
 import static org.opensearch.neuralsearch.util.TestUtils.getModelId;
 import static org.opensearch.neuralsearch.util.TestUtils.NODES_BWC_CLUSTER;
 import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_WEIGHTS;

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
@@ -124,11 +124,12 @@ public class HybridSearchIT extends AbstractRestartUpgradeRestTestCase {
         final Map<String, ?> methodParameters,
         final RescoreContext rescoreContext
     ) {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_embedding");
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(QUERY);
-        neuralQueryBuilder.k(5);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .modelId(modelId)
+            .queryText(QUERY)
+            .k(5)
+            .build();
         if (expandNestedDocs != null) {
             neuralQueryBuilder.expandNested(expandNestedDocs);
         }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -51,37 +51,25 @@ public class KnnRadialSearchIT extends AbstractRestartUpgradeRestTestCase {
     }
 
     private void validateIndexQuery(final String modelId) {
-        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            TEXT,
-            TEST_IMAGE_TEXT,
-            modelId,
-            null,
-            null,
-            0.01f,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(TEXT)
+            .queryImage(TEST_IMAGE_TEXT)
+            .modelId(modelId)
+            .minScore(0.01f)
+            .build();
+
         Map<String, Object> responseWithMinScoreQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
         assertNotNull(responseWithMinScoreQuery);
 
-        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            TEXT,
-            TEST_IMAGE_TEXT,
-            modelId,
-            null,
-            100000f,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(TEXT)
+            .queryImage(TEST_IMAGE_TEXT)
+            .modelId(modelId)
+            .minScore(100000f)
+            .build();
+
         Map<String, Object> responseWithMaxDistanceQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);
         assertNotNull(responseWithMaxDistanceQuery);
     }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -67,7 +67,7 @@ public class KnnRadialSearchIT extends AbstractRestartUpgradeRestTestCase {
             .queryText(TEXT)
             .queryImage(TEST_IMAGE_TEXT)
             .modelId(modelId)
-            .minScore(100000f)
+            .maxDistance(100000f)
             .build();
 
         Map<String, Object> responseWithMaxDistanceQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -53,20 +53,13 @@ public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
     private void validateTestIndex(final String modelId) throws Exception {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(2, docCount);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-            "passage_embedding",
-            TEXT,
-            TEST_IMAGE_TEXT,
-            modelId,
-            1,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(TEXT)
+            .queryImage(TEST_IMAGE_TEXT)
+            .modelId(modelId)
+            .k(1)
+            .build();
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertNotNull(response);
     }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
@@ -76,8 +76,14 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRestartUpgradeRestTe
 
     public void testNeuralQueryEnricherProcessor_NeuralSearch_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
-        NeuralQueryBuilder neuralQueryBuilderWithoutModelId = new NeuralQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
-        NeuralQueryBuilder neuralQueryBuilderWithModelId = new NeuralQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
+        NeuralQueryBuilder neuralQueryBuilderWithoutModelId = NeuralQueryBuilder.builder()
+            .fieldName(TEST_ENCODING_FIELD)
+            .queryText(TEXT_1)
+            .build();
+        NeuralQueryBuilder neuralQueryBuilderWithModelId = NeuralQueryBuilder.builder()
+            .fieldName(TEST_ENCODING_FIELD)
+            .queryText(TEXT_1)
+            .build();
 
         if (isRunningAgainstOldCluster()) {
             String modelId = uploadTextEmbeddingModel();

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
@@ -51,11 +51,12 @@ public class SemanticSearchIT extends AbstractRestartUpgradeRestTestCase {
     private void validateTestIndex(final String modelId) throws Exception {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(2, docCount);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_embedding");
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(TEXT);
-        neuralQueryBuilder.k(1);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(TEXT)
+            .modelId(modelId)
+            .k(1)
+            .build();
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertNotNull(response);
     }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
@@ -128,11 +128,12 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
         final Map<String, ?> methodParameters,
         final RescoreContext rescoreContextForNeuralQuery
     ) {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName(VECTOR_EMBEDDING_FIELD);
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(QUERY);
-        neuralQueryBuilder.k(5);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_EMBEDDING_FIELD)
+            .modelId(modelId)
+            .queryText(QUERY)
+            .k(5)
+            .build();
         if (expandNestedDocs != null) {
             neuralQueryBuilder.expandNested(expandNestedDocs);
         }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -77,37 +77,25 @@ public class KnnRadialSearchIT extends AbstractRollingUpgradeTestCase {
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
 
-        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            text,
-            imageText,
-            modelId,
-            null,
-            null,
-            0.01f,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(text)
+            .queryImage(imageText)
+            .modelId(modelId)
+            .minScore(0.01f)
+            .build();
+
         Map<String, Object> responseWithMinScore = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
         assertNotNull(responseWithMinScore);
 
-        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            text,
-            imageText,
-            modelId,
-            null,
-            100000f,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(text)
+            .queryImage(imageText)
+            .modelId(modelId)
+            .maxDistance(100000f)
+            .build();
+
         Map<String, Object> responseWithMaxScore = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);
         assertNotNull(responseWithMaxScore);
     }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -76,20 +76,14 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
-        NeuralQueryBuilder neuralQueryBuilderWithKQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            text,
-            imageText,
-            modelId,
-            1,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithKQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(text)
+            .queryImage(imageText)
+            .modelId(modelId)
+            .k(1)
+            .build();
+
         Map<String, Object> responseWithKQuery = search(getIndexNameForTest(), neuralQueryBuilderWithKQuery, 1);
         assertNotNull(responseWithKQuery);
     }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
@@ -94,8 +94,14 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
     // the feature is introduced from 2.11
     public void testNeuralQueryEnricherProcessor_NeuralSearch_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
-        NeuralQueryBuilder neuralQueryBuilderWithoutModelId = new NeuralQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
-        NeuralQueryBuilder neuralQueryBuilderWithModelId = new NeuralQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
+        NeuralQueryBuilder neuralQueryBuilderWithoutModelId = NeuralQueryBuilder.builder()
+            .fieldName(TEST_ENCODING_FIELD)
+            .queryText(TEXT_1)
+            .build();
+        NeuralQueryBuilder neuralQueryBuilderWithModelId = NeuralQueryBuilder.builder()
+            .fieldName(TEST_ENCODING_FIELD)
+            .queryText(TEXT_1)
+            .build();
 
         switch (getClusterType()) {
             case OLD:

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
@@ -71,11 +71,12 @@ public class SemanticSearchIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_embedding");
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(text);
-        neuralQueryBuilder.k(1);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .modelId(modelId)
+            .queryText(text)
+            .k(1)
+            .build();
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertNotNull(response);
     }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -201,7 +201,6 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
 
         public NeuralQueryBuilder build() {
             validateQueryParameters(fieldName, queryText, queryImage);
-            int k = this.k == null ? DEFAULT_K : this.k;
             boolean queryTypeIsProvided = validateKNNQueryType(k, maxDistance, minScore);
             if (queryTypeIsProvided == false) {
                 k = DEFAULT_K;

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import lombok.Builder;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -67,6 +68,7 @@ import lombok.extern.log4j.Log4j2;
 @Getter
 @Setter
 @Accessors(chain = true, fluent = true)
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder> implements ModelInferenceQueryBuilder {

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -109,7 +109,7 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
     private RescoreContext rescoreContext;
 
     /**
-     * A custom builder class to enforce valid Neural Query Builder instance by validating the required fields are initialized
+     * A custom builder class to enforce valid Neural Query Builder instantiation
      */
     public static class Builder {
         private String fieldName;

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
@@ -54,10 +54,11 @@ public class NeuralQueryEnricherProcessorIT extends BaseNeuralSearchIT {
             createSearchRequestProcessor(modelId, search_pipeline);
             createPipelineProcessor(modelId, ingest_pipeline, ProcessorType.TEXT_EMBEDDING);
             updateIndexSettings(index, Settings.builder().put("index.search.default_pipeline", search_pipeline));
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-            neuralQueryBuilder.fieldName(TEST_KNN_VECTOR_FIELD_NAME_1);
-            neuralQueryBuilder.queryText("Hello World");
-            neuralQueryBuilder.k(1);
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText("Hello World")
+                .k(1)
+                .build();
             Map<String, Object> response = search(index, neuralQueryBuilder, 2);
             assertFalse(response.isEmpty());
         } finally {
@@ -112,10 +113,11 @@ public class NeuralQueryEnricherProcessorIT extends BaseNeuralSearchIT {
             createSearchRequestProcessor(modelId, search_pipeline);
             createPipelineProcessor(modelId, ingest_pipeline, ProcessorType.TEXT_EMBEDDING);
             updateIndexSettings(index, Settings.builder().put("index.search.default_pipeline", search_pipeline));
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-            neuralQueryBuilder.fieldName(TEST_KNN_VECTOR_FIELD_NAME_1);
-            neuralQueryBuilder.queryText("Hello World");
-            neuralQueryBuilder.k(1);
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText("Hello World")
+                .k(1)
+                .build();
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
             hybridQueryBuilder.add(neuralQueryBuilder);
             Map<String, Object> response = search(index, hybridQueryBuilder, 2);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorTests.java
@@ -38,7 +38,7 @@ public class NeuralQueryEnricherProcessorTests extends OpenSearchTestCase {
 
     public void testProcessRequest_whenVisitingQueryBuilder_thenSuccess() throws Exception {
         NeuralQueryEnricherProcessor.Factory factory = new NeuralQueryEnricherProcessor.Factory();
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder().fieldName("field_name").queryText("query_text").build();
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.source(new SearchSourceBuilder().query(neuralQueryBuilder));
         NeuralQueryEnricherProcessor processor = createTestProcessor(factory);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -87,20 +87,13 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
 
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_DOC_TEXT1,
-                "",
-                modelId,
-                5,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(5)
+                .build();
+
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -140,20 +133,13 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             modelId = prepareModel();
             createSearchPipelineWithDefaultResultsPostProcessor(SEARCH_PIPELINE);
 
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_DOC_TEXT1,
-                "",
-                modelId,
-                5,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(5)
+                .build();
+
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -182,20 +168,13 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             int totalExpectedDocQty = 6;
 
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_DOC_TEXT1,
-                "",
-                modelId,
-                6,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(6)
+                .build();
+
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
@@ -224,20 +224,7 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
             hybridQueryBuilderDefaultNorm.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -262,20 +249,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
             hybridQueryBuilderL2Norm.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
+
             );
             hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -325,20 +300,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
             hybridQueryBuilderDefaultNorm.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
+
             );
             hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -363,20 +326,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
             hybridQueryBuilderL2Norm.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
+
             );
             hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
@@ -85,20 +85,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
             hybridQueryBuilderArithmeticMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -123,20 +110,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
             hybridQueryBuilderHarmonicMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -161,20 +135,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
             hybridQueryBuilderGeometricMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -224,20 +185,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
             hybridQueryBuilderArithmeticMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -262,20 +210,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
             hybridQueryBuilderHarmonicMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -300,20 +235,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
             hybridQueryBuilderGeometricMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -114,20 +114,13 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             );
             assertDoc((Map<String, Object>) getDocById(INDEX_NAME, "4").get("_source"), TEXT_FIELD_VALUE_2, Optional.empty());
 
-            NeuralQueryBuilder neuralQueryBuilderQuery = new NeuralQueryBuilder(
-                LEVEL_1_FIELD + "." + LEVEL_2_FIELD + "." + LEVEL_3_FIELD_CONTAINER + "." + LEVEL_3_FIELD_EMBEDDING,
-                QUERY_TEXT,
-                "",
-                modelId,
-                10,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilderQuery = NeuralQueryBuilder.builder()
+                .fieldName(LEVEL_1_FIELD + "." + LEVEL_2_FIELD + "." + LEVEL_3_FIELD_CONTAINER + "." + LEVEL_3_FIELD_EMBEDDING)
+                .queryText(QUERY_TEXT)
+                .modelId(modelId)
+                .k(10)
+                .build();
+
             QueryBuilder queryNestedLowerLevel = QueryBuilders.nestedQuery(
                 LEVEL_1_FIELD + "." + LEVEL_2_FIELD,
                 neuralQueryBuilderQuery,

--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessorTests.java
@@ -102,8 +102,12 @@ public class MLOpenSearchRerankProcessorTests extends OpenSearchTestCase {
 
     private void setupParams(Map<String, Object> params) {
         SearchSourceBuilder ssb = new SearchSourceBuilder();
-        NeuralQueryBuilder nqb = new NeuralQueryBuilder();
-        nqb.fieldName("embedding").k(3).modelId("embedding_id").queryText("Question about dolphins");
+        NeuralQueryBuilder nqb = NeuralQueryBuilder.builder()
+            .fieldName("embedding")
+            .k(3)
+            .modelId("embedding_id")
+            .queryText("Question about dolphins")
+            .build();
         ssb.query(nqb);
         List<SearchExtBuilder> exts = List.of(
             new RerankSearchExtBuilder(new HashMap<>(Map.of(QueryContextSourceFetcher.NAME, new HashMap<>(params))))

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -131,11 +131,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
 
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         queryBuilder.add(neuralQueryBuilder);
         Query queryOnlyNeural = queryBuilder.doToQuery(mockQueryShardContext);
@@ -164,11 +166,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
 
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         queryBuilder.add(neuralQueryBuilder);
 
@@ -415,12 +419,14 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(mockKNNVectorField.getKnnMappingConfig().getDimension()).thenReturn(4);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
 
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
             .vectorSupplier(TEST_VECTOR_SUPPLIER)
-            .filter(TEST_FILTER);
+            .filter(TEST_FILTER)
+            .build();
 
         queryBuilder.add(neuralQueryBuilder);
 
@@ -466,11 +472,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     public void testStreams_whenWrittingToStream_thenSuccessful() {
         setUpClusterService();
         HybridQueryBuilder original = new HybridQueryBuilder();
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         original.add(neuralQueryBuilder);
 
@@ -498,23 +506,27 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     public void testHashAndEquals_whenSameOrIdenticalObject_thenReturnEqual() {
         HybridQueryBuilder hybridQueryBuilderBaseline = new HybridQueryBuilder();
         hybridQueryBuilderBaseline.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderBaseline.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderBaselineCopy = new HybridQueryBuilder();
         hybridQueryBuilderBaselineCopy.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderBaselineCopy.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
@@ -533,66 +545,78 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
 
         HybridQueryBuilder hybridQueryBuilderBaseline = new HybridQueryBuilder();
         hybridQueryBuilderBaseline.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderBaseline.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderOnlyOneSubQuery = new HybridQueryBuilder();
         hybridQueryBuilderOnlyOneSubQuery.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
 
         HybridQueryBuilder hybridQueryBuilderOnlyDifferentModelId = new HybridQueryBuilder();
         hybridQueryBuilderOnlyDifferentModelId.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(modelId)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderBaseline.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderOnlyDifferentFieldName = new HybridQueryBuilder();
         hybridQueryBuilderOnlyDifferentFieldName.add(
-            new NeuralQueryBuilder().fieldName(fieldName)
+            NeuralQueryBuilder.builder()
+                .fieldName(fieldName)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderOnlyDifferentFieldName.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderOnlyDifferentQuery = new HybridQueryBuilder();
         hybridQueryBuilderOnlyDifferentQuery.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(queryText)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderOnlyDifferentQuery.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderOnlyDifferentTermValue = new HybridQueryBuilder();
         hybridQueryBuilderOnlyDifferentTermValue.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderOnlyDifferentTermValue.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, termText));
 
@@ -615,11 +639,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     @SneakyThrows
     public void testRewrite_whenMultipleSubQueries_thenReturnBuilderForEachSubQuery() {
         HybridQueryBuilder queryBuilder = new HybridQueryBuilder();
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         queryBuilder.add(neuralQueryBuilder);
 
@@ -789,9 +815,17 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     @SneakyThrows
     public void testDoEquals_whenSameParameters_thenEqual() {
         // Create neural queries
-        NeuralQueryBuilder neuralQueryBuilder1 = new NeuralQueryBuilder().queryText("test").modelId("test_model");
+        NeuralQueryBuilder neuralQueryBuilder1 = NeuralQueryBuilder.builder()
+            .fieldName("test")
+            .queryText("test")
+            .modelId("test_model")
+            .build();
 
-        NeuralQueryBuilder neuralQueryBuilder2 = new NeuralQueryBuilder().queryText("test").modelId("test_model");
+        NeuralQueryBuilder neuralQueryBuilder2 = NeuralQueryBuilder.builder()
+            .fieldName("test")
+            .queryText("test")
+            .modelId("test_model")
+            .build();
 
         // Create neural sparse queries with queryTokensSupplier
         NeuralSparseQueryBuilder neuralSparseQueryBuilder1 = new NeuralSparseQueryBuilder().fieldName("test_field")
@@ -822,7 +856,9 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     }
 
     public void testVisit() {
-        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new NeuralQueryBuilder()).add(new NeuralSparseQueryBuilder());
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(
+            NeuralQueryBuilder.builder().fieldName("test").queryText("test").build()
+        ).add(new NeuralSparseQueryBuilder());
         List<QueryBuilder> visitedQueries = new ArrayList<>();
         hybridQueryBuilder.visit(createTestVisitor(visitedQueries));
         assertEquals(3, visitedQueries.size());

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -425,6 +425,66 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         expectThrows(ParsingException.class, () -> NeuralQueryBuilder.fromXContent(contentParser));
     }
 
+    @SneakyThrows
+    public void testToBuilder_whenBuiltWithDefaults_thenBuildSuccessfully() {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "query_image": "string",
+                "model_id": "string",
+                "k": int
+              }
+          }
+        */
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .queryText(QUERY_TEXT)
+            .modelId(MODEL_ID)
+            .k(K)
+            .build();
+
+        assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
+        assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
+        assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
+        assertEquals(K, neuralQueryBuilder.k());
+    }
+
+    @SneakyThrows
+    public void testToBuilder_whenBuiltWithOptionals_thenBuildSuccessfully() {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "query_text": "string",
+                "model_id": "string",
+                "k": int,
+                "boost": 10.0,
+                "_name": "something",
+                "expandNestedDocs": true
+              }
+          }
+        */
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .queryText(QUERY_TEXT)
+            .queryImage(IMAGE_TEXT)
+            .modelId(MODEL_ID)
+            .k(K)
+            .expandNested(Boolean.TRUE)
+            .build()
+            .boost(BOOST)
+            .queryName(QUERY_NAME);
+
+        assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
+        assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
+        assertEquals(IMAGE_TEXT, neuralQueryBuilder.queryImage());
+        assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
+        assertEquals(K, neuralQueryBuilder.k());
+        assertEquals(BOOST, neuralQueryBuilder.boost(), 0.0);
+        assertEquals(QUERY_NAME, neuralQueryBuilder.queryName());
+        assertEquals(Boolean.TRUE, neuralQueryBuilder.expandNested());
+    }
+
     @SuppressWarnings("unchecked")
     @SneakyThrows
     public void testToXContent() {

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -426,7 +426,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
     }
 
     @SneakyThrows
-    public void testToBuilder_whenBuiltWithDefaults_thenBuildSuccessfully() {
+    public void testBuilderInstantiation_whenBuiltWithRequiredFields_thenBuildSuccessfully() {
         /*
           {
               "VECTOR_FIELD": {
@@ -437,21 +437,14 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
               }
           }
         */
-        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
-            .fieldName(FIELD_NAME)
-            .queryText(QUERY_TEXT)
-            .modelId(MODEL_ID)
-            .k(K)
-            .build();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder().fieldName(FIELD_NAME).queryText(QUERY_TEXT).build();
 
         assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
         assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
-        assertEquals(MODEL_ID, neuralQueryBuilder.modelId());
-        assertEquals(K, neuralQueryBuilder.k());
     }
 
     @SneakyThrows
-    public void testToBuilder_whenBuiltWithOptionals_thenBuildSuccessfully() {
+    public void testBuilderInstantiation_whenBuiltWithOptionalFields_thenBuildSuccessfully() {
         /*
           {
               "VECTOR_FIELD": {
@@ -471,9 +464,9 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .modelId(MODEL_ID)
             .k(K)
             .expandNested(Boolean.TRUE)
-            .build()
             .boost(BOOST)
-            .queryName(QUERY_NAME);
+            .queryName(QUERY_NAME)
+            .build();
 
         assertEquals(FIELD_NAME, neuralQueryBuilder.fieldName());
         assertEquals(QUERY_TEXT, neuralQueryBuilder.queryText());
@@ -485,15 +478,53 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         assertEquals(Boolean.TRUE, neuralQueryBuilder.expandNested());
     }
 
+    @SneakyThrows
+    public void testBuilderInstantiation_whenMissingFieldName_thenFail() {
+        /*
+          {
+              null : {
+                "query_text": "string",
+                "model_id": "string",
+                "k": int
+              }
+          }
+        */
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> NeuralQueryBuilder.builder().queryText(QUERY_TEXT).modelId(MODEL_ID).k(K).build()
+        );
+        assertEquals("Field name must be provided for neural query", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testBuilderInstantiation_whenMissingBothQueryTextAndQueryImage_thenFail() {
+        /*
+          {
+              "VECTOR_FIELD": {
+                "model_id": "string",
+                "k": int
+              }
+          }
+        */
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> NeuralQueryBuilder.builder().fieldName(FIELD_NAME).modelId(MODEL_ID).k(K).build()
+        );
+        assertEquals("Either query text or image text must be provided for neural query", exception.getMessage());
+    }
+
     @SuppressWarnings("unchecked")
     @SneakyThrows
     public void testToXContent() {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
             .modelId(MODEL_ID)
             .queryText(QUERY_TEXT)
             .k(K)
             .expandNested(Boolean.TRUE)
-            .filter(TEST_FILTER);
+            .filter(TEST_FILTER)
+            .build();
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder = neuralQueryBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -537,15 +568,16 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
 
     @SneakyThrows
     private void testStreams() {
-        NeuralQueryBuilder original = new NeuralQueryBuilder();
-        original.fieldName(FIELD_NAME);
-        original.queryText(QUERY_TEXT);
-        original.queryImage(IMAGE_TEXT);
-        original.modelId(MODEL_ID);
-        original.k(K);
-        original.boost(BOOST);
-        original.queryName(QUERY_NAME);
-        original.filter(TEST_FILTER);
+        NeuralQueryBuilder original = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .queryText(QUERY_TEXT)
+            .queryImage(IMAGE_TEXT)
+            .modelId(MODEL_ID)
+            .k(K)
+            .boost(BOOST)
+            .queryName(QUERY_NAME)
+            .filter(TEST_FILTER)
+            .build();
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         original.writeTo(streamOutput);
@@ -579,101 +611,123 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         QueryBuilder filter1 = new MatchAllQueryBuilder();
         QueryBuilder filter2 = new MatchNoneQueryBuilder();
 
-        NeuralQueryBuilder neuralQueryBuilder_baseline = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_baseline = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText1)
             .queryImage(imageText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline
-        NeuralQueryBuilder neuralQueryBuilder_baselineCopy = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_baselineCopy = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline except default boost and query name
-        NeuralQueryBuilder neuralQueryBuilder_defaultBoostAndQueryName = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_defaultBoostAndQueryName = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline except diff field name
-        NeuralQueryBuilder neuralQueryBuilder_diffFieldName = new NeuralQueryBuilder().fieldName(fieldName2)
+        NeuralQueryBuilder neuralQueryBuilder_diffFieldName = NeuralQueryBuilder.builder()
+            .fieldName(fieldName2)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline except diff query text
-        NeuralQueryBuilder neuralQueryBuilder_diffQueryText = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_diffQueryText = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText2)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline except diff model ID
-        NeuralQueryBuilder neuralQueryBuilder_diffModelId = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_diffModelId = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId2)
             .k(k1)
             .boost(boost1)
             .queryName(queryName1)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline except diff k
-        NeuralQueryBuilder neuralQueryBuilder_diffK = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_diffK = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k2)
             .boost(boost1)
             .queryName(queryName1)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline except diff boost
-        NeuralQueryBuilder neuralQueryBuilder_diffBoost = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_diffBoost = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost2)
             .queryName(queryName1)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline except diff query name
-        NeuralQueryBuilder neuralQueryBuilder_diffQueryName = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_diffQueryName = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName2)
-            .filter(filter1);
+            .filter(filter1)
+            .build();
 
         // Identical to neuralQueryBuilder_baseline except no filter
-        NeuralQueryBuilder neuralQueryBuilder_noFilter = new NeuralQueryBuilder().fieldName(fieldName1)
-            .queryText(queryText1)
-            .modelId(modelId1)
-            .k(k1)
-            .boost(boost1)
-            .queryName(queryName2);
-
-        // Identical to neuralQueryBuilder_baseline except no filter
-        NeuralQueryBuilder neuralQueryBuilder_diffFilter = new NeuralQueryBuilder().fieldName(fieldName1)
+        NeuralQueryBuilder neuralQueryBuilder_noFilter = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
             .queryText(queryText1)
             .modelId(modelId1)
             .k(k1)
             .boost(boost1)
             .queryName(queryName2)
-            .filter(filter2);
+            .build();
+
+        // Identical to neuralQueryBuilder_baseline except no filter
+        NeuralQueryBuilder neuralQueryBuilder_diffFilter = NeuralQueryBuilder.builder()
+            .fieldName(fieldName1)
+            .queryText(queryText1)
+            .modelId(modelId1)
+            .k(k1)
+            .boost(boost1)
+            .queryName(queryName2)
+            .filter(filter2)
+            .build();
 
         assertEquals(neuralQueryBuilder_baseline, neuralQueryBuilder_baseline);
         assertEquals(neuralQueryBuilder_baseline.hashCode(), neuralQueryBuilder_baseline.hashCode());
@@ -711,7 +765,12 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
 
     @SneakyThrows
     public void testRewrite_whenVectorSupplierNull_thenSetVectorSupplier() {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME).queryText(QUERY_TEXT).modelId(MODEL_ID).k(K);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .queryText(QUERY_TEXT)
+            .modelId(MODEL_ID)
+            .k(K)
+            .build();
         List<Float> expectedVector = Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
         MLCommonsClientAccessor mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         doAnswer(invocation -> {
@@ -743,11 +802,13 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
 
     @SneakyThrows
     public void testRewrite_whenVectorSupplierNullAndQueryTextAndImageTextSet_thenSetVectorSupplier() {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
             .queryText(QUERY_TEXT)
             .queryImage(IMAGE_TEXT)
             .modelId(MODEL_ID)
-            .k(K);
+            .k(K)
+            .build();
         List<Float> expectedVector = Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
         MLCommonsClientAccessor mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         doAnswer(invocation -> {
@@ -779,19 +840,22 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
 
     public void testRewrite_whenVectorNull_thenReturnCopy() {
         Supplier<float[]> nullSupplier = () -> null;
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
             .queryText(QUERY_TEXT)
             .queryImage(IMAGE_TEXT)
             .modelId(MODEL_ID)
             .k(K)
             .expandNested(Boolean.TRUE)
-            .vectorSupplier(nullSupplier);
+            .vectorSupplier(nullSupplier)
+            .build();
         QueryBuilder queryBuilder = neuralQueryBuilder.doRewrite(null);
         assertEquals(neuralQueryBuilder, queryBuilder);
     }
 
     public void testRewrite_whenVectorSupplierAndVectorSet_thenReturnKNNQueryBuilder() {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
             .queryText(QUERY_TEXT)
             .queryImage(IMAGE_TEXT)
             .modelId(MODEL_ID)
@@ -799,7 +863,8 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .expandNested(Boolean.TRUE)
             .methodParameters(Map.of("ef_search", 100))
             .rescoreContext(RescoreContext.getDefault())
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         KNNQueryBuilder expected = KNNQueryBuilder.builder()
             .k(K)
@@ -815,12 +880,14 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
     }
 
     public void testRewrite_whenFilterSet_thenKNNQueryBuilderFilterSet() {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
             .vectorSupplier(TEST_VECTOR_SUPPLIER)
-            .filter(TEST_FILTER);
+            .filter(TEST_FILTER)
+            .build();
         QueryBuilder queryBuilder = neuralQueryBuilder.doRewrite(null);
         assertTrue(queryBuilder instanceof KNNQueryBuilder);
         KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) queryBuilder;
@@ -828,12 +895,14 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
     }
 
     public void testQueryCreation_whenCreateQueryWithDoToQuery_thenFail() {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
             .vectorSupplier(TEST_VECTOR_SUPPLIER)
-            .filter(TEST_FILTER);
+            .filter(TEST_FILTER)
+            .build();
         QueryShardContext queryShardContext = mock(QueryShardContext.class);
         UnsupportedOperationException exception = expectThrows(
             UnsupportedOperationException.class,

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
@@ -102,20 +102,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             modelId = prepareModel();
-            NeuralQueryBuilder neuralQueryBuilderTextQuery = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilderTextQuery = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             final float boost = 2.0f;
             neuralQueryBuilderTextQuery.boost(boost);
@@ -126,20 +118,16 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             float expectedScore = 2 * computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
             assertEquals(expectedScore, objectToFloat(firstInnerHitTextQuery.get("_score")), DELTA_FOR_SCORE_ASSERTION);
 
-            NeuralQueryBuilder neuralQueryBuilderMultimodalQuery = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                TEST_IMAGE_TEXT,
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                Map.of("ef_search", 10),
-                RescoreContext.getDefault()
-            );
+            NeuralQueryBuilder neuralQueryBuilderMultimodalQuery = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryImage(TEST_IMAGE_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .methodParameters(Map.of("ef_search", 10))
+                .rescoreContext(RescoreContext.getDefault())
+                .build();
+
             Map<String, Object> searchResponseAsMapMultimodalQuery = search(TEST_BASIC_INDEX_NAME, neuralQueryBuilderMultimodalQuery, 1);
             Map<String, Object> firstInnerHitMultimodalQuery = getFirstInnerHit(searchResponseAsMapMultimodalQuery);
 
@@ -155,20 +143,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             // Context: https://github.com/opensearch-project/neural-search/pull/697#discussion_r1571549776
 
             // Test radial search max distance query
-            NeuralQueryBuilder neuralQueryWithMaxDistanceBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                null,
-                100.0f,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryWithMaxDistanceBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .maxDistance(100.0f)
+                .build();
 
             Map<String, Object> searchResponseAsMapWithMaxDistanceQuery = search(
                 TEST_BASIC_INDEX_NAME,
@@ -186,20 +166,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             );
 
             // Test radial search min score query
-            NeuralQueryBuilder neuralQueryWithMinScoreBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                null,
-                null,
-                0.01f,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryWithMinScoreBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .minScore(0.01f)
+                .build();
 
             Map<String, Object> searchResponseAsMapWithMinScoreQuery = search(TEST_BASIC_INDEX_NAME, neuralQueryWithMinScoreBuilder, 1);
             Map<String, Object> firstInnerHitWithMinScoreQuery = getFirstInnerHit(searchResponseAsMapWithMinScoreQuery);
@@ -243,20 +215,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             modelId = prepareModel();
             MatchAllQueryBuilder matchAllQueryBuilder = new MatchAllQueryBuilder();
-            NeuralQueryBuilder rescoreNeuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder rescoreNeuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, matchAllQueryBuilder, rescoreNeuralQueryBuilder, 1);
             Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
@@ -323,34 +287,19 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             modelId = prepareModel();
             // verify two neural queries wrapped into bool
             BoolQueryBuilder boolQueryBuilderTwoNeuralQueries = new BoolQueryBuilder();
-            NeuralQueryBuilder neuralQueryBuilder1 = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
-            NeuralQueryBuilder neuralQueryBuilder2 = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_2,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder1 = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
+
+            NeuralQueryBuilder neuralQueryBuilder2 = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_2)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             boolQueryBuilderTwoNeuralQueries.should(neuralQueryBuilder1).should(neuralQueryBuilder2);
 
@@ -367,20 +316,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
 
             // verify bool with one neural and one bm25 query
             BoolQueryBuilder boolQueryBuilderMixOfNeuralAndBM25 = new BoolQueryBuilder();
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             MatchQueryBuilder matchQueryBuilder = new MatchQueryBuilder(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT);
 
@@ -425,20 +366,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_NESTED_INDEX_NAME);
             modelId = prepareModel();
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_NESTED,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_NESTED)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             Map<String, Object> searchResponseAsMap = search(TEST_NESTED_INDEX_NAME, neuralQueryBuilder, 1);
             Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
@@ -478,20 +411,14 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_NAME);
             modelId = prepareModel();
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                new MatchQueryBuilder("_id", "3"),
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .filter(new MatchQueryBuilder("_id", "3"))
+                .build();
+
             Map<String, Object> searchResponseAsMap = search(TEST_MULTI_DOC_INDEX_NAME, neuralQueryBuilder, 3);
             assertEquals(1, getHitCount(searchResponseAsMap));
             Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);

--- a/src/test/java/org/opensearch/neuralsearch/query/visitor/NeuralSearchQueryVisitorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/visitor/NeuralSearchQueryVisitorTests.java
@@ -16,9 +16,11 @@ public class NeuralSearchQueryVisitorTests extends OpenSearchTestCase {
 
     public void testAccept_whenNeuralQueryBuilderWithoutModelId_thenSetModelId() {
         String modelId = "bdcvjkcdjvkddcjxdjsc";
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_text");
-        neuralQueryBuilder.k(768);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_text")
+            .queryText("query_text")
+            .k(768)
+            .build();
 
         NeuralSearchQueryVisitor neuralSearchQueryVisitor = new NeuralSearchQueryVisitor(modelId, null);
         neuralSearchQueryVisitor.accept(neuralQueryBuilder);
@@ -29,9 +31,11 @@ public class NeuralSearchQueryVisitorTests extends OpenSearchTestCase {
     public void testAccept_whenNeuralQueryBuilderWithoutFieldModelId_thenSetFieldModelId() {
         Map<String, Object> neuralInfoMap = new HashMap<>();
         neuralInfoMap.put("passage_text", "bdcvjkcdjvkddcjxdjsc");
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_text");
-        neuralQueryBuilder.k(768);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_text")
+            .queryText("query_text")
+            .k(768)
+            .build();
 
         NeuralSearchQueryVisitor neuralSearchQueryVisitor = new NeuralSearchQueryVisitor(null, neuralInfoMap);
         neuralSearchQueryVisitor.accept(neuralQueryBuilder);
@@ -76,7 +80,7 @@ public class NeuralSearchQueryVisitorTests extends OpenSearchTestCase {
     }
 
     public void testAccept_whenNullValuesInVisitor_thenFail() {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder().fieldName("passage_text").queryText("query_text").build();
         NeuralSparseQueryBuilder neuralSparseQueryBuilder = new NeuralSparseQueryBuilder();
         NeuralSearchQueryVisitor neuralSearchQueryVisitor = new NeuralSearchQueryVisitor(null, null);
 


### PR DESCRIPTION
### Description
Adds support for builder constructor for Neural Query Builder

This PR adds support for builder constructor with `@Builder` lombok annotation in `NeuralQueryBuilder`

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->
#1025
 
### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
