### PR TITLE
increase cluster node timeout value for time consuming test cases

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/BatchIngestionIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/BatchIngestionIT.java
@@ -21,7 +21,7 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
     private static final String EMBEDDING_FIELD_NAME = "passage_embedding";
 
     public void testBatchIngestion_SparseEncodingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
         String indexName = getIndexNameForTest();
         String sparseModelId = null;
         switch (getClusterType()) {

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -30,7 +30,7 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Text Image Embedding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testTextImageEmbeddingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextImageEmbeddingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralSparseSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralSparseSearchIT.java
@@ -38,7 +38,7 @@ public class NeuralSparseSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Sparse Encoding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testSparseEncodingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadSparseEncodingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
@@ -25,7 +25,7 @@ public class SemanticSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Text Embedding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testSemanticSearch_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextEmbeddingModel();

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1285,13 +1285,18 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     }
 
     // Method that waits till the health of nodes in the cluster goes green
-    protected void waitForClusterHealthGreen(final String numOfNodes) throws IOException {
+    protected void waitForClusterHealthGreen(final String numOfNodes, final int timeoutInSeconds) throws IOException {
         Request waitForGreen = new Request("GET", "/_cluster/health");
         waitForGreen.addParameter("wait_for_nodes", numOfNodes);
         waitForGreen.addParameter("wait_for_status", "green");
-        waitForGreen.addParameter("cluster_manager_timeout", "60s");
-        waitForGreen.addParameter("timeout", "60s");
+        waitForGreen.addParameter("cluster_manager_timeout", String.format(LOCALE, "%ds", timeoutInSeconds));
+        waitForGreen.addParameter("timeout", String.format(LOCALE, "%ds", timeoutInSeconds));
         client().performRequest(waitForGreen);
+    }
+
+    // Method that waits till the health of nodes in the cluster goes green with default timeout value of 60
+    protected void waitForClusterHealthGreen(final String numOfNodes) throws IOException {
+        waitForClusterHealthGreen(numOfNodes, 60);
     }
 
     /**


### PR DESCRIPTION
### Description
This change introduces a refactor of the code in `BaseNeuralSearchIT` to enable flexible timeout setting for cluster nodes, and increases the time out value from 60s to 90s for the below test cases:

`testBatchIngestion_SparseEncodingProcessor_E2EFlow`
`testTextImageEmbeddingProcessor_E2EFlow`
`testSparseEncodingProcessor_E2EFlow`
`testSemanticSearch_E2EFlow`

Based on the previous PRs ([link](https://github.com/opensearch-project/neural-search/actions/workflows/backwards_compatibility_tests_workflow.yml?query=event%3Apull_request)), these test cases in BWC suite frequently failed with timeout, which requires manual re-run of the CI action

### Related Issues
Resolves #1035 #981 



### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
