### PR TITLE
Adding job scheduler dependency in bwc tests

### DIFF
--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -131,8 +131,19 @@ task pullOpensearchArtifact {
    }
 }
 
+// Task to pull job scheduler plugin from archive
+task pullJobSchedulerBwcPlugin {
+    doLast {
+        copy {
+            from(Path.of(tmp_dir.absolutePath, "opensearch-${neural_search_bwc_version_no_qualifier}", "plugins", "opensearch-job-scheduler"))
+            into Path.of(tmp_dir.absolutePath, "opensearch-job-scheduler")
+        }
+    }
+}
+
 // Task to pull ml plugin from archive
 task pullMlCommonsBwcPlugin {
+    dependsOn "pullJobSchedulerBwcPlugin"
     doLast {
         copy {
             from(Path.of(tmp_dir.absolutePath, "opensearch-${neural_search_bwc_version_no_qualifier}", "plugins", "opensearch-ml"))
@@ -164,9 +175,21 @@ task pullBwcPlugin {
     }
 }
 
+// Task to zip opensearch-job-scheduler plugin from archive
+task zipBwcJobSchedulerPlugin(type: Zip) {
+    dependsOn "pullJobSchedulerBwcPlugin"
+    from(Path.of(tmp_dir.absolutePath, "opensearch-ml"))
+    destinationDirectory = tmp_dir
+    archiveFileName = "opensearch-ml-${neural_search_bwc_version_no_qualifier}.zip"
+    doLast {
+        delete Path.of(tmp_dir.absolutePath, "opensearch-ml")
+    }
+}
+
 // Task to zip ml-commons plugin from archive
 task zipBwcMlCommonsPlugin(type: Zip) {
     dependsOn "pullMlCommonsBwcPlugin"
+    dependsOn "zipBwcJobSchedulerPlugin"
     from(Path.of(tmp_dir.absolutePath, "opensearch-ml"))
     destinationDirectory = tmp_dir
     archiveFileName = "opensearch-ml-${neural_search_bwc_version_no_qualifier}.zip"

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -75,6 +75,16 @@ ext{
             return new RegularFile() {
                 @Override
                 File getAsFile() {
+                    return configurations.zipArchive.asFileTree.matching{include "**/opensearch-job-scheduler-${opensearch_build}.zip"}.getSingleFile()
+                }
+            }
+        }
+    }),provider(new Callable<RegularFile>(){
+        @Override
+        RegularFile call() throws Exception {
+            return new RegularFile() {
+                @Override
+                File getAsFile() {
                     return configurations.zipArchive.asFileTree.matching{include "**/opensearch-ml-plugin-${opensearch_build}.zip"}.getSingleFile()
                 }
             }
@@ -131,19 +141,8 @@ task pullOpensearchArtifact {
    }
 }
 
-// Task to pull job scheduler plugin from archive
-task pullJobSchedulerBwcPlugin {
-    doLast {
-        copy {
-            from(Path.of(tmp_dir.absolutePath, "opensearch-${neural_search_bwc_version_no_qualifier}", "plugins", "opensearch-job-scheduler"))
-            into Path.of(tmp_dir.absolutePath, "opensearch-job-scheduler")
-        }
-    }
-}
-
 // Task to pull ml plugin from archive
 task pullMlCommonsBwcPlugin {
-    dependsOn "pullJobSchedulerBwcPlugin"
     doLast {
         copy {
             from(Path.of(tmp_dir.absolutePath, "opensearch-${neural_search_bwc_version_no_qualifier}", "plugins", "opensearch-ml"))
@@ -160,6 +159,17 @@ task pullKnnBwcPlugin {
         copy {
             from(Path.of(tmp_dir.absolutePath, "opensearch-${neural_search_bwc_version_no_qualifier}", "plugins", "opensearch-knn"))
             into Path.of(tmp_dir.absolutePath, "opensearch-knn")
+        }
+    }
+}
+
+// Task to pull job scheduler plugin from archive
+task pullJobSchedulerBwcPlugin {
+    dependsOn "pullKnnBwcPlugin"
+    doLast {
+        copy {
+            from(Path.of(tmp_dir.absolutePath, "opensearch-${neural_search_bwc_version_no_qualifier}", "plugins", "opensearch-job-scheduler"))
+            into Path.of(tmp_dir.absolutePath, "opensearch-job-scheduler")
         }
     }
 }

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -178,11 +178,11 @@ task pullBwcPlugin {
 // Task to zip opensearch-job-scheduler plugin from archive
 task zipBwcJobSchedulerPlugin(type: Zip) {
     dependsOn "pullJobSchedulerBwcPlugin"
-    from(Path.of(tmp_dir.absolutePath, "opensearch-ml"))
+    from(Path.of(tmp_dir.absolutePath, "opensearch-job-scheduler"))
     destinationDirectory = tmp_dir
-    archiveFileName = "opensearch-ml-${neural_search_bwc_version_no_qualifier}.zip"
+    archiveFileName = "opensearch-job-scheduler-${neural_search_bwc_version_no_qualifier}.zip"
     doLast {
-        delete Path.of(tmp_dir.absolutePath, "opensearch-ml")
+        delete Path.of(tmp_dir.absolutePath, "opensearch-job-scheduler")
     }
 }
 

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -86,7 +86,7 @@ ext{
                 }
             }
         }
-    }),provider(new Callable<RegularFile>(){
+    }), provider(new Callable<RegularFile>(){
         @Override
         RegularFile call() throws Exception {
             return new RegularFile() {

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -45,6 +45,7 @@ testClusters {
             }
         }else{
             versions = [ext.neural_search_bwc_version, opensearch_version]
+            plugin(project.tasks.zipBwcJobSchedulerPlugin.archiveFile)
             plugin(project.tasks.zipBwcMlCommonsPlugin.archiveFile)
             plugin(project.tasks.zipBwcKnnPlugin.archiveFile)
             plugin(project.tasks.zipBwcPlugin.archiveFile)

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -45,6 +45,7 @@ testClusters {
             }
         }else{
             versions = [ext.neural_search_bwc_version, opensearch_version]
+            plugin(project.tasks.zipBwcJobSchedulerPlugin.archiveFile)
             plugin(project.tasks.zipBwcMlCommonsPlugin.archiveFile)
             plugin(project.tasks.zipBwcKnnPlugin.archiveFile)
             plugin(project.tasks.zipBwcPlugin.archiveFile)


### PR DESCRIPTION
### Description
This PR contains a fix for bwc tests where now ml-commons has a dependency on job-scheduler plugin for running integ tests. Therefore adding js plugin in test cluster will resolve the dependency failure in test cluster.

Failure logs

https://github.com/opensearch-project/neural-search/actions/runs/13062503692/job/36498500139?pr=1154

```
> Task :qa:restart-upgrade:testAgainstOldCluster FAILED
Exec output and error:
| Output for ./bin/opensearch-plugin:-> Installing file:/home/runner/work/neural-search/neural-search/qa/restart-upgrade/build/private/artifact_tmp/opensearch-ml-2.19.0.zip
| -> Downloading file:/home/runner/work/neural-search/neural-search/qa/restart-upgrade/build/private/artifact_tmp/opensearch-ml-2.19.0.zip
| -> Failed installing file:/home/runner/work/neural-search/neural-search/qa/restart-upgrade/build/private/artifact_tmp/opensearch-ml-2.19.0.zip

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

| -> Rolling back file:/home/runner/work/neural-search/neural-search/qa/restart-upgrade/build/private/artifact_tmp/opensearch-ml-2.19.0.zip
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

| -> Rolled back file:/home/runner/work/neural-search/neural-search/qa/restart-upgrade/build/private/artifact_tmp/opensearch-ml-2.19.0.zip
| Exception in thread "main" java.lang.IllegalArgumentException: Missing plugin [opensearch-job-scheduler], dependency of [opensearch-ml]
| 	at org.opensearch.plugins.PluginsService.addSortedBundle(PluginsService.java:532)
| 	at org.opensearch.plugins.PluginsService.sortBundles(PluginsService.java:495)
| 	at org.opensearch.plugins.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:833)
| 	at org.opensearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:807)
| 	at org.opensearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:852)
| 	at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:274)
| 	at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:248)
| 	at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
| 	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
| 	at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
| 	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
| 	at org.opensearch.cli.Command.main(Command.java:101)
| 	at org.opensearch.plugins.PluginCli.main(PluginCli.java:60)

```
