### PR TITLE
Fix a bug to unflatten the doc with list of map with multiple entries correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Set neural-search plugin 3.0.0 baseline JDK version to JDK-21 ([#838](https://github.com/opensearch-project/neural-search/pull/838))
 - Support different embedding types in model's response ([#1007](https://github.com/opensearch-project/neural-search/pull/1007))
 ### Bug Fixes
+- Fix a bug to unflatten the doc with list of map with multiple entries correctly ([#1204](https://github.com/opensearch-project/neural-search/pull/1204)).
 ### Infrastructure
 - [3.0] Update neural-search for OpenSearch 3.0 compatibility ([#1141](https://github.com/opensearch-project/neural-search/pull/1141))
 ### Documentation

--- a/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtils.java
@@ -263,7 +263,7 @@ public class ProcessorDocumentUtils {
                 ProcessJsonObjectItem processJsonObjectItem = (ProcessJsonObjectItem) value;
                 Map<String, Object> tempMap = new HashMap<>();
                 unflattenSingleItem(processJsonObjectItem.key, processJsonObjectItem.value, tempMap);
-                targetList.set(targetList.size() - 1, tempMap);
+                processJsonObjectItem.targetMap.putAll(tempMap);
             } else {
                 targetList.add(value);
             }

--- a/src/test/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtilsTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/ProcessorDocumentUtilsTests.java
@@ -134,6 +134,25 @@ public class ProcessorDocumentUtilsTests extends OpenSearchQueryTestCase {
         assertEquals(expected, result);
     }
 
+    public void testUnflatten_withListOfObject_thenSuccess() {
+        Map<String, Object> map1 = Map.of("b.c", "d", "f", "h");
+        Map<String, Object> map2 = Map.of("b.c", "e", "f", "i");
+        List<Map<String, Object>> list = Arrays.asList(map1, map2);
+        Map<String, Object> input = Map.of("a", list);
+
+        Map<String, Object> nestedB1 = Map.of("c", "d");
+        Map<String, Object> expectedMap1 = Map.of("b", nestedB1, "f", "h");
+        Map<String, Object> nestedB2 = Map.of("c", "e");
+        Map<String, Object> expectedMap2 = Map.of("b", nestedB2, "f", "i");
+
+        List<Map<String, Object>> expectedList = Arrays.asList(expectedMap1, expectedMap2);
+
+        Map<String, Object> expected = Map.of("a", expectedList);
+
+        Map<String, Object> result = ProcessorDocumentUtils.unflattenJson(input);
+        assertEquals(expected, result);
+    }
+
     public void testUnflatten_withMixedContent_thenSuccess() {
         Map<String, Object> input = Map.of("a.b", "c", "d", "e", "f.g.h", "i");
 


### PR DESCRIPTION
### Description
Fix a bug to unflatten the doc with list of map with multiple entries correctly.

Let's say we have a doc like:
```
{
   "test.products":[
      {
         "product_description":"product_description 1",
         "price":10
      },
      {
         "product_description":"product_description 2",
         "price":20
      }
   ]
}
```
If we define an ingest pipeline to create the embedding for the product_description we will try to unflatten the doc first to ensure the **.** in the field name will be handled properly. Before my fix the doc will be unflattened like:

```
{
   "test":{
      "products":[
         {
            "price":10
         },
         {
            "price":20
         }
      ]
   }
}
```
We lose the product_description because when we handle the map in a list we incorrectly do `targetList.set(targetList.size() - 1, tempMap);`. With my fix the doc will be unflattened correctly:

```
{
   "test":{
      "products":[
         {
            "product_description":"product_description 1",
            "price":10
         },
         {
            "product_description":"product_description 2",
            "price":20
         }
      ]
   }
}
```

### Related Issues
There is no related issue.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
