### PR TITLE
[Feature branch] Lower bounds for min-max normalization in hybrid query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/neural-search/compare/2.x...HEAD)
 ### Features
+- Lower bound for min-max normalization technique in hybrid query ([#1195](https://github.com/opensearch-project/neural-search/pull/1195))
 ### Enhancements
 - Set neural-search plugin 3.0.0 baseline JDK version to JDK-21 ([#838](https://github.com/opensearch-project/neural-search/pull/838))
 ### Bug Fixes

--- a/src/main/java/org/opensearch/neuralsearch/processor/CompoundTopDocs.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/CompoundTopDocs.java
@@ -170,10 +170,10 @@ public class CompoundTopDocs {
             if (thisTopDoc == null) {
                 continue;
             }
-            if (!Objects.equals(thisTopDoc.totalHits, thatTopDoc.totalHits)) {
+            if (Objects.equals(thisTopDoc.totalHits, thatTopDoc.totalHits) == false) {
                 return false;
             }
-            if (!compareScoreDocs(thisTopDoc.scoreDocs, thatTopDoc.scoreDocs)) {
+            if (compareScoreDocs(thisTopDoc.scoreDocs, thatTopDoc.scoreDocs) == false) {
                 return false;
             }
         }
@@ -202,7 +202,7 @@ public class CompoundTopDocs {
             }
             if (firstDoc instanceof FieldDoc firstFieldDoc) {
                 FieldDoc secondFieldDoc = (FieldDoc) secondDoc;
-                if (!Arrays.equals(firstFieldDoc.fields, secondFieldDoc.fields)) {
+                if (Arrays.equals(firstFieldDoc.fields, secondFieldDoc.fields) == false) {
                     return false;
                 }
             }

--- a/src/main/java/org/opensearch/neuralsearch/processor/CompoundTopDocs.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/CompoundTopDocs.java
@@ -13,6 +13,7 @@ import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUt
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -149,5 +150,79 @@ public class CompoundTopDocs {
         }
         FieldDoc fieldDoc = (FieldDoc) scoreDoc;
         return new FieldDoc(fieldDoc.doc, fieldDoc.score, fieldDoc.fields, fieldDoc.shardIndex);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        CompoundTopDocs that = (CompoundTopDocs) other;
+
+        if (this.topDocs.size() != that.topDocs.size()) {
+            return false;
+        }
+        for (int i = 0; i < topDocs.size(); i++) {
+            TopDocs thisTopDoc = this.topDocs.get(i);
+            TopDocs thatTopDoc = that.topDocs.get(i);
+            if ((thisTopDoc == null) != (thatTopDoc == null)) {
+                return false;
+            }
+            if (thisTopDoc == null) {
+                continue;
+            }
+            if (!Objects.equals(thisTopDoc.totalHits, thatTopDoc.totalHits)) {
+                return false;
+            }
+            if (!compareScoreDocs(thisTopDoc.scoreDocs, thatTopDoc.scoreDocs)) {
+                return false;
+            }
+        }
+        return Objects.equals(totalHits, that.totalHits) && Objects.equals(searchShard, that.searchShard);
+    }
+
+    private boolean compareScoreDocs(ScoreDoc[] first, ScoreDoc[] second) {
+        if (first.length != second.length) {
+            return false;
+        }
+
+        for (int i = 0; i < first.length; i++) {
+            ScoreDoc firstDoc = first[i];
+            ScoreDoc secondDoc = second[i];
+            if ((firstDoc == null) != (secondDoc == null)) {
+                return false;
+            }
+            if (firstDoc == null) {
+                continue;
+            }
+            if (firstDoc.doc != secondDoc.doc || Float.compare(firstDoc.score, secondDoc.score) != 0) {
+                return false;
+            }
+            if (firstDoc instanceof FieldDoc != secondDoc instanceof FieldDoc) {
+                return false;
+            }
+            if (firstDoc instanceof FieldDoc firstFieldDoc) {
+                FieldDoc secondFieldDoc = (FieldDoc) secondDoc;
+                if (!Arrays.equals(firstFieldDoc.fields, secondFieldDoc.fields)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(totalHits, searchShard);
+        for (TopDocs topDoc : topDocs) {
+            result = 31 * result + topDoc.totalHits.hashCode();
+            for (ScoreDoc scoreDoc : topDoc.scoreDocs) {
+                result = 31 * result + Float.floatToIntBits(scoreDoc.score);
+                result = 31 * result + scoreDoc.doc;
+                if (scoreDoc instanceof FieldDoc fieldDoc && fieldDoc.fields != null) {
+                    result = 31 * result + Arrays.deepHashCode(fieldDoc.fields);
+                }
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
@@ -58,7 +58,8 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
                 TECHNIQUE,
                 MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME
             );
-            normalizationTechnique = scoreNormalizationFactory.createNormalization(normalizationTechniqueName);
+            Map<String, Object> normalizationParams = readOptionalMap(NormalizationProcessor.TYPE, tag, normalizationClause, PARAMETERS);
+            normalizationTechnique = scoreNormalizationFactory.createNormalization(normalizationTechniqueName, normalizationParams);
         }
 
         Map<String, Object> combinationClause = readOptionalMap(NormalizationProcessor.TYPE, tag, config, COMBINATION_CLAUSE);

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -31,6 +32,14 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
     @ToString.Include
     public static final String TECHNIQUE_NAME = "l2";
     private static final float MIN_SCORE = 0.0f;
+
+    public L2ScoreNormalizationTechnique() {
+        this(Map.of(), new ScoreNormalizationUtil());
+    }
+
+    public L2ScoreNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
+        scoreNormalizationUtil.validateParameters(params, Set.of(), Map.of());
+    }
 
     /**
      * L2 normalization method.

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
@@ -246,11 +246,10 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
             return Optional.empty();
         }
 
-        Object lowerBoundsObj = params.get(PARAM_NAME_LOWER_BOUNDS);
-        if (lowerBoundsObj instanceof List<?> == false) {
-            throw new IllegalArgumentException("lower_bounds must be a List");
-        }
-        List<?> lowerBoundsParams = (List<?>) lowerBoundsObj;
+        List<?> lowerBoundsParams = Optional.ofNullable(params.get(PARAM_NAME_LOWER_BOUNDS))
+            .filter(List.class::isInstance)
+            .map(List.class::cast)
+            .orElseThrow(() -> new IllegalArgumentException("lower_bounds must be a List"));
         // number of lower bounds must match the number of sub-queries in a hybrid query
         if (lowerBoundsParams.size() > MAX_NUMBER_OF_SUB_QUERIES) {
             throw new IllegalArgumentException(
@@ -324,7 +323,7 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
      * Result class to hold lower bound for each sub query
      */
     @Getter
-    public static class LowerBound {
+    static class LowerBound {
         static final float MIN_LOWER_BOUND_SCORE = -10_000f;
         static final float MAX_LOWER_BOUND_SCORE = 10_000f;
         static final float DEFAULT_LOWER_BOUND_SCORE = 0.0f;

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
@@ -31,6 +31,7 @@ import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
 
 import static org.opensearch.neuralsearch.processor.explain.ExplanationUtils.getDocIdAtQueryForNormalization;
+import static org.opensearch.neuralsearch.query.HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES;
 
 /**
  * Abstracts normalization of scores based on min-max method
@@ -44,10 +45,10 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
     private final List<Pair<Mode, Float>> lowerBounds;
 
     public MinMaxScoreNormalizationTechnique() {
-        this(Map.of(), new ScoreNormalizationUtil());
+        this(Map.of());
     }
 
-    public MinMaxScoreNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
+    public MinMaxScoreNormalizationTechnique(final Map<String, Object> params) {
         lowerBounds = getLowerBounds(params);
     }
 
@@ -236,6 +237,17 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
         Object lowerBoundsObj = params.get("lower_bounds");
         if (!(lowerBoundsObj instanceof List<?> lowerBoundsParams)) {
             throw new IllegalArgumentException("lower_bounds must be a List");
+        }
+
+        if (lowerBoundsParams.size() > MAX_NUMBER_OF_SUB_QUERIES) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "lower_bounds size %d should be less than or equal to %d",
+                    lowerBoundsParams.size(),
+                    MAX_NUMBER_OF_SUB_QUERIES
+                )
+            );
         }
 
         for (Object boundObj : lowerBoundsParams) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
@@ -107,7 +107,7 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
 
     private boolean isLowerBoundsAndSubQueriesCountMismatched(List<TopDocs> topDocsPerSubQuery) {
         return lowerBoundsOptional.isPresent()
-            && !topDocsPerSubQuery.isEmpty()
+            && topDocsPerSubQuery.isEmpty() == false
             && lowerBoundsOptional.get().size() != topDocsPerSubQuery.size();
     }
 
@@ -175,7 +175,7 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
     private int getNumOfSubqueries(final List<CompoundTopDocs> queryTopDocs) {
         return queryTopDocs.stream()
             .filter(Objects::nonNull)
-            .filter(topDocs -> !topDocs.getTopDocs().isEmpty())
+            .filter(topDocs -> topDocs.getTopDocs().isEmpty() == false)
             .findAny()
             .get()
             .getTopDocs()
@@ -229,7 +229,7 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
         if (Floats.compare(maxScore, minScore) == 0 && Floats.compare(maxScore, score) == 0) {
             return SINGLE_RESULT_SCORE;
         }
-        if (!lowerBound.isEnabled()) {
+        if (lowerBound.isEnabled() == false) {
             return LowerBound.Mode.IGNORE.normalize(score, minScore, maxScore, lowerBound.getMinScore());
         }
         return lowerBound.getMode().normalize(score, minScore, maxScore, lowerBound.getMinScore());
@@ -242,14 +242,15 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
      */
     private Optional<List<Pair<LowerBound.Mode, Float>>> getLowerBounds(final Map<String, Object> params) {
         // validate that the input parameters are in correct format
-        if (Objects.isNull(params) || !params.containsKey(PARAM_NAME_LOWER_BOUNDS)) {
+        if (Objects.isNull(params) || params.containsKey(PARAM_NAME_LOWER_BOUNDS) == false) {
             return Optional.empty();
         }
 
         Object lowerBoundsObj = params.get(PARAM_NAME_LOWER_BOUNDS);
-        if (!(lowerBoundsObj instanceof List<?> lowerBoundsParams)) {
+        if (lowerBoundsObj instanceof List<?> == false) {
             throw new IllegalArgumentException("lower_bounds must be a List");
         }
+        List<?> lowerBoundsParams = (List<?>) lowerBoundsObj;
         // number of lower bounds must match the number of sub-queries in a hybrid query
         if (lowerBoundsParams.size() > MAX_NUMBER_OF_SUB_QUERIES) {
             throw new IllegalArgumentException(
@@ -274,7 +275,7 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
      * @return a single pair of mode and min score
      */
     private Pair<LowerBound.Mode, Float> parseLowerBound(Object boundObj) {
-        if (!(boundObj instanceof Map)) {
+        if ((boundObj instanceof Map) == false) {
             throw new IllegalArgumentException("each lower bound must be a map");
         }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
@@ -48,7 +48,7 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
     private final int rankConstant;
 
     public RRFNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
-        scoreNormalizationUtil.validateParams(params, SUPPORTED_PARAMS);
+        scoreNormalizationUtil.validateParameters(params, SUPPORTED_PARAMS, Map.of());
         rankConstant = getRankConstant(params);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
@@ -15,11 +15,14 @@ public class ScoreNormalizationFactory {
 
     private static final ScoreNormalizationUtil scoreNormalizationUtil = new ScoreNormalizationUtil();
 
-    public static final ScoreNormalizationTechnique DEFAULT_METHOD = new MinMaxScoreNormalizationTechnique();
+    public static final ScoreNormalizationTechnique DEFAULT_METHOD = new MinMaxScoreNormalizationTechnique(
+        Map.of(),
+        scoreNormalizationUtil
+    );
 
     private final Map<String, Function<Map<String, Object>, ScoreNormalizationTechnique>> scoreNormalizationMethodsMap = Map.of(
         MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new MinMaxScoreNormalizationTechnique(),
+        params -> new MinMaxScoreNormalizationTechnique(params, scoreNormalizationUtil),
         L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
         params -> new L2ScoreNormalizationTechnique(),
         RRFNormalizationTechnique.TECHNIQUE_NAME,

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
@@ -15,14 +15,11 @@ public class ScoreNormalizationFactory {
 
     private static final ScoreNormalizationUtil scoreNormalizationUtil = new ScoreNormalizationUtil();
 
-    public static final ScoreNormalizationTechnique DEFAULT_METHOD = new MinMaxScoreNormalizationTechnique(
-        Map.of(),
-        scoreNormalizationUtil
-    );
+    public static final ScoreNormalizationTechnique DEFAULT_METHOD = new MinMaxScoreNormalizationTechnique(Map.of());
 
     private final Map<String, Function<Map<String, Object>, ScoreNormalizationTechnique>> scoreNormalizationMethodsMap = Map.of(
         MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new MinMaxScoreNormalizationTechnique(params, scoreNormalizationUtil),
+        MinMaxScoreNormalizationTechnique::new,
         L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
         params -> new L2ScoreNormalizationTechnique(),
         RRFNormalizationTechnique.TECHNIQUE_NAME,

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
@@ -15,13 +15,13 @@ public class ScoreNormalizationFactory {
 
     private static final ScoreNormalizationUtil scoreNormalizationUtil = new ScoreNormalizationUtil();
 
-    public static final ScoreNormalizationTechnique DEFAULT_METHOD = new MinMaxScoreNormalizationTechnique(Map.of());
+    public static final ScoreNormalizationTechnique DEFAULT_METHOD = new MinMaxScoreNormalizationTechnique();
 
     private final Map<String, Function<Map<String, Object>, ScoreNormalizationTechnique>> scoreNormalizationMethodsMap = Map.of(
         MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
-        MinMaxScoreNormalizationTechnique::new,
+        params -> new MinMaxScoreNormalizationTechnique(params, scoreNormalizationUtil),
         L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new L2ScoreNormalizationTechnique(),
+        params -> new L2ScoreNormalizationTechnique(params, scoreNormalizationUtil),
         RRFNormalizationTechnique.TECHNIQUE_NAME,
         params -> new RRFNormalizationTechnique(params, scoreNormalizationUtil)
     );

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtil.java
@@ -82,4 +82,78 @@ class ScoreNormalizationUtil {
         }
         scores.set(subQueryIndex, normalizedScore);
     }
+
+    /**
+     * Validate parameters for this technique. Following is example of structured parameters that we will validate
+     * {
+     *     "technique": "arithmetic_mean",  // top-level parameter 1
+     *     "details": {                     // top-level parameter 2
+     *         "weights": [1, 2, 3],        // nested parameter 1
+     *         "color": "green".            // nested parameter 2
+     *     }
+     * }
+     * for this example client should pass:
+     *     top-level parameters: ["technique", "details"]
+     *     nested parameters: ["details" -> ["weights", "color"]]
+     * @param actualParameters map of actual parameters in form of name-value
+     * @param supportedParametersTopLevel collection of top-level parameters that we should validate against
+     * @param supportedParametersNested map of nested parameters that we should validate against, key is one of top level parameters and value is set of allowed nested params
+     */
+    public void validateParameters(
+        final Map<String, Object> actualParameters,
+        final Set<String> supportedParametersTopLevel,
+        final Map<String, Set<String>> supportedParametersNested
+    ) {
+        if (Objects.isNull(actualParameters) || actualParameters.isEmpty()) {
+            return;
+        }
+        boolean hasUnknownParameters = false;
+        for (Map.Entry<String, Object> entry : actualParameters.entrySet()) {
+            String paramName = entry.getKey();
+            Object paramValue = entry.getValue();
+
+            if (!supportedParametersTopLevel.contains(paramName)) {
+                hasUnknownParameters = true;
+                continue;
+            }
+            if (paramValue instanceof Map) {
+                Map<String, Object> nestedParams = (Map<String, Object>) paramValue;
+                validateNestedParameters(nestedParams, supportedParametersNested.get(paramName));
+            } else if (paramValue instanceof List) {
+                for (Object item : (List<?>) paramValue) {
+                    if (item instanceof Map) {
+                        validateNestedParameters((Map<String, Object>) item, supportedParametersNested.get(paramName));
+                    } else {
+                        hasUnknownParameters = true;
+                    }
+                }
+            } else {
+                if (supportedParametersNested.isEmpty()) {
+                    continue;
+                }
+                hasUnknownParameters = true;
+            }
+        }
+        if (hasUnknownParameters) {
+            throw new IllegalArgumentException("unrecognized parameters in normalization technique");
+        }
+    }
+
+    private void validateNestedParameters(Map<String, Object> parameters, Set<String> supportedNestedParams) {
+        if (Objects.isNull(parameters) || parameters.isEmpty()) {
+            return;
+        }
+        boolean hasUnknownParameters = false;
+        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+            String paramName = entry.getKey();
+
+            if (Objects.nonNull(supportedNestedParams) && !supportedNestedParams.contains(paramName)) {
+                hasUnknownParameters = true;
+                break;
+            }
+        }
+        if (hasUnknownParameters) {
+            throw new IllegalArgumentException("unrecognized parameters in normalization technique");
+        }
+    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtil.java
@@ -49,7 +49,7 @@ class ScoreNormalizationUtil {
 
         // check param types
         if (actualParams.keySet().stream().anyMatch(PARAM_NAME_WEIGHTS::equalsIgnoreCase)) {
-            if (!(actualParams.get(PARAM_NAME_WEIGHTS) instanceof List)) {
+            if (actualParams.get(PARAM_NAME_WEIGHTS) instanceof List == false) {
                 throw new IllegalArgumentException(
                     String.format(Locale.ROOT, "parameter [%s] must be a collection of numbers", PARAM_NAME_WEIGHTS)
                 );
@@ -112,7 +112,7 @@ class ScoreNormalizationUtil {
             String paramName = entry.getKey();
             Object paramValue = entry.getValue();
 
-            if (!supportedParametersTopLevel.contains(paramName)) {
+            if (supportedParametersTopLevel.contains(paramName) == false) {
                 hasUnknownParameters = true;
                 continue;
             }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -57,7 +57,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
 
     private Integer paginationDepth;
 
-    static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
+    public static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
     private static final int LOWER_BOUND_OF_PAGINATION_DEPTH = 0;
 
     public HybridQueryBuilder(StreamInput in) throws IOException {

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -4,6 +4,8 @@
  */
 package org.opensearch.neuralsearch.processor;
 
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_COMBINATION_METHOD;
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_NORMALIZATION_METHOD;
 import static org.opensearch.neuralsearch.util.TestUtils.RELATION_EQUAL_TO;
 import static org.opensearch.neuralsearch.util.TestUtils.TEST_DIMENSION;
 import static org.opensearch.neuralsearch.util.TestUtils.TEST_SPACE_TYPE;
@@ -48,6 +50,8 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
     private static final String TEST_TEXT_FIELD_NAME_1 = "test-text-field-1";
     private static final String TEST_TEXT_FIELD_NAME_2 = "test-text-field-2";
     private static final String SEARCH_PIPELINE = "phase-results-normalization-processor-pipeline";
+    private static final String SEARCH_PIPELINE_LOWER_BOUNDS_2_QUERIES = "normalization-processor-with-lower-bounds-two-queries";
+    private static final String SEARCH_PIPELINE_LOWER_BOUNDS_3_QUERIES = "normalization-processor-with-lower-bounds-three-queries";
     private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
     private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
@@ -235,6 +239,123 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             null,
             5,
             Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertQueryResults(searchResponseAsMapNoMatches, 0, true);
+    }
+
+    @SneakyThrows
+    public void testMinMaxLowerBounds_whenMultipleShards_thenSuccessful() {
+        String modelId = null;
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME);
+        modelId = prepareModel();
+        createSearchPipeline(
+            SEARCH_PIPELINE_LOWER_BOUNDS_2_QUERIES,
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(
+                "lower_bounds",
+                List.of(
+                    Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
+                    Map.of("mode", "clip", "min_score", Float.toString(0.0f))
+                )
+            ),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            false
+        );
+        int totalExpectedDocQty = 6;
+
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+            .queryText(TEST_DOC_TEXT1)
+            .modelId(modelId)
+            .k(6)
+            .build();
+
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(neuralQueryBuilder);
+        hybridQueryBuilder.add(termQueryBuilder);
+
+        Map<String, Object> searchResponseAsMap = search(
+            TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+            hybridQueryBuilder,
+            null,
+            6,
+            Map.of("search_pipeline", SEARCH_PIPELINE_LOWER_BOUNDS_2_QUERIES)
+        );
+
+        assertNotNull(searchResponseAsMap);
+        Map<String, Object> total = getTotalHits(searchResponseAsMap);
+        assertNotNull(total.get("value"));
+        assertEquals(totalExpectedDocQty, total.get("value"));
+        assertNotNull(total.get("relation"));
+        assertEquals(RELATION_EQUAL_TO, total.get("relation"));
+        assertTrue(getMaxScore(searchResponseAsMap).isPresent());
+        assertTrue(Range.between(.5f, 1.0f).contains(getMaxScore(searchResponseAsMap).get()));
+        List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
+        List<String> ids = new ArrayList<>();
+        List<Double> scores = new ArrayList<>();
+        for (Map<String, Object> oneHit : hitsNestedList) {
+            ids.add((String) oneHit.get("_id"));
+            scores.add((Double) oneHit.get("_score"));
+        }
+        // verify scores order
+        assertTrue(IntStream.range(0, scores.size() - 1).noneMatch(idx -> scores.get(idx) < scores.get(idx + 1)));
+
+        // verify the scores are normalized. we need special assert logic because combined score may vary as neural search query
+        // based on random vectors and return results for every doc. In some cases that may affect 1.0 score from term query and make it
+        // lower.
+        float highestScore = scores.stream().max(Double::compare).get().floatValue();
+        assertTrue(Range.between(.5f, 1.0f).contains(highestScore));
+        float lowestScore = scores.stream().min(Double::compare).get().floatValue();
+        assertTrue(Range.between(.0f, .5f).contains(lowestScore));
+
+        // verify that all ids are unique
+        assertEquals(Set.copyOf(ids).size(), ids.size());
+
+        createSearchPipeline(
+            SEARCH_PIPELINE_LOWER_BOUNDS_3_QUERIES,
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(
+                "lower_bounds",
+                List.of(
+                    Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
+                    Map.of("mode", "clip", "min_score", Float.toString(0.0f)),
+                    Map.of("mode", "ignore", "min_score", Float.toString(0.0f))
+                )
+            ),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            false
+        );
+
+        // verify case when there are partial match
+        HybridQueryBuilder hybridQueryBuilderPartialMatch = new HybridQueryBuilder();
+        hybridQueryBuilderPartialMatch.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3));
+        hybridQueryBuilderPartialMatch.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4));
+        hybridQueryBuilderPartialMatch.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT7));
+
+        Map<String, Object> searchResponseAsMapPartialMatch = search(
+            TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+            hybridQueryBuilderPartialMatch,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE_LOWER_BOUNDS_3_QUERIES)
+        );
+        assertQueryResults(searchResponseAsMapPartialMatch, 4, false, Range.between(0.33f, 1.0f));
+
+        // verify case when query doesn't have a match
+        HybridQueryBuilder hybridQueryBuilderNoMatches = new HybridQueryBuilder();
+        hybridQueryBuilderNoMatches.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT6));
+        hybridQueryBuilderNoMatches.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT7));
+
+        Map<String, Object> searchResponseAsMapNoMatches = search(
+            TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+            hybridQueryBuilderNoMatches,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE_LOWER_BOUNDS_2_QUERIES)
         );
         assertQueryResults(searchResponseAsMapNoMatches, 0, true);
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.processor.normalization;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -318,6 +319,34 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
         assertTrue(doc1Scores.get(0).getValue().contains("l2 normalization"));
         assertTrue(doc1Scores.get(1).getValue().contains("l2 normalization"));
         assertTrue(doc1Scores.get(2).getValue().contains("l2 normalization"));
+    }
+
+    public void testInvalidParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsList = List.of(
+            Map.of("min_score", 0.1, "mode", "clip"),
+            Map.of("mode", "ignore", "invalid_param", "value")
+        );
+        parameters.put("lower_bounds", lowerBoundsList);
+
+        try {
+            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            fail("expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("unrecognized parameters in normalization technique", e.getMessage());
+        }
+    }
+
+    public void testUnsupportedTopLevelParameter() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("invalid_top_level_param", "value"); // Adding an invalid top-level parameter
+
+        try {
+            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            fail("expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("unrecognized parameters in normalization technique", e.getMessage());
+        }
     }
 
     private float l2Norm(float score, List<Float> scores) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -28,6 +28,7 @@ import org.opensearch.search.SearchShardTarget;
 import static org.opensearch.neuralsearch.processor.normalization.MinMaxScoreNormalizationTechnique.MIN_SCORE;
 import static org.opensearch.neuralsearch.query.HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES;
 import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
+import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_LOWER_BOUNDS;
 
 /**
  * Abstracts normalization of scores based on min-max method
@@ -274,86 +275,124 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         assertEquals(1.0f, topDocs3.scoreDocs[0].score, DELTA_FOR_SCORE_ASSERTION); // doc1 in third subquery
     }
 
-    public void testMode_fromString_validValues() {
-        assertEquals(MinMaxScoreNormalizationTechnique.Mode.APPLY, MinMaxScoreNormalizationTechnique.Mode.fromString("apply"));
-        assertEquals(MinMaxScoreNormalizationTechnique.Mode.CLIP, MinMaxScoreNormalizationTechnique.Mode.fromString("clip"));
-        assertEquals(MinMaxScoreNormalizationTechnique.Mode.IGNORE, MinMaxScoreNormalizationTechnique.Mode.fromString("ignore"));
+    public void testLowerBoundsModeFromString_whenValidValues_thenSuccessful() {
+        assertEquals(
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY,
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("apply")
+        );
+        assertEquals(
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.CLIP,
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("clip")
+        );
+        assertEquals(
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.IGNORE,
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("ignore")
+        );
         // Case insensitive check
-        assertEquals(MinMaxScoreNormalizationTechnique.Mode.APPLY, MinMaxScoreNormalizationTechnique.Mode.fromString("APPLY"));
+        assertEquals(
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY,
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("APPLY")
+        );
     }
 
     public void testMode_fromString_invalidValues() {
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> MinMaxScoreNormalizationTechnique.Mode.fromString("invalid")
+            () -> MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("invalid")
         );
         assertEquals("invalid mode: invalid, valid values are: apply, clip, ignore", exception.getMessage());
     }
 
-    public void testMode_fromString_nullOrEmpty() {
+    public void testLowerBoundsModeFromString_whenNullOrEmpty_thenFail() {
         IllegalArgumentException nullException = expectThrows(
             IllegalArgumentException.class,
-            () -> MinMaxScoreNormalizationTechnique.Mode.fromString(null)
+            () -> MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString(null)
         );
         assertEquals("mode value cannot be null or empty", nullException.getMessage());
-
-        IllegalArgumentException emptyException = expectThrows(
-            IllegalArgumentException.class,
-            () -> MinMaxScoreNormalizationTechnique.Mode.fromString("")
-        );
-        assertEquals("mode value cannot be null or empty", emptyException.getMessage());
     }
 
-    public void testMode_normalize_apply() {
+    public void testLowerBounds_whenModeIsApply_thenSuccessful() {
         float score = 0.5f;
-        float minScore = 0.2f;
+        float minScore = 0.1f;
         float maxScore = 0.8f;
         float lowerBoundScore = 0.3f;
 
-        float normalizedScore = MinMaxScoreNormalizationTechnique.Mode.APPLY.normalize(score, minScore, maxScore, lowerBoundScore);
+        float normalizedScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY.normalize(
+            score,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        // we expect score as 0.5 - 0.3 / 0.8 - 0.3 = 0.2 / 0.5 = 0.4
         assertEquals(0.4f, normalizedScore, DELTA_FOR_SCORE_ASSERTION);
 
         // Test when score is below lower bound
-        float lowScore = 0.1f;
-        float normalizedLowScore = MinMaxScoreNormalizationTechnique.Mode.APPLY.normalize(lowScore, minScore, maxScore, lowerBoundScore);
+        float lowScore = 0.2f;
+        float normalizedLowScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY.normalize(
+            lowScore,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        // we expect score as 0.2 - 0.1 / 0.8 - 0.1 = 0.1 / 0.7 = 0.1
         assertEquals(0.143f, normalizedLowScore, DELTA_FOR_SCORE_ASSERTION);
     }
 
-    public void testMode_normalize_clip() {
+    public void testLowerBounds_whenModeIsClip_thenSuccessful() {
         float score = 0.5f;
         float minScore = 0.2f;
         float maxScore = 0.8f;
         float lowerBoundScore = 0.3f;
 
-        float normalizedScore = MinMaxScoreNormalizationTechnique.Mode.CLIP.normalize(score, minScore, maxScore, lowerBoundScore);
+        float normalizedScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.CLIP.normalize(
+            score,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
         assertEquals(0.4f, normalizedScore, DELTA_FOR_SCORE_ASSERTION);
 
         // Test when score is below min score
         float lowScore = 0.1f;
-        float normalizedLowScore = MinMaxScoreNormalizationTechnique.Mode.CLIP.normalize(lowScore, minScore, maxScore, lowerBoundScore);
-        assertEquals(0.6f, normalizedLowScore, DELTA_FOR_SCORE_ASSERTION);
+        float normalizedLowScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.CLIP.normalize(
+            lowScore,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        assertEquals(0.0f, normalizedLowScore, DELTA_FOR_SCORE_ASSERTION);
     }
 
-    public void testMode_normalize_ignore() {
+    public void testLowerBounds_whenModeIsIgnore_thenSuccessful() {
         float score = 0.5f;
         float minScore = 0.2f;
         float maxScore = 0.8f;
         float lowerBoundScore = 0.3f;
 
-        float normalizedScore = MinMaxScoreNormalizationTechnique.Mode.IGNORE.normalize(score, minScore, maxScore, lowerBoundScore);
+        float normalizedScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.IGNORE.normalize(
+            score,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
         assertEquals(0.5f, normalizedScore, DELTA_FOR_SCORE_ASSERTION);
 
         // Test when normalized score would be 0
         float lowScore = 0.2f;
-        float normalizedLowScore = MinMaxScoreNormalizationTechnique.Mode.IGNORE.normalize(lowScore, minScore, maxScore, lowerBoundScore);
+        float normalizedLowScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.IGNORE.normalize(
+            lowScore,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
         assertEquals(MIN_SCORE, normalizedLowScore, DELTA_FOR_SCORE_ASSERTION);
     }
 
-    public void testMode_defaultValue() {
-        assertEquals(MinMaxScoreNormalizationTechnique.Mode.APPLY, MinMaxScoreNormalizationTechnique.Mode.DEFAULT);
+    public void testLowerBoundsMode_whenDefaultValue_thenSuccessful() {
+        assertEquals(MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY, MinMaxScoreNormalizationTechnique.LowerBound.Mode.DEFAULT);
     }
 
-    public void testLowerBoundsExceedsMaxSubQueries() {
+    public void testLowerBounds_whenExceedsMaxSubQueries_thenFail() {
         List<Map<String, Object>> lowerBounds = new ArrayList<>();
 
         for (int i = 0; i <= 100; i++) {
@@ -375,7 +414,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
 
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> new MinMaxScoreNormalizationTechnique(parameters)
+            () -> new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil())
         );
 
         assertEquals(
@@ -387,6 +426,203 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
             ),
             exception.getMessage()
         );
+    }
+
+    public void testDescribe_whenLowerBoundsArePresent_thenSuccessful() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBounds = Arrays.asList(
+            Map.of("mode", "apply", "min_score", 0.2),
+
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parameters.put("lower_bounds", lowerBounds);
+        MinMaxScoreNormalizationTechnique techniqueWithBounds = new MinMaxScoreNormalizationTechnique(
+            parameters,
+            new ScoreNormalizationUtil()
+        );
+        assertEquals("min_max, lower bounds [(apply, 0.2), (clip, 0.1)]", techniqueWithBounds.describe());
+
+        // Test case 2: without lower bounds
+        Map<String, Object> emptyParameters = new HashMap<>();
+        MinMaxScoreNormalizationTechnique techniqueWithoutBounds = new MinMaxScoreNormalizationTechnique(
+            emptyParameters,
+            new ScoreNormalizationUtil()
+        );
+        assertEquals("min_max", techniqueWithoutBounds.describe());
+
+        Map<String, Object> parametersMissingMode = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsMissingMode = Arrays.asList(
+            Map.of("min_score", 0.2),
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parametersMissingMode.put("lower_bounds", lowerBoundsMissingMode);
+        MinMaxScoreNormalizationTechnique techniqueMissingMode = new MinMaxScoreNormalizationTechnique(
+            parametersMissingMode,
+            new ScoreNormalizationUtil()
+        );
+        assertEquals("min_max, lower bounds [(apply, 0.2), (clip, 0.1)]", techniqueMissingMode.describe());
+
+        Map<String, Object> parametersMissingScore = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsMissingScore = Arrays.asList(
+            Map.of("mode", "apply"),
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parametersMissingScore.put("lower_bounds", lowerBoundsMissingScore);
+        MinMaxScoreNormalizationTechnique techniqueMissingScore = new MinMaxScoreNormalizationTechnique(
+            parametersMissingScore,
+            new ScoreNormalizationUtil()
+        );
+        assertEquals("min_max, lower bounds [(apply, 0.0), (clip, 0.1)]", techniqueMissingScore.describe());
+    }
+
+    public void testLowerBounds_whenInvalidInput_thenFail() {
+        // Test case 1: Invalid mode value
+        Map<String, Object> parametersInvalidMode = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsInvalidMode = Arrays.asList(
+            Map.of("mode", "invalid_mode", "min_score", 0.2),
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parametersInvalidMode.put("lower_bounds", lowerBoundsInvalidMode);
+        IllegalArgumentException invalidModeException = expectThrows(
+            IllegalArgumentException.class,
+            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidMode, new ScoreNormalizationUtil())
+        );
+        assertEquals("invalid mode: invalid_mode, valid values are: apply, clip, ignore", invalidModeException.getMessage());
+
+        // Test case 4: Invalid min_score type
+        Map<String, Object> parametersInvalidScore = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsInvalidScore = Arrays.asList(
+            Map.of("mode", "apply", "min_score", "not_a_number"),
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parametersInvalidScore.put("lower_bounds", lowerBoundsInvalidScore);
+        IllegalArgumentException invalidScoreException = expectThrows(
+            IllegalArgumentException.class,
+            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidScore, new ScoreNormalizationUtil())
+        );
+        assertEquals("invalid format for min_score: must be a valid float value", invalidScoreException.getMessage());
+    }
+
+    public void testLowerBoundsValidation_whenLowerBoundsAndSubQueriesCountMismatch_thenFail() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBounds = Arrays.asList(Map.of("mode", "clip", "min_score", 0.1));
+        parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
+
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    ),
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(3, 0.1f) })
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(minMaxTechnique)
+            .build();
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> minMaxTechnique.normalize(normalizeScoresDTO)
+        );
+
+        assertEquals(
+            "expected lower bounds array to contain 2 elements matching the number of sub-queries, but found a mismatch",
+            exception.getMessage()
+        );
+    }
+
+    public void testLowerBoundsValidation_whenTopDocsIsEmpty_thenSuccessful() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBounds = Arrays.asList(
+            Map.of("mode", "clip", "min_score", 0.1),
+            Map.of("mode", "apply", "min_score", 0.0)
+        );
+        parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
+
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), List.of(), false, SEARCH_SHARD),
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    ),
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(3, 0.1f) })
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(minMaxTechnique)
+            .build();
+
+        minMaxTechnique.normalize(normalizeScoresDTO);
+
+        CompoundTopDocs expectedCompoundDocsZero = new CompoundTopDocs(
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+            List.of(),
+            false,
+            SEARCH_SHARD
+        );
+        CompoundTopDocs expectedCompoundDocsOne = new CompoundTopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, 0.25f) }
+                ),
+                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(3, 1.0f) })
+            ),
+            false,
+            SEARCH_SHARD
+        );
+        expectedCompoundDocsOne.setScoreDocs(List.of(new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f)));
+        assertNotNull(compoundTopDocs);
+        assertEquals(2, compoundTopDocs.size());
+        CompoundTopDocs compoundTopDocsZero = compoundTopDocs.get(0);
+        assertEquals(expectedCompoundDocsZero, compoundTopDocsZero);
+        CompoundTopDocs compoundTopDocsOne = compoundTopDocs.get(1);
+        assertEquals(expectedCompoundDocsOne, compoundTopDocsOne);
+    }
+
+    public void testInvalidParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsList = List.of(
+            Map.of("min_score", 0.1, "mode", "clip"),
+            Map.of("mode", "ignore", "invalid_param", "value") // Adding an invalid nested parameter
+        );
+        parameters.put("lower_bounds", lowerBoundsList);
+
+        try {
+            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            fail("Expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("unrecognized parameters in normalization technique", e.getMessage());
+        }
+    }
+
+    public void testUnsupportedTopLevelParameter() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("invalid_top_level_param", "value"); // Adding an invalid top-level parameter
+
+        try {
+            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            fail("Expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("unrecognized parameters in normalization technique", e.getMessage());
+        }
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactoryTests.java
@@ -5,8 +5,14 @@
 package org.opensearch.neuralsearch.processor.normalization;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_LOWER_BOUNDS;
 
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ScoreNormalizationFactoryTests extends OpenSearchQueryTestCase {
 
@@ -42,4 +48,32 @@ public class ScoreNormalizationFactoryTests extends OpenSearchQueryTestCase {
         );
         assertThat(illegalArgumentException.getMessage(), containsString("provided normalization technique is not supported"));
     }
+
+    public void testCreateMinMaxNormalizationWithParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+
+        List<Map<String, Object>> lowerBounds = Arrays.asList(Map.of("mode", "clip", "min_score", 0.1));
+        parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
+
+        ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
+        ScoreNormalizationTechnique normalizationTechnique = scoreNormalizationFactory.createNormalization("min_max", parameters);
+
+        assertNotNull(normalizationTechnique);
+        assertTrue(normalizationTechnique instanceof MinMaxScoreNormalizationTechnique);
+    }
+
+    public void testThrowsExceptionForInvalidTechniqueWithParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+
+        List<Map<String, Object>> lowerBounds = Arrays.asList(Map.of("mode", "clip", "min_score", 0.1));
+        parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
+
+        ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationFactory.createNormalization(L2ScoreNormalizationTechnique.TECHNIQUE_NAME, parameters)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
+    }
+
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtilTests.java
@@ -8,6 +8,7 @@ import org.opensearch.neuralsearch.processor.SearchShard;
 import org.opensearch.neuralsearch.processor.explain.DocIdAtSearchShard;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -19,11 +20,16 @@ import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_FLOATS_ASSERT
 public class ScoreNormalizationUtilTests extends OpenSearchTestCase {
 
     private ScoreNormalizationUtil scoreNormalizationUtil;
+    private Set<String> supportedTopLevelParams;
+    private Map<String, Set<String>> supportedNestedParams;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         scoreNormalizationUtil = new ScoreNormalizationUtil();
+        supportedTopLevelParams = new HashSet<>(Arrays.asList("method", "parameters"));
+        supportedNestedParams = new HashMap<>();
+        supportedNestedParams.put("parameters", new HashSet<>(Arrays.asList("factor", "offset")));
     }
 
     public void testValidateParamsWithUnsupportedParameter() {
@@ -66,5 +72,98 @@ public class ScoreNormalizationUtilTests extends OpenSearchTestCase {
         assertEquals(normalizedScore, scores.get(subQueryIndex), DELTA_FOR_FLOATS_ASSERTION);
         assertEquals(0.0f, scores.get(0), DELTA_FOR_FLOATS_ASSERTION);
         assertEquals(0.0f, scores.get(2), DELTA_FOR_FLOATS_ASSERTION);
+    }
+
+    public void testValidateParametersWithNullParameters() {
+        scoreNormalizationUtil.validateParameters(null, supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithEmptyParameters() {
+        scoreNormalizationUtil.validateParameters(new HashMap<>(), supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithValidTopLevelParameters() {
+        Map<String, Object> params = new HashMap<>();
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("factor", 1.0);
+        params.put("parameters", nestedParams);
+
+        scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithValidNestedParameters() {
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("factor", 1.0);
+        nestedParams.put("offset", 0.0);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("parameters", nestedParams);
+
+        scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithInvalidTopLevelParameter() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("invalid_param", "value");
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
+    }
+
+    public void testValidateParametersWithInvalidNestedParameter() {
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("invalid_nested", "value");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("parameters", nestedParams);
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
+    }
+
+    public void testValidateParametersWithListOfMaps() {
+        Map<String, Object> validNestedParams1 = new HashMap<>();
+        validNestedParams1.put("factor", 1.0);
+        Map<String, Object> validNestedParams2 = new HashMap<>();
+        validNestedParams2.put("offset", 0.0);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("parameters", Arrays.asList(validNestedParams1, validNestedParams2));
+
+        scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithInvalidListContent() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("parameters", Arrays.asList("invalid", "content"));
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
+    }
+
+    public void testValidateParametersWithMixedValidAndInvalidParameters() {
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("factor", 1.0);
+        nestedParams.put("invalid_nested", "value");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("method", "min_max");
+        params.put("parameters", nestedParams);
+        params.put("invalid_top", "value");
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -79,7 +79,14 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
     public void testExplain_whenMultipleSubqueriesAndOneShard_thenSuccessful() {
         initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
         // create search pipeline with both normalization processor and explain response processor
-        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
+        createSearchPipeline(
+            NORMALIZATION_SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            true
+        );
 
         TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
         TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4);
@@ -195,6 +202,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         createSearchPipeline(
             NORMALIZATION_SEARCH_PIPELINE,
             NORMALIZATION_TECHNIQUE_L2,
+            Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
             true
@@ -324,7 +332,14 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
     public void testExplanationResponseProcessor_whenProcessorIsNotConfigured_thenResponseHasQueryExplanations() {
         initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
         // create search pipeline with normalization processor, no explanation response processor
-        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), false);
+        createSearchPipeline(
+            NORMALIZATION_SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            false
+        );
 
         TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
         TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4);
@@ -472,7 +487,14 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
     public void testExplain_whenLargeNumberOfDocuments_thenSuccessful() {
         initializeIndexIfNotExist(TEST_LARGE_DOCS_INDEX_NAME);
         // create search pipeline with both normalization processor and explain response processor
-        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
+        createSearchPipeline(
+            NORMALIZATION_SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            true
+        );
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -526,7 +548,14 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
     public void testSpecificQueryTypes_whenMultiMatchAndKnn_thenSuccessful() {
         initializeIndexIfNotExist(TEST_LARGE_DOCS_INDEX_NAME);
         // create search pipeline with both normalization processor and explain response processor
-        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
+        createSearchPipeline(
+            NORMALIZATION_SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            true
+        );
 
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
         hybridQueryBuilder.add(QueryBuilders.multiMatchQuery(TEST_QUERY_TEXT3, TEST_TEXT_FIELD_NAME_1, TEST_TEXT_FIELD_NAME_2));

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -129,71 +129,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         // explain
         Map<String, Object> searchHit1 = hitsNestedList.get(0);
         Map<String, Object> topLevelExplanationsHit1 = getValueByKey(searchHit1, "_explanation");
-        assertNotNull(topLevelExplanationsHit1);
-        assertEquals((double) searchHit1.get("_score"), (double) topLevelExplanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        String expectedTopLevelDescription = "arithmetic_mean combination of:";
-        assertEquals(expectedTopLevelDescription, topLevelExplanationsHit1.get("description"));
-        List<Map<String, Object>> normalizationExplanationHit1 = getListOfValues(topLevelExplanationsHit1, "details");
-        assertEquals(1, normalizationExplanationHit1.size());
-        Map<String, Object> hit1DetailsForHit1 = normalizationExplanationHit1.get(0);
-        assertEquals(1.0, hit1DetailsForHit1.get("value"));
-        assertEquals("min_max normalization of:", hit1DetailsForHit1.get("description"));
-        assertEquals(1, ((List) hit1DetailsForHit1.get("details")).size());
-
-        Map<String, Object> explanationsHit1 = getListOfValues(hit1DetailsForHit1, "details").get(0);
-        assertEquals("sum of:", explanationsHit1.get("description"));
-        assertEquals(0.343f, (double) explanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals(1, ((List) explanationsHit1.get("details")).size());
-
-        // search hit 2
-        Map<String, Object> searchHit2 = hitsNestedList.get(1);
-        Map<String, Object> topLevelExplanationsHit2 = getValueByKey(searchHit2, "_explanation");
-        assertNotNull(topLevelExplanationsHit2);
-        assertEquals((double) searchHit2.get("_score"), (double) topLevelExplanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
-
-        assertEquals(expectedTopLevelDescription, topLevelExplanationsHit2.get("description"));
-        List<Map<String, Object>> normalizationExplanationHit2 = getListOfValues(topLevelExplanationsHit2, "details");
-        assertEquals(1, normalizationExplanationHit2.size());
-
-        Map<String, Object> hit1DetailsForHit2 = normalizationExplanationHit2.get(0);
-        assertEquals(1.0, hit1DetailsForHit2.get("value"));
-        assertEquals("min_max normalization of:", hit1DetailsForHit2.get("description"));
-        assertEquals(1, getListOfValues(hit1DetailsForHit2, "details").size());
-
-        Map<String, Object> explanationsHit2 = getListOfValues(hit1DetailsForHit2, "details").get(0);
-        assertEquals(0.13f, (double) explanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", explanationsHit2.get("description"));
-        assertEquals(1, getListOfValues(explanationsHit2, "details").size());
-
-        Map<String, Object> explanationsHit2Details = getListOfValues(explanationsHit2, "details").get(0);
-        assertEquals(0.13f, (double) explanationsHit2Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit2Details.get("description"));
-        assertEquals(2, getListOfValues(explanationsHit2Details, "details").size());
-
-        // search hit 3
-        Map<String, Object> searchHit3 = hitsNestedList.get(1);
-        Map<String, Object> topLevelExplanationsHit3 = getValueByKey(searchHit3, "_explanation");
-        assertNotNull(topLevelExplanationsHit3);
-        assertEquals((double) searchHit2.get("_score"), (double) topLevelExplanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
-
-        assertEquals(expectedTopLevelDescription, topLevelExplanationsHit3.get("description"));
-        List<Map<String, Object>> normalizationExplanationHit3 = getListOfValues(topLevelExplanationsHit3, "details");
-        assertEquals(1, normalizationExplanationHit3.size());
-
-        Map<String, Object> hit1DetailsForHit3 = normalizationExplanationHit3.get(0);
-        assertEquals(1.0, hit1DetailsForHit3.get("value"));
-        assertEquals("min_max normalization of:", hit1DetailsForHit3.get("description"));
-        assertEquals(1, getListOfValues(hit1DetailsForHit3, "details").size());
-
-        Map<String, Object> explanationsHit3 = getListOfValues(hit1DetailsForHit3, "details").get(0);
-        assertEquals(0.13f, (double) explanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", explanationsHit3.get("description"));
-        assertEquals(1, getListOfValues(explanationsHit3, "details").size());
-
-        Map<String, Object> explanationsHit3Details = getListOfValues(explanationsHit3, "details").get(0);
-        assertEquals(0.13f, (double) explanationsHit3Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit3Details.get("description"));
-        assertEquals(2, getListOfValues(explanationsHit3Details, "details").size());
+        assertExplanation(topLevelExplanationsHit1, searchHit1, hitsNestedList, false);
     }
 
     @SneakyThrows
@@ -730,6 +666,154 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
         assertEquals("ConstantScore(FieldExistsQuery [field=test-text-field-1])", explanationsHit4.get("description"));
         assertEquals(0, getListOfValues(explanationsHit4, "details").size());
         assertTrue((double) explanationsHit4.get("value") > 0.0f);
+    }
+
+    @SneakyThrows
+    public void testExplain_whenMinMaxNormalizationWithLowerBounds_thenSuccessful() {
+        initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
+        // create search pipeline with both normalization processor and explain response processor
+        createSearchPipeline(
+            NORMALIZATION_SEARCH_PIPELINE,
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(
+                "lower_bounds",
+                List.of(
+                    Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
+                    Map.of("mode", "clip", "min_score", Float.toString(0.0f))
+                )
+            ),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            true
+        );
+
+        TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
+        TermQueryBuilder termQueryBuilder2 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT4);
+        TermQueryBuilder termQueryBuilder3 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT5);
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+        boolQueryBuilder.should(termQueryBuilder2).should(termQueryBuilder3);
+
+        HybridQueryBuilder hybridQueryBuilderNeuralThenTerm = new HybridQueryBuilder();
+        hybridQueryBuilderNeuralThenTerm.add(termQueryBuilder1);
+        hybridQueryBuilderNeuralThenTerm.add(boolQueryBuilder);
+
+        Map<String, Object> searchResponseAsMap1 = search(
+            TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME,
+            hybridQueryBuilderNeuralThenTerm,
+            null,
+            10,
+            Map.of("search_pipeline", NORMALIZATION_SEARCH_PIPELINE, "explain", "true")
+        );
+        // Assert
+        // search hits
+        assertEquals(3, getHitCount(searchResponseAsMap1));
+
+        List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap1);
+        List<String> ids = new ArrayList<>();
+        List<Double> scores = new ArrayList<>();
+        for (Map<String, Object> oneHit : hitsNestedList) {
+            ids.add((String) oneHit.get("_id"));
+            scores.add((Double) oneHit.get("_score"));
+        }
+
+        assertTrue(IntStream.range(0, scores.size() - 1).noneMatch(idx -> scores.get(idx) < scores.get(idx + 1)));
+        assertEquals(Set.copyOf(ids).size(), ids.size());
+
+        Map<String, Object> total = getTotalHits(searchResponseAsMap1);
+        assertNotNull(total.get("value"));
+        assertEquals(3, total.get("value"));
+        assertNotNull(total.get("relation"));
+        assertEquals(RELATION_EQUAL_TO, total.get("relation"));
+
+        // explain
+        Map<String, Object> searchHit1 = hitsNestedList.get(0);
+        Map<String, Object> topLevelExplanationsHit1 = getValueByKey(searchHit1, "_explanation");
+        assertExplanation(topLevelExplanationsHit1, searchHit1, hitsNestedList, true);
+    }
+
+    private void assertExplanation(
+        Map<String, Object> topLevelExplanationsHit1,
+        Map<String, Object> searchHit1,
+        List<Map<String, Object>> hitsNestedList,
+        boolean withLowerBounds
+    ) {
+        assertNotNull(topLevelExplanationsHit1);
+        assertEquals((double) searchHit1.get("_score"), (double) topLevelExplanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        String expectedTopLevelDescription = "arithmetic_mean combination of:";
+        assertEquals(expectedTopLevelDescription, topLevelExplanationsHit1.get("description"));
+        List<Map<String, Object>> normalizationExplanationHit1 = getListOfValues(topLevelExplanationsHit1, "details");
+        assertEquals(1, normalizationExplanationHit1.size());
+        Map<String, Object> hit1DetailsForHit1 = normalizationExplanationHit1.get(0);
+        assertEquals(1.0, hit1DetailsForHit1.get("value"));
+        if (withLowerBounds) {
+            assertEquals("min_max, lower bounds [(apply, 0.01), (clip, 0.0)] normalization of:", hit1DetailsForHit1.get("description"));
+        } else {
+            assertEquals("min_max normalization of:", hit1DetailsForHit1.get("description"));
+        }
+        assertEquals(1, ((List) hit1DetailsForHit1.get("details")).size());
+
+        Map<String, Object> explanationsHit1 = getListOfValues(hit1DetailsForHit1, "details").get(0);
+        assertEquals("sum of:", explanationsHit1.get("description"));
+        assertEquals(0.343f, (double) explanationsHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(1, ((List) explanationsHit1.get("details")).size());
+
+        // search hit 2
+        Map<String, Object> searchHit2 = hitsNestedList.get(1);
+        Map<String, Object> topLevelExplanationsHit2 = getValueByKey(searchHit2, "_explanation");
+        assertNotNull(topLevelExplanationsHit2);
+        assertEquals((double) searchHit2.get("_score"), (double) topLevelExplanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
+
+        assertEquals(expectedTopLevelDescription, topLevelExplanationsHit2.get("description"));
+        List<Map<String, Object>> normalizationExplanationHit2 = getListOfValues(topLevelExplanationsHit2, "details");
+        assertEquals(1, normalizationExplanationHit2.size());
+
+        Map<String, Object> hit1DetailsForHit2 = normalizationExplanationHit2.get(0);
+        assertEquals(1.0, hit1DetailsForHit2.get("value"));
+        if (withLowerBounds) {
+            assertEquals("min_max, lower bounds [(apply, 0.01), (clip, 0.0)] normalization of:", hit1DetailsForHit2.get("description"));
+        } else {
+            assertEquals("min_max normalization of:", hit1DetailsForHit2.get("description"));
+        }
+        assertEquals(1, getListOfValues(hit1DetailsForHit2, "details").size());
+
+        Map<String, Object> explanationsHit2 = getListOfValues(hit1DetailsForHit2, "details").get(0);
+        assertEquals(0.13f, (double) explanationsHit2.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", explanationsHit2.get("description"));
+        assertEquals(1, getListOfValues(explanationsHit2, "details").size());
+
+        Map<String, Object> explanationsHit2Details = getListOfValues(explanationsHit2, "details").get(0);
+        assertEquals(0.13f, (double) explanationsHit2Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit2Details.get("description"));
+        assertEquals(2, getListOfValues(explanationsHit2Details, "details").size());
+
+        // search hit 3
+        Map<String, Object> searchHit3 = hitsNestedList.get(1);
+        Map<String, Object> topLevelExplanationsHit3 = getValueByKey(searchHit3, "_explanation");
+        assertNotNull(topLevelExplanationsHit3);
+        assertEquals((double) searchHit2.get("_score"), (double) topLevelExplanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
+
+        assertEquals(expectedTopLevelDescription, topLevelExplanationsHit3.get("description"));
+        List<Map<String, Object>> normalizationExplanationHit3 = getListOfValues(topLevelExplanationsHit3, "details");
+        assertEquals(1, normalizationExplanationHit3.size());
+
+        Map<String, Object> hit1DetailsForHit3 = normalizationExplanationHit3.get(0);
+        assertEquals(1.0, hit1DetailsForHit3.get("value"));
+        if (withLowerBounds) {
+            assertEquals("min_max, lower bounds [(apply, 0.01), (clip, 0.0)] normalization of:", hit1DetailsForHit3.get("description"));
+        } else {
+            assertEquals("min_max normalization of:", hit1DetailsForHit3.get("description"));
+        }
+        assertEquals(1, getListOfValues(hit1DetailsForHit3, "details").size());
+
+        Map<String, Object> explanationsHit3 = getListOfValues(hit1DetailsForHit3, "details").get(0);
+        assertEquals(0.13f, (double) explanationsHit3.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals("weight(test-text-field-1:hello in 0) [PerFieldSimilarity], result of:", explanationsHit3.get("description"));
+        assertEquals(1, getListOfValues(explanationsHit3, "details").size());
+
+        Map<String, Object> explanationsHit3Details = getListOfValues(explanationsHit3, "details").get(0);
+        assertEquals(0.13f, (double) explanationsHit3Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals("score(freq=1.0), computed as boost * idf * tf from:", explanationsHit3Details.get("description"));
+        assertEquals(2, getListOfValues(explanationsHit3Details, "details").size());
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
@@ -490,7 +490,7 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
         updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
 
         initializeIndexIfNotExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SHARDS_COUNT_IN_MULTI_NODE_CLUSTER);
-        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
+        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true);
         // Assert
         // scores for search hits
         HybridQueryBuilder hybridQueryBuilder = createHybridQueryBuilderWithMatchTermAndRangeQuery(

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -248,7 +248,10 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             isComplete = checkComplete(taskQueryResult);
             Thread.sleep(DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND);
         }
-        assertTrue(String.format(Locale.ROOT, "failed to load the model, last task finished with status %s", taskQueryResult.get("state")), isComplete);
+        assertTrue(
+            String.format(Locale.ROOT, "failed to load the model, last task finished with status %s", taskQueryResult.get("state")),
+            isComplete
+        );
     }
 
     /**

--- a/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
@@ -65,6 +65,7 @@ public class TestUtils {
     public static final String DEFAULT_NORMALIZATION_METHOD = "min_max";
     public static final String DEFAULT_COMBINATION_METHOD = "arithmetic_mean";
     public static final String PARAM_NAME_WEIGHTS = "weights";
+    public static final String PARAM_NAME_LOWER_BOUNDS = "lower_bounds";
     public static final String SPARSE_ENCODING_PROCESSOR = "sparse_encoding";
     public static final int MAX_TIME_OUT_INTERVAL = 3000;
     public static final int MAX_RETRY = 5;


### PR DESCRIPTION
### Description

I'm adding `lower_bounds` parameter for min-max normalization technique of hybrid query.
User will be able to create search pipeline with `lower_bounds` using following request:

```
{
  "description": "Normalization processor for hybrid search",
  "phase_results_processors": [
    {
      "normalization-processor": {
        "normalization": {
          "technique": "min_max",
          "parameters": {
            "lower_bounds": [
              { 
                "mode": "apply",
                "min_score": 0.1
              }, 
                "mode": "clip",
                "min_score": 0.1
              }, 
                "mode": "ignore"
              }
            ]
          }
        },
        "combination": {
          "technique": "arithmetic_mean"
        }
      }
    }
  ]
}
```

I'm planning to merge this into feature branch in main repo until app sec team give a signoff. 

### Related Issues
https://github.com/opensearch-project/neural-search/issues/150
Implemented design described in RFC https://github.com/opensearch-project/neural-search/issues/1189

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
