### PR TITLE
Fixed single shard pagination issue of from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix bug where embedding is missing when ingested document has "." in field name, and mismatches fieldMap config ([#1062](https://github.com/opensearch-project/neural-search/pull/1062))
 - Fix explain exception in hybrid queries with partial subquery matches ([#1123](https://github.com/opensearch-project/neural-search/pull/1123))
 - Handle pagination_depth when from =0 and removes default value of pagination_depth ([#1132](https://github.com/opensearch-project/neural-search/pull/1132))
+- Fix single shard pagination issue of from ([#1140](https://github.com/opensearch-project/neural-search/pull/1140))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -113,7 +113,16 @@ public class NormalizationProcessorWorkflow {
         if (searchPhaseContext.getNumShards() > 1 || request.fetchSearchResultOptional.isEmpty()) {
             return -1;
         }
-        return searchPhaseContext.getRequest().source().from();
+        int from = searchPhaseContext.getRequest().source().from();
+        // for the initial searchRequest, it creates a default search context which sets the value of
+        // from to 0 if it's -1. That's not the case with SearchPhaseContext, that's why need to
+        // explicitly set to 0 for the single shard case
+        // Ref:
+        // https://github.com/opensearch-project/OpenSearch/blob/2.18/server/src/main/java/org/opensearch/search/DefaultSearchContext.java#L288
+        if (from == -1) {
+            return 0;
+        }
+        return from;
     }
 
     /**


### PR DESCRIPTION
### Description
For the initial searchRequest, it creates a default search context which sets the value of from to 0 if it's -1. That's not the case with SearchPhasedContext, that's why need to explicitly set to 0 for the single shard case
Ref: https://github.com/opensearch-project/OpenSearch/blob/2.18/server/src/main/java/org/opensearch/search/DefaultSearchContext.java#L288 and https://github.com/opensearch-project/neural-search/issues/1139

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/1139

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
