### PR TITLE
Fix race condition in TextImageEmbeddingProcessor integration tests

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorIT.java
@@ -16,8 +16,11 @@ import org.opensearch.neuralsearch.BaseNeuralSearchIT;
  */
 public class TextImageEmbeddingProcessorIT extends BaseNeuralSearchIT {
 
-    private static final String INDEX_NAME = "text_image_embedding_index";
-    private static final String PIPELINE_NAME = "ingest-pipeline";
+    private static final String INDEX_NAME_1 = "text_image_embedding_index-1";
+    private static final String INDEX_NAME_2 = "text_image_embedding_index-2";
+    private static final String FROM_INDEX_NAME = "test-reindex-from";
+    private static final String PIPELINE_NAME_1 = "text_image_embedding_ingest_pipeline-1";
+    private static final String PIPELINE_NAME_2 = "text_image_embedding_ingest_pipeline-2";
     private static final String INGEST_DOCUMENT = "{\n"
         + "  \"title\": \"This is a good day\",\n"
         + "  \"description\": \"daily logging\",\n"
@@ -45,16 +48,16 @@ public class TextImageEmbeddingProcessorIT extends BaseNeuralSearchIT {
         try {
             modelId = uploadModel();
             loadModel(modelId);
-            createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_IMAGE_EMBEDDING);
-            createIndexWithPipeline(INDEX_NAME, "IndexMappings.json", PIPELINE_NAME);
+            createPipelineProcessor(modelId, PIPELINE_NAME_1, ProcessorType.TEXT_IMAGE_EMBEDDING);
+            createIndexWithPipeline(INDEX_NAME_1, "IndexMappings.json", PIPELINE_NAME_1);
             // verify doc with mapping
-            ingestDocument(INDEX_NAME, INGEST_DOCUMENT);
-            assertEquals(1, getDocCount(INDEX_NAME));
+            ingestDocument(INDEX_NAME_1, INGEST_DOCUMENT);
+            assertEquals(1, getDocCount(INDEX_NAME_1));
             // verify doc without mapping
-            ingestDocument(INDEX_NAME, INGEST_DOCUMENT_UNMAPPED_FIELDS);
-            assertEquals(2, getDocCount(INDEX_NAME));
+            ingestDocument(INDEX_NAME_1, INGEST_DOCUMENT_UNMAPPED_FIELDS);
+            assertEquals(2, getDocCount(INDEX_NAME_1));
         } finally {
-            wipeOfTestResources(INDEX_NAME, PIPELINE_NAME, modelId, null);
+            wipeOfTestResources(INDEX_NAME_1, PIPELINE_NAME_1, modelId, null);
         }
     }
 
@@ -65,20 +68,18 @@ public class TextImageEmbeddingProcessorIT extends BaseNeuralSearchIT {
 
     public void testEmbeddingProcessor_whenReindexingDocument_thenSuccessful() throws Exception {
         // create a simple index and indexing data into this index.
-        String fromIndexName = "test-reindex-from";
-        createIndexWithConfiguration(fromIndexName, "{ \"settings\": { \"number_of_shards\": 1, \"number_of_replicas\": 0 } }", null);
-        ingestDocument(fromIndexName, "{ \"text\": \"hello world\" }");
+        createIndexWithConfiguration(FROM_INDEX_NAME, "{ \"settings\": { \"number_of_shards\": 1, \"number_of_replicas\": 0 } }", null);
+        ingestDocument(FROM_INDEX_NAME, "{ \"text\": \"hello world\" }");
         String modelId = null;
         try {
             modelId = uploadModel();
             loadModel(modelId);
-            String toIndexName = "test-reindex-to";
-            createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_IMAGE_EMBEDDING);
-            createIndexWithPipeline(toIndexName, "IndexMappings.json", PIPELINE_NAME);
-            reindex(fromIndexName, toIndexName);
-            assertEquals(1, getDocCount(toIndexName));
+            createPipelineProcessor(modelId, PIPELINE_NAME_2, ProcessorType.TEXT_IMAGE_EMBEDDING);
+            createIndexWithPipeline(INDEX_NAME_2, "IndexMappings.json", PIPELINE_NAME_2);
+            reindex(FROM_INDEX_NAME, INDEX_NAME_2);
+            assertEquals(1, getDocCount(INDEX_NAME_2));
         } finally {
-            wipeOfTestResources(fromIndexName, PIPELINE_NAME, modelId, null);
+            wipeOfTestResources(INDEX_NAME_2, PIPELINE_NAME_2, modelId, null);
         }
     }
 }


### PR DESCRIPTION
### Description
The integration tests for TextImageEmbeddingProcessor create and delete resources with the same name leading to issues when running integration tests in parallel, e.g. [failed Jenkins run](https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/9259/pipeline/130/)

```
REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessorIT.testEmbeddingProcessor_whenIngestingDocumentWithOrWithoutSourceMatchingMapping_thenSuccessful" -Dtests.seed=E062306E78BCA0FB -Dtests.security.manager=false -Dtests.locale=zh-SG -Dtests.timezone=America/Vancouver -Druntime.java=21

Suite: Test class org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessorIT

  2> REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessorIT.testEmbeddingProcessor_whenIngestingDocumentWithOrWithoutSourceMatchingMapping_thenSuccessful" -Dtests.seed=E062306E78BCA0FB -Dtests.security.manager=false -Dtests.locale=zh-SG -Dtests.timezone=America/Vancouver -Druntime.java=21
  2> org.opensearch.client.ResponseException: method [DELETE], host [http://localhost:9200/], URI [/_ingest/pipeline/ingest-pipeline], status line [HTTP/1.1 404 Not Found]
    {"error":{"root_cause":[{"type":"resource_not_found_exception","reason":"pipeline [ingest-pipeline] is missing"}],"type":"resource_not_found_exception","reason":"pipeline [ingest-pipeline] is missing"},"status":404}
        at __randomizedtesting.SeedInfo.seed([E062306E78BCA0FB:CD13011798778F4D]:0)
        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:479)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:371)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:346)
        at app//org.opensearch.neuralsearch.BaseNeuralSearchIT.deletePipeline(BaseNeuralSearchIT.java:1440)
        at app//org.opensearch.neuralsearch.BaseNeuralSearchIT.wipeOfTestResources(BaseNeuralSearchIT.java:1509)
        at app//org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessorIT.testEmbeddingProcessor_whenIngestingDocumentWithOrWithoutSourceMatchingMapping_thenSuccessful(TextImageEmbeddingProcessorIT.java:57)
  2> NOTE: leaving temporary files on disk at: /tmp/tmpb1cp4gph/neural-search/build/testrun/integTest/temp/org.opensearch.neuralsearch.processor.TextImageEmbeddingProcessorIT_E062306E78BCA0FB-001
  2> NOTE: test params are: codec=Lucene912, sim=Asserting(RandomSimilarity(queryNorm=false): {}), locale=zh-SG, timezone=America/Vancouver
  2> NOTE: Linux 6.1.109-118.189.amzn2023.aarch64 aarch64/Eclipse Adoptium 21.0.1 (64-bit)/cpus=4,threads=3,free=502566984,total=536870912
  2> NOTE: All tests run in this JVM: [NeuralSearchIT, ValidateDependentPluginInstallationIT, HybridQueryExecutorIT, NeuralQueryEnricherProcessorIT, NeuralSparseTwoPhaseProcessorIT, NormalizationProcessorIT, ScoreCombinationIT, ScoreNormalizationIT, SparseEncodingProcessIT, TextChunkingProcessorIT, TextEmbeddingProcessorIT, TextImageEmbeddingProcessorIT]
```

This PR renames the pipelines/indices per test that are created to prevent a collision where one test deletes a resource needed in another test. 

### Related Issues
Resolves #1091 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
