### PR TITLE
[Backport 2.x] add support for builder constructor in neural query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support new knn query parameter expand_nested ([#1013](https://github.com/opensearch-project/neural-search/pull/1013))
 - Support empty string for fields in text embedding processor ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
 - Optimize ML inference connection retry logic ([#1054](https://github.com/opensearch-project/neural-search/pull/1054))
+- Support for builder constructor in Neural Query Builder ([#1047](https://github.com/opensearch-project/neural-search/pull/1047))
 ### Bug Fixes
 - Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 - Fix bug where ingested document has list of nested objects ([#1040](https://github.com/opensearch-project/neural-search/pull/1040))

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
@@ -122,11 +122,12 @@ public class HybridSearchIT extends AbstractRestartUpgradeRestTestCase {
         final Map<String, ?> methodParameters,
         final RescoreContext rescoreContext
     ) {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_embedding");
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(QUERY);
-        neuralQueryBuilder.k(5);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .modelId(modelId)
+            .queryText(QUERY)
+            .k(5)
+            .build();
         if (expandNestedDocs != null) {
             neuralQueryBuilder.expandNested(expandNestedDocs);
         }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchWithRescoreIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchWithRescoreIT.java
@@ -93,11 +93,11 @@ public class HybridSearchWithRescoreIT extends AbstractRestartUpgradeRestTestCas
         final Map<String, ?> methodParameters,
         final RescoreContext rescoreContextForNeuralQuery
     ) {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName(VECTOR_EMBEDDING_FIELD);
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(QUERY);
-        neuralQueryBuilder.k(5);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_EMBEDDING_FIELD)
+            .modelId(modelId)
+            .queryText(QUERY)
+            .k(5);
         if (methodParameters != null) {
             neuralQueryBuilder.methodParameters(methodParameters);
         }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchWithRescoreIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchWithRescoreIT.java
@@ -97,7 +97,8 @@ public class HybridSearchWithRescoreIT extends AbstractRestartUpgradeRestTestCas
             .fieldName(VECTOR_EMBEDDING_FIELD)
             .modelId(modelId)
             .queryText(QUERY)
-            .k(5);
+            .k(5)
+            .build();
         if (methodParameters != null) {
             neuralQueryBuilder.methodParameters(methodParameters);
         }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -51,37 +51,25 @@ public class KnnRadialSearchIT extends AbstractRestartUpgradeRestTestCase {
     }
 
     private void validateIndexQuery(final String modelId) {
-        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            TEXT,
-            TEST_IMAGE_TEXT,
-            modelId,
-            null,
-            null,
-            0.01f,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(TEXT)
+            .queryImage(TEST_IMAGE_TEXT)
+            .modelId(modelId)
+            .minScore(0.01f)
+            .build();
+
         Map<String, Object> responseWithMinScoreQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
         assertNotNull(responseWithMinScoreQuery);
 
-        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            TEXT,
-            TEST_IMAGE_TEXT,
-            modelId,
-            null,
-            100000f,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(TEXT)
+            .queryImage(TEST_IMAGE_TEXT)
+            .modelId(modelId)
+            .maxDistance(100000f)
+            .build();
+
         Map<String, Object> responseWithMaxDistanceQuery = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);
         assertNotNull(responseWithMaxDistanceQuery);
     }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -53,20 +53,13 @@ public class MultiModalSearchIT extends AbstractRestartUpgradeRestTestCase {
     private void validateTestIndex(final String modelId) throws Exception {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(2, docCount);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-            "passage_embedding",
-            TEXT,
-            TEST_IMAGE_TEXT,
-            modelId,
-            1,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(TEXT)
+            .queryImage(TEST_IMAGE_TEXT)
+            .modelId(modelId)
+            .k(1)
+            .build();
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertNotNull(response);
     }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
@@ -76,8 +76,14 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRestartUpgradeRestTe
 
     public void testNeuralQueryEnricherProcessor_NeuralSearch_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
-        NeuralQueryBuilder neuralQueryBuilderWithoutModelId = new NeuralQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
-        NeuralQueryBuilder neuralQueryBuilderWithModelId = new NeuralQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
+        NeuralQueryBuilder neuralQueryBuilderWithoutModelId = NeuralQueryBuilder.builder()
+            .fieldName(TEST_ENCODING_FIELD)
+            .queryText(TEXT_1)
+            .build();
+        NeuralQueryBuilder neuralQueryBuilderWithModelId = NeuralQueryBuilder.builder()
+            .fieldName(TEST_ENCODING_FIELD)
+            .queryText(TEXT_1)
+            .build();
 
         if (isRunningAgainstOldCluster()) {
             String modelId = uploadTextEmbeddingModel();

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
@@ -51,11 +51,12 @@ public class SemanticSearchIT extends AbstractRestartUpgradeRestTestCase {
     private void validateTestIndex(final String modelId) throws Exception {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(2, docCount);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_embedding");
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(TEXT);
-        neuralQueryBuilder.k(1);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(TEXT)
+            .modelId(modelId)
+            .k(1)
+            .build();
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertNotNull(response);
     }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchIT.java
@@ -126,11 +126,12 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
         final Map<String, ?> methodParameters,
         final RescoreContext rescoreContextForNeuralQuery
     ) {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName(VECTOR_EMBEDDING_FIELD);
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(QUERY);
-        neuralQueryBuilder.k(5);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_EMBEDDING_FIELD)
+            .modelId(modelId)
+            .queryText(QUERY)
+            .k(5)
+            .build();
         if (expandNestedDocs != null) {
             neuralQueryBuilder.expandNested(expandNestedDocs);
         }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchWithRescoreIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchWithRescoreIT.java
@@ -131,7 +131,8 @@ public class HybridSearchWithRescoreIT extends AbstractRollingUpgradeTestCase {
             .fieldName(VECTOR_EMBEDDING_FIELD)
             .modelId(modelId)
             .queryText(QUERY)
-            .k(5);
+            .k(5)
+            .build();
         if (methodParameters != null) {
             neuralQueryBuilder.methodParameters(methodParameters);
         }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchWithRescoreIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/HybridSearchWithRescoreIT.java
@@ -127,11 +127,11 @@ public class HybridSearchWithRescoreIT extends AbstractRollingUpgradeTestCase {
         final Map<String, ?> methodParameters,
         final RescoreContext rescoreContextForNeuralQuery
     ) {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName(VECTOR_EMBEDDING_FIELD);
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(QUERY);
-        neuralQueryBuilder.k(5);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_EMBEDDING_FIELD)
+            .modelId(modelId)
+            .queryText(QUERY)
+            .k(5);
         if (methodParameters != null) {
             neuralQueryBuilder.methodParameters(methodParameters);
         }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/KnnRadialSearchIT.java
@@ -77,37 +77,25 @@ public class KnnRadialSearchIT extends AbstractRollingUpgradeTestCase {
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
 
-        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            text,
-            imageText,
-            modelId,
-            null,
-            null,
-            0.01f,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithMinScoreQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(text)
+            .queryImage(imageText)
+            .modelId(modelId)
+            .minScore(0.01f)
+            .build();
+
         Map<String, Object> responseWithMinScore = search(getIndexNameForTest(), neuralQueryBuilderWithMinScoreQuery, 1);
         assertNotNull(responseWithMinScore);
 
-        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            text,
-            imageText,
-            modelId,
-            null,
-            100000f,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithMaxDistanceQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(text)
+            .queryImage(imageText)
+            .modelId(modelId)
+            .maxDistance(100000f)
+            .build();
+
         Map<String, Object> responseWithMaxScore = search(getIndexNameForTest(), neuralQueryBuilderWithMaxDistanceQuery, 1);
         assertNotNull(responseWithMaxScore);
     }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/MultiModalSearchIT.java
@@ -76,20 +76,14 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
-        NeuralQueryBuilder neuralQueryBuilderWithKQuery = new NeuralQueryBuilder(
-            "passage_embedding",
-            text,
-            imageText,
-            modelId,
-            1,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
+        NeuralQueryBuilder neuralQueryBuilderWithKQuery = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .queryText(text)
+            .queryImage(imageText)
+            .modelId(modelId)
+            .k(1)
+            .build();
+
         Map<String, Object> responseWithKQuery = search(getIndexNameForTest(), neuralQueryBuilderWithKQuery, 1);
         assertNotNull(responseWithKQuery);
     }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/NeuralQueryEnricherProcessorIT.java
@@ -94,8 +94,14 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
     // the feature is introduced from 2.11
     public void testNeuralQueryEnricherProcessor_NeuralSearch_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
-        NeuralQueryBuilder neuralQueryBuilderWithoutModelId = new NeuralQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
-        NeuralQueryBuilder neuralQueryBuilderWithModelId = new NeuralQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
+        NeuralQueryBuilder neuralQueryBuilderWithoutModelId = NeuralQueryBuilder.builder()
+            .fieldName(TEST_ENCODING_FIELD)
+            .queryText(TEXT_1)
+            .build();
+        NeuralQueryBuilder neuralQueryBuilderWithModelId = NeuralQueryBuilder.builder()
+            .fieldName(TEST_ENCODING_FIELD)
+            .queryText(TEXT_1)
+            .build();
 
         switch (getClusterType()) {
             case OLD:

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/SemanticSearchIT.java
@@ -71,11 +71,12 @@ public class SemanticSearchIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         loadModel(modelId);
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_embedding");
-        neuralQueryBuilder.modelId(modelId);
-        neuralQueryBuilder.queryText(text);
-        neuralQueryBuilder.k(1);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_embedding")
+            .modelId(modelId)
+            .queryText(text)
+            .k(1)
+            .build();
         Map<String, Object> response = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertNotNull(response);
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorIT.java
@@ -54,10 +54,11 @@ public class NeuralQueryEnricherProcessorIT extends BaseNeuralSearchIT {
             createSearchRequestProcessor(modelId, search_pipeline);
             createPipelineProcessor(modelId, ingest_pipeline, ProcessorType.TEXT_EMBEDDING);
             updateIndexSettings(index, Settings.builder().put("index.search.default_pipeline", search_pipeline));
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-            neuralQueryBuilder.fieldName(TEST_KNN_VECTOR_FIELD_NAME_1);
-            neuralQueryBuilder.queryText("Hello World");
-            neuralQueryBuilder.k(1);
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText("Hello World")
+                .k(1)
+                .build();
             Map<String, Object> response = search(index, neuralQueryBuilder, 2);
             assertFalse(response.isEmpty());
         } finally {
@@ -112,10 +113,11 @@ public class NeuralQueryEnricherProcessorIT extends BaseNeuralSearchIT {
             createSearchRequestProcessor(modelId, search_pipeline);
             createPipelineProcessor(modelId, ingest_pipeline, ProcessorType.TEXT_EMBEDDING);
             updateIndexSettings(index, Settings.builder().put("index.search.default_pipeline", search_pipeline));
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-            neuralQueryBuilder.fieldName(TEST_KNN_VECTOR_FIELD_NAME_1);
-            neuralQueryBuilder.queryText("Hello World");
-            neuralQueryBuilder.k(1);
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText("Hello World")
+                .k(1)
+                .build();
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
             hybridQueryBuilder.add(neuralQueryBuilder);
             Map<String, Object> response = search(index, hybridQueryBuilder, 2);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralQueryEnricherProcessorTests.java
@@ -38,7 +38,7 @@ public class NeuralQueryEnricherProcessorTests extends OpenSearchTestCase {
 
     public void testProcessRequest_whenVisitingQueryBuilder_thenSuccess() throws Exception {
         NeuralQueryEnricherProcessor.Factory factory = new NeuralQueryEnricherProcessor.Factory();
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder().fieldName("field_name").queryText("query_text").build();
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.source(new SearchSourceBuilder().query(neuralQueryBuilder));
         NeuralQueryEnricherProcessor processor = createTestProcessor(factory);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -87,20 +87,13 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             modelId = prepareModel();
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
 
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_DOC_TEXT1,
-                "",
-                modelId,
-                5,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(5)
+                .build();
+
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -140,20 +133,13 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             modelId = prepareModel();
             createSearchPipelineWithDefaultResultsPostProcessor(SEARCH_PIPELINE);
 
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_DOC_TEXT1,
-                "",
-                modelId,
-                5,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(5)
+                .build();
+
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -182,20 +168,13 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             int totalExpectedDocQty = 6;
 
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_DOC_TEXT1,
-                "",
-                modelId,
-                6,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(6)
+                .build();
+
             TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
             HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
@@ -224,20 +224,7 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
             hybridQueryBuilderDefaultNorm.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -262,20 +249,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
             hybridQueryBuilderL2Norm.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
+
             );
             hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -325,20 +300,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
             hybridQueryBuilderDefaultNorm.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
+
             );
             hybridQueryBuilderDefaultNorm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -363,20 +326,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
             hybridQueryBuilderL2Norm.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
+
             );
             hybridQueryBuilderL2Norm.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
@@ -85,20 +85,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
             hybridQueryBuilderArithmeticMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -123,20 +110,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
             hybridQueryBuilderHarmonicMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -161,20 +135,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
             hybridQueryBuilderGeometricMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -224,20 +185,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
             hybridQueryBuilderArithmeticMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderArithmeticMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -262,20 +210,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
             hybridQueryBuilderHarmonicMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderHarmonicMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 
@@ -300,20 +235,7 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
 
             HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
             hybridQueryBuilderGeometricMean.add(
-                new NeuralQueryBuilder(
-                    TEST_KNN_VECTOR_FIELD_NAME_1,
-                    TEST_DOC_TEXT1,
-                    "",
-                    modelId,
-                    5,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                )
+                NeuralQueryBuilder.builder().fieldName(TEST_KNN_VECTOR_FIELD_NAME_1).queryText(TEST_DOC_TEXT1).modelId(modelId).k(5).build()
             );
             hybridQueryBuilderGeometricMean.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -114,20 +114,13 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
             );
             assertDoc((Map<String, Object>) getDocById(INDEX_NAME, "4").get("_source"), TEXT_FIELD_VALUE_2, Optional.empty());
 
-            NeuralQueryBuilder neuralQueryBuilderQuery = new NeuralQueryBuilder(
-                LEVEL_1_FIELD + "." + LEVEL_2_FIELD + "." + LEVEL_3_FIELD_CONTAINER + "." + LEVEL_3_FIELD_EMBEDDING,
-                QUERY_TEXT,
-                "",
-                modelId,
-                10,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilderQuery = NeuralQueryBuilder.builder()
+                .fieldName(LEVEL_1_FIELD + "." + LEVEL_2_FIELD + "." + LEVEL_3_FIELD_CONTAINER + "." + LEVEL_3_FIELD_EMBEDDING)
+                .queryText(QUERY_TEXT)
+                .modelId(modelId)
+                .k(10)
+                .build();
+
             QueryBuilder queryNestedLowerLevel = QueryBuilders.nestedQuery(
                 LEVEL_1_FIELD + "." + LEVEL_2_FIELD,
                 neuralQueryBuilderQuery,

--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessorTests.java
@@ -102,8 +102,12 @@ public class MLOpenSearchRerankProcessorTests extends OpenSearchTestCase {
 
     private void setupParams(Map<String, Object> params) {
         SearchSourceBuilder ssb = new SearchSourceBuilder();
-        NeuralQueryBuilder nqb = new NeuralQueryBuilder();
-        nqb.fieldName("embedding").k(3).modelId("embedding_id").queryText("Question about dolphins");
+        NeuralQueryBuilder nqb = NeuralQueryBuilder.builder()
+            .fieldName("embedding")
+            .k(3)
+            .modelId("embedding_id")
+            .queryText("Question about dolphins")
+            .build();
         ssb.query(nqb);
         List<SearchExtBuilder> exts = List.of(
             new RerankSearchExtBuilder(new HashMap<>(Map.of(QueryContextSourceFetcher.NAME, new HashMap<>(params))))

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -131,11 +131,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
 
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         queryBuilder.add(neuralQueryBuilder);
         Query queryOnlyNeural = queryBuilder.doToQuery(mockQueryShardContext);
@@ -164,11 +166,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
 
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         queryBuilder.add(neuralQueryBuilder);
 
@@ -415,12 +419,14 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(mockKNNVectorField.getKnnMappingConfig().getDimension()).thenReturn(4);
         when(mockQueryShardContext.fieldMapper(eq(VECTOR_FIELD_NAME))).thenReturn(mockKNNVectorField);
 
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
             .vectorSupplier(TEST_VECTOR_SUPPLIER)
-            .filter(TEST_FILTER);
+            .filter(TEST_FILTER)
+            .build();
 
         queryBuilder.add(neuralQueryBuilder);
 
@@ -466,11 +472,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     public void testStreams_whenWrittingToStream_thenSuccessful() {
         setUpClusterService();
         HybridQueryBuilder original = new HybridQueryBuilder();
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         original.add(neuralQueryBuilder);
 
@@ -498,23 +506,27 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     public void testHashAndEquals_whenSameOrIdenticalObject_thenReturnEqual() {
         HybridQueryBuilder hybridQueryBuilderBaseline = new HybridQueryBuilder();
         hybridQueryBuilderBaseline.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderBaseline.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderBaselineCopy = new HybridQueryBuilder();
         hybridQueryBuilderBaselineCopy.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderBaselineCopy.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
@@ -533,66 +545,78 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
 
         HybridQueryBuilder hybridQueryBuilderBaseline = new HybridQueryBuilder();
         hybridQueryBuilderBaseline.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderBaseline.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderOnlyOneSubQuery = new HybridQueryBuilder();
         hybridQueryBuilderOnlyOneSubQuery.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
 
         HybridQueryBuilder hybridQueryBuilderOnlyDifferentModelId = new HybridQueryBuilder();
         hybridQueryBuilderOnlyDifferentModelId.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(modelId)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderBaseline.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderOnlyDifferentFieldName = new HybridQueryBuilder();
         hybridQueryBuilderOnlyDifferentFieldName.add(
-            new NeuralQueryBuilder().fieldName(fieldName)
+            NeuralQueryBuilder.builder()
+                .fieldName(fieldName)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderOnlyDifferentFieldName.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderOnlyDifferentQuery = new HybridQueryBuilder();
         hybridQueryBuilderOnlyDifferentQuery.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(queryText)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderOnlyDifferentQuery.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
 
         HybridQueryBuilder hybridQueryBuilderOnlyDifferentTermValue = new HybridQueryBuilder();
         hybridQueryBuilderOnlyDifferentTermValue.add(
-            new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+            NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_FIELD_NAME)
                 .queryText(QUERY_TEXT)
                 .modelId(MODEL_ID)
                 .k(K)
                 .vectorSupplier(TEST_VECTOR_SUPPLIER)
                 .filter(TEST_FILTER)
+                .build()
         );
         hybridQueryBuilderOnlyDifferentTermValue.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, termText));
 
@@ -615,11 +639,13 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     @SneakyThrows
     public void testRewrite_whenMultipleSubQueries_thenReturnBuilderForEachSubQuery() {
         HybridQueryBuilder queryBuilder = new HybridQueryBuilder();
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder().fieldName(VECTOR_FIELD_NAME)
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_FIELD_NAME)
             .queryText(QUERY_TEXT)
             .modelId(MODEL_ID)
             .k(K)
-            .vectorSupplier(TEST_VECTOR_SUPPLIER);
+            .vectorSupplier(TEST_VECTOR_SUPPLIER)
+            .build();
 
         queryBuilder.add(neuralQueryBuilder);
 
@@ -789,9 +815,17 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     @SneakyThrows
     public void testDoEquals_whenSameParameters_thenEqual() {
         // Create neural queries
-        NeuralQueryBuilder neuralQueryBuilder1 = new NeuralQueryBuilder().queryText("test").modelId("test_model");
+        NeuralQueryBuilder neuralQueryBuilder1 = NeuralQueryBuilder.builder()
+            .fieldName("test")
+            .queryText("test")
+            .modelId("test_model")
+            .build();
 
-        NeuralQueryBuilder neuralQueryBuilder2 = new NeuralQueryBuilder().queryText("test").modelId("test_model");
+        NeuralQueryBuilder neuralQueryBuilder2 = NeuralQueryBuilder.builder()
+            .fieldName("test")
+            .queryText("test")
+            .modelId("test_model")
+            .build();
 
         // Create neural sparse queries with queryTokensSupplier
         NeuralSparseQueryBuilder neuralSparseQueryBuilder1 = new NeuralSparseQueryBuilder().fieldName("test_field")
@@ -822,7 +856,9 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     }
 
     public void testVisit() {
-        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new NeuralQueryBuilder()).add(new NeuralSparseQueryBuilder());
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(
+            NeuralQueryBuilder.builder().fieldName("test").queryText("test").build()
+        ).add(new NeuralSparseQueryBuilder());
         List<QueryBuilder> visitedQueries = new ArrayList<>();
         hybridQueryBuilder.visit(createTestVisitor(visitedQueries));
         assertEquals(3, visitedQueries.size());

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
@@ -102,20 +102,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             modelId = prepareModel();
-            NeuralQueryBuilder neuralQueryBuilderTextQuery = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilderTextQuery = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             final float boost = 2.0f;
             neuralQueryBuilderTextQuery.boost(boost);
@@ -126,20 +118,16 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             float expectedScore = 2 * computeExpectedScore(modelId, testVector, TEST_SPACE_TYPE, TEST_QUERY_TEXT);
             assertEquals(expectedScore, objectToFloat(firstInnerHitTextQuery.get("_score")), DELTA_FOR_SCORE_ASSERTION);
 
-            NeuralQueryBuilder neuralQueryBuilderMultimodalQuery = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                TEST_IMAGE_TEXT,
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                Map.of("ef_search", 10),
-                RescoreContext.getDefault()
-            );
+            NeuralQueryBuilder neuralQueryBuilderMultimodalQuery = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .queryImage(TEST_IMAGE_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .methodParameters(Map.of("ef_search", 10))
+                .rescoreContext(RescoreContext.getDefault())
+                .build();
+
             Map<String, Object> searchResponseAsMapMultimodalQuery = search(TEST_BASIC_INDEX_NAME, neuralQueryBuilderMultimodalQuery, 1);
             Map<String, Object> firstInnerHitMultimodalQuery = getFirstInnerHit(searchResponseAsMapMultimodalQuery);
 
@@ -155,20 +143,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             // Context: https://github.com/opensearch-project/neural-search/pull/697#discussion_r1571549776
 
             // Test radial search max distance query
-            NeuralQueryBuilder neuralQueryWithMaxDistanceBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                null,
-                100.0f,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryWithMaxDistanceBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .maxDistance(100.0f)
+                .build();
 
             Map<String, Object> searchResponseAsMapWithMaxDistanceQuery = search(
                 TEST_BASIC_INDEX_NAME,
@@ -186,20 +166,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             );
 
             // Test radial search min score query
-            NeuralQueryBuilder neuralQueryWithMinScoreBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                null,
-                null,
-                0.01f,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryWithMinScoreBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .minScore(0.01f)
+                .build();
 
             Map<String, Object> searchResponseAsMapWithMinScoreQuery = search(TEST_BASIC_INDEX_NAME, neuralQueryWithMinScoreBuilder, 1);
             Map<String, Object> firstInnerHitWithMinScoreQuery = getFirstInnerHit(searchResponseAsMapWithMinScoreQuery);
@@ -243,20 +215,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             initializeIndexIfNotExist(TEST_BASIC_INDEX_NAME);
             modelId = prepareModel();
             MatchAllQueryBuilder matchAllQueryBuilder = new MatchAllQueryBuilder();
-            NeuralQueryBuilder rescoreNeuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder rescoreNeuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             Map<String, Object> searchResponseAsMap = search(TEST_BASIC_INDEX_NAME, matchAllQueryBuilder, rescoreNeuralQueryBuilder, 1);
             Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
@@ -323,34 +287,19 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
             modelId = prepareModel();
             // verify two neural queries wrapped into bool
             BoolQueryBuilder boolQueryBuilderTwoNeuralQueries = new BoolQueryBuilder();
-            NeuralQueryBuilder neuralQueryBuilder1 = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
-            NeuralQueryBuilder neuralQueryBuilder2 = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_2,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder1 = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
+
+            NeuralQueryBuilder neuralQueryBuilder2 = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_2)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             boolQueryBuilderTwoNeuralQueries.should(neuralQueryBuilder1).should(neuralQueryBuilder2);
 
@@ -367,20 +316,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
 
             // verify bool with one neural and one bm25 query
             BoolQueryBuilder boolQueryBuilderMixOfNeuralAndBM25 = new BoolQueryBuilder();
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             MatchQueryBuilder matchQueryBuilder = new MatchQueryBuilder(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT);
 
@@ -425,20 +366,12 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_NESTED_INDEX_NAME);
             modelId = prepareModel();
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_NESTED,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_NESTED)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .build();
 
             Map<String, Object> searchResponseAsMap = search(TEST_NESTED_INDEX_NAME, neuralQueryBuilder, 1);
             Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
@@ -478,20 +411,14 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         try {
             initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_NAME);
             modelId = prepareModel();
-            NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder(
-                TEST_KNN_VECTOR_FIELD_NAME_1,
-                TEST_QUERY_TEXT,
-                "",
-                modelId,
-                1,
-                null,
-                null,
-                null,
-                null,
-                new MatchQueryBuilder("_id", "3"),
-                null,
-                null
-            );
+            NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_QUERY_TEXT)
+                .modelId(modelId)
+                .k(1)
+                .filter(new MatchQueryBuilder("_id", "3"))
+                .build();
+
             Map<String, Object> searchResponseAsMap = search(TEST_MULTI_DOC_INDEX_NAME, neuralQueryBuilder, 3);
             assertEquals(1, getHitCount(searchResponseAsMap));
             Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);

--- a/src/test/java/org/opensearch/neuralsearch/query/visitor/NeuralSearchQueryVisitorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/visitor/NeuralSearchQueryVisitorTests.java
@@ -16,9 +16,11 @@ public class NeuralSearchQueryVisitorTests extends OpenSearchTestCase {
 
     public void testAccept_whenNeuralQueryBuilderWithoutModelId_thenSetModelId() {
         String modelId = "bdcvjkcdjvkddcjxdjsc";
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_text");
-        neuralQueryBuilder.k(768);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_text")
+            .queryText("query_text")
+            .k(768)
+            .build();
 
         NeuralSearchQueryVisitor neuralSearchQueryVisitor = new NeuralSearchQueryVisitor(modelId, null);
         neuralSearchQueryVisitor.accept(neuralQueryBuilder);
@@ -29,9 +31,11 @@ public class NeuralSearchQueryVisitorTests extends OpenSearchTestCase {
     public void testAccept_whenNeuralQueryBuilderWithoutFieldModelId_thenSetFieldModelId() {
         Map<String, Object> neuralInfoMap = new HashMap<>();
         neuralInfoMap.put("passage_text", "bdcvjkcdjvkddcjxdjsc");
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
-        neuralQueryBuilder.fieldName("passage_text");
-        neuralQueryBuilder.k(768);
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("passage_text")
+            .queryText("query_text")
+            .k(768)
+            .build();
 
         NeuralSearchQueryVisitor neuralSearchQueryVisitor = new NeuralSearchQueryVisitor(null, neuralInfoMap);
         neuralSearchQueryVisitor.accept(neuralQueryBuilder);
@@ -76,7 +80,7 @@ public class NeuralSearchQueryVisitorTests extends OpenSearchTestCase {
     }
 
     public void testAccept_whenNullValuesInVisitor_thenFail() {
-        NeuralQueryBuilder neuralQueryBuilder = new NeuralQueryBuilder();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder().fieldName("passage_text").queryText("query_text").build();
         NeuralSparseQueryBuilder neuralSparseQueryBuilder = new NeuralSparseQueryBuilder();
         NeuralSearchQueryVisitor neuralSearchQueryVisitor = new NeuralSearchQueryVisitor(null, null);
 


### PR DESCRIPTION
Backport https://github.com/opensearch-project/neural-search/commit/2ecd32c5cc6db70aeb5832578afa41998b01ba40 from https://github.com/opensearch-project/neural-search/pull/1047