### PR TITLE
Update pagination_depth datatype from int to Integer

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
@@ -47,7 +47,7 @@ public final class HybridQuery extends Query implements Iterable<Query> {
             throw new IllegalArgumentException("collection of queries must not be empty");
         }
         Integer paginationDepth = hybridQueryContext.getPaginationDepth();
-        if (paginationDepth != null && paginationDepth == 0) {
+        if (Objects.nonNull(paginationDepth) && paginationDepth == 0) {
             throw new IllegalArgumentException("pagination_depth must not be zero");
         }
         if (Objects.isNull(filterQueries) || filterQueries.isEmpty()) {

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
@@ -46,7 +46,8 @@ public final class HybridQuery extends Query implements Iterable<Query> {
         if (subQueries.isEmpty()) {
             throw new IllegalArgumentException("collection of queries must not be empty");
         }
-        if (hybridQueryContext.getPaginationDepth() == 0) {
+        Integer paginationDepth = hybridQueryContext.getPaginationDepth();
+        if (paginationDepth != null && paginationDepth == 0) {
             throw new IllegalArgumentException("pagination_depth must not be zero");
         }
         if (Objects.isNull(filterQueries) || filterQueries.isEmpty()) {

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -109,6 +109,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             queryBuilder.toXContent(builder, params);
         }
         builder.endArray();
+        // TODO https://github.com/opensearch-project/neural-search/issues/1097
         if (Objects.nonNull(paginationDepth)) {
             builder.field(PAGINATION_DEPTH_FIELD.getPreferredName(), paginationDepth);
         }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryContext.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryContext.java
@@ -6,7 +6,6 @@ package org.opensearch.neuralsearch.query;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 
 /**
  * Class that holds the low level information of hybrid query in the form of context
@@ -14,6 +13,5 @@ import lombok.NonNull;
 @Builder
 @Getter
 public class HybridQueryContext {
-    @NonNull
-    private int paginationDepth;
+    private Integer paginationDepth;
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -491,6 +491,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
         if (searchContext.from() == 0) {
             return searchContext.size();
         }
+        log.info("pagination_depth is {}", paginationDepth);
         return paginationDepth;
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -426,7 +426,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertEquals(2, queryTwoSubQueries.queries().size());
         assertTrue(queryTwoSubQueries.queries().get(0) instanceof NeuralQueryBuilder);
         assertTrue(queryTwoSubQueries.queries().get(1) instanceof TermQueryBuilder);
-        assertEquals(10, queryTwoSubQueries.paginationDepth());
+        assertEquals(10, queryTwoSubQueries.paginationDepth().intValue());
         // verify knn vector query
         NeuralQueryBuilder neuralQueryBuilder = (NeuralQueryBuilder) queryTwoSubQueries.queries().get(0);
         assertEquals(VECTOR_FIELD_NAME, neuralQueryBuilder.fieldName());

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
@@ -99,7 +99,7 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
             countOfQueries++;
         }
         assertEquals(2, countOfQueries);
-        assertEquals(10, query3.getQueryContext().getPaginationDepth());
+        assertEquals(10, query3.getQueryContext().getPaginationDepth().intValue());
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
This PR changes pagination_depth datatype from int to Integer. We are doing as the current code is breaking the bwc on 2.x by sending pagination_depth in the older versions of Opensearch. 


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
