### PR TITLE
Add filter function for NeuralQueryBuilder and HybridQueryBuilder and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.x](https://github.com/opensearch-project/neural-search/compare/main...HEAD)
 ### Features
 - Lower bound for min-max normalization technique in hybrid query ([#1195](https://github.com/opensearch-project/neural-search/pull/1195))
+- Support filter function for HybridQueryBuilder and NeuralQueryBuilder ([#1206](https://github.com/opensearch-project/neural-search/pull/1206))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -51,6 +52,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     public static final String NAME = "hybrid";
 
     private static final ParseField QUERIES_FIELD = new ParseField("queries");
+    private static final ParseField FILTER_FIELD = new ParseField("filter");
     private static final ParseField PAGINATION_DEPTH_FIELD = new ParseField("pagination_depth");
 
     private final List<QueryBuilder> queries = new ArrayList<>();
@@ -91,6 +93,26 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             throw new IllegalArgumentException(String.format(Locale.ROOT, "inner %s query clause cannot be null", NAME));
         }
         queries.add(queryBuilder);
+        return this;
+    }
+
+    /**
+     * Function to support filter on HybridQueryBuilder filter.
+     * If the filter is null, then we do nothing and return.
+     * Otherwise, we push down the filter to queries list.
+     * @param filter the filter parameter
+     * @return HybridQueryBuilder itself
+     */
+    public QueryBuilder filter(QueryBuilder filter) {
+        if (validateFilterParams(filter) == false) {
+            return this;
+        }
+        ListIterator<QueryBuilder> iterator = queries.listIterator();
+        while (iterator.hasNext()) {
+            QueryBuilder query = iterator.next();
+            // set the query again because query.filter(filter) can return new query.
+            iterator.set(query.filter(filter));
+        }
         return this;
     }
 
@@ -155,6 +177,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
      *                       }
      *                    }
      *               ]
+     *               "filter":
+     *                  "term": {
+     *                      "text": "keyword"
+     *                  }
      *          }
      *     }
      * }
@@ -168,6 +194,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
 
         Integer paginationDepth = null;
         final List<QueryBuilder> queries = new ArrayList<>();
+        QueryBuilder filter = null;
         String queryName = null;
 
         String currentFieldName = null;
@@ -178,6 +205,8 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (QUERIES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     queries.add(parseInnerQueryBuilder(parser));
+                } else if (FILTER_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    filter = parseInnerQueryBuilder(parser);
                 } else {
                     log.error(String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, currentFieldName));
                     throw new ParsingException(
@@ -240,7 +269,11 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             compoundQueryBuilder.paginationDepth(paginationDepth);
         }
         for (QueryBuilder query : queries) {
-            compoundQueryBuilder.add(query);
+            if (filter == null) {
+                compoundQueryBuilder.add(query);
+            } else {
+                compoundQueryBuilder.add(query.filter(filter));
+            }
         }
         return compoundQueryBuilder;
     }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -309,6 +309,24 @@ public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder>
         RescoreParser.streamOutput(out, rescoreContext);
     }
 
+    /**
+     * Add a filter to Neural Query Builder
+     * @param filterToBeAdded filter to be added
+     * @return return itself with underlying filter combined with passed in filter
+     */
+    public QueryBuilder filter(QueryBuilder filterToBeAdded) {
+        if (validateFilterParams(filterToBeAdded) == false) {
+            return this;
+        }
+        if (filter == null) {
+            filter = filterToBeAdded;
+        } else {
+            filter = filter.filter(filterToBeAdded);
+        }
+        return this;
+
+    }
+
     @Override
     protected void doXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
         xContentBuilder.startObject(NAME);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFilterIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFilterIT.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import com.google.common.primitives.Floats;
+import lombok.SneakyThrows;
+import org.junit.BeforeClass;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.neuralsearch.util.TestUtils.TEST_DIMENSION;
+import static org.opensearch.neuralsearch.util.TestUtils.TEST_SPACE_TYPE;
+import static org.opensearch.neuralsearch.util.TestUtils.createRandomVector;
+
+public class HybridQueryFilterIT extends BaseNeuralSearchIT {
+    private static final String TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS =
+        "test-hybrid-post-filter-multi-doc-index-multiple-shards";
+    private static final String TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD =
+        "test-hybrid-post-filter-multi-doc-index-single-shard";
+    private static final String SEARCH_PIPELINE = "phase-results-hybrid-post-filter-pipeline";
+    private static final String INTEGER_FIELD_1_STOCK = "stock";
+    private static final String TEXT_FIELD_1_NAME = "name";
+    private static final String KEYWORD_FIELD_2_CATEGORY = "category";
+    private static final String TEXT_FIELD_VALUE_1_DUNES = "Dunes part 1";
+    private static final String TEXT_FIELD_VALUE_2_DUNES = "Dunes part 2";
+    private static final String TEXT_FIELD_VALUE_3_MI_1 = "Mission Impossible 1";
+    private static final String TEXT_FIELD_VALUE_4_MI_2 = "Mission Impossible 2";
+    private static final String TEXT_FIELD_VALUE_5_TERMINAL = "The Terminal";
+    private static final String TEXT_FIELD_VALUE_6_AVENGERS = "Avengers";
+    private static final String TEST_QUERY_TEXT = "Hello world";
+    private static final int INTEGER_FIELD_STOCK_1_25 = 25;
+    private static final int INTEGER_FIELD_STOCK_2_22 = 22;
+    private static final int INTEGER_FIELD_STOCK_3_256 = 256;
+    private static final int INTEGER_FIELD_STOCK_4_25 = 25;
+    private static final int INTEGER_FIELD_STOCK_5_20 = 20;
+    private static final String KEYWORD_FIELD_CATEGORY_1_DRAMA = "Drama";
+    private static final String KEYWORD_FIELD_CATEGORY_2_ACTION = "Action";
+    private static final String KEYWORD_FIELD_CATEGORY_3_SCI_FI = "Sci-fi";
+    private static final int SHARDS_COUNT_IN_SINGLE_NODE_CLUSTER = 1;
+    private static final String TEST_KNN_VECTOR_FIELD_NAME_1 = "test-knn-vector-1";
+    private final float[] testVector1 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector2 = createRandomVector(TEST_DIMENSION);
+    private final float[] testVector3 = createRandomVector(TEST_DIMENSION);
+
+    @BeforeClass
+    @SneakyThrows
+    public static void setUpCluster() {
+        // we need new instance because we're calling non-static methods from static method.
+        // main purpose is to minimize network calls, initialization is only needed once
+        HybridQueryFilterIT instance = new HybridQueryFilterIT();
+        instance.initClient();
+        instance.updateClusterSettings();
+    }
+
+    @SneakyThrows
+    public void testFilterOnNeuralQueryFilterAndTermQueryFilter_thenSuccessful() {
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
+        prepareResourcesBeforeTestExecution(SHARDS_COUNT_IN_SINGLE_NODE_CLUSTER);
+        testNeuralQueryBuilder(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD);
+    }
+
+    @SneakyThrows
+    private void testNeuralQueryBuilder(String indexName) {
+        String modelId = null;
+        modelId = prepareModel();
+        NeuralQueryBuilder neuralQueryBuilderTextQuery = NeuralQueryBuilder.builder()
+            .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+            .queryText(TEST_QUERY_TEXT)
+            .modelId(modelId)
+            .k(1)
+            .build();
+
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEXT_FIELD_1_NAME, TEST_QUERY_TEXT);
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(neuralQueryBuilderTextQuery);
+        hybridQueryBuilder.add(termQueryBuilder);
+
+        hybridQueryBuilder.filter(new MatchQueryBuilder("_id", "1"));
+
+        Map<String, Object> searchResponseAsMapTextQuery = search(indexName, hybridQueryBuilder, 1);
+        assertEquals(1, getHitCount(searchResponseAsMapTextQuery));
+
+        Map<String, Object> firstInnerHitTextQuery = getFirstInnerHit(searchResponseAsMapTextQuery);
+        assertEquals("1", firstInnerHitTextQuery.get("_id"));
+    }
+
+    @SneakyThrows
+    void prepareResourcesBeforeTestExecution(int numShards) {
+        if (numShards == 1) {
+            initializeIndexIfNotExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_SINGLE_SHARD, numShards);
+        } else {
+            initializeIndexIfNotExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, numShards);
+        }
+        createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
+    }
+
+    @SneakyThrows
+    private void initializeIndexIfNotExists(String indexName, int numShards) {
+        if (!indexExists(indexName)) {
+            prepareKnnIndex(
+                indexName,
+                Collections.singletonList(new KNNFieldConfig(TEST_KNN_VECTOR_FIELD_NAME_1, TEST_DIMENSION, TEST_SPACE_TYPE))
+            );
+
+            addKnnDoc(
+                indexName,
+                "1",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector1).toArray()),
+                Collections.singletonList(TEXT_FIELD_1_NAME),
+                Collections.singletonList(TEXT_FIELD_VALUE_2_DUNES),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1_STOCK),
+                List.of(INTEGER_FIELD_STOCK_1_25),
+                List.of(KEYWORD_FIELD_2_CATEGORY),
+                List.of(KEYWORD_FIELD_CATEGORY_1_DRAMA),
+                List.of(),
+                List.of()
+            );
+
+            addKnnDoc(
+                indexName,
+                "2",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector2).toArray()),
+                Collections.singletonList(TEXT_FIELD_1_NAME),
+                Collections.singletonList(TEXT_FIELD_VALUE_1_DUNES),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1_STOCK),
+                List.of(INTEGER_FIELD_STOCK_2_22),
+                List.of(KEYWORD_FIELD_2_CATEGORY),
+                List.of(KEYWORD_FIELD_CATEGORY_1_DRAMA),
+                List.of(),
+                List.of()
+            );
+
+            addKnnDoc(
+                indexName,
+                "3",
+                Collections.singletonList(TEST_KNN_VECTOR_FIELD_NAME_1),
+                Collections.singletonList(Floats.asList(testVector3).toArray()),
+                Collections.singletonList(TEXT_FIELD_1_NAME),
+                Collections.singletonList(TEXT_FIELD_VALUE_3_MI_1),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1_STOCK),
+                List.of(INTEGER_FIELD_STOCK_3_256),
+                List.of(KEYWORD_FIELD_2_CATEGORY),
+                List.of(KEYWORD_FIELD_CATEGORY_2_ACTION),
+                List.of(),
+                List.of()
+            );
+
+            addKnnDoc(
+                indexName,
+                "4",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEXT_FIELD_1_NAME),
+                Collections.singletonList(TEXT_FIELD_VALUE_4_MI_2),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1_STOCK),
+                List.of(INTEGER_FIELD_STOCK_4_25),
+                List.of(KEYWORD_FIELD_2_CATEGORY),
+                List.of(KEYWORD_FIELD_CATEGORY_2_ACTION),
+                List.of(),
+                List.of()
+            );
+
+            addKnnDoc(
+                indexName,
+                "5",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEXT_FIELD_1_NAME),
+                Collections.singletonList(TEXT_FIELD_VALUE_5_TERMINAL),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1_STOCK),
+                List.of(INTEGER_FIELD_STOCK_5_20),
+                List.of(KEYWORD_FIELD_2_CATEGORY),
+                List.of(KEYWORD_FIELD_CATEGORY_1_DRAMA),
+                List.of(),
+                List.of()
+            );
+
+            addKnnDoc(
+                indexName,
+                "6",
+                List.of(),
+                List.of(),
+                Collections.singletonList(TEXT_FIELD_1_NAME),
+                Collections.singletonList(TEXT_FIELD_VALUE_6_AVENGERS),
+                List.of(),
+                List.of(),
+                List.of(INTEGER_FIELD_1_STOCK),
+                List.of(INTEGER_FIELD_STOCK_5_20),
+                List.of(KEYWORD_FIELD_2_CATEGORY),
+                List.of(KEYWORD_FIELD_CATEGORY_3_SCI_FI),
+                List.of(),
+                List.of()
+            );
+        }
+    }
+
+    private HybridQueryBuilder createHybridQueryBuilderWithMatchTermAndRangeQuery(String text, String value, int lte, int gte) {
+        MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery(TEXT_FIELD_1_NAME, text);
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEXT_FIELD_1_NAME, value);
+        RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(INTEGER_FIELD_1_STOCK).gte(gte).lte(lte);
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(matchQueryBuilder).add(termQueryBuilder).add(rangeQueryBuilder);
+        return hybridQueryBuilder;
+    }
+
+    private QueryBuilder createQueryBuilderWithRangeQuery(int lte, int gte) {
+        return QueryBuilders.rangeQuery(INTEGER_FIELD_1_STOCK).gte(gte).lte(lte);
+    }
+
+}


### PR DESCRIPTION
… modify fromXContent function in HybridQueryBuilder to support filter field.

### Description
Add filter function to NeuralQueryBuilder and HybridQueryBuilder, which allows to push down non null filter. One exception is that when HybridQueryBuilder has a nested HybridQueryBuilder, then calling the filter function will cause UnsupportedOperationException

### Related Issues
Resolves #1206 
Related: #282, #1135
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
