### PR TITLE
Reverts Java 15 features from a backport to 2.x

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessorTests.java
@@ -825,7 +825,7 @@ public class ByFieldRerankProcessorTests extends OpenSearchTestCase {
             int docId = sampleIndexMLScorePairs.get(i).getKey();
             String mlScore = sampleIndexMLScorePairs.get(i).getValue() + "";
 
-            String sourceMap = String.format(templateString, i, mlScore);
+            String sourceMap = String.format(Locale.ROOT, templateString, i, mlScore);
 
             hits[i] = new SearchHit(docId, docId + "", Collections.emptyMap(), Collections.emptyMap());
             hits[i].sourceRef(new BytesArray(sourceMap));

--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessorTests.java
@@ -762,7 +762,7 @@ public class ByFieldRerankProcessorTests extends OpenSearchTestCase {
         setUpValidSearchResultsWithNestedTargetValueWithNumericalString();
         List<Map.Entry<Integer, Float>> sortedScoresDescending = sampleIndexMLScorePairs.stream()
             .sorted(Map.Entry.<Integer, Float>comparingByValue().reversed())
-            .toList();
+            .collect(Collectors.toList());
 
         Map<String, Object> config = new HashMap<>(
             Map.of(RerankType.BY_FIELD.getLabel(), new HashMap<>(Map.of(ByFieldRerankProcessor.TARGET_FIELD, targetField)))
@@ -783,7 +783,7 @@ public class ByFieldRerankProcessorTests extends OpenSearchTestCase {
         SearchResponse searchResponse = argCaptor.getValue();
 
         assertEquals(sampleIndexMLScorePairs.size(), searchResponse.getHits().getHits().length);
-        assertEquals(sortedScoresDescending.getFirst().getValue(), searchResponse.getHits().getMaxScore(), 0.0001);
+        assertEquals(sortedScoresDescending.get(0).getValue(), searchResponse.getHits().getMaxScore(), 0.0001);
 
         for (int i = 0; i < sortedScoresDescending.size(); i++) {
             int docId = sortedScoresDescending.get(i).getKey();
@@ -812,22 +812,20 @@ public class ByFieldRerankProcessorTests extends OpenSearchTestCase {
     private void setUpValidSearchResultsWithNestedTargetValueWithNumericalString() {
         SearchHit[] hits = new SearchHit[sampleIndexMLScorePairs.size()];
 
-        String templateString = """
-            {
-               "my_field" : "%s",
-               "ml": {
-                    "info"  : {
-                         "score": "%s"
-                    }
-               }
-            }
-            """.replace("\n", "");
+        String templateString = "{\n"
+            + "   \"my_field\" : \"%s\",\n"
+            + "   \"ml\": {\n"
+            + "        \"info\"  : {\n"
+            + "             \"score\": \"%s\"\n"
+            + "        }\n"
+            + "   }\n"
+            + "}\n".replace("\n", "");
 
         for (int i = 0; i < sampleIndexMLScorePairs.size(); i++) {
             int docId = sampleIndexMLScorePairs.get(i).getKey();
             String mlScore = sampleIndexMLScorePairs.get(i).getValue() + "";
 
-            String sourceMap = templateString.formatted(i, mlScore);
+            String sourceMap = String.format(templateString, i, mlScore);
 
             hits[i] = new SearchHit(docId, docId + "", Collections.emptyMap(), Collections.emptyMap());
             hits[i].sourceRef(new BytesArray(sourceMap));


### PR DESCRIPTION
2.x branch compiles Java 11 code thus any features subsequent of this version will have issues

### Description
used string literals. And used get(0) instead of getFirst(). and on streams used .collect(Collectors.toList())

### Testing
- /gradlew test <-- where the issue could be found initially via the UT that had the Java 15 feature
- ./gradlew spotlessApply


### Related Issues
Resolves https://github.com/opensearch-project/neural-search/pull/1117
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
