### PR TITLE
code refactoring on MLCommonsClientAccessor request

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -116,7 +116,8 @@ public class MLCommonsClientAccessor {
         retryableInferenceSentencesWithSingleVectorResult(
             (inferenceRequest.getTargetResponseFilters() == null || inferenceRequest.getTargetResponseFilters().isEmpty())
                 ? TARGET_RESPONSE_FILTERS
-                : inferenceRequest.getTargetResponseFilters(),            inferenceRequest.getModelId(),
+                : inferenceRequest.getTargetResponseFilters(),
+            inferenceRequest.getModelId(),
             inferenceRequest.getInputObjects(),
             0,
             listener

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceRequest.java
@@ -6,25 +6,32 @@ package org.opensearch.neuralsearch.processor;
 
 import java.util.List;
 
-import java.util.Map;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
-@Builder
-@AllArgsConstructor
+@SuperBuilder
+@NoArgsConstructor
 @Getter
 @Setter
 /**
- * POJO class to hold request parameters to call ml commons client accessor.
+ *  Base abstract class for inference requests.
+ *  This class contains common fields and behaviors shared across different types of inference requests.
  */
-public class InferenceRequest {
+public abstract class InferenceRequest {
+    /**
+     * Unique identifier for the model to be used for inference.
+     * This field is required and cannot be null.
+     */
     @NonNull
-    private String modelId; // required
-    private List<String> inputTexts; // on which inference needs to happen
-    private Map<String, String> inputObjects;
-    private List<String> targetResponseFilters;
-    private String queryText;
+    private String modelId;
+    /**
+     * List of targetResponseFilters to be applied.
+     * Defaults value if not specified.
+     */
+    @Builder.Default
+    private List<String> targetResponseFilters = List.of("sentence_embedding");
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceRequest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import java.util.List;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@Setter
+/**
+ * POJO class to hold request parameters to call ml commons client accessor.
+ */
+public class InferenceRequest {
+    @NonNull
+    private String modelId; // required
+    private List<String> inputTexts; // on which inference needs to happen
+    private Map<String, String> inputObjects;
+    private List<String> targetResponseFilters;
+    private String queryText;
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/MapInferenceRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/MapInferenceRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Implementation of InferenceRequest for inputObjects based inference requests.
+ * Use this class when the input data consists of key-value pairs.
+ *
+ * @see InferenceRequest
+ */
+@SuperBuilder
+@NoArgsConstructor
+@Getter
+@Setter
+public class MapInferenceRequest extends InferenceRequest {
+    private Map<String, String> inputObjects;
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/SimilarityInferenceRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SimilarityInferenceRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Implementation of InferenceRequest for similarity based text inference requests.
+ *
+ * @see TextInferenceRequest
+ */
+@SuperBuilder
+@NoArgsConstructor
+@Getter
+@Setter
+public class SimilarityInferenceRequest extends TextInferenceRequest {
+    private String queryText;
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
@@ -59,24 +59,30 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
         List<String> inferenceList,
         BiConsumer<IngestDocument, Exception> handler
     ) {
-        mlCommonsClientAccessor.inferenceSentencesWithMapResult(this.modelId, inferenceList, ActionListener.wrap(resultMaps -> {
-            List<Map<String, Float>> sparseVectors = TokenWeightUtil.fetchListOfTokenWeightMap(resultMaps)
-                .stream()
-                .map(vector -> PruneUtils.pruneSparseVector(pruneType, pruneRatio, vector))
-                .toList();
-            setVectorFieldsToDocument(ingestDocument, ProcessMap, sparseVectors);
-            handler.accept(ingestDocument, null);
-        }, e -> { handler.accept(null, e); }));
+        mlCommonsClientAccessor.inferenceSentencesWithMapResult(
+            InferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            ActionListener.wrap(resultMaps -> {
+                List<Map<String, Float>> sparseVectors = TokenWeightUtil.fetchListOfTokenWeightMap(resultMaps)
+                    .stream()
+                    .map(vector -> PruneUtils.pruneSparseVector(pruneType, pruneRatio, vector))
+                    .toList();
+                setVectorFieldsToDocument(ingestDocument, ProcessMap, sparseVectors);
+                handler.accept(ingestDocument, null);
+            }, e -> { handler.accept(null, e); })
+        );
     }
 
     @Override
     public void doBatchExecute(List<String> inferenceList, Consumer<List<?>> handler, Consumer<Exception> onException) {
-        mlCommonsClientAccessor.inferenceSentencesWithMapResult(this.modelId, inferenceList, ActionListener.wrap(resultMaps -> {
-            List<Map<String, Float>> sparseVectors = TokenWeightUtil.fetchListOfTokenWeightMap(resultMaps)
-                .stream()
-                .map(vector -> PruneUtils.pruneSparseVector(pruneType, pruneRatio, vector))
-                .toList();
-            handler.accept(sparseVectors);
-        }, onException));
+        mlCommonsClientAccessor.inferenceSentencesWithMapResult(
+            InferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            ActionListener.wrap(resultMaps -> {
+                List<Map<String, Float>> sparseVectors = TokenWeightUtil.fetchListOfTokenWeightMap(resultMaps)
+                    .stream()
+                    .map(vector -> PruneUtils.pruneSparseVector(pruneType, pruneRatio, vector))
+                    .toList();
+                handler.accept(sparseVectors);
+            }, onException)
+        );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
@@ -60,7 +60,7 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
         BiConsumer<IngestDocument, Exception> handler
     ) {
         mlCommonsClientAccessor.inferenceSentencesWithMapResult(
-            InferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            TextInferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
             ActionListener.wrap(resultMaps -> {
                 List<Map<String, Float>> sparseVectors = TokenWeightUtil.fetchListOfTokenWeightMap(resultMaps)
                     .stream()
@@ -75,7 +75,7 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
     @Override
     public void doBatchExecute(List<String> inferenceList, Consumer<List<?>> handler, Consumer<Exception> onException) {
         mlCommonsClientAccessor.inferenceSentencesWithMapResult(
-            InferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            TextInferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
             ActionListener.wrap(resultMaps -> {
                 List<Map<String, Float>> sparseVectors = TokenWeightUtil.fetchListOfTokenWeightMap(resultMaps)
                     .stream()

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -48,7 +48,7 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
         BiConsumer<IngestDocument, Exception> handler
     ) {
         mlCommonsClientAccessor.inferenceSentences(
-            InferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            TextInferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
             ActionListener.wrap(vectors -> {
                 setVectorFieldsToDocument(ingestDocument, ProcessMap, vectors);
                 handler.accept(ingestDocument, null);
@@ -59,7 +59,7 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
     @Override
     public void doBatchExecute(List<String> inferenceList, Consumer<List<?>> handler, Consumer<Exception> onException) {
         mlCommonsClientAccessor.inferenceSentences(
-            InferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            TextInferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
             ActionListener.wrap(handler::accept, onException)
         );
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -47,14 +47,20 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
         List<String> inferenceList,
         BiConsumer<IngestDocument, Exception> handler
     ) {
-        mlCommonsClientAccessor.inferenceSentences(this.modelId, inferenceList, ActionListener.wrap(vectors -> {
-            setVectorFieldsToDocument(ingestDocument, ProcessMap, vectors);
-            handler.accept(ingestDocument, null);
-        }, e -> { handler.accept(null, e); }));
+        mlCommonsClientAccessor.inferenceSentences(
+            InferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            ActionListener.wrap(vectors -> {
+                setVectorFieldsToDocument(ingestDocument, ProcessMap, vectors);
+                handler.accept(ingestDocument, null);
+            }, e -> { handler.accept(null, e); })
+        );
     }
 
     @Override
     public void doBatchExecute(List<String> inferenceList, Consumer<List<?>> handler, Consumer<Exception> onException) {
-        mlCommonsClientAccessor.inferenceSentences(this.modelId, inferenceList, ActionListener.wrap(handler::accept, onException));
+        mlCommonsClientAccessor.inferenceSentences(
+            InferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            ActionListener.wrap(handler::accept, onException)
+        );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -113,10 +113,13 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
             if (inferenceMap.isEmpty()) {
                 handler.accept(ingestDocument, null);
             } else {
-                mlCommonsClientAccessor.inferenceSentences(this.modelId, inferenceMap, ActionListener.wrap(vectors -> {
-                    setVectorFieldsToDocument(ingestDocument, vectors);
-                    handler.accept(ingestDocument, null);
-                }, e -> { handler.accept(null, e); }));
+                mlCommonsClientAccessor.inferenceSentencesMap(
+                    InferenceRequest.builder().modelId(this.modelId).inputObjects(inferenceMap).build(),
+                    ActionListener.wrap(vectors -> {
+                        setVectorFieldsToDocument(ingestDocument, vectors);
+                        handler.accept(ingestDocument, null);
+                    }, e -> { handler.accept(null, e); })
+                );
             }
         } catch (Exception e) {
             handler.accept(null, e);

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -114,7 +114,7 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
                 handler.accept(ingestDocument, null);
             } else {
                 mlCommonsClientAccessor.inferenceSentencesMap(
-                    InferenceRequest.builder().modelId(this.modelId).inputObjects(inferenceMap).build(),
+                    MapInferenceRequest.builder().modelId(this.modelId).inputObjects(inferenceMap).build(),
                     ActionListener.wrap(vectors -> {
                         setVectorFieldsToDocument(ingestDocument, vectors);
                         handler.accept(ingestDocument, null);

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextInferenceRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextInferenceRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Implementation of InferenceRequest for inputTexts based inference requests.
+ * Use this class when the input data consists of list of strings.
+ *
+ * @see InferenceRequest
+ */
+@SuperBuilder
+@NoArgsConstructor
+@Getter
+@Setter
+public class TextInferenceRequest extends InferenceRequest {
+    private List<String> inputTexts; // on which inference needs to happen
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessor.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
-import org.opensearch.neuralsearch.processor.InferenceRequest;
+import org.opensearch.neuralsearch.processor.SimilarityInferenceRequest;
 import org.opensearch.neuralsearch.processor.factory.RerankProcessorFactory;
 import org.opensearch.neuralsearch.processor.rerank.context.ContextSourceFetcher;
 import org.opensearch.neuralsearch.processor.rerank.context.DocumentContextSourceFetcher;
@@ -74,7 +74,7 @@ public class MLOpenSearchRerankProcessor extends RescoringRerankProcessor {
         List<?> ctxList = (List<?>) ctxObj;
         List<String> contexts = ctxList.stream().map(str -> (String) str).collect(Collectors.toList());
         mlCommonsClientAccessor.inferenceSimilarity(
-            InferenceRequest.builder()
+            SimilarityInferenceRequest.builder()
                 .modelId(modelId)
                 .queryText((String) rerankingContext.get(QueryContextSourceFetcher.QUERY_TEXT_FIELD))
                 .inputTexts(contexts)

--- a/src/main/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessor.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.processor.InferenceRequest;
 import org.opensearch.neuralsearch.processor.factory.RerankProcessorFactory;
 import org.opensearch.neuralsearch.processor.rerank.context.ContextSourceFetcher;
 import org.opensearch.neuralsearch.processor.rerank.context.DocumentContextSourceFetcher;
@@ -73,9 +74,11 @@ public class MLOpenSearchRerankProcessor extends RescoringRerankProcessor {
         List<?> ctxList = (List<?>) ctxObj;
         List<String> contexts = ctxList.stream().map(str -> (String) str).collect(Collectors.toList());
         mlCommonsClientAccessor.inferenceSimilarity(
-            modelId,
-            (String) rerankingContext.get(QueryContextSourceFetcher.QUERY_TEXT_FIELD),
-            contexts,
+            InferenceRequest.builder()
+                .modelId(modelId)
+                .queryText((String) rerankingContext.get(QueryContextSourceFetcher.QUERY_TEXT_FIELD))
+                .inputTexts(contexts)
+                .build(),
             listener
         );
     }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -56,6 +56,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.log4j.Log4j2;
+import org.opensearch.neuralsearch.processor.InferenceRequest;
 
 /**
  * NeuralQueryBuilder is responsible for producing "neural" query types. A "neural" query type is a wrapper around a
@@ -490,10 +491,13 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
             inferenceInput.put(INPUT_IMAGE, queryImage());
         }
         queryRewriteContext.registerAsyncAction(
-            ((client, actionListener) -> ML_CLIENT.inferenceSentences(modelId(), inferenceInput, ActionListener.wrap(floatList -> {
-                vectorSetOnce.set(vectorAsListToArray(floatList));
-                actionListener.onResponse(null);
-            }, actionListener::onFailure)))
+            ((client, actionListener) -> ML_CLIENT.inferenceSentencesMap(
+                InferenceRequest.builder().modelId(modelId()).inputObjects(inferenceInput).build(),
+                ActionListener.wrap(floatList -> {
+                    vectorSetOnce.set(vectorAsListToArray(floatList));
+                    actionListener.onResponse(null);
+                }, actionListener::onFailure)
+            ))
         );
         return new NeuralQueryBuilder(
             fieldName(),

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -56,7 +56,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.log4j.Log4j2;
-import org.opensearch.neuralsearch.processor.InferenceRequest;
+import org.opensearch.neuralsearch.processor.MapInferenceRequest;
 
 /**
  * NeuralQueryBuilder is responsible for producing "neural" query types. A "neural" query type is a wrapper around a
@@ -492,7 +492,7 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
         }
         queryRewriteContext.registerAsyncAction(
             ((client, actionListener) -> ML_CLIENT.inferenceSentencesMap(
-                InferenceRequest.builder().modelId(modelId()).inputObjects(inferenceInput).build(),
+                MapInferenceRequest.builder().modelId(modelId()).inputObjects(inferenceInput).build(),
                 ActionListener.wrap(floatList -> {
                     vectorSetOnce.set(vectorAsListToArray(floatList));
                     actionListener.onResponse(null);

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -37,6 +37,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.processor.InferenceRequest;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.neuralsearch.util.TokenWeightUtil;
 
@@ -343,8 +344,7 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
         // it splits the tokens using a threshold defined by a ratio of the maximum score of tokens, updating the token set
         // accordingly.
         return ((client, actionListener) -> ML_CLIENT.inferenceSentencesWithMapResult(
-            modelId(),
-            List.of(queryText),
+            InferenceRequest.builder().modelId(modelId()).inputTexts(List.of(queryText)).build(),
             ActionListener.wrap(mapResultList -> {
                 Map<String, Float> queryTokens = TokenWeightUtil.fetchListOfTokenWeightMap(mapResultList).get(0);
                 if (Objects.nonNull(twoPhaseSharedQueryToken)) {

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilder.java
@@ -37,7 +37,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
-import org.opensearch.neuralsearch.processor.InferenceRequest;
+import org.opensearch.neuralsearch.processor.TextInferenceRequest;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.neuralsearch.util.TokenWeightUtil;
 
@@ -344,7 +344,7 @@ public class NeuralSparseQueryBuilder extends AbstractQueryBuilder<NeuralSparseQ
         // it splits the tokens using a threshold defined by a ratio of the maximum score of tokens, updating the token set
         // accordingly.
         return ((client, actionListener) -> ML_CLIENT.inferenceSentencesWithMapResult(
-            InferenceRequest.builder().modelId(modelId()).inputTexts(List.of(queryText)).build(),
+            TextInferenceRequest.builder().modelId(modelId()).inputTexts(List.of(queryText)).build(),
             ActionListener.wrap(mapResultList -> {
                 Map<String, Float> queryTokens = TokenWeightUtil.fetchListOfTokenWeightMap(mapResultList).get(0);
                 if (Objects.nonNull(twoPhaseSharedQueryToken)) {

--- a/src/test/java/org/opensearch/neuralsearch/constants/TestCommonConstants.java
+++ b/src/test/java/org/opensearch/neuralsearch/constants/TestCommonConstants.java
@@ -9,20 +9,33 @@ import java.util.Map;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.opensearch.neuralsearch.processor.InferenceRequest;
+import org.opensearch.neuralsearch.processor.MapInferenceRequest;
+import org.opensearch.neuralsearch.processor.SimilarityInferenceRequest;
+import org.opensearch.neuralsearch.processor.TextInferenceRequest;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestCommonConstants {
     public static final String MODEL_ID = "modeId";
     public static final List<String> TARGET_RESPONSE_FILTERS = List.of("sentence_embedding");
     public static final Float[] PREDICT_VECTOR_ARRAY = new Float[] { 2.0f, 3.0f };
-    public static final List<String> SENTENCES_LIST = List.of("TEXT");
+    public static final List<String> SENTENCES_LIST = List.of("it is sunny today", "roses are red");
     public static final Map<String, String> SENTENCES_MAP = Map.of("inputText", "Text query", "inputImage", "base641234567890");
-    public static final InferenceRequest INFERENCE_REQUEST = InferenceRequest.builder()
+
+    public static final String QUERY_TEST = "is it sunny";
+
+    public static final TextInferenceRequest TEXT_INFERENCE_REQUEST = TextInferenceRequest.builder()
         .modelId(MODEL_ID)
         .inputTexts(SENTENCES_LIST)
+        .build();
+
+    public static final MapInferenceRequest MAP_INFERENCE_REQUEST = MapInferenceRequest.builder()
+        .modelId(MODEL_ID)
         .inputObjects(SENTENCES_MAP)
-        .queryText("is it sunny")
-        .targetResponseFilters(TARGET_RESPONSE_FILTERS)
+        .build();
+
+    public static final SimilarityInferenceRequest SIMILARITY_INFERENCE_REQUEST = SimilarityInferenceRequest.builder()
+        .modelId(MODEL_ID)
+        .inputTexts(SENTENCES_LIST)
+        .queryText(QUERY_TEST)
         .build();
 }

--- a/src/test/java/org/opensearch/neuralsearch/constants/TestCommonConstants.java
+++ b/src/test/java/org/opensearch/neuralsearch/constants/TestCommonConstants.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.opensearch.neuralsearch.processor.InferenceRequest;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestCommonConstants {
@@ -17,4 +18,11 @@ public class TestCommonConstants {
     public static final Float[] PREDICT_VECTOR_ARRAY = new Float[] { 2.0f, 3.0f };
     public static final List<String> SENTENCES_LIST = List.of("TEXT");
     public static final Map<String, String> SENTENCES_MAP = Map.of("inputText", "Text query", "inputImage", "base641234567890");
+    public static final InferenceRequest INFERENCE_REQUEST = InferenceRequest.builder()
+        .modelId(MODEL_ID)
+        .inputTexts(SENTENCES_LIST)
+        .inputObjects(SENTENCES_MAP)
+        .queryText("is it sunny")
+        .targetResponseFilters(TARGET_RESPONSE_FILTERS)
+        .build();
 }

--- a/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
@@ -60,7 +60,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSentence(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
+        accessor.inferenceSentence(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST.get(0), singleSentenceResultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -76,7 +76,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -92,7 +92,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(createModelTensorOutput(new Float[] {}));
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -107,7 +107,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onFailure(exception);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -127,7 +127,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSimilarity(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
+        accessor.inferenceSimilarity(TestCommonConstants.SIMILARITY_INFERENCE_REQUEST, singleSentenceResultListener);
 
         // Verify client.predict is called 4 times (1 initial + 3 retries)
         Mockito.verify(client, times(4))
@@ -150,7 +150,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onFailure(nodeNodeConnectedException);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client, times(4))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -164,7 +164,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onFailure(illegalStateException);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client, times(1))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -179,7 +179,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(createModelTensorOutput(map));
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -195,7 +195,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(modelTensorOutput);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -219,7 +219,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(modelTensorOutput);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -246,7 +246,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(modelTensorOutput);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -265,7 +265,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client, times(4))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -280,7 +280,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client, times(1))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -295,7 +295,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSentencesMap(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
+        accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -315,7 +315,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSentencesMap(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
+        accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
         // Verify client.predict is called 4 times (1 initial + 3 retries)
         Mockito.verify(client, times(4))
@@ -338,7 +338,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onFailure(nodeNodeConnectedException);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesMap(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
+        accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client, times(4))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -353,7 +353,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSimilarity(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
+        accessor.inferenceSimilarity(TestCommonConstants.SIMILARITY_INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -369,7 +369,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSimilarity(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
+        accessor.inferenceSimilarity(TestCommonConstants.SIMILARITY_INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));

--- a/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
@@ -60,7 +60,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSentence(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST.get(0), singleSentenceResultListener);
+        accessor.inferenceSentence(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -76,7 +76,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -92,7 +92,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(createModelTensorOutput(new Float[] {}));
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -107,12 +107,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onFailure(exception);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(
-            TestCommonConstants.TARGET_RESPONSE_FILTERS,
-            TestCommonConstants.MODEL_ID,
-            TestCommonConstants.SENTENCES_LIST,
-            resultListener
-        );
+        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -132,12 +127,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSimilarity(
-            TestCommonConstants.MODEL_ID,
-            "is it sunny",
-            List.of("it is sunny today", "roses are red"),
-            singleSentenceResultListener
-        );
+        accessor.inferenceSimilarity(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
 
         // Verify client.predict is called 4 times (1 initial + 3 retries)
         Mockito.verify(client, times(4))
@@ -160,12 +150,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onFailure(nodeNodeConnectedException);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(
-            TestCommonConstants.TARGET_RESPONSE_FILTERS,
-            TestCommonConstants.MODEL_ID,
-            TestCommonConstants.SENTENCES_LIST,
-            resultListener
-        );
+        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client, times(4))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -179,12 +164,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onFailure(illegalStateException);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(
-            TestCommonConstants.TARGET_RESPONSE_FILTERS,
-            TestCommonConstants.MODEL_ID,
-            TestCommonConstants.SENTENCES_LIST,
-            resultListener
-        );
+        accessor.inferenceSentences(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client, times(1))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -199,7 +179,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(createModelTensorOutput(map));
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -215,7 +195,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(modelTensorOutput);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -239,7 +219,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(modelTensorOutput);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -266,7 +246,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onResponse(modelTensorOutput);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -285,7 +265,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client, times(4))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -300,7 +280,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
-        accessor.inferenceSentencesWithMapResult(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST, resultListener);
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.INFERENCE_REQUEST, resultListener);
 
         Mockito.verify(client, times(1))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -315,7 +295,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSentences(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_MAP, singleSentenceResultListener);
+        accessor.inferenceSentencesMap(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -335,7 +315,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSentences(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_MAP, singleSentenceResultListener);
+        accessor.inferenceSentencesMap(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
 
         // Verify client.predict is called 4 times (1 initial + 3 retries)
         Mockito.verify(client, times(4))
@@ -358,7 +338,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             actionListener.onFailure(nodeNodeConnectedException);
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
-        accessor.inferenceSentences(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_MAP, singleSentenceResultListener);
+        accessor.inferenceSentencesMap(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client, times(4))
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -373,12 +353,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSimilarity(
-            TestCommonConstants.MODEL_ID,
-            "is it sunny",
-            List.of("it is sunny today", "roses are red"),
-            singleSentenceResultListener
-        );
+        accessor.inferenceSimilarity(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
@@ -394,12 +369,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             return null;
         }).when(client).predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
-        accessor.inferenceSimilarity(
-            TestCommonConstants.MODEL_ID,
-            "is it sunny",
-            List.of("it is sunny today", "roses are red"),
-            singleSentenceResultListener
-        );
+        accessor.inferenceSimilarity(TestCommonConstants.INFERENCE_REQUEST, singleSentenceResultListener);
 
         Mockito.verify(client)
             .predict(Mockito.eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
@@ -14,6 +14,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
+import org.opensearch.neuralsearch.constants.TestCommonConstants;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 
 import java.util.ArrayList;
@@ -100,9 +101,9 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertNull(captor.getValue().get(i).getException());
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
-        ArgumentCaptor<List<String>> inferenceTextCaptor = ArgumentCaptor.forClass(List.class);
-        verify(clientAccessor).inferenceSentences(any(), any());
-        assertEquals(4, inferenceTextCaptor.getValue().size());
+        ArgumentCaptor<InferenceRequest> inferenceRequest = ArgumentCaptor.forClass(InferenceRequest.class);
+        verify(clientAccessor).inferenceSentences(inferenceRequest.capture(), any());
+        assertEquals(1, inferenceRequest.getValue().getInputTexts().size());
     }
 
     public void test_batchExecute_sort() {
@@ -121,10 +122,10 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertNull(captor.getValue().get(i).getException());
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
-        ArgumentCaptor<List<String>> inferenceTextCaptor = ArgumentCaptor.forClass(List.class);
-        verify(clientAccessor).inferenceSentences(any(), any());
-        assertEquals(4, inferenceTextCaptor.getValue().size());
-        assertEquals(Arrays.asList("cc", "bbb", "ddd", "aaaaa"), inferenceTextCaptor.getValue());
+        ArgumentCaptor<InferenceRequest> inferenceRequestArgumentCaptor = ArgumentCaptor.forClass(InferenceRequest.class);
+        verify(clientAccessor).inferenceSentences(inferenceRequestArgumentCaptor.capture(), any());
+        assertEquals(1, inferenceRequestArgumentCaptor.getValue().getInputTexts().size());
+        assertEquals(TestCommonConstants.SENTENCES_LIST, inferenceRequestArgumentCaptor.getValue().getInputTexts());
 
         List<?> doc1Embeddings = (List) (captor.getValue().get(0).getIngestDocument().getFieldValue("embedding_key1", List.class));
         List<?> doc2Embeddings = (List) (captor.getValue().get(1).getIngestDocument().getFieldValue("embedding_key1", List.class));

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
@@ -25,13 +25,12 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.constants.TestCommonConstants.INFERENCE_REQUEST;
 
 public class InferenceProcessorTests extends InferenceProcessorTestCase {
     private MLCommonsClientAccessor clientAccessor;
@@ -63,7 +62,7 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
         ArgumentCaptor<List<IngestDocumentWrapper>> captor = ArgumentCaptor.forClass(List.class);
         verify(resultHandler).accept(captor.capture());
         assertTrue(captor.getValue().isEmpty());
-        verify(clientAccessor, never()).inferenceSentences(anyString(), anyList(), any());
+        verify(clientAccessor, never()).inferenceSentences(any(), any());
     }
 
     public void test_batchExecuteWithNull_allFailedValidation() {
@@ -82,7 +81,7 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertEquals("list type field [key1] has null, cannot process it", captor.getValue().get(i).getException().getMessage());
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
-        verify(clientAccessor, never()).inferenceSentences(anyString(), anyList(), any());
+        verify(clientAccessor, never()).inferenceSentences(any(), any());
     }
 
     public void test_batchExecute_happyCase() {
@@ -102,7 +101,7 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
         ArgumentCaptor<List<String>> inferenceTextCaptor = ArgumentCaptor.forClass(List.class);
-        verify(clientAccessor).inferenceSentences(anyString(), inferenceTextCaptor.capture(), any());
+        verify(clientAccessor).inferenceSentences(any(), any());
         assertEquals(4, inferenceTextCaptor.getValue().size());
     }
 
@@ -123,7 +122,7 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
         ArgumentCaptor<List<String>> inferenceTextCaptor = ArgumentCaptor.forClass(List.class);
-        verify(clientAccessor).inferenceSentences(anyString(), inferenceTextCaptor.capture(), any());
+        verify(clientAccessor).inferenceSentences(any(), any());
         assertEquals(4, inferenceTextCaptor.getValue().size());
         assertEquals(Arrays.asList("cc", "bbb", "ddd", "aaaaa"), inferenceTextCaptor.getValue());
 
@@ -154,7 +153,7 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertNotNull(captor.getValue().get(i).getException());
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
-        verify(clientAccessor).inferenceSentences(anyString(), anyList(), any());
+        verify(clientAccessor).inferenceSentences(any(), any());
     }
 
     public void test_batchExecute_subBatches() {
@@ -202,7 +201,7 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
         @Override
         void doBatchExecute(List<String> inferenceList, Consumer<List<?>> handler, Consumer<Exception> onException) {
             // use to verify if doBatchExecute is called from InferenceProcessor
-            clientAccessor.inferenceSentences(MODEL_ID, inferenceList, ActionListener.wrap(results -> {}, ex -> {}));
+            clientAccessor.inferenceSentences(INFERENCE_REQUEST, ActionListener.wrap(results -> {}, ex -> {}));
             allInferenceInputs.add(inferenceList);
             if (this.exception != null) {
                 onException.accept(this.exception);

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.neuralsearch.constants.TestCommonConstants.INFERENCE_REQUEST;
+import static org.opensearch.neuralsearch.constants.TestCommonConstants.TEXT_INFERENCE_REQUEST;
 
 public class InferenceProcessorTests extends InferenceProcessorTestCase {
     private MLCommonsClientAccessor clientAccessor;
@@ -101,9 +101,9 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertNull(captor.getValue().get(i).getException());
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
-        ArgumentCaptor<InferenceRequest> inferenceRequest = ArgumentCaptor.forClass(InferenceRequest.class);
+        ArgumentCaptor<TextInferenceRequest> inferenceRequest = ArgumentCaptor.forClass(TextInferenceRequest.class);
         verify(clientAccessor).inferenceSentences(inferenceRequest.capture(), any());
-        assertEquals(1, inferenceRequest.getValue().getInputTexts().size());
+        assertEquals(2, inferenceRequest.getValue().getInputTexts().size());
     }
 
     public void test_batchExecute_sort() {
@@ -122,9 +122,9 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
             assertNull(captor.getValue().get(i).getException());
             assertEquals(wrapperList.get(i).getIngestDocument(), captor.getValue().get(i).getIngestDocument());
         }
-        ArgumentCaptor<InferenceRequest> inferenceRequestArgumentCaptor = ArgumentCaptor.forClass(InferenceRequest.class);
+        ArgumentCaptor<TextInferenceRequest> inferenceRequestArgumentCaptor = ArgumentCaptor.forClass(TextInferenceRequest.class);
         verify(clientAccessor).inferenceSentences(inferenceRequestArgumentCaptor.capture(), any());
-        assertEquals(1, inferenceRequestArgumentCaptor.getValue().getInputTexts().size());
+        assertEquals(2, inferenceRequestArgumentCaptor.getValue().getInputTexts().size());
         assertEquals(TestCommonConstants.SENTENCES_LIST, inferenceRequestArgumentCaptor.getValue().getInputTexts());
 
         List<?> doc1Embeddings = (List) (captor.getValue().get(0).getIngestDocument().getFieldValue("embedding_key1", List.class));
@@ -202,7 +202,7 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
         @Override
         void doBatchExecute(List<String> inferenceList, Consumer<List<?>> handler, Consumer<Exception> onException) {
             // use to verify if doBatchExecute is called from InferenceProcessor
-            clientAccessor.inferenceSentences(INFERENCE_REQUEST, ActionListener.wrap(results -> {}, ex -> {}));
+            clientAccessor.inferenceSentences(TEXT_INFERENCE_REQUEST, ActionListener.wrap(results -> {}, ex -> {}));
             allInferenceInputs.add(inferenceList);
             if (this.exception != null) {
                 onException.accept(this.exception);

--- a/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.neuralsearch.processor;
 
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
@@ -113,10 +114,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
 
         List<Map<String, ?>> dataAsMapList = createMockMapResult(2);
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -145,7 +147,8 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             DESCRIPTION,
             config
         );
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(any(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(any(IngestDocument.class), isNull());
@@ -163,10 +166,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
 
         List<Map<String, ?>> dataAsMapList = createMockMapResult(6);
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -182,10 +186,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         SparseEncodingProcessor processor = createInstance();
 
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -219,10 +224,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
 
         List<Map<String, ?>> dataAsMapList = createMockMapResult(2);
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -236,10 +242,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         SparseEncodingProcessor processor = createInstance(docCount);
         List<Map<String, ?>> dataAsMapList = createMockMapResult(10);
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         Consumer resultHandler = mock(Consumer.class);
         processor.batchExecute(ingestDocumentWrappers, resultHandler);
@@ -257,10 +264,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
         SparseEncodingProcessor processor = createInstance(docCount);
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onFailure(new RuntimeException());
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         Consumer resultHandler = mock(Consumer.class);
         processor.batchExecute(ingestDocumentWrappers, resultHandler);
@@ -288,10 +296,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         );
 
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -330,10 +339,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         );
 
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onResponse(mockMLResponse);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         Consumer<List<?>> resultHandler = mock(Consumer.class);
         Consumer<Exception> exceptionHandler = mock(Consumer.class);

--- a/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
@@ -7,7 +7,6 @@ package org.opensearch.neuralsearch.processor;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.any;
 
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -117,7 +116,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -146,7 +145,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             DESCRIPTION,
             config
         );
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor).inferenceSentences(any(), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(any(IngestDocument.class), isNull());
@@ -167,7 +166,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -186,7 +185,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -223,7 +222,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -240,7 +239,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
 
         Consumer resultHandler = mock(Consumer.class);
         processor.batchExecute(ingestDocumentWrappers, resultHandler);
@@ -261,7 +260,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onFailure(new RuntimeException());
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
 
         Consumer resultHandler = mock(Consumer.class);
         processor.batchExecute(ingestDocumentWrappers, resultHandler);
@@ -292,7 +291,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onResponse(dataAsMapList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -334,7 +333,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onResponse(mockMLResponse);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), isA(ActionListener.class));
 
         Consumer<List<?>> resultHandler = mock(Consumer.class);
         Consumer<Exception> exceptionHandler = mock(Consumer.class);

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.neuralsearch.processor;
 
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
@@ -159,7 +158,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -189,7 +188,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             DESCRIPTION,
             config
         );
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor).inferenceSentences(any(), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(RuntimeException.class));
@@ -217,7 +216,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             DESCRIPTION,
             config
         );
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor).inferenceSentences(any(), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(any(IngestDocument.class), isNull());
@@ -238,7 +237,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -314,7 +313,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -355,7 +354,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -415,7 +414,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -473,7 +472,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -552,7 +551,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -608,7 +607,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -677,7 +676,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -717,7 +716,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
@@ -1079,7 +1078,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         Consumer resultHandler = mock(Consumer.class);
         processor.batchExecute(ingestDocumentWrappers, resultHandler);
@@ -1100,7 +1099,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onFailure(new RuntimeException());
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyList(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         Consumer resultHandler = mock(Consumer.class);
         processor.batchExecute(ingestDocumentWrappers, resultHandler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.processor;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -155,10 +156,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -188,7 +189,8 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             DESCRIPTION,
             config
         );
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(any(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor)
+            .inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(RuntimeException.class));
@@ -216,7 +218,8 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
             DESCRIPTION,
             config
         );
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(any(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor)
+            .inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(any(IngestDocument.class), isNull());
@@ -234,10 +237,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -310,10 +313,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -351,10 +354,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(1, 100, 0.0f, 1.0f);
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -411,10 +414,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(1, 100, 0.0f, 1.0f);
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -469,10 +472,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(1, 100, 0.0f, 1.0f);
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -548,10 +551,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(2, 100, 0.0f, 1.0f);
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -604,10 +607,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createRandomOneDimensionalMockVector(1, 100, 0.0f, 1.0f);
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         processor.execute(ingestDocument, (BiConsumer) (doc, ex) -> {});
         assertNotNull(ingestDocument);
@@ -673,10 +676,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
 
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -713,10 +716,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         sourceAndMetadata.put("key2", 100.232D);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig();
@@ -1075,10 +1078,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorWithLength(10);
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         Consumer resultHandler = mock(Consumer.class);
         processor.batchExecute(ingestDocumentWrappers, resultHandler);
@@ -1096,10 +1099,10 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
         TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(docCount);
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onFailure(new RuntimeException());
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
 
         Consumer resultHandler = mock(Consumer.class);
         processor.batchExecute(ingestDocumentWrappers, resultHandler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.neuralsearch.processor;
 
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
@@ -195,7 +194,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyMap(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -229,7 +228,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             config
         );
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(anyString(), anyMap(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor).inferenceSentences(any(), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(RuntimeException.class));
@@ -248,7 +247,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyMap(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -280,7 +279,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyMap(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -339,7 +338,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
             ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(anyString(), anyMap(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.processor;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -191,10 +192,11 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesMap(argThat(request -> request.getInputObjects() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -228,7 +230,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             config
         );
-        doThrow(new RuntimeException()).when(accessor).inferenceSentences(any(), isA(ActionListener.class));
+        doThrow(new RuntimeException()).when(accessor).inferenceSentencesMap(any(), isA(ActionListener.class));
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
         verify(handler).accept(isNull(), any(RuntimeException.class));
@@ -244,10 +246,11 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesMap(argThat(request -> request.getInputObjects() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -276,10 +279,11 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
         TextImageEmbeddingProcessor processor = createInstance();
 
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onFailure(new IllegalArgumentException("illegal argument"));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesMap(argThat(request -> request.getInputObjects() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);
@@ -335,10 +339,11 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
 
         List<List<Float>> modelTensorList = createMockVectorResult();
         doAnswer(invocation -> {
-            ActionListener<List<List<Float>>> listener = invocation.getArgument(2);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
             listener.onResponse(modelTensorList);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), isA(ActionListener.class));
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesMap(argThat(request -> request.getInputObjects() != null), isA(ActionListener.class));
 
         BiConsumer handler = mock(BiConsumer.class);
         processor.execute(ingestDocument, handler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/MLOpenSearchRerankProcessorTests.java
@@ -5,8 +5,6 @@
 package org.opensearch.neuralsearch.processor.rerank;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -122,7 +120,7 @@ public class MLOpenSearchRerankProcessorTests extends OpenSearchTestCase {
             List<Float> scores = List.of(1f, 2f, 3f);
             listener.onResponse(scores);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSimilarity(anyString(), anyString(), anyList(), any());
+        }).when(mlCommonsClientAccessor).inferenceSimilarity(any(), any());
     }
 
     private void setupSearchResults() throws IOException {
@@ -353,7 +351,7 @@ public class MLOpenSearchRerankProcessorTests extends OpenSearchTestCase {
             List<Float> scores = List.of(1f, 2f);
             listener.onResponse(scores);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSimilarity(anyString(), anyString(), anyList(), any());
+        }).when(mlCommonsClientAccessor).inferenceSimilarity(any(), any());
         setupSearchResults();
         @SuppressWarnings("unchecked")
         ActionListener<SearchResponse> listener = mock(ActionListener.class);

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -5,6 +5,8 @@
 package org.opensearch.neuralsearch.query;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
@@ -773,10 +775,11 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         List<Float> expectedVector = Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
         MLCommonsClientAccessor mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         doAnswer(invocation -> {
-            ActionListener<List<Float>> listener = invocation.getArgument(2);
+            ActionListener<List<Float>> listener = invocation.getArgument(1);
             listener.onResponse(expectedVector);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), any());
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesMap(argThat(request -> request.getInputObjects() != null), isA(ActionListener.class));
         NeuralQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
@@ -811,10 +814,11 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         List<Float> expectedVector = Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
         MLCommonsClientAccessor mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         doAnswer(invocation -> {
-            ActionListener<List<Float>> listener = invocation.getArgument(2);
+            ActionListener<List<Float>> listener = invocation.getArgument(1);
             listener.onResponse(expectedVector);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), any());
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesMap(argThat(request -> request.getInputObjects() != null), isA(ActionListener.class));
         NeuralQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -5,7 +5,6 @@
 package org.opensearch.neuralsearch.query;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
@@ -777,7 +776,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             ActionListener<List<Float>> listener = invocation.getArgument(2);
             listener.onResponse(expectedVector);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), anyMap(), any());
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), any());
         NeuralQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
@@ -815,7 +814,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             ActionListener<List<Float>> listener = invocation.getArgument(2);
             listener.onResponse(expectedVector);
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentences(any(), anyMap(), any());
+        }).when(mlCommonsClientAccessor).inferenceSentences(any(), any());
         NeuralQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilderTests.java
@@ -5,6 +5,8 @@
 package org.opensearch.neuralsearch.query;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
@@ -624,10 +626,11 @@ public class NeuralSparseQueryBuilderTests extends OpenSearchTestCase {
         Map<String, Float> expectedMap = Map.of("1", 1f, "2", 2f);
         MLCommonsClientAccessor mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onResponse(List.of(Map.of("response", List.of(expectedMap))));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), any());
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
         NeuralSparseQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
@@ -661,10 +664,11 @@ public class NeuralSparseQueryBuilderTests extends OpenSearchTestCase {
         Map<String, Float> expectedMap = Map.of("1", 1f, "2", 5f);
         MLCommonsClientAccessor mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         doAnswer(invocation -> {
-            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onResponse(List.of(Map.of("response", List.of(expectedMap))));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), any());
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
         NeuralSparseQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryBuilderTests.java
@@ -627,7 +627,7 @@ public class NeuralSparseQueryBuilderTests extends OpenSearchTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onResponse(List.of(Map.of("response", List.of(expectedMap))));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), any(), any());
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), any());
         NeuralSparseQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
@@ -664,7 +664,7 @@ public class NeuralSparseQueryBuilderTests extends OpenSearchTestCase {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(2);
             listener.onResponse(List.of(Map.of("response", List.of(expectedMap))));
             return null;
-        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), any(), any());
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(any(), any());
         NeuralSparseQueryBuilder.initialize(mlCommonsClientAccessor);
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);


### PR DESCRIPTION
### Description
This is a code refactoring on encapsulation of MLCommonsClientAccessor required parameters into a POJO object.

- create a new request java object
- update MLCommonsClientAccessor interface with new request

### Related Issues
Resolves #790 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
