### PR TITLE
Fix github CI by adding eclipse dependency in formatting.gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 ### Documentation
 ### Maintenance
+- Fix github CI by adding eclipse dependency in formatting.gradle ([#1079](https://github.com/opensearch-project/neural-search/pull/1079))
 ### Refactoring

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -7,7 +7,7 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
+            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
@@ -20,7 +20,6 @@ import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_COMBINATION_MET
 import static org.opensearch.neuralsearch.util.TestUtils.getModelId;
 
 import org.opensearch.index.query.QueryBuilder;
-import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;


### PR DESCRIPTION
### Description
This PR contains changes to fix error `Failed to load eclipse jdt formatter` in github CI. Added download eclipse in the formatting.gradle.
