### PR TITLE
Fixing integ tests due to missing opensearch-job-scheduler plugin and jayway lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,6 +250,7 @@ def knnJarDirectory = "$buildDir/dependencies/opensearch-knn"
 
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
     secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"

--- a/build.gradle
+++ b/build.gradle
@@ -269,6 +269,7 @@ dependencies {
     runtimeOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     runtimeOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     runtimeOnly group: 'org.json', name: 'json', version: '20231013'
+    runtimeOnly 'com.jayway.jsonpath:json-path:2.9.0'
     runtimeOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     runtimeOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testFixturesImplementation "org.opensearch:common-utils:${version}"

--- a/build.gradle
+++ b/build.gradle
@@ -269,7 +269,12 @@ dependencies {
     runtimeOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     runtimeOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     runtimeOnly group: 'org.json', name: 'json', version: '20231013'
-    runtimeOnly 'com.jayway.jsonpath:json-path:2.9.0'
+    // json-path 2.9.0 depends on slf4j 2.0.11, which conflicts with the version used by OpenSearch core.
+    // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.
+    runtimeOnly('com.jayway.jsonpath:json-path:2.9.0') {
+        // OpenSearch core is using slf4j 1.7.36. Therefore, we cannot change the version here.
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     runtimeOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     runtimeOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testFixturesImplementation "org.opensearch:common-utils:${version}"

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compileOnly fileTree(dir: knnJarDirectory, include: "opensearch-knn-${opensearch_build}.jar")
     compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     compileOnly group: 'commons-lang', name: 'commons-lang', version: '2.6'
+    runtimeOnly 'com.jayway.jsonpath:json-path:2.9.0'
     api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     api "junit:junit:${versions.junit}"

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -34,6 +34,7 @@ def knnJarDirectory = "$rootDir/build/dependencies/opensearch-knn"
 
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
     compileOnly fileTree(dir: knnJarDirectory, include: "opensearch-knn-${opensearch_build}.jar")
@@ -70,6 +71,16 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
 
 ext{
     plugins = [provider(new Callable<RegularFile>(){
+        @Override
+        RegularFile call() throws Exception {
+            return new RegularFile() {
+                @Override
+                File getAsFile() {
+                    return configurations.zipArchive.asFileTree.matching{include "**/opensearch-job-scheduler-${opensearch_build}.zip"}.getSingleFile()
+                }
+            }
+        }
+    }), provider(new Callable<RegularFile>(){
         @Override
         RegularFile call() throws Exception {
             return new RegularFile() {

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -40,7 +40,12 @@ dependencies {
     compileOnly fileTree(dir: knnJarDirectory, include: "opensearch-knn-${opensearch_build}.jar")
     compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     compileOnly group: 'commons-lang', name: 'commons-lang', version: '2.6'
-    runtimeOnly 'com.jayway.jsonpath:json-path:2.9.0'
+    // json-path 2.9.0 depends on slf4j 2.0.11, which conflicts with the version used by OpenSearch core.
+    // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.
+    testRuntimeOnly('com.jayway.jsonpath:json-path:2.9.0') {
+        // OpenSearch core is using slf4j 1.7.36. Therefore, we cannot change the version here.
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     api "junit:junit:${versions.junit}"


### PR DESCRIPTION
### Description
Fixing integ tests due to missing opensearch-job-scheduler plugin.

This is needed since ML commons introduces new dependency on job-scheduler: https://github.com/opensearch-project/ml-commons/pull/3421/files#diff-520f178549fabd7e74f5b1fedb7275a1434a2ac153fc49e0212455ceeef38e37R47 

Before this change, integ test will fail due to below job-scheduler missing error:
```
| Exception in thread "main" java.lang.IllegalArgumentException: Missing plugin [opensearch-job-scheduler], dependency of [opensearch-ml]
|       at org.opensearch.plugins.PluginsService.addSortedBundle(PluginsService.java:527)
|       at org.opensearch.plugins.PluginsService.sortBundles(PluginsService.java:495)
|       at org.opensearch.plugins.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:833)
|       at org.opensearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:807)
|       at org.opensearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:852)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:274)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:248)
|       at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.Command.main(Command.java:101)
|       at org.opensearch.plugins.PluginCli.main(PluginCli.java:66)

FAILURE: Build failed with an exception.
```

Also, integ test fail with the error saying below, which is captured in https://github.com/opensearch-project/neural-search/issues/1145
```
  2> REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.neuralsearch.processor.SparseEncodingProcessIT.testSparseEncodingProcessor" -Dtests.seed=C9C47530B30641AB -Dtests.security.manager=false -Dtests.locale=cs -Dtests.timezone=America/Fort_Nelson -Druntime.java=21
  2> org.opensearch.client.ResponseException: method [POST], host [http://[::1]:41111], URI [sparse_encoding_index/_doc?refresh], status line [HTTP/1.1 500 Internal Server Error]
    {"error":{"root_cause":[{"type":"null_pointer_exception","reason":"Cannot invoke \"org.opensearch.ml.common.output.model.ModelTensorOutput.getMlModelOutputs()\" because \"modelTensorOutput\" is null"}],"type":"null_pointer_exception","reason":"Cannot invoke \"org.opensearch.ml.common.output.model.ModelTensorOutput.getMlModelOutputs()\" because \"modelTensorOutput\" is null"},"status":500}
```
Root cause of this error is that jayway lib is not included as runtime dependency
```
»       at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
»  Caused by: java.lang.NoClassDefFoundError: com/jayway/jsonpath/PathNotFoundException
»       at org.opensearch.ml.common.output.model.ModelTensor.<init>(ModelTensor.java:235) ~[opensearch-ml-common-2.19.0.0.jar:?]
»       at org.opensearch.ml.common.output.model.ModelTensors.<init>(ModelTensors.java:66) ~[opensearch-ml-common-2.19.0.0.jar:?]
»       at org.opensearch.ml.common.output.model.ModelTensorOutput.<init>(ModelTensorOutput.java:44) ~[opensearch-ml-common-2.19.0.0.jar:?]
»       at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[?:?]
»       ... 21 more
»  Caused by: java.lang.ClassNotFoundException: com.jayway.jsonpath.PathNotFoundException
```


### Related Issues
#1145 
ML-commons side: https://github.com/opensearch-project/ml-commons/issues/3464

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
