### PR TITLE
Validate Disjuction query in HybridQueryPhaseSearcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support empty string for fields in text embedding processor ([#1041](https://github.com/opensearch-project/neural-search/pull/1041))
 - Optimize ML inference connection retry logic ([#1054](https://github.com/opensearch-project/neural-search/pull/1054))
 - Support for builder constructor in Neural Query Builder ([#1047](https://github.com/opensearch-project/neural-search/pull/1047))
+- Validate Disjunction query to avoid having nested hybrid query ([#1127](https://github.com/opensearch-project/neural-search/pull/1127))
 ### Bug Fixes
 - Address inconsistent scoring in hybrid query results ([#998](https://github.com/opensearch-project/neural-search/pull/998))
 - Fix bug where ingested document has list of nested objects ([#1040](https://github.com/opensearch-project/neural-search/pull/1040))


### PR DESCRIPTION
### Description
Validate Disjuction query in HybridQueryPhaseSearcher to avoid having hybrid as a nested query

```
{
    "query": {
        "dis_max": {
            "queries": [
                {
                    "match": {
                        "title": "Shakespeare poems"
                    }
                },
                {
                    "hybrid": {
                        "queries": [
                            {
                                "match": {
                                    "passage_text": {
                                        "query": "Hi world"
                                    }
                                }
                            }
                        ]
                    }
                }
            ]
        }
    }
}
```

Response
```
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "hybrid query must be a top level query and cannot be wrapped into other queries"
            }
        ],
```

### Related Issues
Part of https://github.com/opensearch-project/neural-search/issues/1125

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
