### PR TITLE
Lower bounds for min-max normalization in hybrid query, feature->main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/neural-search/compare/2.x...HEAD)
 ### Features
+- Lower bound for min-max normalization technique in hybrid query ([#1195](https://github.com/opensearch-project/neural-search/pull/1195))
 ### Enhancements
 - Set neural-search plugin 3.0.0 baseline JDK version to JDK-21 ([#838](https://github.com/opensearch-project/neural-search/pull/838))
 - Support different embedding types in model's response ([#1007](https://github.com/opensearch-project/neural-search/pull/1007))

--- a/src/main/java/org/opensearch/neuralsearch/processor/CompoundTopDocs.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/CompoundTopDocs.java
@@ -13,6 +13,7 @@ import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUt
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -149,5 +150,79 @@ public class CompoundTopDocs {
         }
         FieldDoc fieldDoc = (FieldDoc) scoreDoc;
         return new FieldDoc(fieldDoc.doc, fieldDoc.score, fieldDoc.fields, fieldDoc.shardIndex);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        CompoundTopDocs that = (CompoundTopDocs) other;
+
+        if (this.topDocs.size() != that.topDocs.size()) {
+            return false;
+        }
+        for (int i = 0; i < topDocs.size(); i++) {
+            TopDocs thisTopDoc = this.topDocs.get(i);
+            TopDocs thatTopDoc = that.topDocs.get(i);
+            if ((thisTopDoc == null) != (thatTopDoc == null)) {
+                return false;
+            }
+            if (thisTopDoc == null) {
+                continue;
+            }
+            if (Objects.equals(thisTopDoc.totalHits, thatTopDoc.totalHits) == false) {
+                return false;
+            }
+            if (compareScoreDocs(thisTopDoc.scoreDocs, thatTopDoc.scoreDocs) == false) {
+                return false;
+            }
+        }
+        return Objects.equals(totalHits, that.totalHits) && Objects.equals(searchShard, that.searchShard);
+    }
+
+    private boolean compareScoreDocs(ScoreDoc[] first, ScoreDoc[] second) {
+        if (first.length != second.length) {
+            return false;
+        }
+
+        for (int i = 0; i < first.length; i++) {
+            ScoreDoc firstDoc = first[i];
+            ScoreDoc secondDoc = second[i];
+            if ((firstDoc == null) != (secondDoc == null)) {
+                return false;
+            }
+            if (firstDoc == null) {
+                continue;
+            }
+            if (firstDoc.doc != secondDoc.doc || Float.compare(firstDoc.score, secondDoc.score) != 0) {
+                return false;
+            }
+            if (firstDoc instanceof FieldDoc != secondDoc instanceof FieldDoc) {
+                return false;
+            }
+            if (firstDoc instanceof FieldDoc firstFieldDoc) {
+                FieldDoc secondFieldDoc = (FieldDoc) secondDoc;
+                if (Arrays.equals(firstFieldDoc.fields, secondFieldDoc.fields) == false) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(totalHits, searchShard);
+        for (TopDocs topDoc : topDocs) {
+            result = 31 * result + topDoc.totalHits.hashCode();
+            for (ScoreDoc scoreDoc : topDoc.scoreDocs) {
+                result = 31 * result + Float.floatToIntBits(scoreDoc.score);
+                result = 31 * result + scoreDoc.doc;
+                if (scoreDoc instanceof FieldDoc fieldDoc && fieldDoc.fields != null) {
+                    result = 31 * result + Arrays.deepHashCode(fieldDoc.fields);
+                }
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
@@ -58,7 +58,8 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
                 TECHNIQUE,
                 MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME
             );
-            normalizationTechnique = scoreNormalizationFactory.createNormalization(normalizationTechniqueName);
+            Map<String, Object> normalizationParams = readOptionalMap(NormalizationProcessor.TYPE, tag, normalizationClause, PARAMETERS);
+            normalizationTechnique = scoreNormalizationFactory.createNormalization(normalizationTechniqueName, normalizationParams);
         }
 
         Map<String, Object> combinationClause = readOptionalMap(NormalizationProcessor.TYPE, tag, config, COMBINATION_CLAUSE);

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -31,6 +32,14 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
     @ToString.Include
     public static final String TECHNIQUE_NAME = "l2";
     private static final float MIN_SCORE = 0.0f;
+
+    public L2ScoreNormalizationTechnique() {
+        this(Map.of(), new ScoreNormalizationUtil());
+    }
+
+    public L2ScoreNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
+        scoreNormalizationUtil.validateParameters(params, Set.of(), Map.of());
+    }
 
     /**
      * L2 normalization method.

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
@@ -10,9 +10,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.opensearch.neuralsearch.processor.CompoundTopDocs;
@@ -26,6 +32,7 @@ import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
 
 import static org.opensearch.neuralsearch.processor.explain.ExplanationUtils.getDocIdAtQueryForNormalization;
+import static org.opensearch.neuralsearch.query.HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES;
 
 /**
  * Abstracts normalization of scores based on min-max method
@@ -34,8 +41,28 @@ import static org.opensearch.neuralsearch.processor.explain.ExplanationUtils.get
 public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTechnique, ExplainableTechnique {
     @ToString.Include
     public static final String TECHNIQUE_NAME = "min_max";
-    private static final float MIN_SCORE = 0.001f;
+    protected static final float MIN_SCORE = 0.001f;
     private static final float SINGLE_RESULT_SCORE = 1.0f;
+    private static final String PARAM_NAME_LOWER_BOUNDS = "lower_bounds";
+    private static final String PARAM_NAME_LOWER_BOUND_MODE = "mode";
+    private static final String PARAM_NAME_LOWER_BOUND_MIN_SCORE = "min_score";
+
+    private static final Set<String> SUPPORTED_PARAMETERS = Set.of(PARAM_NAME_LOWER_BOUNDS);
+    private static final Map<String, Set<String>> NESTED_PARAMETERS = Map.of(
+        PARAM_NAME_LOWER_BOUNDS,
+        Set.of(PARAM_NAME_LOWER_BOUND_MODE, PARAM_NAME_LOWER_BOUND_MIN_SCORE)
+    );
+
+    private final Optional<List<Pair<LowerBound.Mode, Float>>> lowerBoundsOptional;
+
+    public MinMaxScoreNormalizationTechnique() {
+        this(Map.of(), new ScoreNormalizationUtil());
+    }
+
+    public MinMaxScoreNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
+        scoreNormalizationUtil.validateParameters(params, SUPPORTED_PARAMETERS, NESTED_PARAMETERS);
+        lowerBoundsOptional = getLowerBounds(params);
+    }
 
     /**
      * Min-max normalization method.
@@ -54,17 +81,40 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
                 continue;
             }
             List<TopDocs> topDocsPerSubQuery = compoundQueryTopDocs.getTopDocs();
+            if (isLowerBoundsAndSubQueriesCountMismatched(topDocsPerSubQuery)) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "expected lower bounds array to contain %d elements matching the number of sub-queries, but found a mismatch",
+                        topDocsPerSubQuery.size()
+                    )
+                );
+            }
             for (int j = 0; j < topDocsPerSubQuery.size(); j++) {
                 TopDocs subQueryTopDoc = topDocsPerSubQuery.get(j);
+                LowerBound lowerBound = getLowerBound(j);
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     scoreDoc.score = normalizeSingleScore(
                         scoreDoc.score,
                         minMaxScores.getMinScoresPerSubquery()[j],
-                        minMaxScores.getMaxScoresPerSubquery()[j]
+                        minMaxScores.getMaxScoresPerSubquery()[j],
+                        lowerBound
                     );
                 }
             }
         }
+    }
+
+    private boolean isLowerBoundsAndSubQueriesCountMismatched(List<TopDocs> topDocsPerSubQuery) {
+        return lowerBoundsOptional.isPresent()
+            && topDocsPerSubQuery.isEmpty() == false
+            && lowerBoundsOptional.get().size() != topDocsPerSubQuery.size();
+    }
+
+    private LowerBound getLowerBound(int subQueryIndex) {
+        return lowerBoundsOptional.map(
+            pairs -> new LowerBound(true, pairs.get(subQueryIndex).getLeft(), pairs.get(subQueryIndex).getRight())
+        ).orElseGet(LowerBound::new);
     }
 
     private MinMaxScores getMinMaxScoresResult(final List<CompoundTopDocs> queryTopDocs) {
@@ -78,7 +128,12 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
 
     @Override
     public String describe() {
-        return String.format(Locale.ROOT, "%s", TECHNIQUE_NAME);
+        return lowerBoundsOptional.map(lb -> {
+            String lowerBounds = lb.stream()
+                .map(pair -> String.format(Locale.ROOT, "(%s, %s)", pair.getLeft(), pair.getRight()))
+                .collect(Collectors.joining(", ", "[", "]"));
+            return String.format(Locale.ROOT, "%s, lower bounds %s", TECHNIQUE_NAME, lowerBounds);
+        }).orElse(String.format(Locale.ROOT, "%s", TECHNIQUE_NAME));
     }
 
     @Override
@@ -96,10 +151,12 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
                 TopDocs subQueryTopDoc = topDocsPerSubQuery.get(subQueryIndex);
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     DocIdAtSearchShard docIdAtSearchShard = new DocIdAtSearchShard(scoreDoc.doc, compoundQueryTopDocs.getSearchShard());
+                    LowerBound lowerBound = getLowerBound(subQueryIndex);
                     float normalizedScore = normalizeSingleScore(
                         scoreDoc.score,
                         minMaxScores.getMinScoresPerSubquery()[subQueryIndex],
-                        minMaxScores.getMaxScoresPerSubquery()[subQueryIndex]
+                        minMaxScores.getMaxScoresPerSubquery()[subQueryIndex],
+                        lowerBound
                     );
                     ScoreNormalizationUtil.setNormalizedScore(
                         normalizedScores,
@@ -118,7 +175,7 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
     private int getNumOfSubqueries(final List<CompoundTopDocs> queryTopDocs) {
         return queryTopDocs.stream()
             .filter(Objects::nonNull)
-            .filter(topDocs -> !topDocs.getTopDocs().isEmpty())
+            .filter(topDocs -> topDocs.getTopDocs().isEmpty() == false)
             .findAny()
             .get()
             .getTopDocs()
@@ -167,13 +224,89 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
         return minScores;
     }
 
-    private float normalizeSingleScore(final float score, final float minScore, final float maxScore) {
+    private float normalizeSingleScore(final float score, final float minScore, final float maxScore, final LowerBound lowerBound) {
         // edge case when there is only one score and min and max scores are same
         if (Floats.compare(maxScore, minScore) == 0 && Floats.compare(maxScore, score) == 0) {
             return SINGLE_RESULT_SCORE;
         }
-        float normalizedScore = (score - minScore) / (maxScore - minScore);
-        return normalizedScore == 0.0f ? MIN_SCORE : normalizedScore;
+        if (lowerBound.isEnabled() == false) {
+            return LowerBound.Mode.IGNORE.normalize(score, minScore, maxScore, lowerBound.getMinScore());
+        }
+        return lowerBound.getMode().normalize(score, minScore, maxScore, lowerBound.getMinScore());
+    }
+
+    /**
+     * Get lower bounds from input parameters
+     * @param params user provided input parameters for this technique
+     * @return optional list of lower bounds. Can be empty in case lower bounds are not provided
+     */
+    private Optional<List<Pair<LowerBound.Mode, Float>>> getLowerBounds(final Map<String, Object> params) {
+        // validate that the input parameters are in correct format
+        if (Objects.isNull(params) || params.containsKey(PARAM_NAME_LOWER_BOUNDS) == false) {
+            return Optional.empty();
+        }
+
+        List<?> lowerBoundsParams = Optional.ofNullable(params.get(PARAM_NAME_LOWER_BOUNDS))
+            .filter(List.class::isInstance)
+            .map(List.class::cast)
+            .orElseThrow(() -> new IllegalArgumentException("lower_bounds must be a List"));
+        // number of lower bounds must match the number of sub-queries in a hybrid query
+        if (lowerBoundsParams.size() > MAX_NUMBER_OF_SUB_QUERIES) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "lower_bounds size %d should be less than or equal to %d",
+                    lowerBoundsParams.size(),
+                    MAX_NUMBER_OF_SUB_QUERIES
+                )
+            );
+        }
+        // parse each lower bound item and put all items in a list
+        List<Pair<LowerBound.Mode, Float>> lowerBounds = lowerBoundsParams.stream().map(this::parseLowerBound).collect(Collectors.toList());
+
+        return Optional.of(lowerBounds);
+    }
+
+    @SuppressWarnings("unchecked")
+    /**
+     * Parse each lower bound item and return a pair of mode and min score
+     * @param boundObj lower bound item provided by the client
+     * @return a single pair of mode and min score
+     */
+    private Pair<LowerBound.Mode, Float> parseLowerBound(Object boundObj) {
+        if ((boundObj instanceof Map) == false) {
+            throw new IllegalArgumentException("each lower bound must be a map");
+        }
+
+        Map<String, Object> lowerBound = (Map<String, Object>) boundObj;
+
+        String lowerBoundModeValue = Objects.toString(lowerBound.get(PARAM_NAME_LOWER_BOUND_MODE), "");
+        LowerBound.Mode mode = LowerBound.Mode.fromString(lowerBoundModeValue);
+        float minScore = extractAndValidateMinScore(lowerBound);
+
+        return ImmutablePair.of(mode, minScore);
+    }
+
+    private float extractAndValidateMinScore(Map<String, Object> lowerBound) {
+        Object minScoreObj = lowerBound.get(PARAM_NAME_LOWER_BOUND_MIN_SCORE);
+        if (minScoreObj == null) {
+            return LowerBound.DEFAULT_LOWER_BOUND_SCORE;
+        }
+        try {
+            float minScore = LowerBound.DEFAULT_LOWER_BOUND_SCORE;
+            if (Objects.nonNull(lowerBound.get(PARAM_NAME_LOWER_BOUND_MIN_SCORE))) {
+                minScore = Float.parseFloat(String.valueOf(lowerBound.get(PARAM_NAME_LOWER_BOUND_MIN_SCORE)));
+            }
+            Validate.isTrue(
+                minScore >= LowerBound.MIN_LOWER_BOUND_SCORE && minScore <= LowerBound.MAX_LOWER_BOUND_SCORE,
+                "min_score must be a valid finite number between %f and %f",
+                LowerBound.MIN_LOWER_BOUND_SCORE,
+                LowerBound.MAX_LOWER_BOUND_SCORE
+            );
+            return minScore;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("invalid format for min_score: must be a valid float value", e);
+        }
     }
 
     /**
@@ -181,8 +314,106 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
      */
     @AllArgsConstructor
     @Getter
-    private class MinMaxScores {
+    private static class MinMaxScores {
         float[] minScoresPerSubquery;
         float[] maxScoresPerSubquery;
+    }
+
+    /**
+     * Result class to hold lower bound for each sub query
+     */
+    @Getter
+    static class LowerBound {
+        static final float MIN_LOWER_BOUND_SCORE = -10_000f;
+        static final float MAX_LOWER_BOUND_SCORE = 10_000f;
+        static final float DEFAULT_LOWER_BOUND_SCORE = 0.0f;
+
+        private final boolean enabled;
+        private final Mode mode;
+        private final float minScore;
+
+        LowerBound() {
+            this(false, Mode.DEFAULT, DEFAULT_LOWER_BOUND_SCORE);
+        }
+
+        LowerBound(boolean enabled, Mode mode, float minScore) {
+            this.enabled = enabled;
+            this.mode = mode;
+            this.minScore = minScore;
+        }
+
+        /**
+         * Enum for normalization mode
+         */
+        protected enum Mode {
+            APPLY {
+                @Override
+                public float normalize(float score, float minScore, float maxScore, float lowerBoundScore) {
+                    // if we apply the lower bound this mean we use actual score in case it's less then the lower bound min score
+                    // same applied to case when actual max_score is less than lower bound min score
+                    if (maxScore < lowerBoundScore || score < lowerBoundScore) {
+                        return (score - minScore) / (maxScore - minScore);
+                    }
+                    return (score - lowerBoundScore) / (maxScore - lowerBoundScore);
+                }
+            },
+            CLIP {
+                @Override
+                public float normalize(float score, float minScore, float maxScore, float lowerBoundScore) {
+                    // apply clipping, return lower bound min score if score is less than min score. This effectively means 0 after
+                    // normalization
+                    if (score < minScore) {
+                        return 0.0f;
+                    }
+                    if (maxScore < lowerBoundScore) {
+                        return (score - minScore) / (maxScore - minScore);
+                    }
+                    return (score - lowerBoundScore) / (maxScore - lowerBoundScore);
+                }
+            },
+            IGNORE {
+                @Override
+                public float normalize(float score, float minScore, float maxScore, float lowerBoundScore) {
+                    // ignore lower bound logic and do raw min-max normalization using actual scores
+                    float normalizedScore = (score - minScore) / (maxScore - minScore);
+                    return normalizedScore == 0.0f ? MIN_SCORE : normalizedScore;
+                }
+            };
+
+            public static final Mode DEFAULT = APPLY;
+            // set of all valid values for mode
+            public static final String VALID_VALUES = Arrays.stream(values())
+                .map(mode -> mode.name().toLowerCase(Locale.ROOT))
+                .collect(Collectors.joining(", "));
+
+            /**
+             * Get mode from string value
+             * @param value string value of mode
+             * @return mode
+             * @throws IllegalArgumentException if mode is not valid
+             */
+            public static Mode fromString(String value) {
+                if (Objects.isNull(value)) {
+                    throw new IllegalArgumentException("mode value cannot be null or empty");
+                }
+                if (value.trim().isEmpty()) {
+                    return DEFAULT;
+                }
+                try {
+                    return valueOf(value.toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException(
+                        String.format(Locale.ROOT, "invalid mode: %s, valid values are: %s", value, VALID_VALUES)
+                    );
+                }
+            }
+
+            public abstract float normalize(float score, float minScore, float maxScore, float lowerBoundScore);
+
+            @Override
+            public String toString() {
+                return name().toLowerCase(Locale.ROOT);
+            }
+        }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
@@ -48,7 +48,7 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
     private final int rankConstant;
 
     public RRFNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
-        scoreNormalizationUtil.validateParams(params, SUPPORTED_PARAMS);
+        scoreNormalizationUtil.validateParameters(params, SUPPORTED_PARAMS, Map.of());
         rankConstant = getRankConstant(params);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
@@ -19,9 +19,9 @@ public class ScoreNormalizationFactory {
 
     private final Map<String, Function<Map<String, Object>, ScoreNormalizationTechnique>> scoreNormalizationMethodsMap = Map.of(
         MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new MinMaxScoreNormalizationTechnique(),
+        params -> new MinMaxScoreNormalizationTechnique(params, scoreNormalizationUtil),
         L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new L2ScoreNormalizationTechnique(),
+        params -> new L2ScoreNormalizationTechnique(params, scoreNormalizationUtil),
         RRFNormalizationTechnique.TECHNIQUE_NAME,
         params -> new RRFNormalizationTechnique(params, scoreNormalizationUtil)
     );

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtil.java
@@ -49,7 +49,7 @@ class ScoreNormalizationUtil {
 
         // check param types
         if (actualParams.keySet().stream().anyMatch(PARAM_NAME_WEIGHTS::equalsIgnoreCase)) {
-            if (!(actualParams.get(PARAM_NAME_WEIGHTS) instanceof List)) {
+            if (actualParams.get(PARAM_NAME_WEIGHTS) instanceof List == false) {
                 throw new IllegalArgumentException(
                     String.format(Locale.ROOT, "parameter [%s] must be a collection of numbers", PARAM_NAME_WEIGHTS)
                 );
@@ -81,5 +81,79 @@ class ScoreNormalizationUtil {
             normalizedScores.put(docIdAtSearchShard, scores);
         }
         scores.set(subQueryIndex, normalizedScore);
+    }
+
+    /**
+     * Validate parameters for this technique. Following is example of structured parameters that we will validate
+     * {
+     *     "technique": "arithmetic_mean",  // top-level parameter 1
+     *     "details": {                     // top-level parameter 2
+     *         "weights": [1, 2, 3],        // nested parameter 1
+     *         "color": "green".            // nested parameter 2
+     *     }
+     * }
+     * for this example client should pass:
+     *     top-level parameters: ["technique", "details"]
+     *     nested parameters: ["details" -> ["weights", "color"]]
+     * @param actualParameters map of actual parameters in form of name-value
+     * @param supportedParametersTopLevel collection of top-level parameters that we should validate against
+     * @param supportedParametersNested map of nested parameters that we should validate against, key is one of top level parameters and value is set of allowed nested params
+     */
+    public void validateParameters(
+        final Map<String, Object> actualParameters,
+        final Set<String> supportedParametersTopLevel,
+        final Map<String, Set<String>> supportedParametersNested
+    ) {
+        if (Objects.isNull(actualParameters) || actualParameters.isEmpty()) {
+            return;
+        }
+        boolean hasUnknownParameters = false;
+        for (Map.Entry<String, Object> entry : actualParameters.entrySet()) {
+            String paramName = entry.getKey();
+            Object paramValue = entry.getValue();
+
+            if (supportedParametersTopLevel.contains(paramName) == false) {
+                hasUnknownParameters = true;
+                continue;
+            }
+            if (paramValue instanceof Map) {
+                Map<String, Object> nestedParams = (Map<String, Object>) paramValue;
+                validateNestedParameters(nestedParams, supportedParametersNested.get(paramName));
+            } else if (paramValue instanceof List) {
+                for (Object item : (List<?>) paramValue) {
+                    if (item instanceof Map) {
+                        validateNestedParameters((Map<String, Object>) item, supportedParametersNested.get(paramName));
+                    } else {
+                        hasUnknownParameters = true;
+                    }
+                }
+            } else {
+                if (supportedParametersNested.isEmpty()) {
+                    continue;
+                }
+                hasUnknownParameters = true;
+            }
+        }
+        if (hasUnknownParameters) {
+            throw new IllegalArgumentException("unrecognized parameters in normalization technique");
+        }
+    }
+
+    private void validateNestedParameters(Map<String, Object> parameters, Set<String> supportedNestedParams) {
+        if (Objects.isNull(parameters) || parameters.isEmpty()) {
+            return;
+        }
+        boolean hasUnknownParameters = false;
+        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+            String paramName = entry.getKey();
+
+            if (Objects.nonNull(supportedNestedParams) && !supportedNestedParams.contains(paramName)) {
+                hasUnknownParameters = true;
+                break;
+            }
+        }
+        if (hasUnknownParameters) {
+            throw new IllegalArgumentException("unrecognized parameters in normalization technique");
+        }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -57,7 +57,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
 
     private Integer paginationDepth;
 
-    static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
+    public static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
     private static final int LOWER_BOUND_OF_PAGINATION_DEPTH = 0;
 
     public HybridQueryBuilder(StreamInput in) throws IOException {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.processor.normalization;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -318,6 +319,34 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
         assertTrue(doc1Scores.get(0).getValue().contains("l2 normalization"));
         assertTrue(doc1Scores.get(1).getValue().contains("l2 normalization"));
         assertTrue(doc1Scores.get(2).getValue().contains("l2 normalization"));
+    }
+
+    public void testInvalidParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsList = List.of(
+            Map.of("min_score", 0.1, "mode", "clip"),
+            Map.of("mode", "ignore", "invalid_param", "value")
+        );
+        parameters.put("lower_bounds", lowerBoundsList);
+
+        try {
+            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            fail("expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("unrecognized parameters in normalization technique", e.getMessage());
+        }
+    }
+
+    public void testUnsupportedTopLevelParameter() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("invalid_top_level_param", "value"); // Adding an invalid top-level parameter
+
+        try {
+            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            fail("expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("unrecognized parameters in normalization technique", e.getMessage());
+        }
     }
 
     private float l2Norm(float score, List<Float> scores) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -4,9 +4,12 @@
  */
 package org.opensearch.neuralsearch.processor.normalization;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -22,7 +25,10 @@ import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 import org.opensearch.search.SearchShardTarget;
 
+import static org.opensearch.neuralsearch.processor.normalization.MinMaxScoreNormalizationTechnique.MIN_SCORE;
+import static org.opensearch.neuralsearch.query.HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES;
 import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
+import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_LOWER_BOUNDS;
 
 /**
  * Abstracts normalization of scores based on min-max method
@@ -267,6 +273,356 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         assertEquals(1.0f, topDocs2.scoreDocs[0].score, DELTA_FOR_SCORE_ASSERTION); // doc2 in second subquery
         assertEquals(0.0f, topDocs2.scoreDocs[1].score, DELTA_FOR_SCORE_ASSERTION); // doc1 in second subquery
         assertEquals(1.0f, topDocs3.scoreDocs[0].score, DELTA_FOR_SCORE_ASSERTION); // doc1 in third subquery
+    }
+
+    public void testLowerBoundsModeFromString_whenValidValues_thenSuccessful() {
+        assertEquals(
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY,
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("apply")
+        );
+        assertEquals(
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.CLIP,
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("clip")
+        );
+        assertEquals(
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.IGNORE,
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("ignore")
+        );
+        // Case insensitive check
+        assertEquals(
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY,
+            MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("APPLY")
+        );
+    }
+
+    public void testMode_fromString_invalidValues() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString("invalid")
+        );
+        assertEquals("invalid mode: invalid, valid values are: apply, clip, ignore", exception.getMessage());
+    }
+
+    public void testLowerBoundsModeFromString_whenNullOrEmpty_thenFail() {
+        IllegalArgumentException nullException = expectThrows(
+            IllegalArgumentException.class,
+            () -> MinMaxScoreNormalizationTechnique.LowerBound.Mode.fromString(null)
+        );
+        assertEquals("mode value cannot be null or empty", nullException.getMessage());
+    }
+
+    public void testLowerBounds_whenModeIsApply_thenSuccessful() {
+        float score = 0.5f;
+        float minScore = 0.1f;
+        float maxScore = 0.8f;
+        float lowerBoundScore = 0.3f;
+
+        float normalizedScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY.normalize(
+            score,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        // we expect score as 0.5 - 0.3 / 0.8 - 0.3 = 0.2 / 0.5 = 0.4
+        assertEquals(0.4f, normalizedScore, DELTA_FOR_SCORE_ASSERTION);
+
+        // Test when score is below lower bound
+        float lowScore = 0.2f;
+        float normalizedLowScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY.normalize(
+            lowScore,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        // we expect score as 0.2 - 0.1 / 0.8 - 0.1 = 0.1 / 0.7 = 0.1
+        assertEquals(0.143f, normalizedLowScore, DELTA_FOR_SCORE_ASSERTION);
+    }
+
+    public void testLowerBounds_whenModeIsClip_thenSuccessful() {
+        float score = 0.5f;
+        float minScore = 0.2f;
+        float maxScore = 0.8f;
+        float lowerBoundScore = 0.3f;
+
+        float normalizedScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.CLIP.normalize(
+            score,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        assertEquals(0.4f, normalizedScore, DELTA_FOR_SCORE_ASSERTION);
+
+        // Test when score is below min score
+        float lowScore = 0.1f;
+        float normalizedLowScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.CLIP.normalize(
+            lowScore,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        assertEquals(0.0f, normalizedLowScore, DELTA_FOR_SCORE_ASSERTION);
+    }
+
+    public void testLowerBounds_whenModeIsIgnore_thenSuccessful() {
+        float score = 0.5f;
+        float minScore = 0.2f;
+        float maxScore = 0.8f;
+        float lowerBoundScore = 0.3f;
+
+        float normalizedScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.IGNORE.normalize(
+            score,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        assertEquals(0.5f, normalizedScore, DELTA_FOR_SCORE_ASSERTION);
+
+        // Test when normalized score would be 0
+        float lowScore = 0.2f;
+        float normalizedLowScore = MinMaxScoreNormalizationTechnique.LowerBound.Mode.IGNORE.normalize(
+            lowScore,
+            minScore,
+            maxScore,
+            lowerBoundScore
+        );
+        assertEquals(MIN_SCORE, normalizedLowScore, DELTA_FOR_SCORE_ASSERTION);
+    }
+
+    public void testLowerBoundsMode_whenDefaultValue_thenSuccessful() {
+        assertEquals(MinMaxScoreNormalizationTechnique.LowerBound.Mode.APPLY, MinMaxScoreNormalizationTechnique.LowerBound.Mode.DEFAULT);
+    }
+
+    public void testLowerBounds_whenExceedsMaxSubQueries_thenFail() {
+        List<Map<String, Object>> lowerBounds = new ArrayList<>();
+
+        for (int i = 0; i <= 100; i++) {
+            Map<String, Object> bound = new HashMap<>();
+            if (i % 3 == 0) {
+                bound.put("mode", "apply");
+                bound.put("min_score", 0.1f);
+            } else if (i % 3 == 1) {
+                bound.put("mode", "clip");
+                bound.put("min_score", 0.1f);
+            } else {
+                bound.put("mode", "ignore");
+            }
+            lowerBounds.add(bound);
+        }
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("lower_bounds", lowerBounds);
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil())
+        );
+
+        assertEquals(
+            String.format(
+                Locale.ROOT,
+                "lower_bounds size %d should be less than or equal to %d",
+                lowerBounds.size(),
+                MAX_NUMBER_OF_SUB_QUERIES
+            ),
+            exception.getMessage()
+        );
+    }
+
+    public void testDescribe_whenLowerBoundsArePresent_thenSuccessful() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBounds = Arrays.asList(
+            Map.of("mode", "apply", "min_score", 0.2),
+
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parameters.put("lower_bounds", lowerBounds);
+        MinMaxScoreNormalizationTechnique techniqueWithBounds = new MinMaxScoreNormalizationTechnique(
+            parameters,
+            new ScoreNormalizationUtil()
+        );
+        assertEquals("min_max, lower bounds [(apply, 0.2), (clip, 0.1)]", techniqueWithBounds.describe());
+
+        // Test case 2: without lower bounds
+        Map<String, Object> emptyParameters = new HashMap<>();
+        MinMaxScoreNormalizationTechnique techniqueWithoutBounds = new MinMaxScoreNormalizationTechnique(
+            emptyParameters,
+            new ScoreNormalizationUtil()
+        );
+        assertEquals("min_max", techniqueWithoutBounds.describe());
+
+        Map<String, Object> parametersMissingMode = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsMissingMode = Arrays.asList(
+            Map.of("min_score", 0.2),
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parametersMissingMode.put("lower_bounds", lowerBoundsMissingMode);
+        MinMaxScoreNormalizationTechnique techniqueMissingMode = new MinMaxScoreNormalizationTechnique(
+            parametersMissingMode,
+            new ScoreNormalizationUtil()
+        );
+        assertEquals("min_max, lower bounds [(apply, 0.2), (clip, 0.1)]", techniqueMissingMode.describe());
+
+        Map<String, Object> parametersMissingScore = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsMissingScore = Arrays.asList(
+            Map.of("mode", "apply"),
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parametersMissingScore.put("lower_bounds", lowerBoundsMissingScore);
+        MinMaxScoreNormalizationTechnique techniqueMissingScore = new MinMaxScoreNormalizationTechnique(
+            parametersMissingScore,
+            new ScoreNormalizationUtil()
+        );
+        assertEquals("min_max, lower bounds [(apply, 0.0), (clip, 0.1)]", techniqueMissingScore.describe());
+    }
+
+    public void testLowerBounds_whenInvalidInput_thenFail() {
+        // Test case 1: Invalid mode value
+        Map<String, Object> parametersInvalidMode = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsInvalidMode = Arrays.asList(
+            Map.of("mode", "invalid_mode", "min_score", 0.2),
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parametersInvalidMode.put("lower_bounds", lowerBoundsInvalidMode);
+        IllegalArgumentException invalidModeException = expectThrows(
+            IllegalArgumentException.class,
+            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidMode, new ScoreNormalizationUtil())
+        );
+        assertEquals("invalid mode: invalid_mode, valid values are: apply, clip, ignore", invalidModeException.getMessage());
+
+        // Test case 4: Invalid min_score type
+        Map<String, Object> parametersInvalidScore = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsInvalidScore = Arrays.asList(
+            Map.of("mode", "apply", "min_score", "not_a_number"),
+            Map.of("mode", "clip", "min_score", 0.1)
+        );
+        parametersInvalidScore.put("lower_bounds", lowerBoundsInvalidScore);
+        IllegalArgumentException invalidScoreException = expectThrows(
+            IllegalArgumentException.class,
+            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidScore, new ScoreNormalizationUtil())
+        );
+        assertEquals("invalid format for min_score: must be a valid float value", invalidScoreException.getMessage());
+    }
+
+    public void testLowerBoundsValidation_whenLowerBoundsAndSubQueriesCountMismatch_thenFail() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBounds = Arrays.asList(Map.of("mode", "clip", "min_score", 0.1));
+        parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
+
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    ),
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(3, 0.1f) })
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(minMaxTechnique)
+            .build();
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> minMaxTechnique.normalize(normalizeScoresDTO)
+        );
+
+        assertEquals(
+            "expected lower bounds array to contain 2 elements matching the number of sub-queries, but found a mismatch",
+            exception.getMessage()
+        );
+    }
+
+    public void testLowerBoundsValidation_whenTopDocsIsEmpty_thenSuccessful() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBounds = Arrays.asList(
+            Map.of("mode", "clip", "min_score", 0.1),
+            Map.of("mode", "apply", "min_score", 0.0)
+        );
+        parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
+
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), List.of(), false, SEARCH_SHARD),
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    ),
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(3, 0.1f) })
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(minMaxTechnique)
+            .build();
+
+        minMaxTechnique.normalize(normalizeScoresDTO);
+
+        CompoundTopDocs expectedCompoundDocsZero = new CompoundTopDocs(
+            new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+            List.of(),
+            false,
+            SEARCH_SHARD
+        );
+        CompoundTopDocs expectedCompoundDocsOne = new CompoundTopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, 0.25f) }
+                ),
+                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(3, 1.0f) })
+            ),
+            false,
+            SEARCH_SHARD
+        );
+        expectedCompoundDocsOne.setScoreDocs(List.of(new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f)));
+        assertNotNull(compoundTopDocs);
+        assertEquals(2, compoundTopDocs.size());
+        CompoundTopDocs compoundTopDocsZero = compoundTopDocs.get(0);
+        assertEquals(expectedCompoundDocsZero, compoundTopDocsZero);
+        CompoundTopDocs compoundTopDocsOne = compoundTopDocs.get(1);
+        assertEquals(expectedCompoundDocsOne, compoundTopDocsOne);
+    }
+
+    public void testInvalidParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+        List<Map<String, Object>> lowerBoundsList = List.of(
+            Map.of("min_score", 0.1, "mode", "clip"),
+            Map.of("mode", "ignore", "invalid_param", "value") // Adding an invalid nested parameter
+        );
+        parameters.put("lower_bounds", lowerBoundsList);
+
+        try {
+            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            fail("Expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("unrecognized parameters in normalization technique", e.getMessage());
+        }
+    }
+
+    public void testUnsupportedTopLevelParameter() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("invalid_top_level_param", "value"); // Adding an invalid top-level parameter
+
+        try {
+            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            fail("Expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("unrecognized parameters in normalization technique", e.getMessage());
+        }
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactoryTests.java
@@ -5,8 +5,14 @@
 package org.opensearch.neuralsearch.processor.normalization;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_LOWER_BOUNDS;
 
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ScoreNormalizationFactoryTests extends OpenSearchQueryTestCase {
 
@@ -42,4 +48,32 @@ public class ScoreNormalizationFactoryTests extends OpenSearchQueryTestCase {
         );
         assertThat(illegalArgumentException.getMessage(), containsString("provided normalization technique is not supported"));
     }
+
+    public void testCreateMinMaxNormalizationWithParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+
+        List<Map<String, Object>> lowerBounds = Arrays.asList(Map.of("mode", "clip", "min_score", 0.1));
+        parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
+
+        ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
+        ScoreNormalizationTechnique normalizationTechnique = scoreNormalizationFactory.createNormalization("min_max", parameters);
+
+        assertNotNull(normalizationTechnique);
+        assertTrue(normalizationTechnique instanceof MinMaxScoreNormalizationTechnique);
+    }
+
+    public void testThrowsExceptionForInvalidTechniqueWithParameters() {
+        Map<String, Object> parameters = new HashMap<>();
+
+        List<Map<String, Object>> lowerBounds = Arrays.asList(Map.of("mode", "clip", "min_score", 0.1));
+        parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
+
+        ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationFactory.createNormalization(L2ScoreNormalizationTechnique.TECHNIQUE_NAME, parameters)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
+    }
+
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationUtilTests.java
@@ -8,6 +8,7 @@ import org.opensearch.neuralsearch.processor.SearchShard;
 import org.opensearch.neuralsearch.processor.explain.DocIdAtSearchShard;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -19,11 +20,16 @@ import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_FLOATS_ASSERT
 public class ScoreNormalizationUtilTests extends OpenSearchTestCase {
 
     private ScoreNormalizationUtil scoreNormalizationUtil;
+    private Set<String> supportedTopLevelParams;
+    private Map<String, Set<String>> supportedNestedParams;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         scoreNormalizationUtil = new ScoreNormalizationUtil();
+        supportedTopLevelParams = new HashSet<>(Arrays.asList("method", "parameters"));
+        supportedNestedParams = new HashMap<>();
+        supportedNestedParams.put("parameters", new HashSet<>(Arrays.asList("factor", "offset")));
     }
 
     public void testValidateParamsWithUnsupportedParameter() {
@@ -66,5 +72,98 @@ public class ScoreNormalizationUtilTests extends OpenSearchTestCase {
         assertEquals(normalizedScore, scores.get(subQueryIndex), DELTA_FOR_FLOATS_ASSERTION);
         assertEquals(0.0f, scores.get(0), DELTA_FOR_FLOATS_ASSERTION);
         assertEquals(0.0f, scores.get(2), DELTA_FOR_FLOATS_ASSERTION);
+    }
+
+    public void testValidateParametersWithNullParameters() {
+        scoreNormalizationUtil.validateParameters(null, supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithEmptyParameters() {
+        scoreNormalizationUtil.validateParameters(new HashMap<>(), supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithValidTopLevelParameters() {
+        Map<String, Object> params = new HashMap<>();
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("factor", 1.0);
+        params.put("parameters", nestedParams);
+
+        scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithValidNestedParameters() {
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("factor", 1.0);
+        nestedParams.put("offset", 0.0);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("parameters", nestedParams);
+
+        scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithInvalidTopLevelParameter() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("invalid_param", "value");
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
+    }
+
+    public void testValidateParametersWithInvalidNestedParameter() {
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("invalid_nested", "value");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("parameters", nestedParams);
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
+    }
+
+    public void testValidateParametersWithListOfMaps() {
+        Map<String, Object> validNestedParams1 = new HashMap<>();
+        validNestedParams1.put("factor", 1.0);
+        Map<String, Object> validNestedParams2 = new HashMap<>();
+        validNestedParams2.put("offset", 0.0);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("parameters", Arrays.asList(validNestedParams1, validNestedParams2));
+
+        scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams);
+    }
+
+    public void testValidateParametersWithInvalidListContent() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("parameters", Arrays.asList("invalid", "content"));
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
+    }
+
+    public void testValidateParametersWithMixedValidAndInvalidParameters() {
+        Map<String, Object> nestedParams = new HashMap<>();
+        nestedParams.put("factor", 1.0);
+        nestedParams.put("invalid_nested", "value");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("method", "min_max");
+        params.put("parameters", nestedParams);
+        params.put("invalid_top", "value");
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> scoreNormalizationUtil.validateParameters(params, supportedTopLevelParams, supportedNestedParams)
+        );
+        assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
@@ -490,7 +490,7 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
         updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
 
         initializeIndexIfNotExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SHARDS_COUNT_IN_MULTI_NODE_CLUSTER);
-        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), true);
+        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true);
         // Assert
         // scores for search hits
         HybridQueryBuilder hybridQueryBuilder = createHybridQueryBuilderWithMatchTermAndRangeQuery(

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -82,6 +82,7 @@ import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_COMBINATION_MET
 import static org.opensearch.neuralsearch.util.TestUtils.ML_PLUGIN_SYSTEM_INDEX_PREFIX;
 import static org.opensearch.neuralsearch.util.TestUtils.OPENDISTRO_SECURITY;
 import static org.opensearch.neuralsearch.util.TestUtils.OPENSEARCH_SYSTEM_INDEX_PREFIX;
+import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_LOWER_BOUNDS;
 import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_WEIGHTS;
 import static org.opensearch.neuralsearch.util.TestUtils.MAX_RETRY;
 import static org.opensearch.neuralsearch.util.TestUtils.MAX_TIME_OUT_INTERVAL;
@@ -248,7 +249,10 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             isComplete = checkComplete(taskQueryResult);
             Thread.sleep(DEFAULT_TASK_RESULT_QUERY_INTERVAL_IN_MILLISECOND);
         }
-        assertTrue(String.format(Locale.ROOT, "failed to load the model, last task finished with status %s", taskQueryResult.get("state")), isComplete);
+        assertTrue(
+            String.format(Locale.ROOT, "failed to load the model, last task finished with status %s", taskQueryResult.get("state")),
+            isComplete
+        );
     }
 
     /**
@@ -1214,13 +1218,14 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         String combinationMethod,
         final Map<String, String> combinationParams
     ) {
-        createSearchPipeline(pipelineId, normalizationMethod, combinationMethod, combinationParams, false);
+        createSearchPipeline(pipelineId, normalizationMethod, Map.of(), combinationMethod, combinationParams, false);
     }
 
     @SneakyThrows
     protected void createSearchPipeline(
         final String pipelineId,
         final String normalizationMethod,
+        final Map<String, Object> normalizationParams,
         final String combinationMethod,
         final Map<String, String> combinationParams,
         boolean addExplainResponseProcessor
@@ -1232,10 +1237,32 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             .append(NormalizationProcessor.TYPE)
             .append("\": {")
             .append("\"normalization\": {")
-            .append("\"technique\": \"%s\"")
-            .append("},")
-            .append("\"combination\": {")
             .append("\"technique\": \"%s\"");
+        if (Objects.nonNull(normalizationParams) && !normalizationParams.isEmpty()) {
+            stringBuilderForContentBody.append(", \"parameters\": {");
+            if (normalizationParams.containsKey(PARAM_NAME_LOWER_BOUNDS)) {
+                stringBuilderForContentBody.append("\"lower_bounds\": [");
+                List<Map> lowerBounds = (List) normalizationParams.get(PARAM_NAME_LOWER_BOUNDS);
+                for (int i = 0; i < lowerBounds.size(); i++) {
+                    Map<String, String> lowerBound = lowerBounds.get(i);
+                    stringBuilderForContentBody.append("{ ")
+                        .append("\"mode\"")
+                        .append(": \"")
+                        .append(lowerBound.get("mode"))
+                        .append("\",")
+                        .append("\"min_score\"")
+                        .append(": ")
+                        .append(lowerBound.get("min_score"))
+                        .append(" }");
+                    if (i < lowerBounds.size() - 1) {
+                        stringBuilderForContentBody.append(", ");
+                    }
+                }
+                stringBuilderForContentBody.append("]");
+            }
+            stringBuilderForContentBody.append(" }");
+        }
+        stringBuilderForContentBody.append("},").append("\"combination\": {").append("\"technique\": \"%s\"");
         if (Objects.nonNull(combinationParams) && !combinationParams.isEmpty()) {
             stringBuilderForContentBody.append(", \"parameters\": {");
             if (combinationParams.containsKey(PARAM_NAME_WEIGHTS)) {

--- a/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
@@ -65,6 +65,7 @@ public class TestUtils {
     public static final String DEFAULT_NORMALIZATION_METHOD = "min_max";
     public static final String DEFAULT_COMBINATION_METHOD = "arithmetic_mean";
     public static final String PARAM_NAME_WEIGHTS = "weights";
+    public static final String PARAM_NAME_LOWER_BOUNDS = "lower_bounds";
     public static final String SPARSE_ENCODING_PROCESSOR = "sparse_encoding";
     public static final int MAX_TIME_OUT_INTERVAL = 3000;
     public static final int MAX_RETRY = 5;


### PR DESCRIPTION
### Description

Moving lower_bounds from feature branch to main after getting clearance from app sec team. Include following PRs:
- https://github.com/opensearch-project/neural-search/pull/1195 

### Related Issues
https://github.com/opensearch-project/neural-search/issues/150
Implemented design described in RFC https://github.com/opensearch-project/neural-search/issues/1189
PR for adding documentation: https://github.com/opensearch-project/documentation-website/issues/9337

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
