### PR TITLE
Add dependent plugins validation during plugin load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support empty string for fields in text embedding processor ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
 - Optimize ML inference connection retry logic ([#1054](https://github.com/opensearch-project/neural-search/pull/1054))
 - Support for builder constructor in Neural Query Builder ([#1047](https://github.com/opensearch-project/neural-search/pull/1047))
+- Add dependent plugins validation during neural search plugin loading ([#1119](https://github.com/opensearch-project/neural-search/pull/1119))
 ### Bug Fixes
 - Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 - Fix bug where ingested document has list of nested objects ([#1040](https://github.com/opensearch-project/neural-search/pull/1040))

--- a/src/test/java/org/opensearch/neuralsearch/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/NeuralSearchTests.java
@@ -4,13 +4,40 @@
  */
 package org.opensearch.neuralsearch;
 
-import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.neuralsearch.plugin.NeuralSearch.DependentPlugin;
 
 public class NeuralSearchTests extends OpenSearchTestCase {
 
-    public void testValidateKNNDependency() {
-        assertEquals(KNNConstants.LUCENE_NAME, KNNEngine.LUCENE.getName());
+    public void testDependentPluginsEnumValues() {
+        // Verify we have exactly two plugins
+        assertEquals("Should have exactly two dependent plugins", 2, DependentPlugin.values().length);
+
+        // Verify the enum contains both required plugins
+        assertTrue("Should contain ML Commons plugin", containsName(DependentPlugin.values(), "ML_COMMONS"));
+        assertTrue("Should contain KNN plugin", containsName(DependentPlugin.values(), "KNN"));
+    }
+
+    public void testPluginValidationWithMissingDependencies() {
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> {
+            try {
+                // Try to load a non-existent class directly
+                Class.forName("org.opensearch.non.existent.TestClass");
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException("Neural Search plugin requires the TEST plugin to be installed", e);
+            }
+        });
+
+        assertTrue("Exception message should mention plugin name", exception.getMessage().contains("TEST"));
+        assertTrue("Exception should be caused by ClassNotFoundException", exception.getCause() instanceof ClassNotFoundException);
+    }
+
+    private boolean containsName(DependentPlugin[] plugins, String name) {
+        for (DependentPlugin plugin : plugins) {
+            if (plugin.name().equals(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Description
Add dependent plugins validation during neural search plugin load stage.

### Related Issues
Closes https://github.com/opensearch-project/neural-search/issues/480

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
