### PR TITLE
[3.0] Update neural-search for OpenSearch 3.0 compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,28 +117,6 @@ jobs:
           name: coverage-report-${{ matrix.os }}-${{ matrix.java }}
           path: ./jacocoTestReport.xml
 
-  Precommit-neural-search-windows:
-    strategy:
-      matrix:
-        java: [21, 23]
-        os: [windows-latest]
-
-    name: Pre-commit Windows
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-
-      - name: Run build
-        run: |
-          ./gradlew precommit --parallel
-
   Precommit-codecov:
     needs: Precommit-neural-search-linux
     strategy:

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -13,9 +13,9 @@ jobs:
   Restart-Upgrade-BWCTests-NeuralSearch:
     strategy:
       matrix:
-        java: [21, 23]
-        os: [ubuntu-latest,windows-latest]
-        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.0-SNAPSHOT"]
+        java: [ 21, 23 ]
+        os: [ubuntu-latest]
+        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.0-SNAPSHOT","2.20.0-SNAPSHOT"]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
 
     name: NeuralSearch Restart-Upgrade BWC Tests
@@ -42,7 +42,7 @@ jobs:
       matrix:
         java: [21, 23]
         os: [ubuntu-latest,windows-latest]
-        bwc_version: [ "2.19.0-SNAPSHOT" ]
+        bwc_version: [ "2.20.0-SNAPSHOT" ]
         opensearch_version: [ "3.0.0-SNAPSHOT" ]
 
     name: NeuralSearch Rolling-Upgrade BWC Tests

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         java: [ 21, 23 ]
         os: [ubuntu-latest]
-        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.0-SNAPSHOT","2.20.0-SNAPSHOT"]
+        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.0","2.20.0-SNAPSHOT"]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
 
     name: NeuralSearch Restart-Upgrade BWC Tests

--- a/.github/workflows/test_aggregations.yml
+++ b/.github/workflows/test_aggregations.yml
@@ -54,7 +54,7 @@ jobs:
   Check-neural-search-windows:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [23]
         os: [windows-latest]
 
     name: Integ Tests Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.0](https://github.com/opensearch-project/neural-search/compare/2.x...HEAD)
 ### Features
 ### Enhancements
-- Set neural-search plugin 3.0.0 baseline JDK version to JDK-2 ([#838](https://github.com/opensearch-project/neural-search/pull/838))
+- Set neural-search plugin 3.0.0 baseline JDK version to JDK-21 ([#838](https://github.com/opensearch-project/neural-search/pull/838))
 ### Bug Fixes
 ### Infrastructure
+- [3.0] Update neural-search for OpenSearch 3.0 compatibility ([#1141](https://github.com/opensearch-project/neural-search/pull/1141))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -252,14 +252,12 @@ dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
-    //TODO need to replace by ${opensearch_build} once dependencies adapt new core version
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "3.0.0.0-SNAPSHOT"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
     secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
     compileOnly fileTree(dir: knnJarDirectory, include: "opensearch-knn-${opensearch_build}.jar")
     compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     compileOnly group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    //TODO need to replace by ${opensearch_build} once dependencies adapt new core version
-    api group: 'org.opensearch', name:'opensearch-ml-client', version: "3.0.0.0-SNAPSHOT"
+    api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     // ml-common excluded reflection for runtime so we need to add it by ourselves.

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ import java.util.concurrent.Callable
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
@@ -252,12 +252,14 @@ dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
+    //TODO need to replace by ${opensearch_build} once dependencies adapt new core version
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "3.0.0.0-SNAPSHOT"
     secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
     compileOnly fileTree(dir: knnJarDirectory, include: "opensearch-knn-${opensearch_build}.jar")
     compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     compileOnly group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
+    //TODO need to replace by ${opensearch_build} once dependencies adapt new core version
+    api group: 'org.opensearch', name:'opensearch-ml-client', version: "3.0.0.0-SNAPSHOT"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     // ml-common excluded reflection for runtime so we need to add it by ourselves.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=2.19.0-SNAPSHOT
+systemProp.bwc.version=2.20.0-SNAPSHOT
 systemProp.bwc.bundle.version=2.19.0
 
 # For fixing Spotless check with Java 17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,8 @@
+#
+#  Copyright OpenSearch Contributors
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6

--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,8 @@
 #!/bin/sh
+#
+#  Copyright OpenSearch Contributors
+#  SPDX-License-Identifier: Apache-2.0
+#
 
 #
 # Copyright © 2015-2021 the original authors.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,4 +1,7 @@
 @rem
+@rem  Copyright OpenSearch Contributors
+@rem  SPDX-License-Identifier: Apache-2.0
+@rem
 @rem Copyright 2015 the original author or authors.
 @rem
 @rem Licensed under the Apache License, Version 2.0 (the "License");

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
@@ -11,7 +11,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.opensearch.neuralsearch.util.BatchIngestionUtils.prepareDataForBulkIngestion;
 import static org.opensearch.neuralsearch.util.TestUtils.NODES_BWC_CLUSTER;

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
@@ -21,7 +21,6 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
     private static final String SPARSE_PIPELINE = "BatchIngestionIT_sparse_pipeline_rolling";
     private static final String TEXT_FIELD_NAME = "passage_text";
     private static final String EMBEDDING_FIELD_NAME = "passage_embedding";
-    private static final Set<MLModelState> READY_FOR_INFERENCE_STATES = Set.of(MLModelState.LOADED, MLModelState.DEPLOYED);
 
     public void testBatchIngestion_SparseEncodingProcessor_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
@@ -92,21 +91,5 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
             default:
                 throw new IllegalStateException("Unexpected value: " + getClusterType());
         }
-    }
-
-    private void waitForModelToLoad(String modelId) throws Exception {
-        int maxAttempts = 30;  // Maximum number of attempts
-        int waitTimeInSeconds = 2;  // Time to wait between attempts
-
-        for (int attempt = 0; attempt < maxAttempts; attempt++) {
-            MLModelState state = getModelState(modelId);
-            if (READY_FOR_INFERENCE_STATES.contains(state)) {
-                logger.info("Model {} is now loaded after {} attempts", modelId, attempt + 1);
-                return;
-            }
-            logger.info("Waiting for model {} to load. Current state: {}. Attempt {}/{}", modelId, state, attempt + 1, maxAttempts);
-            Thread.sleep(waitTimeInSeconds * 1000);
-        }
-        throw new RuntimeException("Model " + modelId + " failed to load after " + maxAttempts + " attempts");
     }
 }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.opensearch.neuralsearch.util.BatchIngestionUtils.prepareDataForBulkIngestion;
 import static org.opensearch.neuralsearch.util.TestUtils.NODES_BWC_CLUSTER;
@@ -20,6 +21,7 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
     private static final String SPARSE_PIPELINE = "BatchIngestionIT_sparse_pipeline_rolling";
     private static final String TEXT_FIELD_NAME = "passage_text";
     private static final String EMBEDDING_FIELD_NAME = "passage_embedding";
+    private static final Set<MLModelState> READY_FOR_INFERENCE_STATES = Set.of(MLModelState.LOADED, MLModelState.DEPLOYED);
 
     public void testBatchIngestion_SparseEncodingProcessor_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
@@ -98,7 +100,7 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
 
         for (int attempt = 0; attempt < maxAttempts; attempt++) {
             MLModelState state = getModelState(modelId);
-            if (state == MLModelState.LOADED) {
+            if (READY_FOR_INFERENCE_STATES.contains(state)) {
                 logger.info("Model {} is now loaded after {} attempts", modelId, attempt + 1);
                 return;
             }

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -242,7 +242,7 @@ public class NormalizationProcessorWorkflow {
      * @return  max score
      */
     private float maxScoreForShard(CompoundTopDocs updatedTopDocs, boolean isSortEnabled) {
-        if (updatedTopDocs.getTotalHits().value == 0 || updatedTopDocs.getScoreDocs().isEmpty()) {
+        if (updatedTopDocs.getTotalHits().value() == 0 || updatedTopDocs.getScoreDocs().isEmpty()) {
             return MAX_SCORE_WHEN_NO_HITS_FOUND;
         }
         if (isSortEnabled) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
@@ -81,7 +81,7 @@ public class ScoreCombiner {
         final CompoundTopDocs compoundQueryTopDocs,
         final Sort sort
     ) {
-        if (Objects.isNull(compoundQueryTopDocs) || compoundQueryTopDocs.getTotalHits().value == 0) {
+        if (Objects.isNull(compoundQueryTopDocs) || compoundQueryTopDocs.getTotalHits().value() == 0) {
             return;
         }
         List<TopDocs> topDocsPerSubQuery = compoundQueryTopDocs.getTopDocs();
@@ -292,7 +292,7 @@ public class ScoreCombiner {
         boolean isSortingEnabled
     ) {
         // - max number of hits will be the same which are passed from QueryPhase
-        long maxHits = compoundQueryTopDocs.getTotalHits().value;
+        long maxHits = compoundQueryTopDocs.getTotalHits().value();
         // - update query search results with normalized scores
         compoundQueryTopDocs.setScoreDocs(
             getCombinedScoreDocs(
@@ -309,7 +309,7 @@ public class ScoreCombiner {
 
     private TotalHits getTotalHits(final List<TopDocs> topDocsPerSubQuery, final long maxHits) {
         TotalHits.Relation totalHits = TotalHits.Relation.EQUAL_TO;
-        if (topDocsPerSubQuery.stream().anyMatch(topDocs -> topDocs.totalHits.relation == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO)) {
+        if (topDocsPerSubQuery.stream().anyMatch(topDocs -> topDocs.totalHits.relation() == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO)) {
             totalHits = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
         }
         return new TotalHits(maxHits, totalHits);
@@ -343,7 +343,7 @@ public class ScoreCombiner {
         final CompoundTopDocs compoundQueryTopDocs,
         final Sort sort
     ) {
-        if (Objects.isNull(compoundQueryTopDocs) || compoundQueryTopDocs.getTotalHits().value == 0) {
+        if (Objects.isNull(compoundQueryTopDocs) || compoundQueryTopDocs.getTotalHits().value() == 0) {
             return List.of();
         }
         // create map of normalized scores results returned from the single shard

--- a/src/main/java/org/opensearch/neuralsearch/processor/rerank/RescoringRerankProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/rerank/RescoringRerankProcessor.java
@@ -59,7 +59,7 @@ public abstract class RescoringRerankProcessor extends RerankProcessor {
         final ActionListener<SearchResponse> listener
     ) {
         try {
-            if (searchResponse.getHits().getTotalHits().value == 0) {
+            if (searchResponse.getHits().getTotalHits().value() == 0) {
                 listener.onResponse(searchResponse);
                 return;
             }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
@@ -49,7 +49,7 @@ public class HybridQueryScorer extends Scorer {
     }
 
     HybridQueryScorer(final Weight weight, final List<Scorer> subScorers, final ScoreMode scoreMode) throws IOException {
-        super(weight);
+        super();
         this.subScorers = Collections.unmodifiableList(subScorers);
         this.numSubqueries = subScorers.size();
         this.subScorersPQ = initializeSubScorersPQ();

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
@@ -110,24 +110,6 @@ public final class HybridQueryWeight extends Weight {
     }
 
     /**
-     * Create the scorer used to score our associated Query
-     *
-     * @param context the {@link LeafReaderContext} for which to return the
-     *                {@link Scorer}.
-     * @return scorer of hybrid query that contains scorers of each sub-query, null if there are no matches in any sub-query
-     * @throws IOException
-     */
-    @Override
-    public Scorer scorer(LeafReaderContext context) throws IOException {
-        ScorerSupplier supplier = scorerSupplier(context);
-        if (supplier == null) {
-            return null;
-        }
-        supplier.setTopLevelScoringClause();
-        return supplier.get(Long.MAX_VALUE);
-    }
-
-    /**
      * Check if weight object can be cached
      *
      * @param ctx

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQuery.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQuery.java
@@ -5,7 +5,6 @@
 package org.opensearch.neuralsearch.query;
 
 import lombok.Getter;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -45,8 +44,8 @@ public class NeuralKNNQuery extends Query {
     }
 
     @Override
-    public Query rewrite(IndexReader reader) throws IOException {
-        Query rewritten = knnQuery.rewrite(reader);
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        Query rewritten = knnQuery.rewrite(indexSearcher);
         if (rewritten == knnQuery) {
             return this;
         }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -21,7 +21,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.Version;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.ParseField;

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridDisiWrapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridDisiWrapper.java
@@ -17,7 +17,7 @@ public class HybridDisiWrapper extends DisiWrapper {
     private final int subQueryIndex;
 
     public HybridDisiWrapper(Scorer scorer, int subQueryIndex) {
-        super(scorer);
+        super(scorer, false);
         this.subQueryIndex = subQueryIndex;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollector.java
@@ -166,13 +166,13 @@ public abstract class HybridTopFieldDocSortCollector implements HybridSearchColl
                 return (HybridQueryScorer) scorer;
             }
             for (Scorable.ChildScorable childScorable : scorer.getChildren()) {
-                HybridQueryScorer hybridQueryScorer = getHybridQueryScorer(childScorable.child);
+                HybridQueryScorer hybridQueryScorer = getHybridQueryScorer(childScorable.child());
                 if (Objects.nonNull(hybridQueryScorer)) {
                     log.debug(
                         String.format(
                             Locale.ROOT,
                             "found hybrid query scorer, it's child of scorer %s",
-                            childScorable.child.getClass().getSimpleName()
+                            childScorable.child().getClass().getSimpleName()
                         )
                     );
                     return hybridQueryScorer;
@@ -289,7 +289,7 @@ public abstract class HybridTopFieldDocSortCollector implements HybridSearchColl
         private void initializeComparators(LeafReaderContext context, int subQueryNumber) throws IOException {
             // as all segments are sorted in the same way, enough to check only the 1st segment for indexSort
             if (searchSortPartOfIndexSort == null) {
-                Sort indexSort = context.reader().getMetaData().getSort();
+                Sort indexSort = context.reader().getMetaData().sort();
                 searchSortPartOfIndexSort = canEarlyTerminate(sort, indexSort);
                 if (searchSortPartOfIndexSort) {
                     firstComparator.disableSkipping();

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
@@ -77,13 +77,13 @@ public class HybridTopScoreDocCollector implements HybridSearchCollector {
                     return (HybridQueryScorer) scorer;
                 }
                 for (Scorable.ChildScorable childScorable : scorer.getChildren()) {
-                    HybridQueryScorer hybridQueryScorer = getHybridQueryScorer(childScorable.child);
+                    HybridQueryScorer hybridQueryScorer = getHybridQueryScorer(childScorable.child());
                     if (Objects.nonNull(hybridQueryScorer)) {
                         log.debug(
                             String.format(
                                 Locale.ROOT,
                                 "found hybrid query scorer, it's child of scorer %s",
-                                childScorable.child.getClass().getSimpleName()
+                                childScorable.child().getClass().getSimpleName()
                             )
                         );
                         return hybridQueryScorer;

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -455,7 +455,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
         }
         // in this case top docs are already present in result, and we need to merge next result object with what we have.
         // if collector doesn't have any hits we can just skip it and save some cycles by not doing merge
-        if (topDocsAndMaxScore.topDocs.totalHits.value == 0) {
+        if (topDocsAndMaxScore.topDocs.totalHits.value() == 0) {
             return;
         }
         // we need to do actual merge because query result and current collector both have some score hits
@@ -509,7 +509,7 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
         // In case of nested fields and alias filter, hybrid query is wrapped under bool query and lies in the first clause.
         if (isHybridQueryWrappedInBooleanQuery(searchContext, searchContext.query())) {
             BooleanQuery booleanQuery = (BooleanQuery) query;
-            hybridQuery = (HybridQuery) booleanQuery.clauses().get(0).getQuery();
+            hybridQuery = (HybridQuery) booleanQuery.clauses().get(0).query();
         } else {
             hybridQuery = (HybridQuery) query;
         }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -79,14 +79,11 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
         if (isHybridQueryWrappedInBooleanQuery(searchContext, query)) {
             List<BooleanClause> booleanClauses = ((BooleanQuery) query).clauses();
             if (!(booleanClauses.get(0).query() instanceof HybridQuery)) {
-                throw new IllegalStateException("cannot process hybrid query due to incorrect structure of top level query");
+                throw new IllegalArgumentException("hybrid query must be a top level query and cannot be wrapped into other queries");
             }
-            HybridQuery hybridQuery = (HybridQuery) booleanClauses.stream().findFirst().get().query();
-            List<Query> filterQueries = booleanClauses.stream()
-                .filter(clause -> BooleanClause.Occur.FILTER == clause.occur())
-                .map(BooleanClause::query)
-                .collect(Collectors.toList());
-            HybridQuery hybridQueryWithFilter = new HybridQuery(hybridQuery.getSubQueries(), filterQueries, hybridQuery.getQueryContext());
+            HybridQuery hybridQuery = (HybridQuery) booleanClauses.get(0).query();
+            List<BooleanClause> filterQueries = booleanClauses.stream().skip(1).collect(Collectors.toList());
+            HybridQuery hybridQueryWithFilter = new HybridQuery(hybridQuery.getSubQueries(), hybridQuery.getQueryContext(), filterQueries);
             return hybridQueryWithFilter;
         }
         return query;

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -78,13 +78,13 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
     protected Query extractHybridQuery(final SearchContext searchContext, final Query query) {
         if (isHybridQueryWrappedInBooleanQuery(searchContext, query)) {
             List<BooleanClause> booleanClauses = ((BooleanQuery) query).clauses();
-            if (!(booleanClauses.get(0).getQuery() instanceof HybridQuery)) {
+            if (!(booleanClauses.get(0).query() instanceof HybridQuery)) {
                 throw new IllegalStateException("cannot process hybrid query due to incorrect structure of top level query");
             }
-            HybridQuery hybridQuery = (HybridQuery) booleanClauses.stream().findFirst().get().getQuery();
+            HybridQuery hybridQuery = (HybridQuery) booleanClauses.stream().findFirst().get().query();
             List<Query> filterQueries = booleanClauses.stream()
-                .filter(clause -> BooleanClause.Occur.FILTER == clause.getOccur())
-                .map(BooleanClause::getQuery)
+                .filter(clause -> BooleanClause.Occur.FILTER == clause.occur())
+                .map(BooleanClause::query)
                 .collect(Collectors.toList());
             HybridQuery hybridQueryWithFilter = new HybridQuery(hybridQuery.getSubQueries(), filterQueries, hybridQuery.getQueryContext());
             return hybridQueryWithFilter;
@@ -113,7 +113,7 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
         if (query instanceof BooleanQuery) {
             List<BooleanClause> booleanClauses = ((BooleanQuery) query).clauses();
             for (BooleanClause booleanClause : booleanClauses) {
-                validateNestedBooleanQuery(booleanClause.getQuery(), getMaxDepthLimit(searchContext));
+                validateNestedBooleanQuery(booleanClause.query(), getMaxDepthLimit(searchContext));
             }
         } else if (query instanceof DisjunctionMaxQuery) {
             for (Query disjunct : (DisjunctionMaxQuery) query) {
@@ -135,7 +135,7 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
         }
         if (query instanceof BooleanQuery) {
             for (BooleanClause booleanClause : ((BooleanQuery) query).clauses()) {
-                validateNestedBooleanQuery(booleanClause.getQuery(), level - 1);
+                validateNestedBooleanQuery(booleanClause.query(), level - 1);
             }
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/TopDocsMerger.java
@@ -80,7 +80,7 @@ class TopDocsMerger {
     private static boolean isEmpty(final TopDocsAndMaxScore topDocsAndMaxScore) {
         if (Objects.isNull(topDocsAndMaxScore)
             || Objects.isNull(topDocsAndMaxScore.topDocs)
-            || topDocsAndMaxScore.topDocs.totalHits.value == 0) {
+            || topDocsAndMaxScore.topDocs.totalHits.value() == 0) {
             return true;
         }
         return false;
@@ -89,11 +89,11 @@ class TopDocsMerger {
     private TotalHits getMergedTotalHits(final TopDocsAndMaxScore source, final TopDocsAndMaxScore newTopDocs) {
         // merged value is a lower bound - if both are equal_to than merged will also be equal_to,
         // otherwise assign greater_than_or_equal
-        TotalHits.Relation mergedHitsRelation = source.topDocs.totalHits.relation == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
-            || newTopDocs.topDocs.totalHits.relation == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+        TotalHits.Relation mergedHitsRelation = source.topDocs.totalHits.relation() == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+            || newTopDocs.topDocs.totalHits.relation() == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
                 ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
                 : TotalHits.Relation.EQUAL_TO;
-        return new TotalHits(source.topDocs.totalHits.value + newTopDocs.topDocs.totalHits.value, mergedHitsRelation);
+        return new TotalHits(source.topDocs.totalHits.value() + newTopDocs.topDocs.totalHits.value(), mergedHitsRelation);
     }
 
     private TopDocs getTopDocs(ScoreDoc[] mergedScoreDocs, TotalHits mergedTotalHits) {

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -24,33 +24,9 @@ public class HybridQueryUtil {
      * This method validates whether the query object is an instance of hybrid query
      */
     public static boolean isHybridQuery(final Query query, final SearchContext searchContext) {
-        if (query instanceof HybridQuery) {
+        if (query instanceof HybridQuery
+            || (Objects.nonNull(searchContext.parsedQuery()) && searchContext.parsedQuery().query() instanceof HybridQuery)) {
             return true;
-        } else if (isWrappedHybridQuery(query)) {
-            /* Checking if this is a hybrid query that is wrapped into a Bool query by core Opensearch code
-            https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/DefaultSearchContext.java#L367-L370.
-            main reason for that is performance optimization, at time of writing we are ok with loosing on performance if that's unblocks
-            hybrid query for indexes with nested field types.
-            in such case we consider query a valid hybrid query. Later in the code we will extract it and execute as a main query for
-            this search request.
-            below is sample structure of such query:
-
-            Boolean {
-                should: {
-                       hybrid: {
-                           sub_query1 {}
-                           sub_query2 {}
-                       }
-                }
-                filter: {
-                       exists: {
-                           field: "_primary_term"
-                       }
-                }
-            }
-            */
-            // we have already checked if query in instance of Boolean in higher level else if condition
-            return hasNestedFieldOrNestedDocs(query, searchContext) || hasAliasFilter(query, searchContext);
         }
         return false;
     }

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -61,7 +61,7 @@ public class HybridQueryUtil {
 
     private static boolean isWrappedHybridQuery(final Query query) {
         return query instanceof BooleanQuery
-            && ((BooleanQuery) query).clauses().stream().anyMatch(clauseQuery -> clauseQuery.getQuery() instanceof HybridQuery);
+            && ((BooleanQuery) query).clauses().stream().anyMatch(clauseQuery -> clauseQuery.query() instanceof HybridQuery);
     }
 
     private static boolean hasAliasFilter(final Query query, final SearchContext searchContext) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessorTests.java
@@ -521,7 +521,7 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
         TotalHits.Relation totalHitsRelation = randomFrom(TotalHits.Relation.values());
         TotalHits totalHits = new TotalHits(randomLongBetween(1, 1000), totalHitsRelation);
 
-        final int numDocs = totalHits.value >= requestedSize ? requestedSize : (int) totalHits.value;
+        final int numDocs = totalHits.value() >= requestedSize ? requestedSize : (int) totalHits.value();
         int scoreFactor = randomIntBetween(1, numResponses);
 
         SearchHit[] searchHitArray = randomSearchHitArray(

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
@@ -52,8 +52,8 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         assertNotNull(resultDoc.getTopDocs());
         assertEquals(1, resultDoc.getTopDocs().size());
         TopDocs topDoc = resultDoc.getTopDocs().get(0);
-        assertEquals(1, topDoc.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDoc.totalHits.relation);
+        assertEquals(1, topDoc.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDoc.totalHits.relation());
         assertNotNull(topDoc.scoreDocs);
         assertEquals(1, topDoc.scoreDocs.length);
         ScoreDoc scoreDoc = topDoc.scoreDocs[0];
@@ -88,8 +88,8 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         assertNotNull(resultDoc.getTopDocs());
         assertEquals(1, resultDoc.getTopDocs().size());
         TopDocs topDoc = resultDoc.getTopDocs().get(0);
-        assertEquals(3, topDoc.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDoc.totalHits.relation);
+        assertEquals(3, topDoc.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDoc.totalHits.relation());
         assertNotNull(topDoc.scoreDocs);
         assertEquals(3, topDoc.scoreDocs.length);
         ScoreDoc highScoreDoc = topDoc.scoreDocs[0];
@@ -132,8 +132,8 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         assertEquals(2, resultDoc.getTopDocs().size());
         // sub-query one
         TopDocs topDocSubqueryOne = resultDoc.getTopDocs().get(0);
-        assertEquals(3, topDocSubqueryOne.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocSubqueryOne.totalHits.relation);
+        assertEquals(3, topDocSubqueryOne.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocSubqueryOne.totalHits.relation());
         assertNotNull(topDocSubqueryOne.scoreDocs);
         assertEquals(3, topDocSubqueryOne.scoreDocs.length);
         ScoreDoc highScoreDoc = topDocSubqueryOne.scoreDocs[0];
@@ -144,8 +144,8 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         assertEquals(4, lowScoreDoc.doc);
         // sub-query two
         TopDocs topDocSubqueryTwo = resultDoc.getTopDocs().get(1);
-        assertEquals(2, topDocSubqueryTwo.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocSubqueryTwo.totalHits.relation);
+        assertEquals(2, topDocSubqueryTwo.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocSubqueryTwo.totalHits.relation());
         assertNotNull(topDocSubqueryTwo.scoreDocs);
         assertEquals(2, topDocSubqueryTwo.scoreDocs.length);
         assertEquals(1.0, topDocSubqueryTwo.scoreDocs[0].score, 0.001f);
@@ -206,8 +206,8 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         assertEquals(2, resultDocShardOne.getTopDocs().size());
         // sub-query one
         TopDocs topDocSubqueryOne = resultDocShardOne.getTopDocs().get(0);
-        assertEquals(3, topDocSubqueryOne.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocSubqueryOne.totalHits.relation);
+        assertEquals(3, topDocSubqueryOne.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocSubqueryOne.totalHits.relation());
         assertNotNull(topDocSubqueryOne.scoreDocs);
         assertEquals(3, topDocSubqueryOne.scoreDocs.length);
         ScoreDoc highScoreDoc = topDocSubqueryOne.scoreDocs[0];
@@ -218,8 +218,8 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         assertEquals(4, lowScoreDoc.doc);
         // sub-query two
         TopDocs topDocSubqueryTwo = resultDocShardOne.getTopDocs().get(1);
-        assertEquals(2, topDocSubqueryTwo.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocSubqueryTwo.totalHits.relation);
+        assertEquals(2, topDocSubqueryTwo.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocSubqueryTwo.totalHits.relation());
         assertNotNull(topDocSubqueryTwo.scoreDocs);
         assertEquals(2, topDocSubqueryTwo.scoreDocs.length);
         assertTrue(Range.between(0.0f, 1.0f).contains(topDocSubqueryTwo.scoreDocs[0].score));
@@ -232,14 +232,14 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         assertEquals(2, resultDocShardTwo.getTopDocs().size());
         // sub-query one
         TopDocs topDocShardTwoSubqueryOne = resultDocShardTwo.getTopDocs().get(0);
-        assertEquals(0, topDocShardTwoSubqueryOne.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocShardTwoSubqueryOne.totalHits.relation);
+        assertEquals(0, topDocShardTwoSubqueryOne.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocShardTwoSubqueryOne.totalHits.relation());
         assertNotNull(topDocShardTwoSubqueryOne.scoreDocs);
         assertEquals(0, topDocShardTwoSubqueryOne.scoreDocs.length);
         // sub-query two
         TopDocs topDocShardTwoSubqueryTwo = resultDocShardTwo.getTopDocs().get(1);
-        assertEquals(4, topDocShardTwoSubqueryTwo.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocShardTwoSubqueryTwo.totalHits.relation);
+        assertEquals(4, topDocShardTwoSubqueryTwo.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocShardTwoSubqueryTwo.totalHits.relation());
         assertNotNull(topDocShardTwoSubqueryTwo.scoreDocs);
         assertEquals(4, topDocShardTwoSubqueryTwo.scoreDocs.length);
         assertEquals(1.0, topDocShardTwoSubqueryTwo.scoreDocs[0].score, 0.001f);
@@ -252,13 +252,13 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         assertEquals(2, resultDocShardThree.getTopDocs().size());
         // sub-query one
         TopDocs topDocShardThreeSubqueryOne = resultDocShardThree.getTopDocs().get(0);
-        assertEquals(0, topDocShardThreeSubqueryOne.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocShardThreeSubqueryOne.totalHits.relation);
+        assertEquals(0, topDocShardThreeSubqueryOne.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocShardThreeSubqueryOne.totalHits.relation());
         assertEquals(0, topDocShardThreeSubqueryOne.scoreDocs.length);
         // sub-query two
         TopDocs topDocShardThreeSubqueryTwo = resultDocShardThree.getTopDocs().get(1);
-        assertEquals(0, topDocShardThreeSubqueryTwo.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocShardThreeSubqueryTwo.totalHits.relation);
+        assertEquals(0, topDocShardThreeSubqueryTwo.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocShardThreeSubqueryTwo.totalHits.relation());
         assertEquals(0, topDocShardThreeSubqueryTwo.scoreDocs.length);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
@@ -325,8 +325,8 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {
-        assertEquals(expected.totalHits.value, actual.totalHits.value);
-        assertEquals(expected.totalHits.relation, actual.totalHits.relation);
+        assertEquals(expected.totalHits.value(), actual.totalHits.value());
+        assertEquals(expected.totalHits.relation(), actual.totalHits.relation());
         assertEquals(expected.scoreDocs.length, actual.scoreDocs.length);
         for (int i = 0; i < expected.scoreDocs.length; i++) {
             assertEquals(expected.scoreDocs[i].score, actual.scoreDocs[i].score, DELTA_FOR_ASSERTION);

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -270,8 +270,8 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {
-        assertEquals(expected.totalHits.value, actual.totalHits.value);
-        assertEquals(expected.totalHits.relation, actual.totalHits.relation);
+        assertEquals(expected.totalHits.value(), actual.totalHits.value());
+        assertEquals(expected.totalHits.relation(), actual.totalHits.relation());
         assertEquals(expected.scoreDocs.length, actual.scoreDocs.length);
         for (int i = 0; i < expected.scoreDocs.length; i++) {
             assertEquals(expected.scoreDocs[i].score, actual.scoreDocs[i].score, DELTA_FOR_ASSERTION);

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -352,8 +352,8 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {
-        assertEquals(expected.totalHits.value, actual.totalHits.value);
-        assertEquals(expected.totalHits.relation, actual.totalHits.relation);
+        assertEquals(expected.totalHits.value(), actual.totalHits.value());
+        assertEquals(expected.totalHits.relation(), actual.totalHits.relation());
         assertEquals(expected.scoreDocs.length, actual.scoreDocs.length);
         for (int i = 0; i < expected.scoreDocs.length; i++) {
             assertEquals(expected.scoreDocs[i].score, actual.scoreDocs[i].score, DELTA_FOR_ASSERTION);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -134,7 +134,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
 
         Map<String, Object> explanationsHit1 = getListOfValues(hit1DetailsForHit1, "details").get(0);
         assertEquals("sum of:", explanationsHit1.get("description"));
-        assertEquals(0.754f, (double) explanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.343f, (double) explanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals(1, ((List) explanationsHit1.get("details")).size());
 
         // search hit 2
@@ -153,14 +153,14 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         assertEquals(1, getListOfValues(hit1DetailsForHit2, "details").size());
 
         Map<String, Object> explanationsHit2 = getListOfValues(hit1DetailsForHit2, "details").get(0);
-        assertEquals(0.287f, (double) explanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) explanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", explanationsHit2.get("description"));
         assertEquals(1, getListOfValues(explanationsHit2, "details").size());
 
         Map<String, Object> explanationsHit2Details = getListOfValues(explanationsHit2, "details").get(0);
-        assertEquals(0.287f, (double) explanationsHit2Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) explanationsHit2Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit2Details.get("description"));
-        assertEquals(3, getListOfValues(explanationsHit2Details, "details").size());
+        assertEquals(2, getListOfValues(explanationsHit2Details, "details").size());
 
         // search hit 3
         Map<String, Object> searchHit3 = hitsNestedList.get(1);
@@ -178,14 +178,14 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         assertEquals(1, getListOfValues(hit1DetailsForHit3, "details").size());
 
         Map<String, Object> explanationsHit3 = getListOfValues(hit1DetailsForHit3, "details").get(0);
-        assertEquals(0.287f, (double) explanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) explanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", explanationsHit3.get("description"));
         assertEquals(1, getListOfValues(explanationsHit3, "details").size());
 
         Map<String, Object> explanationsHit3Details = getListOfValues(explanationsHit3, "details").get(0);
-        assertEquals(0.287f, (double) explanationsHit3Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) explanationsHit3Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit3Details.get("description"));
-        assertEquals(3, getListOfValues(explanationsHit3Details, "details").size());
+        assertEquals(2, getListOfValues(explanationsHit3Details, "details").size());
     }
 
     @SneakyThrows
@@ -254,7 +254,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         assertEquals(1, ((List) hit1DetailsForHit2.get("details")).size());
 
         Map<String, Object> explanationsHit2 = getListOfValues(hit1DetailsForHit2, "details").get(0);
-        assertEquals("within top 10", explanationsHit2.get("description"));
+        assertEquals("within top 3 docs", explanationsHit2.get("description"));
         assertTrue((double) explanationsHit2.get("value") > 0.0f);
         assertEquals(0, ((List) explanationsHit2.get("details")).size());
 
@@ -294,7 +294,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         assertEquals(1, ((List) hit3DetailsForHit1.get("details")).size());
 
         Map<String, Object> explanationsHit3 = getListOfValues(hit3DetailsForHit1, "details").get(0);
-        assertEquals("within top 10", explanationsHit3.get("description"));
+        assertEquals("within top 3 docs", explanationsHit3.get("description"));
         assertEquals(0, getListOfValues(explanationsHit3, "details").size());
         assertTrue((double) explanationsHit3.get("value") > 0.0f);
 
@@ -367,7 +367,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         Map<String, Object> searchHit1 = hitsNestedList.get(0);
         Map<String, Object> topLevelExplanationsHit1 = getValueByKey(searchHit1, "_explanation");
         assertNotNull(topLevelExplanationsHit1);
-        assertEquals(0.754f, (double) topLevelExplanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.343f, (double) topLevelExplanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
         String expectedTopLevelDescription = "combined score of:";
         assertEquals(expectedTopLevelDescription, topLevelExplanationsHit1.get("description"));
         List<Map<String, Object>> normalizationExplanationHit1 = getListOfValues(topLevelExplanationsHit1, "details");
@@ -379,31 +379,26 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         assertEquals(0, ((List) noMatchDetailsForHit1.get("details")).size());
 
         Map<String, Object> hit1DetailsForHit1 = normalizationExplanationHit1.get(1);
-        assertEquals(0.754f, (double) hit1DetailsForHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.343f, (double) hit1DetailsForHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("sum of:", hit1DetailsForHit1.get("description"));
         assertEquals(1, ((List) hit1DetailsForHit1.get("details")).size());
 
         Map<String, Object> explanationsHit1 = getListOfValues(hit1DetailsForHit1, "details").get(0);
         assertEquals("weight(test-text-field-1:place in 0) [PerFieldSimilarity], result of:", explanationsHit1.get("description"));
-        assertEquals(0.754f, (double) explanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.343f, (double) explanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals(1, ((List) explanationsHit1.get("details")).size());
 
         Map<String, Object> explanationsHit1Details = getListOfValues(explanationsHit1, "details").get(0);
-        assertEquals(0.754f, (double) explanationsHit1Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.343f, (double) explanationsHit1Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit1Details.get("description"));
-        assertEquals(3, getListOfValues(explanationsHit1Details, "details").size());
+        assertEquals(2, getListOfValues(explanationsHit1Details, "details").size());
 
-        Map<String, Object> explanationsDetails1Hit1Details = getListOfValues(explanationsHit1Details, "details").get(0);
-        assertEquals(2.2f, (double) explanationsDetails1Hit1Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("boost", explanationsDetails1Hit1Details.get("description"));
-        assertEquals(0, getListOfValues(explanationsDetails1Hit1Details, "details").size());
-
-        Map<String, Object> explanationsDetails2Hit1Details = getListOfValues(explanationsHit1Details, "details").get(1);
+        Map<String, Object> explanationsDetails2Hit1Details = getListOfValues(explanationsHit1Details, "details").get(0);
         assertEquals(0.693f, (double) explanationsDetails2Hit1Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:", explanationsDetails2Hit1Details.get("description"));
         assertFalse(getListOfValues(explanationsDetails2Hit1Details, "details").isEmpty());
 
-        Map<String, Object> explanationsDetails3Hit1Details = getListOfValues(explanationsHit1Details, "details").get(2);
+        Map<String, Object> explanationsDetails3Hit1Details = getListOfValues(explanationsHit1Details, "details").get(1);
         assertEquals(0.495f, (double) explanationsDetails3Hit1Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals(
             "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
@@ -415,56 +410,56 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         Map<String, Object> searchHit2 = hitsNestedList.get(1);
         Map<String, Object> topLevelExplanationsHit2 = getValueByKey(searchHit2, "_explanation");
         assertNotNull(topLevelExplanationsHit2);
-        assertEquals(0.287f, (double) topLevelExplanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) topLevelExplanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
 
         assertEquals(expectedTopLevelDescription, topLevelExplanationsHit2.get("description"));
         List<Map<String, Object>> normalizationExplanationHit2 = getListOfValues(topLevelExplanationsHit2, "details");
         assertEquals(2, normalizationExplanationHit2.size());
 
         Map<String, Object> hit1DetailsForHit2 = normalizationExplanationHit2.get(0);
-        assertEquals(0.287f, (double) hit1DetailsForHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) hit1DetailsForHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", hit1DetailsForHit2.get("description"));
         assertEquals(1, getListOfValues(hit1DetailsForHit2, "details").size());
 
         Map<String, Object> explanationsHit2 = getListOfValues(hit1DetailsForHit2, "details").get(0);
-        assertEquals(0.287f, (double) explanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) explanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit2.get("description"));
-        assertEquals(3, getListOfValues(explanationsHit2, "details").size());
+        assertEquals(2, getListOfValues(explanationsHit2, "details").size());
 
-        Map<String, Object> explanationsHit2Details = getListOfValues(explanationsHit2, "details").get(0);
-        assertEquals(2.2f, (double) explanationsHit2Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("boost", explanationsHit2Details.get("description"));
-        assertEquals(0, getListOfValues(explanationsHit2Details, "details").size());
+        Map<String, Object> explanationsHit2Details = getListOfValues(explanationsHit2, "details").get(1);
+        assertEquals(0.454f, (double) explanationsHit2Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals("tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:", explanationsHit2Details.get("description"));
+        assertEquals(5, getListOfValues(explanationsHit2Details, "details").size());
 
-        Map<String, Object> hit1DetailsForHit2NoMatch = normalizationExplanationHit2.get(1);
-        assertEquals(0.0f, (double) hit1DetailsForHit2NoMatch.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("No matching clauses", hit1DetailsForHit2NoMatch.get("description"));
-        assertEquals(0, ((List) hit1DetailsForHit2NoMatch.get("details")).size());
+        Map<String, Object> hit1DetailsForHit2NoMatch = normalizationExplanationHit2.get(0);
+        assertEquals(0.13f, (double) hit1DetailsForHit2NoMatch.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", hit1DetailsForHit2NoMatch.get("description"));
+        assertEquals(1, ((List) hit1DetailsForHit2NoMatch.get("details")).size());
 
         // search hit 3
         Map<String, Object> searchHit3 = hitsNestedList.get(1);
         Map<String, Object> topLevelExplanationsHit3 = getValueByKey(searchHit3, "_explanation");
         assertNotNull(topLevelExplanationsHit3);
-        assertEquals(0.287f, (double) topLevelExplanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) topLevelExplanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
 
         assertEquals(expectedTopLevelDescription, topLevelExplanationsHit3.get("description"));
         List<Map<String, Object>> normalizationExplanationHit3 = getListOfValues(topLevelExplanationsHit3, "details");
         assertEquals(2, normalizationExplanationHit3.size());
 
         Map<String, Object> hit1DetailsForHit3 = normalizationExplanationHit3.get(0);
-        assertEquals(0.287, (double) hit1DetailsForHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) hit1DetailsForHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", hit1DetailsForHit3.get("description"));
         assertEquals(1, getListOfValues(hit1DetailsForHit3, "details").size());
 
         Map<String, Object> explanationsHit3 = getListOfValues(hit1DetailsForHit3, "details").get(0);
-        assertEquals(0.287f, (double) explanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(0.13f, (double) explanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit3.get("description"));
-        assertEquals(3, getListOfValues(explanationsHit3, "details").size());
+        assertEquals(2, getListOfValues(explanationsHit3, "details").size());
 
         Map<String, Object> explanationsHit3Details = getListOfValues(explanationsHit3, "details").get(0);
-        assertEquals(2.2f, (double) explanationsHit3Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("boost", explanationsHit3Details.get("description"));
-        assertEquals(0, getListOfValues(explanationsHit3Details, "details").size());
+        assertEquals(0.287f, (double) explanationsHit3Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals("idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:", explanationsHit3Details.get("description"));
+        assertEquals(2, getListOfValues(explanationsHit3Details, "details").size());
 
         Map<String, Object> hit1DetailsForHit3NoMatch = normalizationExplanationHit2.get(1);
         assertEquals(0.0f, (double) hit1DetailsForHit3NoMatch.get("value"), DELTA_FOR_SCORE_ASSERTION);
@@ -642,7 +637,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         assertEquals(1, ((List) hit1DetailsForHit2.get("details")).size());
 
         Map<String, Object> explanationsHit2 = getListOfValues(hit1DetailsForHit2, "details").get(0);
-        assertEquals("within top 10", explanationsHit2.get("description"));
+        assertEquals("within top 3 docs", explanationsHit2.get("description"));
         assertTrue((double) explanationsHit2.get("value") > 0.0f);
         assertEquals(0, ((List) explanationsHit2.get("details")).size());
 
@@ -682,7 +677,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         assertEquals(1, ((List) hit3DetailsForHit1.get("details")).size());
 
         Map<String, Object> explanationsHit3 = getListOfValues(hit3DetailsForHit1, "details").get(0);
-        assertEquals("within top 10", explanationsHit3.get("description"));
+        assertEquals("within top 3 docs", explanationsHit3.get("description"));
         assertEquals(0, getListOfValues(explanationsHit3, "details").size());
         assertTrue((double) explanationsHit3.get("value") > 0.0f);
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_COMBINATION_METHOD;
 import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_NORMALIZATION_METHOD;
 import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
@@ -562,10 +563,10 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             assertNotNull(explanation);
             assertEquals("arithmetic_mean combination of:", explanation.get("description"));
             Map<String, Object> hitDetailsForHit = getListOfValues(explanation, "details").get(0);
-            assertTrue((double) hitDetailsForHit.get("value") > 0.0f);
+            org.hamcrest.MatcherAssert.assertThat((double) hitDetailsForHit.get("value"), greaterThanOrEqualTo(0.0));
             assertEquals("min_max normalization of:", hitDetailsForHit.get("description"));
             Map<String, Object> subQueryDetailsForHit = getListOfValues(hitDetailsForHit, "details").get(0);
-            assertTrue((double) subQueryDetailsForHit.get("value") > 0.0f);
+            org.hamcrest.MatcherAssert.assertThat((double) subQueryDetailsForHit.get("value"), greaterThanOrEqualTo(0.0));
             assertFalse(subQueryDetailsForHit.get("description").toString().isEmpty());
             assertNotNull(getListOfValues(subQueryDetailsForHit, "details"));
         }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerTests.java
@@ -230,7 +230,7 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
         Weight weight = mock(Weight.class);
 
         Scorer scorer = mock(Scorer.class);
-        when(scorer.getWeight()).thenReturn(fakeWeight(new MatchAllDocsQuery()));
+        // when(scorer.getWeight()).thenReturn(fakeWeight(new MatchAllDocsQuery()));
         when(scorer.iterator()).thenReturn(iterator(docs));
         when(scorer.getMaxScore(anyInt())).thenThrow(new IOException("Test exception"));
 
@@ -301,8 +301,8 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
         when(scorer2.score()).thenReturn(0.3f);
 
         // Create DisiWrapper list
-        DisiWrapper wrapper1 = new DisiWrapper(scorer1);
-        wrapper1.next = new DisiWrapper(scorer2);
+        DisiWrapper wrapper1 = new DisiWrapper(scorer1, false);
+        wrapper1.next = new DisiWrapper(scorer2, false);
 
         Weight weight = mock(Weight.class);
         HybridQueryScorer hybridScorer = new HybridQueryScorer(weight, Arrays.asList(scorer1, scorer2));
@@ -331,7 +331,7 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
         when(scorer.twoPhaseIterator()).thenReturn(twoPhase);
 
         // Create wrapper
-        DisiWrapper wrapper = new DisiWrapper(scorer);
+        DisiWrapper wrapper = new DisiWrapper(scorer, false);
 
         // Create weight mock
         Weight weight = mock(Weight.class);
@@ -536,8 +536,8 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
         when(neuralScorer.score()).thenReturn(0.9f);
 
         // Create DisiWrapper chain
-        DisiWrapper boolWrapper = new DisiWrapper(boolScorer);
-        DisiWrapper neuralWrapper = new DisiWrapper(neuralScorer);
+        DisiWrapper boolWrapper = new DisiWrapper(boolScorer, false);
+        DisiWrapper neuralWrapper = new DisiWrapper(neuralScorer, false);
         boolWrapper.next = neuralWrapper;
 
         Weight weight = mock(Weight.class);
@@ -661,7 +661,7 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
 
     protected static Scorer scorerWithTwoPhaseIterator(final int[] docs, final float[] scores, Weight weight, int maxDoc) {
         final DocIdSetIterator iterator = DocIdSetIterator.all(maxDoc);
-        return new Scorer(weight) {
+        return new Scorer() {
 
             int lastScoredDoc = -1;
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
@@ -546,20 +546,18 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
             hit1DetailsForHit1DetailsForHit1DetailsForHit1.get("description")
         );
         assertTrue((double) hit1DetailsForHit1DetailsForHit1DetailsForHit1.get("value") > 0.0f);
-        assertEquals(3, getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").size());
+        assertEquals(2, getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").size());
 
-        assertEquals("boost", getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").get(0).get("description"));
-        assertTrue((double) getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").get(0).get("value") > 0.0f);
         assertEquals(
             "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
+            getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").get(0).get("description")
+        );
+        assertTrue((double) getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").get(0).get("value") > 0.0f);
+        assertEquals(
+            "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
             getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").get(1).get("description")
         );
         assertTrue((double) getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").get(1).get("value") > 0.0f);
-        assertEquals(
-            "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
-            getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").get(2).get("description")
-        );
-        assertTrue((double) getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit1, "details").get(2).get("value") > 0.0f);
 
         // hit 4
         Map<String, Object> searchHit4 = nestedHits.get(3);
@@ -588,7 +586,7 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
             hit1DetailsForHit1DetailsForHit1DetailsForHit4.get("description")
         );
         assertTrue((double) hit1DetailsForHit1DetailsForHit1DetailsForHit4.get("value") > 0.0f);
-        assertEquals(3, getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit4, "details").size());
+        assertEquals(2, getListOfValues(hit1DetailsForHit1DetailsForHit1DetailsForHit4, "details").size());
 
         // hit 6
         Map<String, Object> searchHit6 = nestedHits.get(5);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
@@ -128,7 +128,7 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
             List.of(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT).toQuery(mockQueryShardContext)),
             new HybridQueryContext(10)
         );
-        Query rewritten = hybridQueryWithTerm.rewrite(reader);
+        Query rewritten = hybridQueryWithTerm.rewrite(new IndexSearcher(reader));
         // term query is the same after we rewrite it
         assertSame(hybridQueryWithTerm, rewritten);
 
@@ -180,7 +180,7 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
         List<Integer> expectedDocIds = List.of(docId1, docId2);
         List<Integer> actualDocIds = Arrays.stream(hybridQueryResult.scoreDocs).map(scoreDoc -> {
             try {
-                return reader.document(scoreDoc.doc).getField("id").stringValue();
+                return reader.storedFields().document(scoreDoc.doc).getField("id").stringValue();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -334,11 +334,11 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
             assertTrue(query instanceof BooleanQuery);
             BooleanQuery booleanQuery = (BooleanQuery) query;
             assertEquals(2, booleanQuery.clauses().size());
-            Query subQuery = booleanQuery.clauses().get(0).getQuery();
+            Query subQuery = booleanQuery.clauses().get(0).query();
             assertTrue(subQuery instanceof TermQuery);
-            Query filterQuery = booleanQuery.clauses().get(1).getQuery();
+            Query filterQuery = booleanQuery.clauses().get(1).query();
             assertTrue(filterQuery instanceof BooleanQuery);
-            assertTrue(((BooleanQuery) filterQuery).clauses().get(0).getQuery() instanceof MatchNoDocsQuery);
+            assertTrue(((BooleanQuery) filterQuery).clauses().get(0).query() instanceof MatchNoDocsQuery);
             countOfQueries++;
         }
         assertEquals(2, countOfQueries);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryWeightTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryWeightTests.java
@@ -89,7 +89,7 @@ public class HybridQueryWeightTests extends OpenSearchQueryTestCase {
 
         DocIdSetIterator iterator = scorer.iterator();
         int actualDoc = iterator.nextDoc();
-        int actualDocId = Integer.parseInt(reader.document(actualDoc).getField("id").stringValue());
+        int actualDocId = Integer.parseInt(reader.storedFields().document(actualDoc).getField("id").stringValue());
 
         assertEquals(docId, actualDocId);
 
@@ -146,7 +146,7 @@ public class HybridQueryWeightTests extends OpenSearchQueryTestCase {
 
         DocIdSetIterator iterator = scorer.iterator();
         int actualDoc = iterator.nextDoc();
-        int actualDocId = Integer.parseInt(reader.document(actualDoc).getField("id").stringValue());
+        int actualDocId = Integer.parseInt(reader.storedFields().document(actualDoc).getField("id").stringValue());
 
         assertEquals(docId, actualDocId);
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridScoreBlockBoundaryPropagatorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridScoreBlockBoundaryPropagatorTests.java
@@ -9,6 +9,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
@@ -60,7 +61,7 @@ public class HybridScoreBlockBoundaryPropagatorTests extends OpenSearchQueryTest
         }
 
         @Override
-        public Scorer scorer(LeafReaderContext context) {
+        public ScorerSupplier scorerSupplier(LeafReaderContext leafReaderContext) {
             return null;
         }
 
@@ -76,7 +77,7 @@ public class HybridScoreBlockBoundaryPropagatorTests extends OpenSearchQueryTest
         final float maxScore;
 
         MockScorer(int boundary, float maxScore) throws IOException {
-            super(new MockWeight());
+            super();
             this.boundary = boundary;
             this.maxScore = maxScore;
         }

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -36,7 +36,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import org.opensearch.Version;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilderTests.java
@@ -33,7 +33,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.junit.Before;
 import org.opensearch.Version;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.io.stream.BytesStreamOutput;

--- a/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
@@ -11,6 +11,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.BooleanClause;
 import org.opensearch.index.query.QueryBuilder;
@@ -150,7 +151,7 @@ public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
             }
 
             @Override
-            public Scorer scorer(LeafReaderContext context) {
+            public ScorerSupplier scorerSupplier(LeafReaderContext leafReaderContext) {
                 return null;
             }
 
@@ -203,7 +204,7 @@ public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
 
     protected static Scorer scorer(final int[] docs, final float[] scores, Weight weight) {
         final DocIdSetIterator iterator = iterator(docs);
-        return new Scorer(weight) {
+        return new Scorer() {
 
             int lastScoredDoc = -1;
 

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollectorTests.java
@@ -144,7 +144,7 @@ public class HybridTopFieldDocSortCollectorTests extends OpenSearchQueryTestCase
         for (TopFieldDocs topFieldDoc : topFieldDocs) {
             // assert results for each sub-query, there must be correct number of matches, all doc id are correct and scores must be desc
             // ordered
-            assertEquals(4, topFieldDoc.totalHits.value);
+            assertEquals(4, topFieldDoc.totalHits.value());
             ScoreDoc[] scoreDocs = topFieldDoc.scoreDocs;
             assertNotNull(scoreDocs);
             assertEquals(4, scoreDocs.length);
@@ -235,7 +235,7 @@ public class HybridTopFieldDocSortCollectorTests extends OpenSearchQueryTestCase
         for (TopFieldDocs topFieldDoc : topFieldDocs) {
             // assert results for each sub-query, there must be correct number of matches, all doc id are correct and scores must be desc
             // ordered
-            assertEquals(4 - (indexPositionOfDocId2 + 1), topFieldDoc.totalHits.value);
+            assertEquals(4 - (indexPositionOfDocId2 + 1), topFieldDoc.totalHits.value());
             ScoreDoc[] scoreDocs = topFieldDoc.scoreDocs;
             assertNotNull(scoreDocs);
             assertEquals(4 - (indexPositionOfDocId2 + 1), scoreDocs.length);

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollectorTests.java
@@ -219,7 +219,7 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         for (TopDocs topDoc : topDocs) {
             // assert results for each sub-query, there must be correct number of matches, all doc id are correct and scores must be desc
             // ordered
-            assertEquals(3, topDoc.totalHits.value);
+            assertEquals(3, topDoc.totalHits.value());
             ScoreDoc[] scoreDocs = topDoc.scoreDocs;
             assertNotNull(scoreDocs);
             assertEquals(3, scoreDocs.length);
@@ -311,7 +311,7 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         // assert result for each sub query
         // term query 1
         TopDocs topDocQuery1 = topDocs.get(0);
-        assertEquals(docIdsQuery1.length, topDocQuery1.totalHits.value);
+        assertEquals(docIdsQuery1.length, topDocQuery1.totalHits.value());
         ScoreDoc[] scoreDocsQuery1 = topDocQuery1.scoreDocs;
         assertNotNull(scoreDocsQuery1);
         assertEquals(docIdsQuery1.length, scoreDocsQuery1.length);
@@ -322,7 +322,7 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         assertTrue(Arrays.stream(docIdsQuery1).allMatch(resultDocIdsQuery1::contains));
         // term query 2
         TopDocs topDocQuery2 = topDocs.get(1);
-        assertEquals(docIdsQuery2.length, topDocQuery2.totalHits.value);
+        assertEquals(docIdsQuery2.length, topDocQuery2.totalHits.value());
         ScoreDoc[] scoreDocsQuery2 = topDocQuery2.scoreDocs;
         assertNotNull(scoreDocsQuery2);
         assertEquals(docIdsQuery2.length, scoreDocsQuery2.length);
@@ -333,13 +333,13 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         assertTrue(Arrays.stream(docIdsQuery2).allMatch(resultDocIdsQuery2::contains));
         // no match query
         TopDocs topDocQuery3 = topDocs.get(2);
-        assertEquals(0, topDocQuery3.totalHits.value);
+        assertEquals(0, topDocQuery3.totalHits.value());
         ScoreDoc[] scoreDocsQuery3 = topDocQuery3.scoreDocs;
         assertNotNull(scoreDocsQuery3);
         assertEquals(0, scoreDocsQuery3.length);
         // all match query
         TopDocs topDocQueryMatchAll = topDocs.get(3);
-        assertEquals(docIdsQueryMatchAll.length, topDocQueryMatchAll.totalHits.value);
+        assertEquals(docIdsQueryMatchAll.length, topDocQueryMatchAll.totalHits.value());
         ScoreDoc[] scoreDocsQueryMatchAll = topDocQueryMatchAll.scoreDocs;
         assertNotNull(scoreDocsQueryMatchAll);
         assertEquals(docIdsQueryMatchAll.length, scoreDocsQueryMatchAll.length);
@@ -437,7 +437,7 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         Weight weight = mock(Weight.class);
         Weight subQueryWeight = mock(Weight.class);
         Scorer subQueryScorer = mock(Scorer.class);
-        when(subQueryScorer.getWeight()).thenReturn(subQueryWeight);
+        // when(subQueryScorer.getWeight()).thenReturn(subQueryWeight);
         DocIdSetIterator iterator = mock(DocIdSetIterator.class);
         when(subQueryScorer.iterator()).thenReturn(iterator);
 
@@ -484,7 +484,7 @@ public class HybridTopScoreDocCollectorTests extends OpenSearchQueryTestCase {
         Weight weight = mock(Weight.class);
         Weight subQueryWeight = mock(Weight.class);
         Scorer subQueryScorer = mock(Scorer.class);
-        when(subQueryScorer.getWeight()).thenReturn(subQueryWeight);
+        // when(subQueryScorer.getWeight()).thenReturn(subQueryWeight);
         DocIdSetIterator iterator = mock(DocIdSetIterator.class);
         when(subQueryScorer.iterator()).thenReturn(iterator);
 

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -9,13 +9,16 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.io.IOException;
 import java.util.Arrays;
 import lombok.SneakyThrows;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.Collector;
@@ -27,11 +30,13 @@ import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.opensearch.common.lucene.search.FilteredCollector;
@@ -65,6 +70,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -87,6 +93,19 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
     private static final String QUERY2 = "hi";
     protected static final String QUERY3 = "everyone";
 
+    private Directory directory;
+    private IndexWriter writer;
+    private IndexReader indexReader;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        IndexObjects indexObjects = createIndexObjects(3);
+        directory = indexObjects.directory();
+        writer = indexObjects.writer();
+        indexReader = indexObjects.indexReader();
+    }
+
     @SneakyThrows
     public void testNewCollector_whenNotConcurrentSearch_thenSuccessful() {
         SearchContext searchContext = mock(SearchContext.class);
@@ -101,7 +120,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         when(searchContext.mapperService()).thenReturn(mapperService);
         when(searchContext.query()).thenReturn(hybridQuery);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
 
@@ -135,7 +153,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         when(searchContext.mapperService()).thenReturn(mapperService);
         when(searchContext.query()).thenReturn(hybridQuery);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
 
@@ -176,7 +193,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
 
         when(searchContext.query()).thenReturn(hybridQuery);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
 
@@ -224,7 +240,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
 
         when(searchContext.query()).thenReturn(hybridQuery);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
 
@@ -267,8 +282,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         );
         when(searchContext.query()).thenReturn(hybridQueryWithTerm);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
-        when(indexReader.numDocs()).thenReturn(3);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
         when(searchContext.size()).thenReturn(1);
@@ -372,7 +385,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         MapperService mapperService = createMapperService();
         when(searchContext.mapperService()).thenReturn(mapperService);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
 
@@ -413,7 +425,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         MapperService mapperService = createMapperService();
         when(searchContext.mapperService()).thenReturn(mapperService);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
 
@@ -447,8 +458,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         );
         when(searchContext.query()).thenReturn(hybridQueryWithMatchAll);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
-        when(indexReader.numDocs()).thenReturn(3);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
         when(searchContext.size()).thenReturn(1);
@@ -552,8 +561,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         MapperService mapperService = createMapperService();
         when(searchContext.mapperService()).thenReturn(mapperService);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
-        when(indexReader.numDocs()).thenReturn(3);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
         when(searchContext.size()).thenReturn(10);
@@ -643,8 +650,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         MapperService mapperService = createMapperService();
         when(searchContext.mapperService()).thenReturn(mapperService);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
-        when(indexReader.numDocs()).thenReturn(2);
+        IndexObjects indexObjects = createIndexObjects(2);
+        IndexReader indexReader = indexObjects.indexReader();
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
         when(searchContext.size()).thenReturn(1);
@@ -682,9 +689,9 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         SearchContext searchContext2 = mock(SearchContext.class);
 
         ContextIndexSearcher indexSearcher2 = mock(ContextIndexSearcher.class);
-        IndexReader indexReader2 = mock(IndexReader.class);
-        when(indexReader2.numDocs()).thenReturn(1);
-        when(indexSearcher2.getIndexReader()).thenReturn(indexReader);
+        IndexObjects indexObjects2 = createIndexObjects(1);
+        IndexReader indexReader2 = indexObjects2.indexReader();
+        when(indexSearcher2.getIndexReader()).thenReturn(indexReader2);
         when(searchContext2.searcher()).thenReturn(indexSearcher2);
         when(searchContext2.size()).thenReturn(1);
 
@@ -777,13 +784,9 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         MapperService mapperService = createMapperService();
         when(searchContext.mapperService()).thenReturn(mapperService);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
-        when(indexReader.numDocs()).thenReturn(3);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
         when(searchContext.size()).thenReturn(2);
-        IndexReaderContext indexReaderContext = mock(IndexReaderContext.class);
-        when(indexReader.getContext()).thenReturn(indexReaderContext);
 
         Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> classCollectorManagerMap = new HashMap<>();
         when(searchContext.queryCollectorManagers()).thenReturn(classCollectorManagerMap);
@@ -812,10 +815,13 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         RescoreContext rescoreContext = rescorerBuilder.buildContext(mockQueryShardContext);
         List<RescoreContext> rescoreContexts = List.of(rescoreContext);
         when(searchContext.rescore()).thenReturn(rescoreContexts);
-        when(indexReader.leaves()).thenReturn(reader.leaves());
         Weight rescoreWeight = mock(Weight.class);
         Scorer rescoreScorer = mock(Scorer.class);
-        when(rescoreWeight.scorer(any())).thenReturn(rescoreScorer);
+        ScorerSupplier mockScorerSupplier = mock(ScorerSupplier.class);
+        when(mockScorerSupplier.get(anyLong())).thenReturn(rescoreScorer);
+        when(mockScorerSupplier.cost()).thenReturn(1L);
+        when(rescoreWeight.scorerSupplier(any(LeafReaderContext.class))).thenReturn(mockScorerSupplier);
+
         when(rescoreScorer.docID()).thenReturn(1);
         DocIdSetIterator iterator = mock(DocIdSetIterator.class);
         when(rescoreScorer.iterator()).thenReturn(iterator);
@@ -899,8 +905,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         MapperService mapperService = createMapperService();
         when(searchContext.mapperService()).thenReturn(mapperService);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
-        when(indexReader.numDocs()).thenReturn(2);
+        IndexObjects indexObjects = createIndexObjects(2);
+        IndexReader indexReader = indexObjects.indexReader();
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
         when(searchContext.size()).thenReturn(1);
@@ -929,9 +935,9 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         SearchContext searchContext2 = mock(SearchContext.class);
 
         ContextIndexSearcher indexSearcher2 = mock(ContextIndexSearcher.class);
-        IndexReader indexReader2 = mock(IndexReader.class);
-        when(indexReader2.numDocs()).thenReturn(1);
-        when(indexSearcher2.getIndexReader()).thenReturn(indexReader);
+        IndexObjects indexObjects2 = createIndexObjects(1);
+        IndexReader indexReader2 = indexObjects2.indexReader();
+        when(indexSearcher2.getIndexReader()).thenReturn(indexReader2);
         when(searchContext2.searcher()).thenReturn(indexSearcher2);
         when(searchContext2.size()).thenReturn(1);
 
@@ -954,18 +960,17 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         IndexReader reader2 = DirectoryReader.open(w2);
         IndexSearcher searcher2 = newSearcher(reader2);
 
-        List<LeafReaderContext> leafReaderContexts = reader1.leaves();
-        IndexReaderContext indexReaderContext = mock(IndexReaderContext.class);
-        when(indexReader.getContext()).thenReturn(indexReaderContext);
-        when(indexReader.leaves()).thenReturn(leafReaderContexts);
-        // set up rescorer in a way that it boosts second documents from the first segment
         RescorerBuilder<QueryRescorerBuilder> rescorerBuilder = new QueryRescorerBuilder(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY2));
         RescoreContext rescoreContext = rescorerBuilder.buildContext(mockQueryShardContext);
         List<RescoreContext> rescoreContexts = List.of(rescoreContext);
         when(searchContext.rescore()).thenReturn(rescoreContexts);
         Weight rescoreWeight = mock(Weight.class);
         Scorer rescoreScorer = mock(Scorer.class);
-        when(rescoreWeight.scorer(any())).thenReturn(rescoreScorer);
+        ScorerSupplier mockScorerSupplier = mock(ScorerSupplier.class);
+        when(mockScorerSupplier.get(anyLong())).thenReturn(rescoreScorer);
+        when(mockScorerSupplier.cost()).thenReturn(1L);
+        when(rescoreWeight.scorerSupplier(any(LeafReaderContext.class))).thenReturn(mockScorerSupplier);
+
         when(rescoreScorer.docID()).thenReturn(1);
         DocIdSetIterator iterator = mock(DocIdSetIterator.class);
         when(rescoreScorer.iterator()).thenReturn(iterator);
@@ -1046,13 +1051,9 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         MapperService mapperService = createMapperService();
         when(searchContext.mapperService()).thenReturn(mapperService);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
-        when(indexReader.numDocs()).thenReturn(3);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
         when(searchContext.size()).thenReturn(2);
-        IndexReaderContext indexReaderContext = mock(IndexReaderContext.class);
-        when(indexReader.getContext()).thenReturn(indexReaderContext);
 
         Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> classCollectorManagerMap = new HashMap<>();
         when(searchContext.queryCollectorManagers()).thenReturn(classCollectorManagerMap);
@@ -1117,7 +1118,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         MapperService mapperService = createMapperService();
         when(searchContext.mapperService()).thenReturn(mapperService);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
 
@@ -1152,7 +1152,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
 
         when(searchContext.query()).thenReturn(hybridQuery);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
 
@@ -1187,7 +1186,6 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
 
         when(searchContext.query()).thenReturn(hybridQuery);
         ContextIndexSearcher indexSearcher = mock(ContextIndexSearcher.class);
-        IndexReader indexReader = mock(IndexReader.class);
         when(indexSearcher.getIndexReader()).thenReturn(indexReader);
         when(searchContext.searcher()).thenReturn(indexSearcher);
         MapperService mapperService = createMapperService();
@@ -1205,5 +1203,25 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
             String.format(Locale.ROOT, "pagination_depth param is missing in the search request"),
             illegalArgumentException.getMessage()
         );
+    }
+
+    private IndexObjects createIndexObjects(int numDocs) throws IOException {
+        Directory directory = new ByteBuffersDirectory();
+        IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig());
+
+        // Add the specified number of documents
+        for (int i = 1; i <= numDocs; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("field", "value" + i, Field.Store.YES));
+            writer.addDocument(doc);
+        }
+
+        writer.commit();
+        IndexReader indexReader = DirectoryReader.open(writer);
+
+        return new IndexObjects(indexReader, directory, writer);
+    }
+
+    private record IndexObjects(IndexReader indexReader, Directory directory, IndexWriter writer) {
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -321,9 +321,9 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
         LeafCollector leafCollector1 = collector1.getLeafCollector(leafReaderContext);
         BulkScorer scorer = weight.bulkScorer(leafReaderContext);
-        scorer.score(leafCollector, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector.finish();
-        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector1.finish();
 
         Object results = hybridCollectorManager.reduce(List.of());
@@ -337,8 +337,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
 
         assertNotNull(topDocsAndMaxScore);
-        assertEquals(1, topDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(1, topDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation());
         float maxScore = topDocsAndMaxScore.maxScore;
         assertTrue(maxScore > 0);
         ScoreDoc[] scoreDocs = topDocsAndMaxScore.topDocs.scoreDocs;
@@ -500,10 +500,10 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         LeafCollector leafCollector = simpleFieldCollector.getLeafCollector(leafReaderContext);
         LeafCollector leafCollector1 = pagingFieldCollector.getLeafCollector(leafReaderContext);
         BulkScorer scorer = weight.bulkScorer(leafReaderContext);
-        scorer.score(leafCollector, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector.finish();
         BulkScorer scorer1 = weight.bulkScorer(leafReaderContext);
-        scorer1.score(leafCollector1, leafReaderContext.reader().getLiveDocs());
+        scorer1.score(leafCollector1, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector1.finish();
 
         Object results = hybridCollectorManager.reduce(List.of());
@@ -517,8 +517,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
 
         assertNotNull(topDocsAndMaxScore);
-        assertEquals(3, topDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(3, topDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation());
         float maxScore = topDocsAndMaxScore.maxScore;
         assertTrue(maxScore > 0);
         ScoreDoc[] scoreDocs = topDocsAndMaxScore.topDocs.scoreDocs;
@@ -591,8 +591,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         LeafCollector leafCollector2 = collector2.getLeafCollector(leafReaderContext);
 
         BulkScorer scorer = weight.bulkScorer(leafReaderContext);
-        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs());
-        scorer.score(leafCollector2, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
+        scorer.score(leafCollector2, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
 
         leafCollector1.finish();
         leafCollector2.finish();
@@ -606,8 +606,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
 
         assertNotNull(topDocsAndMaxScore);
-        assertEquals(2, topDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(2, topDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation());
         float maxScore = topDocsAndMaxScore.maxScore;
         assertTrue(maxScore > 0);
 
@@ -723,10 +723,10 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         LeafReaderContext leafReaderContext2 = searcher2.getIndexReader().leaves().get(0);
         LeafCollector leafCollector2 = collector2.getLeafCollector(leafReaderContext2);
         BulkScorer scorer = weight1.bulkScorer(leafReaderContext);
-        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector1.finish();
         BulkScorer scorer2 = weight2.bulkScorer(leafReaderContext2);
-        scorer2.score(leafCollector2, leafReaderContext2.reader().getLiveDocs());
+        scorer2.score(leafCollector2, leafReaderContext2.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector2.finish();
 
         Object results = hybridCollectorManager.reduce(List.of(collector1, collector2));
@@ -738,8 +738,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
 
         assertNotNull(topDocsAndMaxScore);
-        assertEquals(3, topDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(3, topDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation());
         float maxScore = topDocsAndMaxScore.maxScore;
         assertTrue(maxScore > 0);
         FieldDoc[] fieldDocs = (FieldDoc[]) topDocsAndMaxScore.topDocs.scoreDocs;
@@ -845,9 +845,9 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
         LeafCollector filteredCollectorLeafCollector = filteredCollector.getLeafCollector(leafReaderContext);
         BulkScorer scorer = weight.bulkScorer(leafReaderContext);
-        scorer.score(leafCollector, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector.finish();
-        scorer.score(filteredCollectorLeafCollector, leafReaderContext.reader().getLiveDocs());
+        scorer.score(filteredCollectorLeafCollector, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         filteredCollectorLeafCollector.finish();
 
         Object results1 = hybridCollectorManager1.reduce(List.of());
@@ -861,8 +861,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
 
         assertNotNull(topDocsAndMaxScore);
-        assertEquals(2, topDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(2, topDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation());
         float maxScore = topDocsAndMaxScore.maxScore;
         assertTrue(maxScore > 0);
         ScoreDoc[] scoreDocs = topDocsAndMaxScore.topDocs.scoreDocs;
@@ -984,13 +984,13 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         LeafReaderContext leafReaderContext = searcher1.getIndexReader().leaves().get(0);
         LeafCollector leafCollector1 = collector1.getLeafCollector(leafReaderContext);
         BulkScorer scorer = weight1.bulkScorer(leafReaderContext);
-        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector1, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector1.finish();
 
         LeafReaderContext leafReaderContext2 = searcher2.getIndexReader().leaves().get(0);
         LeafCollector leafCollector2 = collector2.getLeafCollector(leafReaderContext2);
         BulkScorer scorer2 = weight2.bulkScorer(leafReaderContext2);
-        scorer2.score(leafCollector2, leafReaderContext2.reader().getLiveDocs());
+        scorer2.score(leafCollector2, leafReaderContext2.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector2.finish();
 
         Object results = hybridCollectorManager.reduce(List.of(collector1, collector2));
@@ -1003,8 +1003,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
 
         assertNotNull(topDocsAndMaxScore);
-        assertEquals(3, topDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(3, topDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, topDocsAndMaxScore.topDocs.totalHits.relation());
         float maxScore = topDocsAndMaxScore.maxScore;
         assertTrue(maxScore > 0);
         ScoreDoc[] scoreDocs = topDocsAndMaxScore.topDocs.scoreDocs;
@@ -1090,7 +1090,7 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
 
         BulkScorer scorer = weight.bulkScorer(leafReaderContext);
-        scorer.score(leafCollector, leafReaderContext.reader().getLiveDocs());
+        scorer.score(leafCollector, leafReaderContext.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
         leafCollector.finish();
 
         expectThrows(HybridSearchRescoreQueryException.class, () -> hybridCollectorManager1.reduce(List.of()));

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -323,7 +323,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         assertNotNull(querySearchResult.topDocs());
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
         TopDocs topDocs = topDocsAndMaxScore.topDocs;
-        assertEquals(0, topDocs.totalHits.value);
+        assertEquals(0, topDocs.totalHits.value());
         ScoreDoc[] scoreDocs = topDocs.scoreDocs;
         assertNotNull(scoreDocs);
         assertEquals(0, scoreDocs.length);
@@ -414,7 +414,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         assertNotNull(querySearchResult.topDocs());
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
         TopDocs topDocs = topDocsAndMaxScore.topDocs;
-        assertEquals(0, topDocs.totalHits.value);
+        assertEquals(0, topDocs.totalHits.value());
         ScoreDoc[] scoreDocs = topDocs.scoreDocs;
         assertNotNull(scoreDocs);
         assertEquals(0, scoreDocs.length);
@@ -831,7 +831,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         assertNotNull(querySearchResult.topDocs());
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
         TopDocs topDocs = topDocsAndMaxScore.topDocs;
-        assertEquals(0, topDocs.totalHits.value);
+        assertEquals(0, topDocs.totalHits.value());
         ScoreDoc[] scoreDocs = topDocs.scoreDocs;
         assertNotNull(scoreDocs);
         assertEquals(0, scoreDocs.length);
@@ -915,7 +915,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         assertNotNull(querySearchResult.topDocs());
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
         TopDocs topDocs = topDocsAndMaxScore.topDocs;
-        assertTrue(topDocs.totalHits.value > 0);
+        assertTrue(topDocs.totalHits.value() > 0);
         ScoreDoc[] scoreDocs = topDocs.scoreDocs;
         assertNotNull(scoreDocs);
         assertTrue(scoreDocs.length > 0);
@@ -1122,7 +1122,7 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         assertNotNull(querySearchResult.topDocs());
         TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
         TopDocs topDocs = topDocsAndMaxScore.topDocs;
-        assertEquals(0, topDocs.totalHits.value);
+        assertEquals(0, topDocs.totalHits.value());
         ScoreDoc[] scoreDocs = topDocs.scoreDocs;
         assertNotNull(scoreDocs);
         assertEquals(0, scoreDocs.length);

--- a/src/test/java/org/opensearch/neuralsearch/search/query/TopDocsMergerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/TopDocsMergerTests.java
@@ -63,8 +63,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertNotNull(mergedTopDocsAndMaxScore);
 
         assertEquals(0.7f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(6, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(6, mergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         // expected number of rows is 5 from sub-query1 and 1 from sub-query2, plus 2 start-stop elements + 2 delimiters
         // 5 + 1 + 2 + 2 = 10
         assertEquals(10, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
@@ -116,8 +116,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertNotNull(mergedTopDocsAndMaxScore);
 
         assertEquals(0.7f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(4, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(4, mergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         // expected number of rows is 3 from sub-query1 and 1 from sub-query2, plus 2 start-stop elements + 2 delimiters
         // 3 + 1 + 2 + 2 = 8
         assertEquals(8, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
@@ -163,8 +163,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertNotNull(mergedTopDocsAndMaxScore);
 
         assertEquals(0f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(0, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(0, mergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         assertEquals(4, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
         // check format, all elements one by one
         ScoreDoc[] scoreDocs = mergedTopDocsAndMaxScore.topDocs.scoreDocs;
@@ -199,8 +199,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertNotNull(mergedTopDocsAndMaxScore);
 
         assertEquals(0.5f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(2, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(2, mergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         assertEquals(5, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
         // check format, all elements one by one
         ScoreDoc[] scoreDocs = mergedTopDocsAndMaxScore.topDocs.scoreDocs;
@@ -221,8 +221,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertNotNull(finalMergedTopDocsAndMaxScore);
 
         assertEquals(0.5f, finalMergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(2, finalMergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, finalMergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(2, finalMergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, finalMergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         assertEquals(5, finalMergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
         // check format, all elements one by one
         ScoreDoc[] finalScoreDocs = finalMergedTopDocsAndMaxScore.topDocs.scoreDocs;
@@ -288,8 +288,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         );
 
         assertEquals(0.85f, finalMergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(9, finalMergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, finalMergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(9, finalMergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, finalMergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         // expected number of rows is 6 from sub-query1 and 3 from sub-query2, plus 2 start-stop elements + 2 delimiters
         // 6 + 3 + 2 + 2 = 13
         assertEquals(13, finalMergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
@@ -351,8 +351,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertNotNull(mergedTopDocsAndMaxScore);
 
         assertEquals(0.7f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(6, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(6, mergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         // expected number of rows is 5 from sub-query1 and 1 from sub-query2, plus 2 start-stop elements + 2 delimiters
         // 5 + 1 + 2 + 2 = 10
         assertEquals(10, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
@@ -410,8 +410,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertNotNull(mergedTopDocsAndMaxScore);
 
         assertEquals(0.7f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(4, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(4, mergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         // expected number of rows is 3 from sub-query1 and 1 from sub-query2, plus 2 start-stop elements + 2 delimiters
         // 3 + 1 + 2 + 2 = 8
         assertEquals(8, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
@@ -463,8 +463,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         assertNotNull(mergedTopDocsAndMaxScore);
 
         assertEquals(0f, mergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(0, mergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(0, mergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.EQUAL_TO, mergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         assertEquals(4, mergedTopDocsAndMaxScore.topDocs.scoreDocs.length);
         // check format, all elements one by one
         FieldDoc[] fieldDocs = (FieldDoc[]) mergedTopDocsAndMaxScore.topDocs.scoreDocs;
@@ -535,8 +535,8 @@ public class TopDocsMergerTests extends OpenSearchQueryTestCase {
         );
 
         assertEquals(0.85f, finalMergedTopDocsAndMaxScore.maxScore, DELTA_FOR_ASSERTION);
-        assertEquals(9, finalMergedTopDocsAndMaxScore.topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, finalMergedTopDocsAndMaxScore.topDocs.totalHits.relation);
+        assertEquals(9, finalMergedTopDocsAndMaxScore.topDocs.totalHits.value());
+        assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, finalMergedTopDocsAndMaxScore.topDocs.totalHits.relation());
         // expected number of rows is 6 from sub-query1 and 3 from sub-query2, plus 2 start-stop elements + 2 delimiters
         // 6 + 3 + 2 + 2 = 13
         assertEquals(13, finalMergedTopDocsAndMaxScore.topDocs.scoreDocs.length);

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -74,7 +74,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.google.common.collect.ImmutableList;
 
 import static org.opensearch.neuralsearch.util.TestUtils.INGEST_PIPELINE_TYPE;
-import static org.opensearch.neuralsearch.util.TestUtils.MAX_TASK_RESULT_QUERY_TIME_IN_SECOND;
+import static org.opensearch.neuralsearch.util.TestUtils.MAX_TASK_RETRIES;
 import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND;
 import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_USER_AGENT;
 import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_NORMALIZATION_METHOD;
@@ -214,7 +214,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
         Map<String, Object> taskQueryResult = getTaskQueryResponse(taskId);
         boolean isComplete = checkComplete(taskQueryResult);
-        for (int i = 0; !isComplete && i < MAX_TASK_RESULT_QUERY_TIME_IN_SECOND; i++) {
+        for (int i = 0; !isComplete && i < MAX_TASK_RETRIES; i++) {
             taskQueryResult = getTaskQueryResponse(taskId);
             isComplete = checkComplete(taskQueryResult);
             Thread.sleep(DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND);
@@ -243,12 +243,12 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
         Map<String, Object> taskQueryResult = getTaskQueryResponse(taskId);
         boolean isComplete = checkComplete(taskQueryResult);
-        for (int i = 0; !isComplete && i < MAX_TASK_RESULT_QUERY_TIME_IN_SECOND; i++) {
+        for (int i = 0; !isComplete && i < MAX_TASK_RETRIES; i++) {
             taskQueryResult = getTaskQueryResponse(taskId);
             isComplete = checkComplete(taskQueryResult);
             Thread.sleep(DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND);
         }
-        assertTrue(isComplete);
+        assertTrue(String.format(Locale.ROOT, "failed to load the model, last task finished with status %s", taskQueryResult.get("state")), isComplete);
     }
 
     /**

--- a/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
@@ -197,9 +197,9 @@ public class TestUtils {
         assertFalse(
             querySearchResults.stream()
                 .map(searchResult -> searchResult.topDocs().topDocs.totalHits)
-                .filter(totalHits -> Objects.isNull(totalHits.relation))
-                .filter(totalHits -> TotalHits.Relation.EQUAL_TO != totalHits.relation)
-                .anyMatch(totalHits -> 0 != totalHits.value)
+                .filter(totalHits -> Objects.isNull(totalHits.relation()))
+                .filter(totalHits -> TotalHits.Relation.EQUAL_TO != totalHits.relation())
+                .anyMatch(totalHits -> 0 != totalHits.value())
         );
     }
 
@@ -289,7 +289,7 @@ public class TestUtils {
         assertEquals(1.0f, maxScore, DELTA_FOR_SCORE_ASSERTION);
         TotalHits totalHits = searchHits.getTotalHits();
         assertNotNull(totalHits);
-        assertEquals(expectedNumberOfHits, totalHits.value);
+        assertEquals(expectedNumberOfHits, totalHits.value());
         assertNotNull(searchHits.getHits());
         assertEquals(expectedNumberOfHits, searchHits.getHits().length);
         float maxScoreScoreFromScoreDocs = Arrays.stream(searchHits.getHits())

--- a/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
@@ -59,14 +59,13 @@ public class TestUtils {
     public static final String SEARCH_PIPELINE_TYPE = "_search";
     public static final String TEXT_EMBEDDING_PROCESSOR = "text_embedding";
     public static final String TEXT_IMAGE_EMBEDDING_PROCESSOR = "text_image_embedding";
-    public static final int MAX_TASK_RESULT_QUERY_TIME_IN_SECOND = 60 * 5;
+    public static final int MAX_TASK_RETRIES = 30;
     public static final int DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND = 1000;
     public static final String DEFAULT_USER_AGENT = "Kibana";
     public static final String DEFAULT_NORMALIZATION_METHOD = "min_max";
     public static final String DEFAULT_COMBINATION_METHOD = "arithmetic_mean";
     public static final String PARAM_NAME_WEIGHTS = "weights";
     public static final String SPARSE_ENCODING_PROCESSOR = "sparse_encoding";
-    public static final String TEXT_CHUNKING_PROCESSOR = "text_chunking";
     public static final int MAX_TIME_OUT_INTERVAL = 3000;
     public static final int MAX_RETRY = 5;
 


### PR DESCRIPTION
### Description
Prepare neural search code base to upcoming 3.x release.

Changes in this PR:

**consume API of 3.0-alpha and related dependencies:**
- lucene 10.1
- latest core OS code
- consume latest format of lower level query explain response 

**changes in logic:**
- accept new format of wrapped query for index alias (core rewrites query into bool, now they do additional rewrite that query and structure of bool clauses can change)

 **infra:**
 - version bump for BWC to 2.19 and 2.20-snapshot
 - fixed flaky BWC tests
 - remove some redundant CI actions: precommit and bwc for windows, extra aggs tests for jdk 21
 

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
