### PR TITLE
Clean up unused validateFieldName() and use existing methods for TextEmbeddingProcessorIT

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
@@ -296,30 +296,6 @@ public class ProcessorDocumentUtils {
         }
     }
 
-    /**
-     * Validate if field name is in correct format, which is either "a", or "a.b.c".
-     * If field name is like "..a..b", "a..b", "a.b..", it should be invalid.
-     * This is done via checking if a string contains empty segments when split by dots.
-     *
-     * @param input the string to check
-     * @throws IllegalArgumentException if the input is null or has invalid dot usage
-     */
-    private static void validateFieldName(String input) {
-        if (StringUtils.isBlank(input)) {
-            throw new IllegalArgumentException("Field name cannot be null or empty");
-        }
-
-        // Use split with -1 limit to preserve trailing empty strings
-        String[] segments = input.split("\\.", -1);
-
-        // Check if any segment is empty
-        for (String segment : segments) {
-            if (StringUtils.isBlank(segment)) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT, "Field name '%s' contains invalid dot usage", input));
-            }
-        }
-    }
-
     // Helper classes to maintain state during iteration
     private static class ProcessJsonObjectItem {
         String key;

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -280,14 +280,9 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             Map<String, Object> searchResponseAsMap = search(INDEX_NAME, queryNestedHighLevel, 2);
             assertNotNull(searchResponseAsMap);
 
-            Map<String, Object> hits = (Map<String, Object>) searchResponseAsMap.get("hits");
-            assertNotNull(hits);
+            assertEquals(1, getHitCount(searchResponseAsMap));
 
-            List<Map<String, Object>> listOfHits = (List<Map<String, Object>>) hits.get("hits");
-            assertNotNull(listOfHits);
-            assertEquals(1, listOfHits.size());
-
-            Map<String, Object> innerHitDetails = listOfHits.getFirst();
+            Map<String, Object> innerHitDetails = getFirstInnerHit(searchResponseAsMap);
             assertEquals("5", innerHitDetails.get("_id"));
         } finally {
             wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);


### PR DESCRIPTION
### Description
Clean up unused validateFieldName() and use existing methods `getHitCount()` and `getFirstInnerHit()` for TextEmbeddingProcessorIT to simplify test code and fix build for `backport 2.x`

### Related Issues
Using existing methods `getHitCount()` and `getFirstInnerHit()` may help to fix build error in #1071: https://github.com/opensearch-project/neural-search/actions/runs/12664516471/job/35292787707?pr=1071

```
/__w/neural-search/neural-search/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java:297: error: cannot find symbol
            Map<String, Object> innerHitDetails = listOfHits.getFirst();
                                                            ^
  symbol:   method getFirst()
  location: variable listOfHits of type List<Map<String,Object>>
``` 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
