### PR TITLE
Encapsulate KNNQueryBuilder creation within NeuralKNNQueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 ### Maintenance
 ### Refactoring
+- Encapsulate KNNQueryBuilder creation within NeuralKNNQueryBuilder ([#1183](https://github.com/opensearch-project/neural-search/pull/1183))
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/neural-search/compare/2.19...2.x)
 ### Features

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.bwc.rolling;
 
 import org.opensearch.neuralsearch.util.TestUtils;
+import org.opensearch.ml.common.model.MLModelState;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,7 +29,14 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
             case OLD:
                 sparseModelId = uploadSparseEncodingModel();
                 loadModel(sparseModelId);
+                MLModelState oldModelState = getModelState(sparseModelId);
+                logger.info("Model state in OLD phase: {}", oldModelState);
+                if (oldModelState != MLModelState.LOADED) {
+                    logger.error("Model {} is not in LOADED state in OLD phase. Current state: {}", sparseModelId, oldModelState);
+                    waitForModelToLoad(sparseModelId);
+                }
                 createPipelineForSparseEncodingProcessor(sparseModelId, SPARSE_PIPELINE, 2);
+                logger.info("Pipeline state in OLD phase: {}", getIngestionPipeline(SPARSE_PIPELINE));
                 createIndexWithConfiguration(
                     indexName,
                     Files.readString(Path.of(classLoader.getResource("processor/SparseIndexMappings.json").toURI())),
@@ -36,21 +44,44 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
                 );
                 List<Map<String, String>> docs = prepareDataForBulkIngestion(0, 5);
                 bulkAddDocuments(indexName, TEXT_FIELD_NAME, SPARSE_PIPELINE, docs);
+                logger.info("Document count after OLD phase ingestion: {}", getDocCount(indexName));
                 validateDocCountAndInfo(indexName, 5, () -> getDocById(indexName, "4"), EMBEDDING_FIELD_NAME, Map.class);
                 break;
             case MIXED:
                 sparseModelId = TestUtils.getModelId(getIngestionPipeline(SPARSE_PIPELINE), SPARSE_ENCODING_PROCESSOR);
                 loadModel(sparseModelId);
+                MLModelState mixedModelState = getModelState(sparseModelId);
+                logger.info("Model state in MIXED phase: {}", mixedModelState);
+                if (mixedModelState != MLModelState.LOADED) {
+                    logger.error("Model {} is not in LOADED state in MIXED phase. Current state: {}", sparseModelId, mixedModelState);
+                    waitForModelToLoad(sparseModelId);
+                }
+                logger.info("Pipeline state in MIXED phase: {}", getIngestionPipeline(SPARSE_PIPELINE));
                 List<Map<String, String>> docsForMixed = prepareDataForBulkIngestion(5, 5);
+                logger.info("Document count before MIXED phase ingestion: {}", getDocCount(indexName));
                 bulkAddDocuments(indexName, TEXT_FIELD_NAME, SPARSE_PIPELINE, docsForMixed);
+                logger.info("Document count after MIXED phase ingestion: {}", getDocCount(indexName));
                 validateDocCountAndInfo(indexName, 10, () -> getDocById(indexName, "9"), EMBEDDING_FIELD_NAME, Map.class);
                 break;
             case UPGRADED:
                 try {
                     sparseModelId = TestUtils.getModelId(getIngestionPipeline(SPARSE_PIPELINE), SPARSE_ENCODING_PROCESSOR);
                     loadModel(sparseModelId);
+                    MLModelState upgradedModelState = getModelState(sparseModelId);
+                    logger.info("Model state in UPGRADED phase: {}", upgradedModelState);
+                    if (upgradedModelState != MLModelState.LOADED) {
+                        logger.error(
+                            "Model {} is not in LOADED state in UPGRADED phase. Current state: {}",
+                            sparseModelId,
+                            upgradedModelState
+                        );
+                        waitForModelToLoad(sparseModelId);
+                    }
+                    logger.info("Pipeline state in UPGRADED phase: {}", getIngestionPipeline(SPARSE_PIPELINE));
                     List<Map<String, String>> docsForUpgraded = prepareDataForBulkIngestion(10, 5);
+                    logger.info("Document count before UPGRADED phase ingestion: {}", getDocCount(indexName));
                     bulkAddDocuments(indexName, TEXT_FIELD_NAME, SPARSE_PIPELINE, docsForUpgraded);
+                    logger.info("Document count after UPGRADED phase ingestion: {}", getDocCount(indexName));
                     validateDocCountAndInfo(indexName, 15, () -> getDocById(indexName, "14"), EMBEDDING_FIELD_NAME, Map.class);
                 } finally {
                     wipeOfTestResources(indexName, SPARSE_PIPELINE, sparseModelId, null);
@@ -59,5 +90,21 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
             default:
                 throw new IllegalStateException("Unexpected value: " + getClusterType());
         }
+    }
+
+    private void waitForModelToLoad(String modelId) throws Exception {
+        int maxAttempts = 30;  // Maximum number of attempts
+        int waitTimeInSeconds = 2;  // Time to wait between attempts
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            MLModelState state = getModelState(modelId);
+            if (state == MLModelState.LOADED) {
+                logger.info("Model {} is now loaded after {} attempts", modelId, attempt + 1);
+                return;
+            }
+            logger.info("Waiting for model {} to load. Current state: {}. Attempt {}/{}", modelId, state, attempt + 1, maxAttempts);
+            Thread.sleep(waitTimeInSeconds * 1000);
+        }
+        throw new RuntimeException("Model " + modelId + " failed to load after " + maxAttempts + " attempts");
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQuery.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.Getter;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Wraps KNN Lucene query to support neural search extensions.
+ * Delegates core operations to the underlying KNN query.
+ */
+@Getter
+public class NeuralKNNQuery extends Query {
+    private final Query knnQuery;
+
+    public NeuralKNNQuery(Query knnQuery) {
+        this.knnQuery = knnQuery;
+    }
+
+    @Override
+    public String toString(String field) {
+        return knnQuery.toString(field);
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        // Delegate the visitor to the underlying KNN query
+        knnQuery.visit(visitor);
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        // Delegate weight creation to the underlying KNN query
+        return knnQuery.createWeight(searcher, scoreMode, boost);
+    }
+
+    @Override
+    public Query rewrite(IndexReader reader) throws IOException {
+        Query rewritten = knnQuery.rewrite(reader);
+        if (rewritten == knnQuery) {
+            return this;
+        }
+        return new NeuralKNNQuery(rewritten);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        NeuralKNNQuery that = (NeuralKNNQuery) other;
+        return Objects.equals(knnQuery, that.knnQuery);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(knnQuery);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilder.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.Getter;
+import org.apache.lucene.search.Query;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryRewriteContext;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * NeuralKNNQueryBuilder wraps KNNQueryBuilder to:
+ * 1. Isolate KNN plugin API changes to a single location
+ * 2. Allow extension with neural-search-specific information (e.g., query text)
+ */
+
+@Getter
+public class NeuralKNNQueryBuilder extends AbstractQueryBuilder<NeuralKNNQueryBuilder> {
+    private final KNNQueryBuilder knnQueryBuilder;
+
+    /**
+     * Creates a new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String fieldName() {
+        return knnQueryBuilder.fieldName();
+    }
+
+    public int k() {
+        return knnQueryBuilder.getK();
+    }
+
+    /**
+     * Builder for NeuralKNNQueryBuilder.
+     */
+    public static class Builder {
+        private String fieldName;
+        private float[] vector;
+        private Integer k;
+        private QueryBuilder filter;
+        private Float maxDistance;
+        private Float minScore;
+        private Boolean expandNested;
+        private Map<String, ?> methodParameters;
+        private RescoreContext rescoreContext;
+
+        private Builder() {}
+
+        public Builder fieldName(String fieldName) {
+            this.fieldName = fieldName;
+            return this;
+        }
+
+        public Builder vector(float[] vector) {
+            this.vector = vector;
+            return this;
+        }
+
+        public Builder k(Integer k) {
+            this.k = k;
+            return this;
+        }
+
+        public Builder filter(QueryBuilder filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder maxDistance(Float maxDistance) {
+            this.maxDistance = maxDistance;
+            return this;
+        }
+
+        public Builder minScore(Float minScore) {
+            this.minScore = minScore;
+            return this;
+        }
+
+        public Builder expandNested(Boolean expandNested) {
+            this.expandNested = expandNested;
+            return this;
+        }
+
+        public Builder methodParameters(Map<String, ?> methodParameters) {
+            this.methodParameters = methodParameters;
+            return this;
+        }
+
+        public Builder rescoreContext(RescoreContext rescoreContext) {
+            this.rescoreContext = rescoreContext;
+            return this;
+        }
+
+        public NeuralKNNQueryBuilder build() {
+            KNNQueryBuilder knnBuilder = KNNQueryBuilder.builder()
+                .fieldName(fieldName)
+                .vector(vector)
+                .k(k)
+                .filter(filter)
+                .maxDistance(maxDistance)
+                .minScore(minScore)
+                .expandNested(expandNested)
+                .methodParameters(methodParameters)
+                .rescoreContext(rescoreContext)
+                .build();
+            return new NeuralKNNQueryBuilder(knnBuilder);
+        }
+    }
+
+    private NeuralKNNQueryBuilder(KNNQueryBuilder knnQueryBuilder) {
+        this.knnQueryBuilder = knnQueryBuilder;
+    }
+
+    @Override
+    public void doWriteTo(StreamOutput out) throws IOException {
+        knnQueryBuilder.writeTo(out);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        knnQueryBuilder.toXContent(builder, params);
+    }
+
+    @Override
+    protected QueryBuilder doRewrite(QueryRewriteContext context) throws IOException {
+        QueryBuilder rewritten = knnQueryBuilder.rewrite(context);
+        if (rewritten == knnQueryBuilder) {
+            return this;
+        }
+        return new NeuralKNNQueryBuilder((KNNQueryBuilder) rewritten);
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        Query knnQuery = knnQueryBuilder.toQuery(context);
+        return new NeuralKNNQuery(knnQuery);
+    }
+
+    @Override
+    protected boolean doEquals(NeuralKNNQueryBuilder other) {
+        return Objects.equals(knnQueryBuilder, other.knnQueryBuilder);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(knnQueryBuilder);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return knnQueryBuilder.getWriteableName();
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilder.java
@@ -13,7 +13,9 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.index.query.parser.KNNQueryBuilderParser;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.knn.index.util.IndexUtil;
 
 import java.io.IOException;
 import java.util.Map;
@@ -127,12 +129,12 @@ public class NeuralKNNQueryBuilder extends AbstractQueryBuilder<NeuralKNNQueryBu
 
     @Override
     public void doWriteTo(StreamOutput out) throws IOException {
-        knnQueryBuilder.writeTo(out);
+        KNNQueryBuilderParser.streamOutput(out, knnQueryBuilder, IndexUtil::isClusterOnOrAfterMinRequiredVersion);
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        knnQueryBuilder.toXContent(builder, params);
+        knnQueryBuilder.doXContent(builder, params);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -40,7 +40,6 @@ import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
-import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.query.parser.MethodParametersParser;
 import org.opensearch.knn.index.query.parser.RescoreParser;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
@@ -463,22 +462,23 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
         // https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/query/Rewriteable.java#L117.
         // With the asynchronous call, on first rewrite, we create a new
         // vector supplier that will get populated once the asynchronous call finishes and pass this supplier in to
-        // create a new builder. Once the supplier's value gets set, we return a KNNQueryBuilder. Otherwise, we just
-        // return the current unmodified query builder.
+        // create a new builder. Once the supplier's value gets set, we return a NeuralKNNQueryBuilder
+        // which wrapped KNNQueryBuilder. Otherwise, we just return the current unmodified query builder.
         if (vectorSupplier() != null) {
             if (vectorSupplier().get() == null) {
                 return this;
             }
-            return KNNQueryBuilder.builder()
+
+            return NeuralKNNQueryBuilder.builder()
                 .fieldName(fieldName())
                 .vector(vectorSupplier.get())
+                .k(k())
                 .filter(filter())
-                .maxDistance(maxDistance)
-                .minScore(minScore)
-                .expandNested(expandNested)
-                .k(k)
-                .methodParameters(methodParameters)
-                .rescoreContext(rescoreContext)
+                .maxDistance(maxDistance())
+                .minScore(minScore())
+                .expandNested(expandNested())
+                .methodParameters(methodParameters())
+                .rescoreContext(rescoreContext())
                 .build();
         }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilderTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.mapper.KNNMappingConfig;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.core.index.Index;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.Version;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NeuralKNNQueryBuilderTests extends OpenSearchTestCase {
+
+    private static final String FIELD_NAME = "test_field";
+    private static final float[] VECTOR = new float[] { 1.0f, 2.0f, 3.0f };
+    private static final int K = 10;
+    private static final Map<String, Object> METHOD_PARAMETERS = Map.of("ef_search", 100);
+
+    private QueryShardContext mockContext;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockContext = mock(QueryShardContext.class);
+
+        // Mock KNN field type
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+        KNNMappingConfig mockKNNMappingConfig = mock(KNNMappingConfig.class);
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, MethodComponentContext.EMPTY);
+
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(mockKNNMappingConfig);
+        when(mockKNNMappingConfig.getKnnMethodContext()).thenReturn(Optional.of(knnMethodContext));
+        when(mockKNNVectorField.getKnnMappingConfig().getDimension()).thenReturn(3);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.typeName()).thenReturn("knn_vector");
+        when(mockKNNVectorField.name()).thenReturn(FIELD_NAME);
+
+        // Mock query shard context
+        Index dummyIndex = new Index("dummy", "dummy");
+        when(mockContext.index()).thenReturn(dummyIndex);
+        when(mockContext.fieldMapper(eq(FIELD_NAME))).thenReturn(mockKNNVectorField);
+
+        // Mock index settings
+        IndexMetadata indexMetadata = IndexMetadata.builder("dummy")
+            .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, Integer.toString(3)).build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
+        when(mockContext.getIndexSettings()).thenReturn(indexSettings);
+    }
+
+    public void testBuilder_withRequiredFields() {
+        NeuralKNNQueryBuilder queryBuilder = NeuralKNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(VECTOR).k(K).build();
+
+        assertNotNull("Query builder should not be null", queryBuilder);
+        assertEquals("Field name should match", "knn", queryBuilder.getWriteableName());
+    }
+
+    public void testBuilder_withAllFields() {
+        QueryBuilder filter = mock(QueryBuilder.class);
+
+        NeuralKNNQueryBuilder queryBuilder = NeuralKNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(VECTOR)
+            .k(K)
+            .filter(filter)
+            .expandNested(true)
+            .methodParameters(METHOD_PARAMETERS)
+            .build();
+
+        assertNotNull("Query builder should not be null", queryBuilder);
+        assertEquals("Field name should match", "knn", queryBuilder.getWriteableName());
+    }
+
+    public void testDoToQuery() throws IOException {
+        NeuralKNNQueryBuilder queryBuilder = NeuralKNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(VECTOR).k(K).build();
+
+        Query query = queryBuilder.doToQuery(mockContext);
+        assertNotNull("Query should not be null", query);
+        assertTrue("Query should be instance of NeuralKNNQuery", query instanceof NeuralKNNQuery);
+    }
+
+    public void testDoRewrite() throws IOException {
+        NeuralKNNQueryBuilder queryBuilder = NeuralKNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(VECTOR).k(K).build();
+
+        QueryBuilder rewritten = queryBuilder.doRewrite(mockContext);
+        assertNotNull("Rewritten query should not be null", rewritten);
+        assertTrue("Rewritten query should be instance of NeuralKNNQueryBuilder", rewritten instanceof NeuralKNNQueryBuilder);
+    }
+
+    public void testEquals() {
+        NeuralKNNQueryBuilder builder1 = NeuralKNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(VECTOR).k(K).build();
+
+        NeuralKNNQueryBuilder builder2 = NeuralKNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(VECTOR).k(K).build();
+
+        assertEquals("Identical builders should be equal", builder1, builder2);
+        assertEquals("Identical builders should have same hash code", builder1.hashCode(), builder2.hashCode());
+    }
+
+    public void testNotEquals() {
+        NeuralKNNQueryBuilder builder1 = NeuralKNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(VECTOR).k(K).build();
+
+        NeuralKNNQueryBuilder builder2 = NeuralKNNQueryBuilder.builder().fieldName("different_field").vector(VECTOR).k(K).build();
+
+        assertNotEquals("Different builders should not be equal", builder1, builder2);
+        assertNotEquals("Different builders should have different hash codes", builder1.hashCode(), builder2.hashCode());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralKNNQueryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralKNNQueryTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NeuralKNNQueryTests extends OpenSearchTestCase {
+
+    public void testNeuralKNNQuery() throws IOException {
+        Query mockKnnQuery = mock(Query.class);
+        NeuralKNNQuery query = new NeuralKNNQuery(mockKnnQuery);
+
+        // Test toString
+        when(mockKnnQuery.toString("field")).thenReturn("test_query");
+        assertEquals("toString should delegate to underlying query", "test_query", query.toString("field"));
+
+        // Test createWeight
+        when(mockKnnQuery.createWeight(any(), any(), anyFloat())).thenReturn(null);
+        query.createWeight(null, null, 1.0f);
+        verify(mockKnnQuery).createWeight(any(), any(), anyFloat());
+
+        // Test equals and hashCode
+        NeuralKNNQuery query2 = new NeuralKNNQuery(mockKnnQuery);
+        assertEquals("Same underlying query should be equal", query, query2);
+        assertEquals("Same underlying query should have same hash code", query.hashCode(), query2.hashCode());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -56,7 +56,6 @@ import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
-import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.neuralsearch.common.MinClusterVersionUtil;
 import org.opensearch.neuralsearch.common.VectorUtil;
@@ -869,7 +868,7 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .vectorSupplier(TEST_VECTOR_SUPPLIER)
             .build();
 
-        KNNQueryBuilder expected = KNNQueryBuilder.builder()
+        NeuralKNNQueryBuilder expected = NeuralKNNQueryBuilder.builder()
             .k(K)
             .fieldName(neuralQueryBuilder.fieldName())
             .methodParameters(neuralQueryBuilder.methodParameters())
@@ -892,9 +891,9 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             .filter(TEST_FILTER)
             .build();
         QueryBuilder queryBuilder = neuralQueryBuilder.doRewrite(null);
-        assertTrue(queryBuilder instanceof KNNQueryBuilder);
-        KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) queryBuilder;
-        assertEquals(neuralQueryBuilder.filter(), knnQueryBuilder.getFilter());
+        assertTrue(queryBuilder instanceof NeuralKNNQueryBuilder);
+        NeuralKNNQueryBuilder neuralKNNQueryBuilder = (NeuralKNNQueryBuilder) queryBuilder;
+        assertEquals(neuralQueryBuilder.filter(), neuralKNNQueryBuilder.getKnnQueryBuilder().getFilter());
     }
 
     public void testQueryCreation_whenCreateQueryWithDoToQuery_thenFail() {


### PR DESCRIPTION
### Description

Centralizes KNNQueryBuilder creation in NeuralKNNQueryBuilder to:
1. Put KNNQueryBuilder in a single location for easier handle breaking change from k-NN plugin.
2. Provide abstraction for future extensions like for neural highlighter feature need the original query text as input, which is currently lost in kNNQuery object. More context can be found at "Neural Query Builder Wrapper (based on Highlighter Framework Approach)" in https://github.com/opensearch-project/neural-search/issues/1175

### Related Issues
Part of https://github.com/opensearch-project/neural-search/issues/1182

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
