### PR TITLE
implement batch document optimization for text embedding processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/neural-search/compare/2.x...HEAD)
 ### Features
-- Add Optimized Text Embedding Processor ([#1191](https://github.com/opensearch-project/neural-search/pull/1191))
+- Optimizing embedding generation in text embedding processor ([#1191](https://github.com/opensearch-project/neural-search/pull/1191))
 ### Enhancements
 - Set neural-search plugin 3.0.0 baseline JDK version to JDK-21 ([#838](https://github.com/opensearch-project/neural-search/pull/838))
 - Support different embedding types in model's response ([#1007](https://github.com/opensearch-project/neural-search/pull/1007))

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -26,6 +26,8 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.action.get.MultiGetItemResponse;
+import org.opensearch.action.get.MultiGetRequest;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.util.CollectionUtils;
@@ -54,6 +56,8 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
 
     public static final String MODEL_ID_FIELD = "model_id";
     public static final String FIELD_MAP_FIELD = "field_map";
+    public static final String INDEX_FIELD = "_index";
+    public static final String ID_FIELD = "_id";
     private static final BiFunction<Object, Object, Object> REMAPPING_FUNCTION = (v1, v2) -> {
         if (v1 instanceof Collection && v2 instanceof Collection) {
             ((Collection) v1).addAll((Collection) v2);
@@ -169,49 +173,91 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
      */
     abstract void doBatchExecute(List<String> inferenceList, Consumer<List<?>> handler, Consumer<Exception> onException);
 
+    /**
+     * This is the function which does actual inference work for subBatchExecute interface.
+     * @param ingestDocumentWrappers a list of IngestDocuments in a batch.
+     * @param handler a callback handler to handle inference results which is a list of objects.
+     */
     @Override
     public void subBatchExecute(List<IngestDocumentWrapper> ingestDocumentWrappers, Consumer<List<IngestDocumentWrapper>> handler) {
-        if (CollectionUtils.isEmpty(ingestDocumentWrappers)) {
-            handler.accept(Collections.emptyList());
-            return;
-        }
+        try {
+            if (CollectionUtils.isEmpty(ingestDocumentWrappers)) {
+                handler.accept(Collections.emptyList());
+                return;
+            }
 
-        List<DataForInference> dataForInferences = getDataForInference(ingestDocumentWrappers);
-        List<String> inferenceList = constructInferenceTexts(dataForInferences);
-        if (inferenceList.isEmpty()) {
+            List<DataForInference> dataForInferences = getDataForInference(ingestDocumentWrappers);
+            List<String> inferenceList = constructInferenceTexts(dataForInferences);
+            if (inferenceList.isEmpty()) {
+                handler.accept(ingestDocumentWrappers);
+                return;
+            }
+            doSubBatchExecute(ingestDocumentWrappers, inferenceList, dataForInferences, handler);
+        } catch (Exception e) {
+            updateWithExceptions(ingestDocumentWrappers, e);
             handler.accept(ingestDocumentWrappers);
-            return;
         }
-        Tuple<List<String>, Map<Integer, Integer>> sortedResult = sortByLengthAndReturnOriginalOrder(inferenceList);
-        inferenceList = sortedResult.v1();
-        Map<Integer, Integer> originalOrder = sortedResult.v2();
-        doBatchExecute(inferenceList, results -> {
-            int startIndex = 0;
-            results = restoreToOriginalOrder(results, originalOrder);
-            for (DataForInference dataForInference : dataForInferences) {
-                if (dataForInference.getIngestDocumentWrapper().getException() != null
-                    || CollectionUtils.isEmpty(dataForInference.getInferenceList())) {
-                    continue;
+    }
+
+    /**
+     * This is a helper function for subBatchExecute, which invokes doBatchExecute for given inference list.
+     * @param ingestDocumentWrappers a list of IngestDocuments in a batch.
+     * @param inferenceList a list of String for inference.
+     * @param dataForInferences a list of data for inference, which includes ingestDocumentWrapper, processMap, inferenceList.
+     * @param handler a callback handler to handle inference results which is a list of objects.
+     */
+    protected void doSubBatchExecute(
+        List<IngestDocumentWrapper> ingestDocumentWrappers,
+        List<String> inferenceList,
+        List<DataForInference> dataForInferences,
+        Consumer<List<IngestDocumentWrapper>> handler
+    ) {
+        try {
+            Tuple<List<String>, Map<Integer, Integer>> sortedResult = sortByLengthAndReturnOriginalOrder(inferenceList);
+            inferenceList = sortedResult.v1();
+            Map<Integer, Integer> originalOrder = sortedResult.v2();
+            doBatchExecute(inferenceList, results -> {
+                try {
+                    int startIndex = 0;
+                    results = restoreToOriginalOrder(results, originalOrder);
+                    for (DataForInference dataForInference : dataForInferences) {
+                        if (dataForInference.getIngestDocumentWrapper().getException() != null
+                            || CollectionUtils.isEmpty(dataForInference.getInferenceList())) {
+                            continue;
+                        }
+                        List<?> inferenceResults = results.subList(startIndex, startIndex + dataForInference.getInferenceList().size());
+                        startIndex += dataForInference.getInferenceList().size();
+                        setVectorFieldsToDocument(
+                            dataForInference.getIngestDocumentWrapper().getIngestDocument(),
+                            dataForInference.getProcessMap(),
+                            inferenceResults
+                        );
+                    }
+                    handler.accept(ingestDocumentWrappers);
+                } catch (Exception e) {
+                    updateWithExceptions(ingestDocumentWrappers, e);
+                    handler.accept(ingestDocumentWrappers);
                 }
-                List<?> inferenceResults = results.subList(startIndex, startIndex + dataForInference.getInferenceList().size());
-                startIndex += dataForInference.getInferenceList().size();
-                setVectorFieldsToDocument(
-                    dataForInference.getIngestDocumentWrapper().getIngestDocument(),
-                    dataForInference.getProcessMap(),
-                    inferenceResults
-                );
-            }
-            handler.accept(ingestDocumentWrappers);
-        }, exception -> {
-            for (IngestDocumentWrapper ingestDocumentWrapper : ingestDocumentWrappers) {
-                // The IngestDocumentWrapper might already run into exception and not sent for inference. So here we only
-                // set exception to IngestDocumentWrapper which doesn't have exception before.
-                if (ingestDocumentWrapper.getException() == null) {
-                    ingestDocumentWrapper.update(ingestDocumentWrapper.getIngestDocument(), exception);
+            }, exception -> {
+                try {
+                    for (IngestDocumentWrapper ingestDocumentWrapper : ingestDocumentWrappers) {
+                        // The IngestDocumentWrapper might already run into exception and not sent for inference. So here we only
+                        // set exception to IngestDocumentWrapper which doesn't have exception before.
+                        if (ingestDocumentWrapper.getException() == null) {
+                            ingestDocumentWrapper.update(ingestDocumentWrapper.getIngestDocument(), exception);
+                        }
+                    }
+                    handler.accept(ingestDocumentWrappers);
+                } catch (Exception e) {
+                    updateWithExceptions(ingestDocumentWrappers, e);
+                    handler.accept(ingestDocumentWrappers);
                 }
-            }
+
+            });
+        } catch (Exception e) {
+            updateWithExceptions(ingestDocumentWrappers, e);
             handler.accept(ingestDocumentWrappers);
-        });
+        }
     }
 
     private Tuple<List<String>, Map<Integer, Integer>> sortByLengthAndReturnOriginalOrder(List<String> inferenceList) {
@@ -238,7 +284,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         return sortedResults;
     }
 
-    private List<String> constructInferenceTexts(List<DataForInference> dataForInferences) {
+    protected List<String> constructInferenceTexts(List<DataForInference> dataForInferences) {
         List<String> inferenceTexts = new ArrayList<>();
         for (DataForInference dataForInference : dataForInferences) {
             if (dataForInference.getIngestDocumentWrapper().getException() != null
@@ -250,7 +296,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         return inferenceTexts;
     }
 
-    private List<DataForInference> getDataForInference(List<IngestDocumentWrapper> ingestDocumentWrappers) {
+    protected List<DataForInference> getDataForInference(List<IngestDocumentWrapper> ingestDocumentWrappers) {
         List<DataForInference> dataForInferences = new ArrayList<>();
         for (IngestDocumentWrapper ingestDocumentWrapper : ingestDocumentWrappers) {
             Map<String, Object> processMap = null;
@@ -272,7 +318,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
 
     @Getter
     @AllArgsConstructor
-    private static class DataForInference {
+    protected static class DataForInference {
         private final IngestDocumentWrapper ingestDocumentWrapper;
         private final Map<String, Object> processMap;
         private final List<String> inferenceList;
@@ -415,6 +461,36 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         nlpResult.forEach(ingestDocument::setFieldValue);
     }
 
+    /**
+     * This method creates a MultiGetRequest from a list of ingest documents to be fetched for comparison
+     * @param ingestDocumentWrappers, list of ingest documents
+     * */
+    protected MultiGetRequest buildMultiGetRequest(List<IngestDocumentWrapper> ingestDocumentWrappers) {
+        MultiGetRequest multiGetRequest = new MultiGetRequest();
+        for (IngestDocumentWrapper ingestDocumentWrapper : ingestDocumentWrappers) {
+            Object index = ingestDocumentWrapper.getIngestDocument().getSourceAndMetadata().get(INDEX_FIELD);
+            Object id = ingestDocumentWrapper.getIngestDocument().getSourceAndMetadata().get(ID_FIELD);
+            if (Objects.nonNull(index) && Objects.nonNull(id)) {
+                multiGetRequest.add(index.toString(), id.toString());
+            }
+        }
+        return multiGetRequest;
+    }
+
+    /**
+     * This method creates a map of documents from MultiGetItemResponse where the key is document ID and value is corresponding document
+     * @param multiGetItemResponses, array of responses from Multi Get Request
+     * */
+    protected Map<String, Map<String, Object>> createDocumentMap(MultiGetItemResponse[] multiGetItemResponses) {
+        Map<String, Map<String, Object>> existingDocuments = new HashMap<>();
+        for (MultiGetItemResponse item : multiGetItemResponses) {
+            String id = item.getId();
+            Map<String, Object> existingDocument = item.getResponse().getSourceAsMap();
+            existingDocuments.put(id, existingDocument);
+        }
+        return existingDocuments;
+    }
+
     @SuppressWarnings({ "unchecked" })
     @VisibleForTesting
     Map<String, Object> buildNLPResult(Map<String, Object> processorMap, List<?> results, Map<String, Object> sourceAndMetadataMap) {
@@ -504,6 +580,13 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         }
     }
 
+    // This method updates each ingestDocument with exceptions
+    protected void updateWithExceptions(List<IngestDocumentWrapper> ingestDocumentWrappers, Exception e) {
+        for (IngestDocumentWrapper ingestDocumentWrapper : ingestDocumentWrappers) {
+            ingestDocumentWrapper.update(ingestDocumentWrapper.getIngestDocument(), e);
+        }
+    }
+
     private void processMapEntryValue(
         List<?> results,
         IndexWrapper indexWrapper,
@@ -582,7 +665,7 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         List<Map<String, Object>> keyToResult = new ArrayList<>();
         sourceValue.stream()
             .filter(Objects::nonNull) // explicit null check is required since sourceValue can contain null values in cases where
-                                      // sourceValue has been filtered
+            // sourceValue has been filtered
             .forEachOrdered(x -> keyToResult.add(ImmutableMap.of(listTypeNestedMapKey, results.get(indexWrapper.index++))));
         return keyToResult;
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -4,6 +4,8 @@
  */
 package org.opensearch.neuralsearch.processor;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -13,10 +15,14 @@ import java.util.stream.Collectors;
 
 import org.opensearch.action.get.GetAction;
 import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.MultiGetAction;
+import org.opensearch.action.get.MultiGetItemResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.IngestDocumentWrapper;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 
 import lombok.extern.log4j.Log4j2;
@@ -105,5 +111,91 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
             TextInferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
             ActionListener.wrap(handler::accept, onException)
         );
+    }
+
+    @Override
+    public void subBatchExecute(List<IngestDocumentWrapper> ingestDocumentWrappers, Consumer<List<IngestDocumentWrapper>> handler) {
+        try {
+            if (CollectionUtils.isEmpty(ingestDocumentWrappers)) {
+                handler.accept(Collections.emptyList());
+                return;
+            }
+            List<DataForInference> dataForInferences = getDataForInference(ingestDocumentWrappers);
+            if (dataForInferences.isEmpty()) {
+                handler.accept(ingestDocumentWrappers);
+                return;
+            }
+            List<String> inferenceList = constructInferenceTexts(dataForInferences);
+            if (inferenceList.isEmpty()) {
+                handler.accept(ingestDocumentWrappers);
+                return;
+            }
+            // skip existing flag is turned off. Call doSubBatchExecute without filtering
+            if (skipExisting == false) {
+                doSubBatchExecute(ingestDocumentWrappers, inferenceList, dataForInferences, handler);
+                return;
+            }
+            // skipExisting flag is turned on, eligible inference texts in dataForInferences will be compared and filtered after embeddings
+            // are copied
+            openSearchClient.execute(
+                MultiGetAction.INSTANCE,
+                buildMultiGetRequest(ingestDocumentWrappers),
+                ActionListener.wrap(response -> {
+                    try {
+                        MultiGetItemResponse[] multiGetItemResponses = response.getResponses();
+                        if (multiGetItemResponses == null || multiGetItemResponses.length == 0) {
+                            doSubBatchExecute(ingestDocumentWrappers, inferenceList, dataForInferences, handler);
+                            return;
+                        }
+                        // create a map of documents with key: doc_id and value: doc
+                        Map<String, Map<String, Object>> existingDocuments = createDocumentMap(multiGetItemResponses);
+                        List<DataForInference> filteredDataForInference = filterDataForInference(dataForInferences, existingDocuments);
+                        List<String> filteredInferenceList = constructInferenceTexts(filteredDataForInference);
+                        if (filteredInferenceList.isEmpty()) {
+                            handler.accept(ingestDocumentWrappers);
+                        } else {
+                            doSubBatchExecute(ingestDocumentWrappers, filteredInferenceList, filteredDataForInference, handler);
+                        }
+                    } catch (Exception e) {
+                        updateWithExceptions(ingestDocumentWrappers, e);
+                        handler.accept(ingestDocumentWrappers);
+                    }
+                }, e -> {
+                    // When exception is thrown in for MultiGetAction, set exception to all ingestDocumentWrappers
+                    updateWithExceptions(ingestDocumentWrappers, e);
+                    handler.accept(ingestDocumentWrappers);
+                })
+            );
+        } catch (Exception e) {
+            updateWithExceptions(ingestDocumentWrappers, e);
+            handler.accept(ingestDocumentWrappers);
+        }
+    }
+
+    // This is a helper method to filter the given list of dataForInferences by comparing its documents with existingDocuments with
+    // textEmbeddingInferenceFilter
+    private List<DataForInference> filterDataForInference(
+        List<DataForInference> dataForInferences,
+        Map<String, Map<String, Object>> existingDocuments
+    ) {
+        List<DataForInference> filteredDataForInference = new ArrayList<>();
+        for (DataForInference dataForInference : dataForInferences) {
+            IngestDocumentWrapper ingestDocumentWrapper = dataForInference.getIngestDocumentWrapper();
+            Map<String, Object> processMap = dataForInference.getProcessMap();
+            Map<String, Object> document = ingestDocumentWrapper.getIngestDocument().getSourceAndMetadata();
+            Object id = document.get(ID_FIELD);
+            // insert non-filtered dataForInference if existing document does not exist
+            if (Objects.isNull(id) || existingDocuments.containsKey(id.toString()) == false) {
+                filteredDataForInference.add(dataForInference);
+                continue;
+            }
+            // filter dataForInference when existing document exists
+            String docId = id.toString();
+            Map<String, Object> existingDocument = existingDocuments.get(docId);
+            Map<String, Object> filteredProcessMap = textEmbeddingInferenceFilter.filter(existingDocument, document, processMap);
+            List<String> filteredInferenceList = createInferenceList(filteredProcessMap);
+            filteredDataForInference.add(new DataForInference(ingestDocumentWrapper, filteredProcessMap, filteredInferenceList));
+        }
+        return filteredDataForInference;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/optimization/TextEmbeddingInferenceFilter.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/optimization/TextEmbeddingInferenceFilter.java
@@ -7,7 +7,6 @@ package org.opensearch.neuralsearch.processor.optimization;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.neuralsearch.processor.util.ProcessorUtils;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -47,7 +46,7 @@ public class TextEmbeddingInferenceFilter extends InferenceFilter {
         Optional<Object> existingValueOptional = ProcessorUtils.getValueFromSource(existingSourceAndMetadataMap, textPath);
         Optional<Object> embeddingValueOptional = ProcessorUtils.getValueFromSource(existingSourceAndMetadataMap, embeddingKey);
         if (existingValueOptional.isPresent() && embeddingValueOptional.isPresent()) {
-            return copyEmbeddingForSingleValue(
+            return copyEmbeddingForSingleObject(
                 embeddingKey,
                 processValue,
                 existingValueOptional.get(),
@@ -67,7 +66,7 @@ public class TextEmbeddingInferenceFilter extends InferenceFilter {
      * @return null if embeddings are reused; the processValue otherwise.
      */
     @Override
-    public Object copyEmbeddingForSingleValue(
+    public Object copyEmbeddingForSingleObject(
         String embeddingKey,
         Object processValue,
         Object existingValue,
@@ -90,7 +89,7 @@ public class TextEmbeddingInferenceFilter extends InferenceFilter {
      * @return empty list if embeddings are reused; processList otherwise.
      */
     @Override
-    public List<Object> copyEmbeddingForMultipleValues(
+    public List<Object> copyEmbeddingForListObject(
         String embeddingKey,
         List<Object> processList,
         List<Object> existingList,
@@ -99,8 +98,8 @@ public class TextEmbeddingInferenceFilter extends InferenceFilter {
     ) {
         if (Objects.equals(processList, existingList)) {
             ProcessorUtils.setValueToSource(sourceAndMetadataMap, embeddingKey, embeddingList);
-            // if successfully copied, return empty list to be filtered out from process map
-            return Collections.emptyList();
+            // if successfully copied, return null to be filtered out from process map
+            return null;
         }
         // source list and existing list are different, return processList to be included in process map
         return processList;

--- a/src/test/java/org/opensearch/neuralsearch/processor/optimization/TextEmbeddingInferenceFilterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/optimization/TextEmbeddingInferenceFilterTests.java
@@ -104,7 +104,7 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
 
         String fullEmbeddingKey = "embeddingField";
 
-        List<Object> result = textEmbeddingInferenceFilter.copyEmbeddingForMultipleValues(
+        List<Object> result = textEmbeddingInferenceFilter.copyEmbeddingForListObject(
             fullEmbeddingKey,
             processList,
             existingList,
@@ -112,7 +112,7 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
             sourceAndMetadataMap
         );
 
-        assertTrue(result.isEmpty());
+        assertNull(result);
         assertEquals(embeddingList, sourceAndMetadataMap.get(fullEmbeddingKey));
     }
 
@@ -123,7 +123,7 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
 
         String fullEmbeddingKey = "embeddingField";
 
-        List<Object> result = textEmbeddingInferenceFilter.copyEmbeddingForMultipleValues(
+        List<Object> result = textEmbeddingInferenceFilter.copyEmbeddingForListObject(
             fullEmbeddingKey,
             processList,
             existingList,
@@ -131,7 +131,7 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
             sourceAndMetadataMap
         );
 
-        assertEquals(processList.size(), result.size());
+        assertEquals(processList, result);
         assertNull(sourceAndMetadataMap.get(fullEmbeddingKey));
     }
 
@@ -139,7 +139,7 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
         List<Object> processList = Arrays.asList("Text A", "Text B");
         String fullEmbeddingKey = "embeddingField";
 
-        List<Object> result = textEmbeddingInferenceFilter.copyEmbeddingForMultipleValues(
+        List<Object> result = textEmbeddingInferenceFilter.copyEmbeddingForListObject(
             fullEmbeddingKey,
             processList,
             Collections.emptyList(),
@@ -204,7 +204,7 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
 
         Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filter(existingMap, sourceAndMetadataMap, processMap);
 
-        assertEquals(0, ((List) ((Map) result.get("outerField")).get("embeddingField")).size());
+        assertNull(((Map) result.get("outerField")).get("embeddingField"));
         assertEquals(Arrays.asList(0.1, 0.2, 0.3), ((List) ((Map) sourceAndMetadataMap.get("outerField")).get("embeddingField")).get(0));
         assertEquals(Arrays.asList(0.4, 0.5, 0.6), ((List) ((Map) sourceAndMetadataMap.get("outerField")).get("embeddingField")).get(1));
     }

--- a/src/test/resources/processor/PipelineConfigurationWithBatchSizeWithSkipExisting.json
+++ b/src/test/resources/processor/PipelineConfigurationWithBatchSizeWithSkipExisting.json
@@ -1,0 +1,34 @@
+{
+  "description": "text embedding pipeline for hybrid",
+  "processors": [
+    {
+      "drop": {
+        "if": "ctx.text.contains('drop')"
+      }
+    },
+    {
+      "fail": {
+        "if": "ctx.text.contains('fail')",
+        "message": "fail"
+      }
+    },
+    {
+      "text_embedding": {
+        "model_id": "%s",
+        "batch_size": 2,
+        "field_map": {
+          "title": "title_knn",
+          "favor_list": "favor_list_knn",
+          "favorites": {
+            "game": "game_knn",
+            "movie": "movie_knn"
+          },
+          "nested_passages": {
+            "text": "embedding"
+          }
+        },
+        "skip_existing": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description
This PR includes changes for:

1. refactor of InferenceFilter to simplify logic for copying embeddings
2. implementation for batch document update optimization by overriding InferenceProcessor's `subBatchExecute` to include filter when `skip_existing` flag is on

### Proposed State [Batch Document Update]

![proposed-batch-flow](https://github.com/user-attachments/assets/b9d4c06a-d9e4-40af-8792-85f9a35b9f2d)

Steps:

1. Process Maps are generated for each IngestDocument based on the Field Map defined. 
2. If skip_existing feature is set to true, filter the process map for each IngestDocument. 
    1. Existing documents are fetched via OpenSearch client’s Multi-Get Action to compare each of the existing inference text against its corresponding IngestDocument 
        1. if documents do not exist, or any exception is thrown, fallback to calling model inference
    2. Locate the embedding fields in each existing document
        1. Recursively traverse the process map to find embedding fields. Keeping track of the traversal path is required for look up in existing document. 
        2. Once embedding fields are found, attempt to copy embeddings from existing document to its corresponding ingest document. 
    3. If eligible, copy over the vector embeddings from existing document to its corresponding ingest document
        1. It is eligible for copy if inference text in ingest document and its corresponding existing document is the same, and embeddings for the inference text exist in its existing document. 
        2. Note, if in case of values in list, the fields in the same index are compared to determine text equality
    4. If eligible fields have been copied, remove the entry in process map 
3. Inference List is generated based on entries in Filtered Process Map. 
4. ML Commons InferenceSentence API is invoked with filtered inference list.
5. Embeddings for filtered inference list are generated in ML Commons. 
6. Embeddings for filtered inference list are mapped to target fields via entries defined in process map.
7. Embeddings for filtered inference list are populated to target fields in IngestDocument.

### Related Issues
HLD: https://github.com/opensearch-project/neural-search/issues/1138
### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
