### PR TITLE
Fix explain exception in hybrid queries with partial subquery matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed document source and score field mismatch in sorted hybrid queries ([#1043](https://github.com/opensearch-project/neural-search/pull/1043))
 - Update NeuralQueryBuilder doEquals() and doHashCode() to cater the missing parameters information ([#1045](https://github.com/opensearch-project/neural-search/pull/1045)).
 - Fix bug where embedding is missing when ingested document has "." in field name, and mismatches fieldMap config ([#1062](https://github.com/opensearch-project/neural-search/pull/1062))
+- Fix explain exception in hybrid queries with partial subquery matches ([#1123](https://github.com/opensearch-project/neural-search/pull/1123))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessor.java
@@ -100,7 +100,7 @@ public class ExplanationResponseProcessor implements SearchResponseProcessor {
                     ExplanationDetails normalizationExplanation = combinedExplainDetail.getNormalizationExplanations();
                     ExplanationDetails combinationExplanation = combinedExplainDetail.getCombinationExplanations();
                     // Create normalized explanations for each detail
-                    List<Explanation> normalizedExplanation = new ArrayList<>();
+                    List<Explanation> normalizedExplanation = new ArrayList<>(queryLevelExplanation.getDetails().length);
                     int normalizationExplanationIndex = 0;
                     for (Explanation queryExplanation : queryLevelExplanation.getDetails()) {
                         // adding only explanations where this hit has matched

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
@@ -75,12 +75,19 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
                 continue;
             }
             List<TopDocs> topDocsPerSubQuery = compoundQueryTopDocs.getTopDocs();
-            for (int j = 0; j < topDocsPerSubQuery.size(); j++) {
-                TopDocs subQueryTopDoc = topDocsPerSubQuery.get(j);
+            int numberOfSubQueries = topDocsPerSubQuery.size();
+            for (int subQueryIndex = 0; subQueryIndex < numberOfSubQueries; subQueryIndex++) {
+                TopDocs subQueryTopDoc = topDocsPerSubQuery.get(subQueryIndex);
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     DocIdAtSearchShard docIdAtSearchShard = new DocIdAtSearchShard(scoreDoc.doc, compoundQueryTopDocs.getSearchShard());
-                    float normalizedScore = normalizeSingleScore(scoreDoc.score, normsPerSubquery.get(j));
-                    normalizedScores.computeIfAbsent(docIdAtSearchShard, k -> new ArrayList<>()).add(normalizedScore);
+                    float normalizedScore = normalizeSingleScore(scoreDoc.score, normsPerSubquery.get(subQueryIndex));
+                    ScoreNormalizationUtil.setNormalizedScore(
+                        normalizedScores,
+                        docIdAtSearchShard,
+                        subQueryIndex,
+                        numberOfSubQueries,
+                        normalizedScore
+                    );
                     scoreDoc.score = normalizedScore;
                 }
             }

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtil.java
@@ -5,7 +5,9 @@
 package org.opensearch.neuralsearch.processor.normalization;
 
 import lombok.extern.log4j.Log4j2;
+import org.opensearch.neuralsearch.processor.explain.DocIdAtSearchShard;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -53,5 +55,31 @@ class ScoreNormalizationUtil {
                 );
             }
         }
+    }
+
+    /**
+     * Sets a normalized score for a specific document at a specific subquery index
+     *
+     * @param normalizedScores map of document IDs to their list of scores
+     * @param docIdAtSearchShard document ID
+     * @param subQueryIndex index of the subquery
+     * @param normalizedScore normalized score to set
+     */
+    public static void setNormalizedScore(
+        Map<DocIdAtSearchShard, List<Float>> normalizedScores,
+        DocIdAtSearchShard docIdAtSearchShard,
+        int subQueryIndex,
+        int numberOfSubQueries,
+        float normalizedScore
+    ) {
+        List<Float> scores = normalizedScores.get(docIdAtSearchShard);
+        if (Objects.isNull(scores)) {
+            scores = new ArrayList<>(numberOfSubQueries);
+            for (int i = 0; i < numberOfSubQueries; i++) {
+                scores.add(0.0f);
+            }
+            normalizedScores.put(docIdAtSearchShard, scores);
+        }
+        scores.set(subQueryIndex, normalizedScore);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
@@ -11,6 +11,8 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
@@ -33,6 +35,7 @@ import static org.opensearch.neuralsearch.query.HybridQueryBuilder.MAX_NUMBER_OF
 public final class HybridQueryWeight extends Weight {
 
     // The Weights for our subqueries, in 1-1 correspondence
+    @Getter(AccessLevel.PACKAGE)
     private final List<Weight> weights;
 
     private final ScoreMode scoreMode;
@@ -157,10 +160,13 @@ public final class HybridQueryWeight extends Weight {
             if (e.isMatch()) {
                 match = true;
                 double score = e.getValue().doubleValue();
-                subsOnMatch.add(e);
                 max = Math.max(max, score);
-            } else if (!match) {
-                subsOnNoMatch.add(e);
+                subsOnMatch.add(e);
+            } else {
+                if (!match) {
+                    subsOnNoMatch.add(e);
+                }
+                subsOnMatch.add(e);
             }
         }
         if (match) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessorTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -29,7 +30,10 @@ import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.RemoteClusterAware;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +41,8 @@ import java.util.PriorityQueue;
 import java.util.TreeMap;
 
 import static org.mockito.Mockito.mock;
+import static org.opensearch.neuralsearch.plugin.NeuralSearch.EXPLANATION_RESPONSE_KEY;
+import static org.opensearch.neuralsearch.processor.explain.ExplanationPayload.PayloadType.NORMALIZATION_PROCESSOR;
 import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_FLOATS_ASSERTION;
 import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
 
@@ -92,15 +98,9 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
         SearchResponse searchResponse = getSearchResponse(searchHits);
         PipelineProcessingContext pipelineProcessingContext = new PipelineProcessingContext();
         Map<SearchShard, List<CombinedExplanationDetails>> combinedExplainDetails = getCombinedExplainDetails(searchHits);
-        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(
-            ExplanationPayload.PayloadType.NORMALIZATION_PROCESSOR,
-            combinedExplainDetails
-        );
+        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(NORMALIZATION_PROCESSOR, combinedExplainDetails);
         ExplanationPayload explanationPayload = ExplanationPayload.builder().explainPayload(explainPayload).build();
-        pipelineProcessingContext.setAttribute(
-            org.opensearch.neuralsearch.plugin.NeuralSearch.EXPLANATION_RESPONSE_KEY,
-            explanationPayload
-        );
+        pipelineProcessingContext.setAttribute(EXPLANATION_RESPONSE_KEY, explanationPayload);
 
         // Act
         SearchResponse processedResponse = explanationResponseProcessor.processResponse(
@@ -136,15 +136,9 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
 
         PipelineProcessingContext pipelineProcessingContext = new PipelineProcessingContext();
         Map<SearchShard, List<CombinedExplanationDetails>> combinedExplainDetails = getCombinedExplainDetails(searchHits);
-        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(
-            ExplanationPayload.PayloadType.NORMALIZATION_PROCESSOR,
-            combinedExplainDetails
-        );
+        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(NORMALIZATION_PROCESSOR, combinedExplainDetails);
         ExplanationPayload explanationPayload = ExplanationPayload.builder().explainPayload(explainPayload).build();
-        pipelineProcessingContext.setAttribute(
-            org.opensearch.neuralsearch.plugin.NeuralSearch.EXPLANATION_RESPONSE_KEY,
-            explanationPayload
-        );
+        pipelineProcessingContext.setAttribute(EXPLANATION_RESPONSE_KEY, explanationPayload);
 
         // Act
         SearchResponse processedResponse = explanationResponseProcessor.processResponse(
@@ -172,15 +166,9 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
         PipelineProcessingContext pipelineProcessingContext = new PipelineProcessingContext();
 
         Map<SearchShard, List<CombinedExplanationDetails>> combinedExplainDetails = getCombinedExplainDetails(searchHits);
-        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(
-            ExplanationPayload.PayloadType.NORMALIZATION_PROCESSOR,
-            combinedExplainDetails
-        );
+        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(NORMALIZATION_PROCESSOR, combinedExplainDetails);
         ExplanationPayload explanationPayload = ExplanationPayload.builder().explainPayload(explainPayload).build();
-        pipelineProcessingContext.setAttribute(
-            org.opensearch.neuralsearch.plugin.NeuralSearch.EXPLANATION_RESPONSE_KEY,
-            explanationPayload
-        );
+        pipelineProcessingContext.setAttribute(EXPLANATION_RESPONSE_KEY, explanationPayload);
 
         // Act
         SearchResponse processedResponse = explanationResponseProcessor.processResponse(
@@ -240,12 +228,9 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
         PipelineProcessingContext context = new PipelineProcessingContext();
 
         // Set invalid payload
-        Map<ExplanationPayload.PayloadType, Object> invalidPayload = Map.of(
-            ExplanationPayload.PayloadType.NORMALIZATION_PROCESSOR,
-            "invalid payload"
-        );
+        Map<ExplanationPayload.PayloadType, Object> invalidPayload = Map.of(NORMALIZATION_PROCESSOR, "invalid payload");
         ExplanationPayload explanationPayload = ExplanationPayload.builder().explainPayload(invalidPayload).build();
-        context.setAttribute(org.opensearch.neuralsearch.plugin.NeuralSearch.EXPLANATION_RESPONSE_KEY, explanationPayload);
+        context.setAttribute(EXPLANATION_RESPONSE_KEY, explanationPayload);
 
         SearchResponse processedResponse = processor.processResponse(searchRequest, searchResponse, context);
         assertNotNull(processedResponse);
@@ -260,12 +245,9 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
         PipelineProcessingContext context = new PipelineProcessingContext();
 
         Map<SearchShard, List<CombinedExplanationDetails>> combinedExplainDetails = getCombinedExplainDetails(searchHits);
-        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(
-            ExplanationPayload.PayloadType.NORMALIZATION_PROCESSOR,
-            combinedExplainDetails
-        );
+        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(NORMALIZATION_PROCESSOR, combinedExplainDetails);
         ExplanationPayload explanationPayload = ExplanationPayload.builder().explainPayload(explainPayload).build();
-        context.setAttribute(org.opensearch.neuralsearch.plugin.NeuralSearch.EXPLANATION_RESPONSE_KEY, explanationPayload);
+        context.setAttribute(EXPLANATION_RESPONSE_KEY, explanationPayload);
 
         SearchResponse processedResponse = processor.processResponse(searchRequest, searchResponse, context);
         assertNotNull(processedResponse);
@@ -284,12 +266,9 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
 
         // Setup explanation payload
         Map<SearchShard, List<CombinedExplanationDetails>> combinedExplainDetails = getCombinedExplainDetails(searchHits);
-        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(
-            ExplanationPayload.PayloadType.NORMALIZATION_PROCESSOR,
-            combinedExplainDetails
-        );
+        Map<ExplanationPayload.PayloadType, Object> explainPayload = Map.of(NORMALIZATION_PROCESSOR, combinedExplainDetails);
         ExplanationPayload explanationPayload = ExplanationPayload.builder().explainPayload(explainPayload).build();
-        context.setAttribute(org.opensearch.neuralsearch.plugin.NeuralSearch.EXPLANATION_RESPONSE_KEY, explanationPayload);
+        context.setAttribute(EXPLANATION_RESPONSE_KEY, explanationPayload);
 
         // Process response
         SearchResponse processedResponse = processor.processResponse(searchRequest, searchResponse, context);
@@ -304,6 +283,112 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
         Explanation explanation = hits[0].getExplanation();
         assertNotNull(explanation);
         assertEquals(0.0f, (float) explanation.getValue(), DELTA_FOR_FLOATS_ASSERTION);
+    }
+
+    @SneakyThrows
+    public void testProcessResponseWithZeroScoreExplanations() {
+        // Setup test data
+        SearchHit searchHit = new SearchHit(1);
+        SearchShardTarget shardTarget = new SearchShardTarget("node1", new ShardId("index", "_na_", 0), null, null);
+        searchHit.shard(shardTarget);
+
+        // Create original explanation with zero and non-zero scores
+        Explanation originalExplanation = Explanation.match(
+            1.0f,
+            "original explanation",
+            Arrays.asList(
+                Explanation.match(0.0f, "zero score explanation"),
+                Explanation.match(0.5f, "non-zero score explanation"),
+                Explanation.match(0.0f, "another zero score explanation")
+            )
+        );
+        searchHit.explanation(originalExplanation);
+
+        // Create normalization details
+        List<Pair<Float, String>> scoreDetails = Arrays.asList(
+            Pair.of(0.0f, "normalized zero score"),
+            Pair.of(0.8f, "normalized non-zero score"),
+            Pair.of(0.0f, "normalized zero score 2")
+        );
+        ExplanationDetails normalizationExplanation = new ExplanationDetails(scoreDetails);
+
+        // Setup response and context
+        SearchHits searchHits = new SearchHits(new SearchHit[] { searchHit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse searchResponse = createSearchResponse(searchHits);
+        PipelineProcessingContext context = createContextWithExplanations(searchHit.getShard(), normalizationExplanation);
+
+        // Execute processor
+        ExplanationResponseProcessor processor = new ExplanationResponseProcessor("test", "tag", false);
+        SearchResponse processedResponse = processor.processResponse(new SearchRequest(), searchResponse, context);
+
+        // Verify results
+        SearchHit processedHit = processedResponse.getHits().getHits()[0];
+        Explanation processedExplanation = processedHit.getExplanation();
+
+        // Verify that only non-zero score explanations are included
+        Explanation[] details = processedExplanation.getDetails();
+        assertEquals(1, details.length);
+        assertEquals(0.8f, details[0].getValue().floatValue(), 0.001f);
+        assertEquals("normalized non-zero score", details[0].getDescription());
+    }
+
+    @SneakyThrows
+    public void testProcessResponseWithAllZeroScores() {
+        // Setup test data
+        SearchHit searchHit = new SearchHit(1);
+        SearchShardTarget shardTarget = new SearchShardTarget("node1", new ShardId("index", "_na_", 0), null, null);
+        searchHit.shard(shardTarget);
+
+        // Create original explanation with all zero scores
+        Explanation originalExplanation = Explanation.match(
+            0.0f,
+            "original explanation",
+            Arrays.asList(Explanation.match(0.0f, "zero score 1"), Explanation.match(0.0f, "zero score 2"))
+        );
+        searchHit.explanation(originalExplanation);
+
+        // Create normalization details with all zeros
+        List<Pair<Float, String>> scoreDetails = Arrays.asList(Pair.of(0.0f, "normalized zero 1"), Pair.of(0.0f, "normalized zero 2"));
+        ExplanationDetails normalizationExplanation = new ExplanationDetails(scoreDetails);
+
+        // Setup response and context
+        SearchHits searchHits = new SearchHits(new SearchHit[] { searchHit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse searchResponse = createSearchResponse(searchHits);
+        PipelineProcessingContext context = createContextWithExplanations(searchHit.getShard(), normalizationExplanation);
+
+        // Execute processor
+        ExplanationResponseProcessor processor = new ExplanationResponseProcessor("test", "tag", false);
+        SearchResponse processedResponse = processor.processResponse(new SearchRequest(), searchResponse, context);
+
+        // Verify results
+        SearchHit processedHit = processedResponse.getHits().getHits()[0];
+        Explanation processedExplanation = processedHit.getExplanation();
+
+        // Verify that no details are included (all scores were zero)
+        assertEquals(0, processedExplanation.getDetails().length);
+    }
+
+    private PipelineProcessingContext createContextWithExplanations(
+        SearchShardTarget shardTarget,
+        ExplanationDetails normalizationExplanation
+    ) {
+
+        SearchShard searchShard = SearchShard.createSearchShard(shardTarget);
+
+        CombinedExplanationDetails combinedDetails = new CombinedExplanationDetails(
+            normalizationExplanation,
+            new ExplanationDetails(Collections.singletonList(Pair.of(1.0f, "combined")))
+        );
+
+        Map<SearchShard, List<CombinedExplanationDetails>> explanationMap = new HashMap<>();
+        explanationMap.put(searchShard, Collections.singletonList(combinedDetails));
+
+        ExplanationPayload explanationPayload = new ExplanationPayload(Map.of(NORMALIZATION_PROCESSOR, explanationMap));
+
+        PipelineProcessingContext context = new PipelineProcessingContext();
+        context.setAttribute(EXPLANATION_RESPONSE_KEY, explanationPayload);
+
+        return context;
     }
 
     private static SearchHits getSearchHits(float maxScore) {
@@ -556,5 +641,18 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
             }
             return Integer.compare(a.docId(), b.docId());
         }
+    }
+
+    private SearchResponse createSearchResponse(SearchHits searchHits) {
+        return new SearchResponse(
+            new SearchResponseSections(searchHits, null, null, false, false, null, 0),
+            "_scrollId",
+            1,
+            1,
+            0,
+            1,
+            new ShardSearchFailure[] {},
+            SearchResponse.Clusters.EMPTY
+        );
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -4,15 +4,25 @@
  */
 package org.opensearch.neuralsearch.processor.normalization;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.neuralsearch.processor.CompoundTopDocs;
 import org.opensearch.neuralsearch.processor.SearchShard;
 import org.opensearch.neuralsearch.processor.NormalizeScoresDTO;
+import org.opensearch.neuralsearch.processor.explain.DocIdAtSearchShard;
+import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+import org.opensearch.search.SearchShardTarget;
+
+import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
 
 /**
  * Abstracts normalization of scores based on min-max method
@@ -47,7 +57,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
             List.of(
                 new TopDocs(
                     new TotalHits(2, TotalHits.Relation.EQUAL_TO),
-                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, 0.001f) }
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, DELTA_FOR_SCORE_ASSERTION) }
                 )
             ),
             false,
@@ -93,12 +103,12 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
             List.of(
                 new TopDocs(
                     new TotalHits(2, TotalHits.Relation.EQUAL_TO),
-                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, 0.001f) }
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, DELTA_FOR_SCORE_ASSERTION) }
                 ),
                 new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
                 new TopDocs(
                     new TotalHits(3, TotalHits.Relation.EQUAL_TO),
-                    new ScoreDoc[] { new ScoreDoc(3, 1.0f), new ScoreDoc(4, 0.75f), new ScoreDoc(2, 0.001f) }
+                    new ScoreDoc[] { new ScoreDoc(3, 1.0f), new ScoreDoc(4, 0.75f), new ScoreDoc(2, DELTA_FOR_SCORE_ASSERTION) }
                 )
             ),
             false,
@@ -155,12 +165,12 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
             List.of(
                 new TopDocs(
                     new TotalHits(2, TotalHits.Relation.EQUAL_TO),
-                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, 0.001f) }
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, DELTA_FOR_SCORE_ASSERTION) }
                 ),
                 new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
                 new TopDocs(
                     new TotalHits(3, TotalHits.Relation.EQUAL_TO),
-                    new ScoreDoc[] { new ScoreDoc(3, 1.0f), new ScoreDoc(4, 0.75f), new ScoreDoc(2, 0.001f) }
+                    new ScoreDoc[] { new ScoreDoc(3, 1.0f), new ScoreDoc(4, 0.75f), new ScoreDoc(2, DELTA_FOR_SCORE_ASSERTION) }
                 )
             ),
             false,
@@ -173,7 +183,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
                 new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]),
                 new TopDocs(
                     new TotalHits(2, TotalHits.Relation.EQUAL_TO),
-                    new ScoreDoc[] { new ScoreDoc(7, 1.0f), new ScoreDoc(9, 0.001f) }
+                    new ScoreDoc[] { new ScoreDoc(7, 1.0f), new ScoreDoc(9, DELTA_FOR_SCORE_ASSERTION) }
                 )
             ),
             false,
@@ -190,6 +200,73 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         for (int i = 0; i < expectedCompoundDocsShard2.getTopDocs().size(); i++) {
             assertCompoundTopDocs(expectedCompoundDocsShard2.getTopDocs().get(i), compoundTopDocs.get(1).getTopDocs().get(i));
         }
+    }
+
+    public void testNormalizedScoresAreSetAtCorrectIndices() {
+        // Setup test data
+        SearchShardTarget shardTarget = new SearchShardTarget("node1", new ShardId("index", "_na_", 0), null, null);
+        SearchShard searchShard = SearchShard.createSearchShard(shardTarget);
+
+        // Create TopDocs with different scores for different subqueries
+        TopDocs topDocs1 = new TopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            new ScoreDoc[] { new ScoreDoc(1, 0.8f), new ScoreDoc(2, 0.6f) }
+        );
+
+        TopDocs topDocs2 = new TopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            new ScoreDoc[] { new ScoreDoc(2, 0.9f), new ScoreDoc(1, 0.7f) }
+        );
+
+        TopDocs topDocs3 = new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(1, 0.5f) });
+
+        // Create CompoundTopDocs with multiple subqueries
+        CompoundTopDocs compoundTopDocs = new CompoundTopDocs(
+            new TotalHits(5, TotalHits.Relation.EQUAL_TO),
+            Arrays.asList(topDocs1, topDocs2, topDocs3),
+            false,  // isSortEnabled
+            searchShard
+        );
+
+        MinMaxScoreNormalizationTechnique normalizer = new MinMaxScoreNormalizationTechnique();
+        Map<DocIdAtSearchShard, ExplanationDetails> result = normalizer.explain(Collections.singletonList(compoundTopDocs));
+
+        // Verify results
+        DocIdAtSearchShard doc1 = new DocIdAtSearchShard(1, searchShard);
+        DocIdAtSearchShard doc2 = new DocIdAtSearchShard(2, searchShard);
+
+        // Verify document 1 normalized scores
+        ExplanationDetails doc1Details = result.get(doc1);
+        assertNotNull(doc1Details);
+        List<Pair<Float, String>> doc1Scores = doc1Details.getScoreDetails();
+        assertEquals(3, doc1Scores.size());
+
+        // First subquery (0.8 is max, 0.6 is min)
+        assertEquals(1.0f, doc1Scores.get(0).getKey(), DELTA_FOR_SCORE_ASSERTION);
+        // Second subquery (0.9 is max, 0.7 is min)
+        assertEquals(0.0f, doc1Scores.get(1).getKey(), DELTA_FOR_SCORE_ASSERTION);
+        // Third subquery (0.5 is both max and min)
+        assertEquals(1.0f, doc1Scores.get(2).getKey(), DELTA_FOR_SCORE_ASSERTION);
+
+        // Verify document 2 normalized scores
+        ExplanationDetails doc2Details = result.get(doc2);
+        assertNotNull(doc2Details);
+        List<Pair<Float, String>> doc2Scores = doc2Details.getScoreDetails();
+        assertEquals(3, doc2Scores.size());
+
+        // First subquery (0.8 is max, 0.6 is min)
+        assertEquals(0.0f, doc2Scores.get(0).getKey(), DELTA_FOR_SCORE_ASSERTION);
+        // Second subquery (0.9 is max, 0.7 is min)
+        assertEquals(1.0f, doc2Scores.get(1).getKey(), DELTA_FOR_SCORE_ASSERTION);
+        // Third subquery (document 2 not present in third subquery)
+        assertEquals(0.0f, doc2Scores.get(2).getKey(), DELTA_FOR_SCORE_ASSERTION);
+
+        // Verify that original ScoreDoc scores were updated
+        assertEquals(1.0f, topDocs1.scoreDocs[0].score, DELTA_FOR_SCORE_ASSERTION); // doc1 in first subquery
+        assertEquals(0.0f, topDocs1.scoreDocs[1].score, DELTA_FOR_SCORE_ASSERTION); // doc2 in first subquery
+        assertEquals(1.0f, topDocs2.scoreDocs[0].score, DELTA_FOR_SCORE_ASSERTION); // doc2 in second subquery
+        assertEquals(0.0f, topDocs2.scoreDocs[1].score, DELTA_FOR_SCORE_ASSERTION); // doc1 in second subquery
+        assertEquals(1.0f, topDocs3.scoreDocs[0].score, DELTA_FOR_SCORE_ASSERTION); // doc1 in third subquery
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtilTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.normalization;
+
+import org.opensearch.neuralsearch.processor.SearchShard;
+import org.opensearch.neuralsearch.processor.explain.DocIdAtSearchShard;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_FLOATS_ASSERTION;
+
+public class ScoreNormalizationUtilTests extends OpenSearchTestCase {
+
+    private ScoreNormalizationUtil scoreNormalizationUtil;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        scoreNormalizationUtil = new ScoreNormalizationUtil();
+    }
+
+    public void testValidateParamsWithUnsupportedParameter() {
+        Map<String, Object> actualParams = new HashMap<>();
+        actualParams.put("unsupported_param", "value");
+        Set<String> supportedParams = new HashSet<>(List.of("weights"));
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParams(actualParams, supportedParams)
+        );
+        assertTrue(exception.getMessage().contains("parameter for combination technique is not supported"));
+    }
+
+    public void testValidateParamsWithInvalidWeightsType() {
+        Map<String, Object> actualParams = new HashMap<>();
+        actualParams.put("weights", "invalid_type");
+        Set<String> supportedParams = new HashSet<>(List.of("weights"));
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParams(actualParams, supportedParams)
+        );
+        assertTrue(exception.getMessage().contains("parameter [weights] must be a collection of numbers"));
+    }
+
+    public void testSetNormalizedScore() {
+        Map<DocIdAtSearchShard, List<Float>> normalizedScores = new HashMap<>();
+        SearchShard searchShard = new SearchShard("index1", 0, "shard1");
+        DocIdAtSearchShard docId = new DocIdAtSearchShard(1, searchShard);
+        int subQueryIndex = 1;
+        int numberOfSubQueries = 3;
+        float normalizedScore = 0.75f;
+
+        ScoreNormalizationUtil.setNormalizedScore(normalizedScores, docId, subQueryIndex, numberOfSubQueries, normalizedScore);
+
+        assertTrue(normalizedScores.containsKey(docId));
+        List<Float> scores = normalizedScores.get(docId);
+        assertEquals(numberOfSubQueries, scores.size());
+        assertEquals(normalizedScore, scores.get(subQueryIndex), DELTA_FOR_FLOATS_ASSERTION);
+        assertEquals(0.0f, scores.get(0), DELTA_FOR_FLOATS_ASSERTION);
+        assertEquals(0.0f, scores.get(2), DELTA_FOR_FLOATS_ASSERTION);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -380,8 +380,14 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             String expectedTopLevelDescription = "combined score of:";
             assertEquals(expectedTopLevelDescription, topLevelExplanationsHit1.get("description"));
             List<Map<String, Object>> normalizationExplanationHit1 = getListOfValues(topLevelExplanationsHit1, "details");
-            assertEquals(1, normalizationExplanationHit1.size());
-            Map<String, Object> hit1DetailsForHit1 = normalizationExplanationHit1.get(0);
+            assertEquals(2, normalizationExplanationHit1.size());
+
+            Map<String, Object> noMatchDetailsForHit1 = normalizationExplanationHit1.get(0);
+            assertEquals(0.0f, (double) noMatchDetailsForHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+            assertEquals("no matching term", noMatchDetailsForHit1.get("description"));
+            assertEquals(0, ((List) noMatchDetailsForHit1.get("details")).size());
+
+            Map<String, Object> hit1DetailsForHit1 = normalizationExplanationHit1.get(1);
             assertEquals(0.754f, (double) hit1DetailsForHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
             assertEquals("sum of:", hit1DetailsForHit1.get("description"));
             assertEquals(1, ((List) hit1DetailsForHit1.get("details")).size());
@@ -422,7 +428,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
 
             assertEquals(expectedTopLevelDescription, topLevelExplanationsHit2.get("description"));
             List<Map<String, Object>> normalizationExplanationHit2 = getListOfValues(topLevelExplanationsHit2, "details");
-            assertEquals(1, normalizationExplanationHit2.size());
+            assertEquals(2, normalizationExplanationHit2.size());
 
             Map<String, Object> hit1DetailsForHit2 = normalizationExplanationHit2.get(0);
             assertEquals(0.287f, (double) hit1DetailsForHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
@@ -439,6 +445,11 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             assertEquals("boost", explanationsHit2Details.get("description"));
             assertEquals(0, getListOfValues(explanationsHit2Details, "details").size());
 
+            Map<String, Object> hit1DetailsForHit2NoMatch = normalizationExplanationHit2.get(1);
+            assertEquals(0.0f, (double) hit1DetailsForHit2NoMatch.get("value"), DELTA_FOR_SCORE_ASSERTION);
+            assertEquals("No matching clauses", hit1DetailsForHit2NoMatch.get("description"));
+            assertEquals(0, ((List) hit1DetailsForHit2NoMatch.get("details")).size());
+
             // search hit 3
             Map<String, Object> searchHit3 = hitsNestedList.get(1);
             Map<String, Object> topLevelExplanationsHit3 = getValueByKey(searchHit3, "_explanation");
@@ -447,7 +458,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
 
             assertEquals(expectedTopLevelDescription, topLevelExplanationsHit3.get("description"));
             List<Map<String, Object>> normalizationExplanationHit3 = getListOfValues(topLevelExplanationsHit3, "details");
-            assertEquals(1, normalizationExplanationHit3.size());
+            assertEquals(2, normalizationExplanationHit3.size());
 
             Map<String, Object> hit1DetailsForHit3 = normalizationExplanationHit3.get(0);
             assertEquals(0.287, (double) hit1DetailsForHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
@@ -463,6 +474,11 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             assertEquals(2.2f, (double) explanationsHit3Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
             assertEquals("boost", explanationsHit3Details.get("description"));
             assertEquals(0, getListOfValues(explanationsHit3Details, "details").size());
+
+            Map<String, Object> hit1DetailsForHit3NoMatch = normalizationExplanationHit2.get(1);
+            assertEquals(0.0f, (double) hit1DetailsForHit3NoMatch.get("value"), DELTA_FOR_SCORE_ASSERTION);
+            assertEquals("No matching clauses", hit1DetailsForHit3NoMatch.get("description"));
+            assertEquals(0, ((List) hit1DetailsForHit3NoMatch.get("details")).size());
         } finally {
             wipeOfTestResources(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, null, null, NORMALIZATION_SEARCH_PIPELINE);
         }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryWeightTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryWeightTests.java
@@ -4,28 +4,37 @@
  */
 package org.opensearch.neuralsearch.query;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.neuralsearch.query.HybridQueryBuilderTests.TEXT_FIELD_NAME;
 
+import java.util.Arrays;
 import java.util.List;
 
+import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Matches;
 import org.apache.lucene.search.MatchesIterator;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.opensearch.index.mapper.TextFieldMapper;
@@ -42,6 +51,10 @@ public class HybridQueryWeightTests extends OpenSearchQueryTestCase {
     private static final String RANGE_FIELD = "date _range";
     private static final String FROM_TEXT = "123";
     private static final String TO_TEXT = "456";
+
+    Directory directory;
+    IndexWriter writer;
+    DirectoryReader reader;
 
     @SneakyThrows
     public void testScorerIterator_whenExecuteQuery_thenScorerIteratorSuccessful() {
@@ -181,5 +194,149 @@ public class HybridQueryWeightTests extends OpenSearchQueryTestCase {
         w.close();
         reader.close();
         directory.close();
+    }
+
+    @SneakyThrows
+    public void testExplainWithNonMatchingExplanationsAddedToMatchingClauses() {
+        float boost = 1.0f;
+        List<Query> queries = Arrays.asList(new TermQuery(new Term("field", "term1")), new TermQuery(new Term("field", "term2")));
+        HybridQuery hybridQuery = new HybridQuery(queries, new HybridQueryContext(10));
+
+        // Create a real LeafReaderContext
+        LeafReaderContext context = createLeafReaderContext();
+
+        IndexSearcher searcher = mock(IndexSearcher.class);
+        HybridQueryWeight weight = new HybridQueryWeight(hybridQuery, searcher, null, boost);
+
+        Weight weight1 = mock(Weight.class);
+        Weight weight2 = mock(Weight.class);
+
+        Explanation matchingExplanation = Explanation.match(1.0f, "matching explanation");
+        Explanation nonMatchingExplanation = Explanation.noMatch("non-matching explanation");
+
+        when(weight1.explain(any(LeafReaderContext.class), anyInt())).thenReturn(matchingExplanation);
+        when(weight2.explain(any(LeafReaderContext.class), anyInt())).thenReturn(nonMatchingExplanation);
+
+        weight.getWeights().clear();
+        weight.getWeights().addAll(Arrays.asList(weight1, weight2));
+
+        Explanation explanation = weight.explain(context, 0);
+
+        assertTrue(explanation.isMatch());
+        assertEquals(1.0f, explanation.getValue().floatValue(), 0.001f);
+
+        Explanation[] details = explanation.getDetails();
+        assertEquals(2, details.length);
+
+        assertEquals(matchingExplanation, details[0]);
+        assertTrue(details[0].isMatch());
+        assertEquals(1.0f, details[0].getValue().floatValue(), 0.001f);
+
+        assertEquals(nonMatchingExplanation, details[1]);
+        assertFalse(details[1].isMatch());
+
+        // Cleanup
+        cleanup();
+    }
+
+    @SneakyThrows
+    public void testExplainWithMultipleMatchingClauses() {
+        float boost = 1.0f;
+        List<Query> queries = Arrays.asList(
+            new TermQuery(new Term("field", "term1")),
+            new TermQuery(new Term("field", "term2")),
+            new TermQuery(new Term("field", "term3"))
+        );
+        HybridQuery hybridQuery = new HybridQuery(queries, new HybridQueryContext(10));
+
+        LeafReaderContext context = createLeafReaderContext();
+        IndexSearcher searcher = mock(IndexSearcher.class);
+        HybridQueryWeight weight = new HybridQueryWeight(hybridQuery, searcher, null, boost);
+
+        Weight weight1 = mock(Weight.class);
+        Weight weight2 = mock(Weight.class);
+        Weight weight3 = mock(Weight.class);
+
+        Explanation matchingExplanation1 = Explanation.match(1.0f, "matching explanation 1");
+        Explanation matchingExplanation2 = Explanation.match(2.0f, "matching explanation 2");
+        Explanation nonMatchingExplanation = Explanation.noMatch("non-matching explanation");
+
+        when(weight1.explain(any(LeafReaderContext.class), anyInt())).thenReturn(matchingExplanation1);
+        when(weight2.explain(any(LeafReaderContext.class), anyInt())).thenReturn(matchingExplanation2);
+        when(weight3.explain(any(LeafReaderContext.class), anyInt())).thenReturn(nonMatchingExplanation);
+
+        weight.getWeights().clear();
+        weight.getWeights().addAll(Arrays.asList(weight1, weight2, weight3));
+
+        Explanation explanation = weight.explain(context, 0);
+
+        assertTrue(explanation.isMatch());
+        assertEquals(2.0f, explanation.getValue().floatValue(), 0.001f);
+
+        Explanation[] details = explanation.getDetails();
+        assertEquals(3, details.length);
+
+        assertEquals(matchingExplanation1, details[0]);
+        assertEquals(matchingExplanation2, details[1]);
+        assertEquals(nonMatchingExplanation, details[2]);
+
+        cleanup();
+    }
+
+    @SneakyThrows
+    public void testExplainWithAllNonMatchingClauses() {
+        float boost = 1.0f;
+        List<Query> queries = Arrays.asList(new TermQuery(new Term("field", "term1")), new TermQuery(new Term("field", "term2")));
+        HybridQuery hybridQuery = new HybridQuery(queries, new HybridQueryContext(10));
+
+        LeafReaderContext context = createLeafReaderContext();
+        IndexSearcher searcher = mock(IndexSearcher.class);
+        HybridQueryWeight weight = new HybridQueryWeight(hybridQuery, searcher, null, boost);
+
+        Weight weight1 = mock(Weight.class);
+        Weight weight2 = mock(Weight.class);
+
+        Explanation nonMatchingExplanation1 = Explanation.noMatch("non-matching explanation 1");
+        Explanation nonMatchingExplanation2 = Explanation.noMatch("non-matching explanation 2");
+
+        when(weight1.explain(any(LeafReaderContext.class), anyInt())).thenReturn(nonMatchingExplanation1);
+        when(weight2.explain(any(LeafReaderContext.class), anyInt())).thenReturn(nonMatchingExplanation2);
+
+        weight.getWeights().clear();
+        weight.getWeights().addAll(Arrays.asList(weight1, weight2));
+
+        Explanation explanation = weight.explain(context, 0);
+
+        assertFalse(explanation.isMatch());
+
+        Explanation[] details = explanation.getDetails();
+        assertEquals(2, details.length);
+        assertEquals(nonMatchingExplanation1, details[0]);
+        assertEquals(nonMatchingExplanation2, details[1]);
+
+        cleanup();
+    }
+
+    @SneakyThrows
+    private LeafReaderContext createLeafReaderContext() {
+        Directory directory = new ByteBuffersDirectory();
+        IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig());
+        writer.addDocument(new Document());
+        DirectoryReader reader = DirectoryReader.open(writer);
+        LeafReaderContext context = reader.leaves().get(0);
+
+        // Store resources for cleanup
+        this.directory = directory;
+        this.writer = writer;
+        this.reader = reader;
+
+        return context;
+    }
+
+    @SneakyThrows
+    private void cleanup() {
+        if (reader != null) reader.close();
+        if (writer != null) writer.close();
+        if (directory != null) directory.close();
     }
 }


### PR DESCRIPTION
### Description
Hybrid query fails with runtime exception in some cases when used with `explain` flag. To get the error you need to design a hybrid query in a way that documents will match only some of multiple subqueries from hybrid query, and does not match other sub-queries.

Example of such scenario:
2 sub-queries, search hit had top match in sub-query 1 and low score in query 2, such that in sub-query2 results this document is below the "size".

```
hybrid {
    neural {}
    multi_match {}
}
```
In this example if score of `multi_match` query is high and score of `neural` is very low explain should still show two matches. This is because `neural` will have positive score for any document, even if that document is below top K  semantically similar documents.

Reason for the error is incorrect assumption that we took during implementation that search hit will have matches in every sub-query. In case of only partial match that leads to the index out of bounds exception because collections with explanation details and search hit details are of different sizes.

Example of query I used to reproduce the problem:

```
{
    "size": 100,
    "_source": {
        "exclude": [
            "passage_embedding"
        ]
    },
    "query": {
        "hybrid": {
            "queries": [
                {
                    "neural": {
                        "passage_embedding": {
                            "query_text": "What is the mechanism of inflammatory response and pathogenesis of COVID-19 cases?",
                            "model_id": "xn0ddpQBU-oejfwL-9TW",
                            "k": 100
                        }
                    }
                },
                {
                    "multi_match": {
                        "query": "What is the mechanism of inflammatory response and pathogenesis of COVID-19 cases?",
                        "type": "best_fields",
                        "fields": [
                            "text_key",
                            "title_key"
                        ],
                        "tie_breaker": 0.5
                    }
                }
            ]
        }
    }
}
```

and this is response I got

```
{
    "error": {
        "root_cause": [
            {
                "type": "index_out_of_bounds_exception",
                "reason": "Index 1 out of bounds for length 1"
            }
        ],
        "type": "index_out_of_bounds_exception",
        "reason": "Index 1 out of bounds for length 1"
    },
    "status": 500
}
```

following exception is in the log

```
[2025-01-21T13:49:16,783][INFO ][o.o.n.s.c.HybridTopScoreDocCollector] [integTest-2] hit count threshold reached: total hits=10000, threshold=10000, action=updating_results
        at org.opensearch.search.pipeline.SearchResponseProcessor.processResponseAsync(SearchResponseProcessor.java:66) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.search.pipeline.Pipeline.lambda$transformResponseListener$9(Pipeline.java:230) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:82) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.search.pipeline.Pipeline.lambda$transformResponseListener$10(Pipeline.java:259) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
    ....
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) [netty-transport-4.1.115.Final.jar:4.1.115.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) [netty-common-4.1.115.Final.jar:4.1.115.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-common-4.1.115.Final.jar:4.1.115.Final]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100) ~[?:?]
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) ~[?:?]
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) ~[?:?]
        at java.base/java.util.Objects.checkIndex(Objects.java:385) ~[?:?]
        at java.base/java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
        at org.opensearch.neuralsearch.processor.ExplanationResponseProcessor.processResponse(ExplanationResponseProcessor.java:106) ~[?:?]
        at org.opensearch.search.pipeline.SearchResponseProcessor.processResponseAsync(SearchResponseProcessor.java:64) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
```

I ran this query for a `trec-covid` dataset https://huggingface.co/datasets/nreimers/trec-covid on a cluster with 3 data nodes and 12 shards.

This fix affects response format for both "by query" and "by document id" requests with explain. 

Below are examples of both responses after my change:

explain in "by query" mode

```
{
    "took": 818,
    "timed_out": false,
    "_shards": {
        "total": 12,
        "successful": 12,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 10000,
            "relation": "gte"
        },
        "max_score": 0.5,
        "hits": [
            {
                "_shard": "[my-nlp-index-1][4]",
                "_node": "So8xwxyzQSaRMx4Mn3wfFA",
                "_index": "my-nlp-index-1",
                "_id": "iaatjew2",
                "_score": 0.5,
                "_source": {
                    "title_key": "The pathogenesis and treatment of the `Cytokine Storm' in COVID-19",
                    "passage_text": "The pathogenesis and treatment of the `Cytokine Storm' in COVID-19 Cytokine storm is an excessive immune response to external stimuli. The pathogenesis of the cytokine storm is complex. The disease progresses rapidly, and the mortality is high. Certain evidence shows that, during the coronavirus disease 2019 (COVID-19) epidemic, the severe deterioration of some patients has been closely related to the cytokine storm in their bodies. This article reviews the occurrence mechanism and treatment strategies of",
                    "text_key": "Cytokine storm is an excessive immune response to external stimuli. The pathogenesis of the cytokine storm is complex. The disease progresses rapidly, and the mortality is high. Certain evidence shows that, during the coronavirus disease 2019 (COVID-19) epidemic, the severe deterioration of some patients has been closely related to the cytokine storm in their bodies. This article reviews the occurrence mechanism and treatment strategies of the COVID-19 virus-induced inflammatory storm in attempt to provide valuable medication guidance for clinical treatment."
                },
                "_explanation": {
                    "value": 0.5,
                    "description": "arithmetic_mean combination of:",
                    "details": [
                        {
                            "value": 1.0,
                            "description": "min_max normalization of:",
                            "details": [
                                {
                                    "value": 27.25991,
                                    "description": "max plus 0.5 times others of:",
                                    "details": [
                                        {
                                            "value": 12.376112,
                                            "description": "sum of:",
                                            "details": [
                                                {
                                                    "value": 1.0223094,
                                                    "description": "weight(title_key:and in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 1.0223094,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 0.94612366,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 5577,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14365,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.49114734,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 11.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.4501915,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 5.8246403,
                                                    "description": "weight(title_key:pathogenesis in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 5.8246403,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 5.390569,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 65,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14365,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.49114734,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 11.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.4501915,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 1.4807031,
                                                    "description": "weight(title_key:the in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 1.4807031,
                                                            "description": "score(freq=2.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 1.0217016,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 5171,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14365,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.6587509,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 2.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 11.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.4501915,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 1.3276497,
                                                    "description": "weight(title_key:19 in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 1.3276497,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 1.228709,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 4204,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14365,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.49114734,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 11.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.4501915,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 1.3189471,
                                                    "description": "weight(title_key:covid in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 1.3189471,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 1.2206548,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 4238,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14365,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.49114734,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 11.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.4501915,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 1.4018621,
                                                    "description": "weight(title_key:of in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 1.4018621,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 4.4,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 0.6486954,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 7509,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14365,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.49114734,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 11.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.4501915,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                }
                                            ]
                                        },
                                        {
                                            "value": 21.071854,
                                            "description": "sum of:",
                                            "details": [
                                                {
                                                    "value": 0.051274747,
                                                    "description": "weight(text_key:and in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 0.051274747,
                                                            "description": "score(freq=2.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 0.030887006,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 10376,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.7545796,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 2.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 4.3727093,
                                                    "description": "weight(text_key:mechanism in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 4.3727093,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 3.2804909,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 402,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.6058834,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 4.576253,
                                                    "description": "weight(text_key:pathogenesis in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 4.576253,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 3.4331932,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 345,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.6058834,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 4.079584,
                                                    "description": "weight(text_key:inflammatory in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 4.079584,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 3.0605824,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 501,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.6058834,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 0.72124374,
                                                    "description": "weight(text_key:is in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 0.72124374,
                                                            "description": "score(freq=3.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 0.39892235,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 7181,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.8218092,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 3.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 0.085298546,
                                                    "description": "weight(text_key:of in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 0.085298546,
                                                            "description": "score(freq=3.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 4.4,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 0.023589456,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 10452,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.8218092,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 3.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 2.1462643,
                                                    "description": "weight(text_key:covid in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 2.1462643,
                                                            "description": "score(freq=2.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 1.2928717,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 2937,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.7545796,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 2.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 0.04428081,
                                                    "description": "weight(text_key:the in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 0.04428081,
                                                            "description": "score(freq=9.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 0.021582382,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 10473,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.93259585,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 9.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 2.9669957,
                                                    "description": "weight(text_key:response in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 2.9669957,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 2.2258976,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1155,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.6058834,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 2.0279489,
                                                    "description": "weight(text_key:19 in 1487) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 2.0279489,
                                                            "description": "score(freq=2.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 1.2216007,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 3154,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 10701,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.7545796,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 2.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 80.0,
                                                                            "description": "dl, length of field (approximate)",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 205.43108,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                }
                                            ]
                                        }
                                    ]
                                }
                            ]
                        }
                    ]
                }
            },
            {
                "_shard": "[my-nlp-index-1][11]",
                "_node": "BwhhFPwCQEuLiqJSSNTjEQ",
                "_index": "my-nlp-index-1",
                "_id": "klcf0eqc",
                "_score": 0.5,
                "_source": {
                    "title_key": "More on Covid-19 in Immune-Mediated Inflammatory Diseases.",
                    "passage_text": "More on Covid-19 in Immune-Mediated Inflammatory Diseases.",
                    "text_key": ""
                },
                "_explanation": {
                    "value": 0.5,
                    "description": "arithmetic_mean combination of:",
                    "details": [
                        {
                            "value": 1.0,
                            "description": "min_max normalization of:",
                            "details": [
                                {
                                    "value": 0.055166073,
                                    "description": "within top 100",
                                    "details": []
                                }
                            ]
                        },
                        {
                            "value": 0.0,
                            "description": "min_max normalization of:",
                            "details": [
                                {
                                    "value": 8.98535,
                                    "description": "max plus 0.5 times others of:",
                                    "details": [
                                        {
                                            "value": 8.98535,
                                            "description": "sum of:",
                                            "details": [
                                                {
                                                    "value": 1.4543076,
                                                    "description": "weight(title_key:covid in 985) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 1.4543076,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 1.2548273,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 4113,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14426,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.5268047,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 9.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.539789,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 6.072501,
                                                    "description": "weight(title_key:inflammatory in 985) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 6.072501,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 5.239566,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 76,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14426,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.5268047,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 9.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.539789,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                },
                                                {
                                                    "value": 1.4585414,
                                                    "description": "weight(title_key:19 in 985) [PerFieldSimilarity], result of:",
                                                    "details": [
                                                        {
                                                            "value": 1.4585414,
                                                            "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                                            "details": [
                                                                {
                                                                    "value": 2.2,
                                                                    "description": "boost",
                                                                    "details": []
                                                                },
                                                                {
                                                                    "value": 1.2584804,
                                                                    "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 4098,
                                                                            "description": "n, number of documents containing term",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 14426,
                                                                            "description": "N, total number of documents with field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                },
                                                                {
                                                                    "value": 0.5268047,
                                                                    "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                                    "details": [
                                                                        {
                                                                            "value": 1.0,
                                                                            "description": "freq, occurrences of term within document",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 1.2,
                                                                            "description": "k1, term saturation parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 0.75,
                                                                            "description": "b, length normalization parameter",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 9.0,
                                                                            "description": "dl, length of field",
                                                                            "details": []
                                                                        },
                                                                        {
                                                                            "value": 13.539789,
                                                                            "description": "avgdl, average length of field",
                                                                            "details": []
                                                                        }
                                                                    ]
                                                                }
                                                            ]
                                                        }
                                                    ]
                                                }
                                            ]
                                        }
                                    ]
                                }
                            ]
                        }
                    ]
                }
            }
        ]
    }
}
```

example response for "explain by doc id" query

```
{
    "_index": "my-nlp-index-1",
    "_id": "klcf0eqc",
    "matched": true,
    "explanation": {
        "value": 8.985349655151367,
        "description": "combined score of:",
        "details": [
            {
                "value": 8.98535,
                "description": "max plus 0.5 times others of:",
                "details": [
                    {
                        "value": 8.98535,
                        "description": "sum of:",
                        "details": [
                            {
                                "value": 1.4543076,
                                "description": "weight(title_key:covid in 985) [PerFieldSimilarity], result of:",
                                "details": [
                                    {
                                        "value": 1.4543076,
                                        "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                        "details": [
                                            {
                                                "value": 2.2,
                                                "description": "boost",
                                                "details": []
                                            },
                                            {
                                                "value": 1.2548273,
                                                "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                "details": [
                                                    {
                                                        "value": 4113,
                                                        "description": "n, number of documents containing term",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 14426,
                                                        "description": "N, total number of documents with field",
                                                        "details": []
                                                    }
                                                ]
                                            },
                                            {
                                                "value": 0.5268047,
                                                "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                "details": [
                                                    {
                                                        "value": 1.0,
                                                        "description": "freq, occurrences of term within document",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 1.2,
                                                        "description": "k1, term saturation parameter",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 0.75,
                                                        "description": "b, length normalization parameter",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 9.0,
                                                        "description": "dl, length of field",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 13.539789,
                                                        "description": "avgdl, average length of field",
                                                        "details": []
                                                    }
                                                ]
                                            }
                                        ]
                                    }
                                ]
                            },
                            {
                                "value": 1.4585414,
                                "description": "weight(title_key:19 in 985) [PerFieldSimilarity], result of:",
                                "details": [
                                    {
                                        "value": 1.4585414,
                                        "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                        "details": [
                                            {
                                                "value": 2.2,
                                                "description": "boost",
                                                "details": []
                                            },
                                            {
                                                "value": 1.2584804,
                                                "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                "details": [
                                                    {
                                                        "value": 4098,
                                                        "description": "n, number of documents containing term",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 14426,
                                                        "description": "N, total number of documents with field",
                                                        "details": []
                                                    }
                                                ]
                                            },
                                            {
                                                "value": 0.5268047,
                                                "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                "details": [
                                                    {
                                                        "value": 1.0,
                                                        "description": "freq, occurrences of term within document",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 1.2,
                                                        "description": "k1, term saturation parameter",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 0.75,
                                                        "description": "b, length normalization parameter",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 9.0,
                                                        "description": "dl, length of field",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 13.539789,
                                                        "description": "avgdl, average length of field",
                                                        "details": []
                                                    }
                                                ]
                                            }
                                        ]
                                    }
                                ]
                            },
                            {
                                "value": 6.072501,
                                "description": "weight(title_key:inflammatory in 985) [PerFieldSimilarity], result of:",
                                "details": [
                                    {
                                        "value": 6.072501,
                                        "description": "score(freq=1.0), computed as boost * idf * tf from:",
                                        "details": [
                                            {
                                                "value": 2.2,
                                                "description": "boost",
                                                "details": []
                                            },
                                            {
                                                "value": 5.239566,
                                                "description": "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                                                "details": [
                                                    {
                                                        "value": 76,
                                                        "description": "n, number of documents containing term",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 14426,
                                                        "description": "N, total number of documents with field",
                                                        "details": []
                                                    }
                                                ]
                                            },
                                            {
                                                "value": 0.5268047,
                                                "description": "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                                                "details": [
                                                    {
                                                        "value": 1.0,
                                                        "description": "freq, occurrences of term within document",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 1.2,
                                                        "description": "k1, term saturation parameter",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 0.75,
                                                        "description": "b, length normalization parameter",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 9.0,
                                                        "description": "dl, length of field",
                                                        "details": []
                                                    },
                                                    {
                                                        "value": 13.539789,
                                                        "description": "avgdl, average length of field",
                                                        "details": []
                                                    }
                                                ]
                                            }
                                        ]
                                    }
                                ]
                            }
                        ]
                    }
                ]
            }
        ]
    }
}
```

### Related Issues
https://github.com/opensearch-project/neural-search/issues/658

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
