### PR TITLE
Fix bug where document embedding fails to be generated due to document has dot in field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 - Fix bug where ingested document has list of nested objects ([#1040](https://github.com/opensearch-project/neural-search/pull/1040))
 - Fixed document source and score field mismatch in sorted hybrid queries ([#1043](https://github.com/opensearch-project/neural-search/pull/1043))
+- Fix bug where embedding is missing when ingested document has "." in field name, and mismatches fieldMap config ([#1062](https://github.com/opensearch-project/neural-search/pull/1062))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -153,9 +153,8 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
 
     @VisibleForTesting
     void preprocessIngestDocument(IngestDocument ingestDocument) {
-        if (ingestDocument == null) return;
+        if (ingestDocument == null || ingestDocument.getSourceAndMetadata() == null) return;
         Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
-        if (sourceAndMetadataMap == null) return;
         Map<String, Object> unflattened = ProcessorDocumentUtils.unflattenJson(sourceAndMetadataMap);
         unflattened.forEach(ingestDocument::setFieldValue);
         sourceAndMetadataMap.keySet().removeIf(key -> key.contains("."));

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -137,6 +137,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
     @Override
     public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
         try {
+            preprocessIngestDocument(ingestDocument);
             validateEmbeddingFieldsValue(ingestDocument);
             Map<String, Object> processMap = buildMapWithTargetKeys(ingestDocument);
             List<String> inferenceList = createInferenceList(processMap);
@@ -148,6 +149,16 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         } catch (Exception e) {
             handler.accept(null, e);
         }
+    }
+
+    @VisibleForTesting
+    void preprocessIngestDocument(IngestDocument ingestDocument) {
+        if (ingestDocument == null) return;
+        Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
+        if (sourceAndMetadataMap == null) return;
+        Map<String, Object> unflattened = ProcessorDocumentUtils.unflattenJson(sourceAndMetadataMap);
+        unflattened.forEach(ingestDocument::setFieldValue);
+        sourceAndMetadataMap.keySet().removeIf(key -> key.contains("."));
     }
 
     /**
@@ -244,12 +255,14 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         for (IngestDocumentWrapper ingestDocumentWrapper : ingestDocumentWrappers) {
             Map<String, Object> processMap = null;
             List<String> inferenceList = null;
+            IngestDocument ingestDocument = ingestDocumentWrapper.getIngestDocument();
             try {
-                validateEmbeddingFieldsValue(ingestDocumentWrapper.getIngestDocument());
-                processMap = buildMapWithTargetKeys(ingestDocumentWrapper.getIngestDocument());
+                preprocessIngestDocument(ingestDocument);
+                validateEmbeddingFieldsValue(ingestDocument);
+                processMap = buildMapWithTargetKeys(ingestDocument);
                 inferenceList = createInferenceList(processMap);
             } catch (Exception e) {
-                ingestDocumentWrapper.update(ingestDocumentWrapper.getIngestDocument(), e);
+                ingestDocumentWrapper.update(ingestDocument, e);
             } finally {
                 dataForInferences.add(new DataForInference(ingestDocumentWrapper, processMap, inferenceList));
             }
@@ -333,13 +346,14 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
             } else if (sourceAndMetadataMap.get(parentKey) instanceof List) {
                 for (Map.Entry<String, Object> nestedFieldMapEntry : ((Map<String, Object>) processorKey).entrySet()) {
                     List<Map<String, Object>> list = (List<Map<String, Object>>) sourceAndMetadataMap.get(parentKey);
+                    Pair<String, Object> processedNestedKey = processNestedKey(nestedFieldMapEntry);
                     List<Object> listOfStrings = list.stream().map(x -> {
-                        Object nestedSourceValue = x.get(nestedFieldMapEntry.getKey());
+                        Object nestedSourceValue = x.get(processedNestedKey.getKey());
                         return normalizeSourceValue(nestedSourceValue);
                     }).collect(Collectors.toList());
                     Map<String, Object> map = new LinkedHashMap<>();
-                    map.put(nestedFieldMapEntry.getKey(), listOfStrings);
-                    buildNestedMap(nestedFieldMapEntry.getKey(), nestedFieldMapEntry.getValue(), map, next);
+                    map.put(processedNestedKey.getKey(), listOfStrings);
+                    buildNestedMap(processedNestedKey.getKey(), processedNestedKey.getValue(), map, next);
                 }
             }
             treeRes.merge(parentKey, next, REMAPPING_FUNCTION);
@@ -387,7 +401,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         ProcessorDocumentUtils.validateMapTypeValue(
             FIELD_MAP_FIELD,
             sourceAndMetadataMap,
-            fieldMap,
+            ProcessorDocumentUtils.unflattenJson(fieldMap),
             indexName,
             clusterService,
             environment,

--- a/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
@@ -12,11 +12,14 @@ import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.env.Environment;
 import org.opensearch.index.mapper.MapperService;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Stack;
 
 /**
  * This class is used to accommodate the common code pieces of parsing, validating and processing the document for multiple
@@ -178,4 +181,166 @@ public class ProcessorDocumentUtils {
             );
         }
     }
+
+    /**
+     * Unflatten a JSON object represented as a {@code Map<String, Object>}, possibly with dot in field name,
+     * into a nested {@code Map<String, Object>}
+     * "Object" can be either a {@code Map<String, Object>} or a {@code List<Object>} or simply a String.
+     * For example, input is {"a.b": "c"}, output is {"a":{"b": "c"}}.
+     * Another example:
+     *     input is {"a": [{"b.c": "d"}, {"b.c": "e"}]},
+     *     output is {"a": [{"b": {"c": "d"}}, {"b": {"c": "e"}}]}
+     * @param originalJsonMap the original JSON object represented as a {@code Map<String, Object>}
+     * @return the nested JSON object represented as a nested {@code Map<String, Object>}
+     * @throws IllegalArgumentException  if the originalJsonMap is null or has invalid dot usage in field name
+     */
+    public static Map<String, Object> unflattenJson(Map<String, Object> originalJsonMap) {
+        if (originalJsonMap == null) {
+            throw new IllegalArgumentException("originalJsonMap cannot be null");
+        }
+        Map<String, Object> result = new HashMap<>();
+        Stack<ProcessJsonObjectItem> stack = new Stack<>();
+
+        // Push initial items to stack
+        for (Map.Entry<String, Object> entry : originalJsonMap.entrySet()) {
+            stack.push(new ProcessJsonObjectItem(entry.getKey(), entry.getValue(), result));
+        }
+
+        // Process items until stack is empty
+        while (!stack.isEmpty()) {
+            ProcessJsonObjectItem item = stack.pop();
+            String key = item.key;
+            Object value = item.value;
+            Map<String, Object> currentMap = item.targetMap;
+
+            // Handle nested value
+            if (value instanceof Map) {
+                Map<String, Object> nestedMap = new HashMap<>();
+                for (Map.Entry<String, Object> entry : ((Map<String, Object>) value).entrySet()) {
+                    stack.push(new ProcessJsonObjectItem(entry.getKey(), entry.getValue(), nestedMap));
+                }
+                value = nestedMap;
+            } else if (value instanceof List) {
+                value = handleList((List<Object>) value);
+            }
+
+            // If key contains dot, split and create nested structure
+            unflattenSingleItem(key, value, currentMap);
+        }
+
+        return result;
+    }
+
+    private static List<Object> handleList(List<Object> list) {
+        List<Object> result = new ArrayList<>();
+        Stack<ProcessJsonListItem> stack = new Stack<>();
+
+        // Push initial items to stack
+        for (int i = list.size() - 1; i >= 0; i--) {
+            stack.push(new ProcessJsonListItem(list.get(i), result));
+        }
+
+        // Process items until stack is empty
+        while (!stack.isEmpty()) {
+            ProcessJsonListItem item = stack.pop();
+            Object value = item.value;
+            List<Object> targetList = item.targetList;
+
+            if (value instanceof Map) {
+                Map<String, Object> nestedMap = new HashMap<>();
+                Map<String, Object> sourceMap = (Map<String, Object>) value;
+                for (Map.Entry<String, Object> entry : sourceMap.entrySet()) {
+                    stack.push(new ProcessJsonListItem(new ProcessJsonObjectItem(entry.getKey(), entry.getValue(), nestedMap), targetList));
+                }
+                targetList.add(nestedMap);
+            } else if (value instanceof List) {
+                List<Object> nestedList = new ArrayList<>();
+                for (Object listItem : (List<Object>) value) {
+                    stack.push(new ProcessJsonListItem(listItem, nestedList));
+                }
+                targetList.add(nestedList);
+            } else if (value instanceof ProcessJsonObjectItem) {
+                ProcessJsonObjectItem processJsonObjectItem = (ProcessJsonObjectItem) value;
+                Map<String, Object> tempMap = new HashMap<>();
+                unflattenSingleItem(processJsonObjectItem.key, processJsonObjectItem.value, tempMap);
+                targetList.set(targetList.size() - 1, tempMap);
+            } else {
+                targetList.add(value);
+            }
+        }
+
+        return result;
+    }
+
+    private static void unflattenSingleItem(String key, Object value, Map<String, Object> result) {
+        if (StringUtils.isBlank(key)) {
+            throw new IllegalArgumentException("Field name cannot be null or empty");
+        }
+        if (key.contains(".")) {
+            // Use split with -1 limit to preserve trailing empty strings
+            String[] parts = key.split("\\.", -1);
+            Map<String, Object> current = result;
+
+            for (int i = 0; i < parts.length; i++) {
+                if (StringUtils.isBlank(parts[i])) {
+                    throw new IllegalArgumentException(String.format(Locale.ROOT, "Field name '%s' contains invalid dot usage", key));
+                }
+                if (i == parts.length - 1) {
+                    current.put(parts[i], value);
+                    continue;
+                }
+                current = (Map<String, Object>) current.computeIfAbsent(parts[i], k -> new HashMap<>());
+            }
+        } else {
+            result.put(key, value);
+        }
+    }
+
+    /**
+     * Validate if field name is in correct format, which is either "a", or "a.b.c".
+     * If field name is like "..a..b", "a..b", "a.b..", it should be invalid.
+     * This is done via checking if a string contains empty segments when split by dots.
+     *
+     * @param input the string to check
+     * @throws IllegalArgumentException if the input is null or has invalid dot usage
+     */
+    private static void validateFieldName(String input) {
+        if (StringUtils.isBlank(input)) {
+            throw new IllegalArgumentException("Field name cannot be null or empty");
+        }
+
+        // Use split with -1 limit to preserve trailing empty strings
+        String[] segments = input.split("\\.", -1);
+
+        // Check if any segment is empty
+        for (String segment : segments) {
+            if (StringUtils.isBlank(segment)) {
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Field name '%s' contains invalid dot usage", input));
+            }
+        }
+    }
+
+    // Helper classes to maintain state during iteration
+    private static class ProcessJsonObjectItem {
+        String key;
+        Object value;
+        Map<String, Object> targetMap;
+
+        ProcessJsonObjectItem(String key, Object value, Map<String, Object> targetMap) {
+            this.key = key;
+            this.value = value;
+            this.targetMap = targetMap;
+        }
+    }
+
+    private static class ProcessJsonListItem {
+        Object value;
+        List<Object> targetList;
+
+        ProcessJsonListItem(Object value, List<Object> targetList) {
+            this.value = value;
+            this.targetList = targetList;
+        }
+    }
+
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -486,28 +486,34 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
           ]
         */
-        Map<String, Object> child1Level2 = buildObjMapWithSingleField(CHILD_1_TEXT_FIELD, TEXT_VALUE_1);
-        Map<String, Object> child1Level1 = buildObjMapWithSingleField(CHILD_FIELD_LEVEL_1, child1Level2);
-        Map<String, Object> child2Level2 = buildObjMapWithSingleField(CHILD_1_TEXT_FIELD, TEXT_VALUE_1);
-        child2Level2.put(CHILD_2_TEXT_FIELD, TEXT_VALUE_2);
-        child2Level2.put(CHILD_3_TEXT_FIELD, TEXT_VALUE_3);
-        Map<String, Object> child2Level1 = buildObjMapWithSingleField(CHILD_FIELD_LEVEL_1, child2Level2);
-        Map<String, Object> sourceAndMetadata = Map.of(
-            PARENT_FIELD,
-            Arrays.asList(child1Level1, child2Level1),
-            IndexFieldMapper.NAME,
-            "my_index"
+        Map<String, Object> child1Level2 = buildObjMap(Pair.of(CHILD_1_TEXT_FIELD, TEXT_VALUE_1));
+        Map<String, Object> child1Level1 = buildObjMap(Pair.of(CHILD_FIELD_LEVEL_1, child1Level2));
+        Map<String, Object> child2Level2 = buildObjMap(
+            Pair.of(CHILD_1_TEXT_FIELD, TEXT_VALUE_1),
+            Pair.of(CHILD_2_TEXT_FIELD, TEXT_VALUE_2),
+            Pair.of(CHILD_3_TEXT_FIELD, TEXT_VALUE_3)
+        );
+        Map<String, Object> child2Level1 = buildObjMap(Pair.of(CHILD_FIELD_LEVEL_1, child2Level2));
+        Map<String, Object> sourceAndMetadata = buildObjMap(
+            Pair.of(PARENT_FIELD, Arrays.asList(child1Level1, child2Level1)),
+            Pair.of(IndexFieldMapper.NAME, "my_index")
         );
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
 
         Map<String, Processor.Factory> registry = new HashMap<>();
-        Map<String, Object> config = new HashMap<>();
-        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
-        config.put(
-            TextEmbeddingProcessor.FIELD_MAP_FIELD,
-            Map.of(
-                PARENT_FIELD,
-                Map.of(CHILD_FIELD_LEVEL_1, Map.of(CHILD_1_TEXT_FIELD, String.join(".", CHILD_FIELD_LEVEL_2, CHILD_LEVEL_2_KNN_FIELD)))
+        Map<String, Object> config = buildObjMap(
+            Pair.of(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId"),
+            Pair.of(
+                TextEmbeddingProcessor.FIELD_MAP_FIELD,
+                buildObjMap(
+                    Pair.of(
+                        PARENT_FIELD,
+                        Map.of(
+                            CHILD_FIELD_LEVEL_1,
+                            Map.of(CHILD_1_TEXT_FIELD, String.join(".", CHILD_FIELD_LEVEL_2, CHILD_LEVEL_2_KNN_FIELD))
+                        )
+                    )
+                )
             )
         );
         TextEmbeddingProcessor processor = (TextEmbeddingProcessor) textEmbeddingProcessorFactory.create(
@@ -770,6 +776,103 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         }
     }
 
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    public void testBuildVectorOutput_withFlattenedNestedMap_successful() {
+        Map<String, Object> config = createNestedMapConfiguration();
+        IngestDocument ingestDocument = createFlattenedNestedMapIngestDocument();
+        TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
+        processor.preprocessIngestDocument(ingestDocument);
+        Map<String, Object> knnMap = processor.buildMapWithTargetKeys(ingestDocument);
+        List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(2, 100, 0.0f, 1.0f);
+        processor.buildNLPResult(knnMap, modelTensorList, ingestDocument.getSourceAndMetadata());
+        /**
+         * "favorites.favorite": {
+         *      "movie": "matrix",
+         *      "actor": "Charlie Chaplin",
+         *      "games" : {
+         *          "adventure": {
+         *              "action": "overwatch",
+         *              "rpg": "elden ring"
+         *          }
+         *      }
+         * }
+         */
+        Map<String, Object> favoritesMap = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("favorites");
+        assertNotNull(favoritesMap);
+        Map<String, Object> favorites = (Map<String, Object>) favoritesMap.get("favorite");
+        assertNotNull(favorites);
+
+        Map<String, Object> favoriteGames = (Map<String, Object>) favorites.get("games");
+        assertNotNull(favoriteGames);
+        Map<String, Object> adventure = (Map<String, Object>) favoriteGames.get("adventure");
+        List<Float> adventureKnnVector = (List<Float>) adventure.get("with_action_knn");
+        assertNotNull(adventureKnnVector);
+        assertEquals(100, adventureKnnVector.size());
+        for (float vector : adventureKnnVector) {
+            assertTrue(vector >= 0.0f && vector <= 1.0f);
+        }
+
+        List<Float> favoriteKnnVector = (List<Float>) favorites.get("favorite_movie_knn");
+        assertNotNull(favoriteKnnVector);
+        assertEquals(100, favoriteKnnVector.size());
+        for (float vector : favoriteKnnVector) {
+            assertTrue(vector >= 0.0f && vector <= 1.0f);
+        }
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    public void testBuildVectorOutput_withFlattenedNestedMapAndList_successful() {
+        Map<String, Object> config = createNestedMapConfiguration();
+        IngestDocument ingestDocument = createFlattenedNestedMapAndListIngestDocument();
+        TextEmbeddingProcessor processor = createInstanceWithNestedMapConfiguration(config);
+        processor.preprocessIngestDocument(ingestDocument);
+        Map<String, Object> knnMap = processor.buildMapWithTargetKeys(ingestDocument);
+        List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(3, 100, 0.0f, 1.0f);
+        processor.buildNLPResult(knnMap, modelTensorList, ingestDocument.getSourceAndMetadata());
+        /**
+         * "favorites.favorite": {
+         *      "movie": "matrix",
+         *      "actor": "Charlie Chaplin",
+         *      "games" : [
+         *          {
+         *              "adventure": {
+         *                  "action": "overwatch",
+         *                  "rpg": "elden ring"
+         *              }
+         *          },
+         *          {
+         *              "adventure.action": "wukong"
+         *          }
+         *      ]
+         * }
+         */
+        Map<String, Object> favoritesMap = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("favorites");
+        assertNotNull(favoritesMap);
+        Map<String, Object> favorite = (Map<String, Object>) favoritesMap.get("favorite");
+        assertNotNull(favorite);
+
+        List<Map<String, Object>> favoriteGames = (List<Map<String, Object>>) favorite.get("games");
+        assertNotNull(favoriteGames);
+        for (Map<String, Object> favoriteGame : favoriteGames) {
+            Map<String, Object> adventure = (Map<String, Object>) favoriteGame.get("adventure");
+            List<Float> adventureKnnVector = (List<Float>) adventure.get("with_action_knn");
+            assertNotNull(adventureKnnVector);
+            assertEquals(100, adventureKnnVector.size());
+            for (float vector : adventureKnnVector) {
+                assertTrue(vector >= 0.0f && vector <= 1.0f);
+            }
+        }
+
+        List<Float> favoriteKnnVector = (List<Float>) favorite.get("favorite_movie_knn");
+        assertNotNull(favoriteKnnVector);
+        assertEquals(100, favoriteKnnVector.size());
+        for (float vector : favoriteKnnVector) {
+            assertTrue(vector >= 0.0f && vector <= 1.0f);
+        }
+    }
+
     public void testBuildVectorOutput_withNestedList_successful() {
         Map<String, Object> config = createNestedListConfiguration();
         IngestDocument ingestDocument = createNestedListIngestDocument();
@@ -853,8 +956,8 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
          * }
          */
         List<Map<String, Object>> nestedList = (List<Map<String, Object>>) ingestDocument.getSourceAndMetadata().get("nestedField");
-        Map<String, Object> objWithNullText = buildObjMapWithSingleField("textField", null);
-        Map<String, Object> nestedObjWithNullText = buildObjMapWithSingleField("nestedField", objWithNullText);
+        Map<String, Object> objWithNullText = buildObjMap(Pair.of("textField", null));
+        Map<String, Object> nestedObjWithNullText = buildObjMap(Pair.of("nestedField", objWithNullText));
         nestedList.set(0, nestedObjWithNullText);
         TextEmbeddingProcessor textEmbeddingProcessor = createInstanceWithNestedMapConfiguration(config);
         Map<String, Object> knnMap = textEmbeddingProcessor.buildMapWithTargetKeys(ingestDocument);
@@ -1142,21 +1245,22 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     @SneakyThrows
     private TextEmbeddingProcessor createInstanceWithNestedMapConfiguration(Map<String, Object> fieldMap) {
         Map<String, Processor.Factory> registry = new HashMap<>();
-        Map<String, Object> config = new HashMap<>();
-        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
-        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, fieldMap);
+        Map<String, Object> config = buildObjMap(
+            Pair.of(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId"),
+            Pair.of(TextEmbeddingProcessor.FIELD_MAP_FIELD, fieldMap)
+        );
         return (TextEmbeddingProcessor) textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
     }
 
     private Map<String, Object> createPlainStringConfiguration() {
-        Map<String, Object> config = new HashMap<>();
-        config.put("oriKey1", "oriKey1_knn");
-        config.put("oriKey2", "oriKey2_knn");
-        config.put("oriKey3", "oriKey3_knn");
-        config.put("oriKey4", "oriKey4_knn");
-        config.put("oriKey5", "oriKey5_knn");
-        config.put("oriKey6", "oriKey6_knn");
-        return config;
+        return buildObjMap(
+            Pair.of("oriKey1", "oriKey1_knn"),
+            Pair.of("oriKey2", "oriKey2_knn"),
+            Pair.of("oriKey3", "oriKey3_knn"),
+            Pair.of("oriKey4", "oriKey4_knn"),
+            Pair.of("oriKey5", "oriKey5_knn"),
+            Pair.of("oriKey6", "oriKey6_knn")
+        );
     }
 
     /**
@@ -1169,24 +1273,24 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
      * }
      */
     private Map<String, Object> createNestedMapConfiguration() {
-        Map<String, Object> adventureGames = new HashMap<>();
-        adventureGames.put("adventure.action", "with_action_knn");
-        Map<String, Object> favorite = new HashMap<>();
-        favorite.put("favorite.movie", "favorite_movie_knn");
-        favorite.put("favorite.games", adventureGames);
-        Map<String, Object> result = new HashMap<>();
-        result.put("favorites", favorite);
+        Map<String, Object> adventureGames = buildObjMap(Pair.of("adventure.action", "with_action_knn"));
+        Map<String, Object> favorite = buildObjMap(
+            Pair.of("favorite.movie", "favorite_movie_knn"),
+            Pair.of("favorite.games", adventureGames)
+        );
+        Map<String, Object> result = buildObjMap(Pair.of("favorites", favorite));
         return result;
     }
 
     private IngestDocument createPlainIngestDocument() {
-        Map<String, Object> result = new HashMap<>();
-        result.put("oriKey1", "oriValue1");
-        result.put("oriKey2", "oriValue2");
-        result.put("oriKey3", "oriValue3");
-        result.put("oriKey4", "oriValue4");
-        result.put("oriKey5", "oriValue5");
-        result.put("oriKey6", ImmutableList.of("oriValue6", "oriValue7"));
+        Map<String, Object> result = buildObjMap(
+            Pair.of("oriKey1", "oriValue1"),
+            Pair.of("oriKey2", "oriValue2"),
+            Pair.of("oriKey3", "oriValue3"),
+            Pair.of("oriKey4", "oriValue4"),
+            Pair.of("oriKey5", "oriValue5"),
+            Pair.of("oriKey6", ImmutableList.of("oriValue6", "oriValue7"))
+        );
         return new IngestDocument(result, new HashMap<>());
     }
 
@@ -1206,81 +1310,131 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
      * }
      */
     private IngestDocument createNestedMapIngestDocument() {
-        Map<String, Object> adventureGames = new HashMap<>();
-        adventureGames.put("action", "overwatch");
-        adventureGames.put("rpg", "elden ring");
-        Map<String, Object> favGames = new HashMap<>();
-        favGames.put("adventure", adventureGames);
-        Map<String, Object> favorites = new HashMap<>();
-        favorites.put("movie", "matrix");
-        favorites.put("games", favGames);
-        favorites.put("actor", "Charlie Chaplin");
-        Map<String, Object> favorite = new HashMap<>();
-        favorite.put("favorite", favorites);
-        Map<String, Object> result = new HashMap<>();
-        result.put("favorites", favorite);
+        Map<String, Object> adventureGames = buildObjMap(Pair.of("action", "overwatch"), Pair.of("rpg", "elden ring"));
+        Map<String, Object> favGames = buildObjMap(Pair.of("adventure", adventureGames));
+        Map<String, Object> favorites = buildObjMap(
+            Pair.of("movie", "matrix"),
+            Pair.of("games", favGames),
+            Pair.of("actor", "Charlie Chaplin")
+        );
+        Map<String, Object> favorite = buildObjMap(Pair.of("favorite", favorites));
+        Map<String, Object> result = buildObjMap(Pair.of("favorites", favorite));
+        return new IngestDocument(result, new HashMap<>());
+    }
+
+    /**
+     * Create following document with flattened nested map
+     * "favorites.favorite": {
+     *      "movie": "matrix",
+     *      "actor": "Charlie Chaplin",
+     *      "games" : {
+     *          "adventure": {
+     *              "action": "overwatch",
+     *              "rpg": "elden ring"
+     *          }
+     *      }
+     * }
+     */
+    private IngestDocument createFlattenedNestedMapIngestDocument() {
+        Map<String, Object> adventureGames = buildObjMap(Pair.of("action", "overwatch"), Pair.of("rpg", "elden ring"));
+        Map<String, Object> favGames = buildObjMap(Pair.of("adventure", adventureGames));
+        Map<String, Object> favorites = buildObjMap(
+            Pair.of("movie", "matrix"),
+            Pair.of("games", favGames),
+            Pair.of("actor", "Charlie Chaplin")
+        );
+        Map<String, Object> result = buildObjMap(Pair.of("favorites.favorite", favorites));
+        return new IngestDocument(result, new HashMap<>());
+    }
+
+    /**
+     * Create following document with flattened nested map and list
+     * "favorites.favorite": {
+     *      "movie": "matrix",
+     *      "actor": "Charlie Chaplin",
+     *      "games" : [
+     *          {
+     *              "adventure": {
+     *                  "action": "overwatch",
+     *                  "rpg": "elden ring"
+     *              }
+     *          },
+     *          {
+     *              "adventure.action": "wukong"
+     *          }
+     *      ]
+     * }
+     */
+    private IngestDocument createFlattenedNestedMapAndListIngestDocument() {
+        Map<String, Object> adventureGames = buildObjMap(Pair.of("action", "overwatch"), Pair.of("rpg", "elden ring"));
+        Map<String, Object> game1 = buildObjMap(Pair.of("adventure", adventureGames));
+        Map<String, Object> game2 = buildObjMap(Pair.of("adventure.action", "wukong"));
+        Map<String, Object> favorites = buildObjMap(
+            Pair.of("movie", "matrix"),
+            Pair.of("games", Arrays.asList(game1, game2)),
+            Pair.of("actor", "Charlie Chaplin")
+        );
+        Map<String, Object> result = buildObjMap(Pair.of("favorites.favorite", favorites));
         return new IngestDocument(result, new HashMap<>());
     }
 
     private Map<String, Object> createNestedListConfiguration() {
-        Map<String, Object> nestedConfig = buildObjMapWithSingleField("textField", "vectorField");
-        return buildObjMapWithSingleField("nestedField", nestedConfig);
+        Map<String, Object> nestedConfig = buildObjMap(Pair.of("textField", "vectorField"));
+        return buildObjMap(Pair.of("nestedField", nestedConfig));
     }
 
     private Map<String, Object> createNestedList2LevelConfiguration() {
-        Map<String, Object> nestedConfig = buildObjMapWithSingleField("textField", "vectorField");
-        Map<String, Object> nestConfigLevel1 = buildObjMapWithSingleField("nestedField", nestedConfig);
-        return buildObjMapWithSingleField("nestedField", nestConfigLevel1);
+        Map<String, Object> nestedConfig = buildObjMap(Pair.of("textField", "vectorField"));
+        Map<String, Object> nestConfigLevel1 = buildObjMap(Pair.of("nestedField", nestedConfig));
+        return buildObjMap(Pair.of("nestedField", nestConfigLevel1));
     }
 
     private IngestDocument createNestedListIngestDocument() {
-        Map<String, Object> nestedObj1 = buildObjMapWithSingleField("textField", "This is a text field");
-        Map<String, Object> nestedObj2 = buildObjMapWithSingleField("textField", "This is another text field");
-        Map<String, Object> nestedList = buildObjMapWithSingleField("nestedField", Arrays.asList(nestedObj1, nestedObj2));
+        Map<String, Object> nestedObj1 = buildObjMap(Pair.of("textField", "This is a text field"));
+        Map<String, Object> nestedObj2 = buildObjMap(Pair.of("textField", "This is another text field"));
+        Map<String, Object> nestedList = buildObjMap(Pair.of("nestedField", Arrays.asList(nestedObj1, nestedObj2)));
         return new IngestDocument(nestedList, new HashMap<>());
     }
 
     private IngestDocument createNestedListWithNotEmbeddingFieldIngestDocument() {
-        Map<String, Object> nestedObj1 = buildObjMapWithSingleField("textFieldNotForEmbedding", "This is a text field");
-        Map<String, Object> nestedObj2 = buildObjMapWithSingleField("textField", "This is another text field");
-        Map<String, Object> nestedList = buildObjMapWithSingleField("nestedField", Arrays.asList(nestedObj1, nestedObj2));
+        Map<String, Object> nestedObj1 = buildObjMap(Pair.of("textFieldNotForEmbedding", "This is a text field"));
+        Map<String, Object> nestedObj2 = buildObjMap(Pair.of("textField", "This is another text field"));
+        Map<String, Object> nestedList = buildObjMap(Pair.of("nestedField", Arrays.asList(nestedObj1, nestedObj2)));
         return new IngestDocument(nestedList, new HashMap<>());
     }
 
     private IngestDocument create2LevelNestedListIngestDocument() {
-        Map<String, Object> nestedObj1 = buildObjMapWithSingleField("textField", "This is a text field");
-        Map<String, Object> nestedObj2 = buildObjMapWithSingleField("textField", "This is another text field");
-        Map<String, Object> nestedList = buildObjMapWithSingleField("nestedField", Arrays.asList(nestedObj1, nestedObj2));
-        Map<String, Object> nestedList1 = buildObjMapWithSingleField("nestedField", nestedList);
+        Map<String, Object> nestedObj1 = buildObjMap(Pair.of("textField", "This is a text field"));
+        Map<String, Object> nestedObj2 = buildObjMap(Pair.of("textField", "This is another text field"));
+        Map<String, Object> nestedList = buildObjMap(Pair.of("nestedField", Arrays.asList(nestedObj1, nestedObj2)));
+        Map<String, Object> nestedList1 = buildObjMap(Pair.of("nestedField", nestedList));
         return new IngestDocument(nestedList1, new HashMap<>());
     }
 
     private IngestDocument create2LevelNestedListWithNestedFieldsIngestDocument() {
-        Map<String, Object> nestedObj1Level2 = buildObjMapWithSingleField("textField", "This is a text field");
-        Map<String, Object> nestedObj1Level1 = buildObjMapWithSingleField("nestedField", nestedObj1Level2);
+        Map<String, Object> nestedObj1Level2 = buildObjMap(Pair.of("textField", "This is a text field"));
+        Map<String, Object> nestedObj1Level1 = buildObjMap(Pair.of("nestedField", nestedObj1Level2));
 
-        Map<String, Object> nestedObj2Level2 = buildObjMapWithSingleField("textField", "This is another text field");
-        Map<String, Object> nestedObj2Level1 = buildObjMapWithSingleField("nestedField", nestedObj2Level2);
+        Map<String, Object> nestedObj2Level2 = buildObjMap(Pair.of("textField", "This is another text field"));
+        Map<String, Object> nestedObj2Level1 = buildObjMap(Pair.of("nestedField", nestedObj2Level2));
 
-        Map<String, Object> nestedList = buildObjMapWithSingleField("nestedField", Arrays.asList(nestedObj1Level1, nestedObj2Level1));
+        Map<String, Object> nestedList = buildObjMap(Pair.of("nestedField", Arrays.asList(nestedObj1Level1, nestedObj2Level1)));
         return new IngestDocument(nestedList, new HashMap<>());
     }
 
-    private Map<String, Object> buildObjMapWithSingleField(String fieldName, Object fieldValue) {
+    private Map<String, Object> buildObjMap(Pair<String, Object>... pairs) {
         Map<String, Object> objMap = new HashMap<>();
-        objMap.put(fieldName, fieldValue);
+        for (Pair<String, Object> pair : pairs) {
+            objMap.put(pair.getKey(), pair.getValue());
+        }
         return objMap;
     }
 
     private IngestDocument create2LevelNestedListWithNotEmbeddingFieldIngestDocument() {
-        HashMap<String, Object> nestedObj1 = new HashMap<>();
-        nestedObj1.put("textFieldNotForEmbedding", "This is a text field");
-        HashMap<String, Object> nestedObj2 = new HashMap<>();
-        nestedObj2.put("textField", "This is another text field");
-        HashMap<String, Object> nestedList = new HashMap<>();
-        nestedList.put("nestedField", Arrays.asList(nestedObj1, nestedObj2));
-        HashMap<String, Object> nestedList1 = new HashMap<>();
-        nestedList1.put("nestedField", nestedList);
+        Map<String, Object> nestedObj1 = buildObjMap(Pair.of("textFieldNotForEmbedding", "This is a text field"));
+        Map<String, Object> nestedObj2 = buildObjMap(Pair.of("textField", "This is another text field"));
+        Map<String, Object> nestedList = buildObjMap(Pair.of("nestedField", Arrays.asList(nestedObj1, nestedObj2)));
+        Map<String, Object> nestedList1 = buildObjMap(Pair.of("nestedField", nestedList));
         return new IngestDocument(nestedList1, new HashMap<>());
     }
 }

--- a/src/test/resources/processor/ingest_doc5.json
+++ b/src/test/resources/processor/ingest_doc5.json
@@ -1,0 +1,24 @@
+{
+  "title": "This is a good day",
+  "description": "daily logging",
+  "favor_list": [
+    "key",
+    "hey",
+    "click"
+  ],
+  "favorites": {
+    "game": "cossacks",
+    "movie": "matrix"
+  },
+  "nested_passages":[
+    {
+      "level_2":
+      {
+        "level_3_text": "clown"
+      }
+    },
+    {
+      "level_2.level_3_text": "batman"
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Fix bug where document embedding fails to be generated due to document has dot in field name, which does not match field mapping exactly

### Related Issues
Resolves #1042 

#### Root cause
Such issue is caused by that we fail to unbox/unflatten field in ingested doc, then it causes mismatch between nested field in fieldMap config and ingested document schema. 

For example, nested field can be represented as either {"a.b": "c"}, or {"a": {"b": "c"}}. If fieldMap is {"a": {"b": "b_embedding"}}, but ingested document is like {"a.b": "c"}, such schema mismatch fieldMap, and then we are not able to fetch "c" as value for inferencing. 

### About the change

Basically, the solution is to unbox/unflatten the field with dot from ingested doc.

Before this change, given fieldMap is below
```
{
  "description": "text embedding pipeline for exampe",
  "processors": [
    {
      "text_embedding": {
        "model_id": "EJTmBpQBz0MpoghfHptn",
        "field_map": {
          "nested_passages.level_2.level_3_text": "level_3_container.level_3_embedding"
        }
      }
    }
  ]
}
```
Simulate ingestion for below doc, there is no `level_3_container.level_3_embedding` generated for it.
```
{
  "docs": [
    {
      "_index": "neural-search-index-v2",
      "_id": "1",
      "_source": {
        "nested_passages": [
          {
            "level_2.level_3_text": "clown"
          },
          {
            "level_2": {
              "level_3_text": "batman"
            }
          }
        ]
      }
    }
  ]
}
```

After this change, embedding can be generated 
```
{
  "docs": [
    {
      "doc": {
        "_index": "neural-search-index-v2",
        "_id": "1",
        "_source": {
          "nested_passages": [
            {
              "level_2": {
                "level_3_container": {
                  "level_3_embedding": [
                    0.17990997,
                    0.064552955,
                    ...
                  ]
                },
                "level_3_text": "clown"
              }
            },
            {
              "level_2": {
                "level_3_container": {
                  "level_3_embedding": [
                    0.20891039,
                    0.09188991,
                    ...
                  ]
                },
                "level_3_text": "batman"
              }
            }
          ]
        },
        "_ingest": {
          "timestamp": "2025-01-06T19:00:12.84077Z"
        }
      }
    }
  ]
}
```


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
