### PR TITLE
Renamed explanation response processor to hybrid_score_explanation

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessor.java
@@ -34,7 +34,7 @@ import static org.opensearch.neuralsearch.processor.explain.ExplanationPayload.P
 @AllArgsConstructor
 public class ExplanationResponseProcessor implements SearchResponseProcessor {
 
-    public static final String TYPE = "explanation_response_processor";
+    public static final String TYPE = "hybrid_score_explanation";
 
     private final String description;
     private final String tag;

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/ExplanationResponseProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/ExplanationResponseProcessorFactoryTests.java
@@ -104,7 +104,7 @@ public class ExplanationResponseProcessorFactoryTests extends OpenSearchTestCase
         assertNotNull(responseProcessor);
         assertTrue(responseProcessor instanceof ExplanationResponseProcessor);
         ExplanationResponseProcessor explanationResponseProcessor = (ExplanationResponseProcessor) responseProcessor;
-        assertEquals("explanation_response_processor", explanationResponseProcessor.getType());
+        assertEquals("hybrid_score_explanation", explanationResponseProcessor.getType());
         assertEquals(tag, explanationResponseProcessor.getTag());
         assertEquals(description, explanationResponseProcessor.getDescription());
         assertEquals(ignoreFailure, explanationResponseProcessor.isIgnoreFailure());


### PR DESCRIPTION
### Description
Change the name of the new response processor from `explanation_response_processor` to `hybrid_score_explanation`. New name is more consistent with naming conventions for other search processors by dropping the `response_processor` suffix (https://opensearch.org/docs/latest/search-plugins/search-pipelines/search-processors/) and reflects the hybrid search specialization. Came up with the new name while working on the documentation PR for explainability https://github.com/opensearch-project/documentation-website/issues/8645

with new processor name this is how the pipeline will look like:
```
{
    "description": "Post processor for hybrid search",
    "phase_results_processors": [
        {
            "normalization-processor": {
                "normalization": {
                    "technique": "min_max"
                },
                "combination": {
                    "technique": "arithmetic_mean",
                    "parameters": {
                        "weights": [
                            0.3,
                            0.7
                        ]
                    }
                }
            }
        }
    ],
    "response_processors": [
        {
            "hybrid_score_explanation": {}
        }
    ]
}
```

### Related Issues
https://github.com/opensearch-project/neural-search/issues/905

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [X] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
