### PR TITLE
Handle pagination_depth when from =0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed document source and score field mismatch in sorted hybrid queries ([#1043](https://github.com/opensearch-project/neural-search/pull/1043))
 - Update NeuralQueryBuilder doEquals() and doHashCode() to cater the missing parameters information ([#1045](https://github.com/opensearch-project/neural-search/pull/1045)).
 - Fix bug where embedding is missing when ingested document has "." in field name, and mismatches fieldMap config ([#1062](https://github.com/opensearch-project/neural-search/pull/1062))
+- Handle pagination_depth when from =0 and removes default value of pagination_depth ([#1132](https://github.com/opensearch-project/neural-search/pull/1132))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -58,7 +58,6 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     private Integer paginationDepth;
 
     static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
-    private final static int DEFAULT_PAGINATION_DEPTH = 10;
     private static final int LOWER_BOUND_OF_PAGINATION_DEPTH = 0;
 
     public HybridQueryBuilder(StreamInput in) throws IOException {
@@ -167,7 +166,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     public static HybridQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
 
-        int paginationDepth = DEFAULT_PAGINATION_DEPTH;
+        Integer paginationDepth = null;
         final List<QueryBuilder> queries = new ArrayList<>();
         String queryName = null;
 
@@ -324,7 +323,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         return queries;
     }
 
-    private static void validatePaginationDepth(final int paginationDepth, final QueryShardContext queryShardContext) {
+    private static void validatePaginationDepth(final Integer paginationDepth, final QueryShardContext queryShardContext) {
         if (Objects.isNull(paginationDepth)) {
             return;
         }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -492,7 +492,6 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
             throw new IllegalArgumentException(String.format(Locale.ROOT, "pagination_depth param is missing in the search request"));
         }
 
-        log.info("pagination_depth is {}", paginationDepth);
         if (Objects.nonNull(paginationDepth)) {
             return paginationDepth;
         }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -485,14 +485,20 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
      */
     private static int getSubqueryResultsRetrievalSize(final SearchContext searchContext) {
         HybridQuery hybridQuery = unwrapHybridQuery(searchContext);
-        int paginationDepth = hybridQuery.getQueryContext().getPaginationDepth();
+        Integer paginationDepth = hybridQuery.getQueryContext().getPaginationDepth();
 
-        // Switch to from+size retrieval size during standard hybrid query execution.
-        if (searchContext.from() == 0) {
-            return searchContext.size();
+        // Pagination is expected to work only when pagination_depth is provided in the search request.
+        if (Objects.isNull(paginationDepth) && searchContext.from() > 0) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "pagination_depth param is missing in the search request"));
         }
+
         log.info("pagination_depth is {}", paginationDepth);
-        return paginationDepth;
+        if (Objects.nonNull(paginationDepth)) {
+            return paginationDepth;
+        }
+
+        // Switch to from+size retrieval size during standard hybrid query execution where from is 0.
+        return searchContext.size();
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -398,6 +398,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
             .endObject()
             .endObject()
             .endArray()
+            .field("pagination_depth", 10)
             .endObject();
 
         NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -871,40 +871,6 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     }
 
     @SneakyThrows
-    public void testHybridQuery_whenFromIsGreaterThanZeroAndPaginationDepthIsNotSent_thenSuccessful() {
-        try {
-            updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
-            initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD);
-            createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
-            HybridQueryBuilder hybridQueryBuilderOnlyMatchAll = new HybridQueryBuilder();
-            hybridQueryBuilderOnlyMatchAll.add(new MatchAllQueryBuilder());
-
-            Map<String, Object> searchResponseAsMap = search(
-                TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD,
-                hybridQueryBuilderOnlyMatchAll,
-                null,
-                10,
-                Map.of("search_pipeline", SEARCH_PIPELINE),
-                null,
-                null,
-                null,
-                false,
-                null,
-                2
-            );
-
-            assertEquals(2, getHitCount(searchResponseAsMap));
-            Map<String, Object> total = getTotalHits(searchResponseAsMap);
-            assertNotNull(total.get("value"));
-            assertEquals(4, total.get("value"));
-            assertNotNull(total.get("relation"));
-            assertEquals(RELATION_EQUAL_TO, total.get("relation"));
-        } finally {
-            wipeOfTestResources(TEST_MULTI_DOC_INDEX_NAME_ONE_SHARD, null, null, SEARCH_PIPELINE);
-        }
-    }
-
-    @SneakyThrows
     public void testHybridQuery_whenFromIsGreaterThanTotalResultCount_thenFail() {
         try {
             updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
@@ -912,6 +878,7 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
             HybridQueryBuilder hybridQueryBuilderOnlyMatchAll = new HybridQueryBuilder();
             hybridQueryBuilderOnlyMatchAll.add(new MatchAllQueryBuilder());
+            hybridQueryBuilderOnlyMatchAll.paginationDepth(10);
 
             ResponseException responseException = assertThrows(
                 ResponseException.class,

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -439,7 +439,7 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
-        HybridQueryContext hybridQueryContext = HybridQueryContext.builder().paginationDepth(10).build();
+        HybridQueryContext hybridQueryContext = HybridQueryContext.builder().build();
 
         HybridQuery hybridQueryWithMatchAll = new HybridQuery(
             List.of(QueryBuilders.matchAllQuery().toQuery(mockQueryShardContext)),
@@ -633,7 +633,7 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
-        HybridQueryContext hybridQueryContext = HybridQueryContext.builder().paginationDepth(10).build();
+        HybridQueryContext hybridQueryContext = HybridQueryContext.builder().build();
 
         HybridQuery hybridQueryWithTerm = new HybridQuery(
             List.of(QueryBuilders.matchAllQuery().toQuery(mockQueryShardContext)),
@@ -1166,6 +1166,43 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         );
         assertEquals(
             String.format(Locale.ROOT, "Scroll operation is not supported in hybrid query"),
+            illegalArgumentException.getMessage()
+        );
+    }
+
+    @SneakyThrows
+    public void testCreateCollectorManager_whenPaginationDepthIsEqualToNullAndFromIsGreaterThanZero_thenFail() {
+        SearchContext searchContext = mock(SearchContext.class);
+        // From >0
+        when(searchContext.from()).thenReturn(5);
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+        TermQueryBuilder termSubQuery = QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY1);
+        // if pagination_depth ==0 then internally by default it will pick 10 as the depth
+        HybridQuery hybridQuery = new HybridQuery(
+            List.of(termSubQuery.toQuery(mockQueryShardContext)),
+            HybridQueryContext.builder().build()
+        );
+
+        when(searchContext.query()).thenReturn(hybridQuery);
+        ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
+        IndexReader indexReader = mock(IndexReader.class);
+        when(indexSearcher.getIndexReader()).thenReturn(indexReader);
+        when(searchContext.searcher()).thenReturn(indexSearcher);
+        MapperService mapperService = createMapperService();
+        when(searchContext.mapperService()).thenReturn(mapperService);
+
+        Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> classCollectorManagerMap = new HashMap<>();
+        when(searchContext.queryCollectorManagers()).thenReturn(classCollectorManagerMap);
+        when(searchContext.shouldUseConcurrentSearch()).thenReturn(false);
+
+        IllegalArgumentException illegalArgumentException = assertThrows(
+            IllegalArgumentException.class,
+            () -> HybridCollectorManager.createHybridCollectorManager(searchContext)
+        );
+        assertEquals(
+            String.format(Locale.ROOT, "pagination_depth param is missing in the search request"),
             illegalArgumentException.getMessage()
         );
     }

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -1179,10 +1179,10 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
         TermQueryBuilder termSubQuery = QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY1);
-        // if pagination_depth ==0 then internally by default it will pick 10 as the depth
+
         HybridQuery hybridQuery = new HybridQuery(
             List.of(termSubQuery.toQuery(mockQueryShardContext)),
-            HybridQueryContext.builder().build()
+            HybridQueryContext.builder().build() // pagination_depth is set to null
         );
 
         when(searchContext.query()).thenReturn(hybridQuery);


### PR DESCRIPTION
### Description
This PR contains following changes
1. Remove default value of pagination_depth as it creates issues during multiple permutations and combinations of from, size and pagination_depth
2. Handle pagination_depth when from =0 to make to hold of the search reference.

### Related Issues
[1131](https://github.com/opensearch-project/neural-search/issues/1131)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
