### PR TITLE
Use latest json-smart lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,7 @@ dependencies {
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: 'net.minidev', module: 'json-smart'
     }
-    runtimeOnly group: 'net.minidev', name:'json-smart', version: '2.5.2'
+    runtimeOnly group: 'net.minidev', name:'json-smart', version: "${versions.json_smart}"
     runtimeOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     runtimeOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testFixturesImplementation "org.opensearch:common-utils:${version}"

--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,9 @@ dependencies {
     runtimeOnly('com.jayway.jsonpath:json-path:2.9.0') {
         // OpenSearch core is using slf4j 1.7.36. Therefore, we cannot change the version here.
         exclude group: 'org.slf4j', module: 'slf4j-api'
+        exclude group: 'net.minidev', module: 'json-smart'
     }
+    runtimeOnly group: 'net.minidev', name:'json-smart', version: '2.5.2'
     runtimeOnly("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
     runtimeOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testFixturesImplementation "org.opensearch:common-utils:${version}"

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -45,7 +45,9 @@ dependencies {
     testRuntimeOnly('com.jayway.jsonpath:json-path:2.9.0') {
         // OpenSearch core is using slf4j 1.7.36. Therefore, we cannot change the version here.
         exclude group: 'org.slf4j', module: 'slf4j-api'
+        exclude group: 'net.minidev', module: 'json-smart'
     }
+    testRuntimeOnly group: 'net.minidev', name:'json-smart', version: '2.5.2'
     api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     api "junit:junit:${versions.junit}"

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -47,7 +47,7 @@ dependencies {
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: 'net.minidev', module: 'json-smart'
     }
-    testRuntimeOnly group: 'net.minidev', name:'json-smart', version: '2.5.2'
+    testRuntimeOnly group: 'net.minidev', name:'json-smart', version: "${versions.json_smart}"
     api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     api "junit:junit:${versions.junit}"


### PR DESCRIPTION
### Description
json-path 2.9.0 has been flagged in CVE-2024-57699. They do not have fix yet, and their devs suggest to switch to json-smart https://github.com/json-path/JsonPath/issues/1031. 

We need to have this library for ml-commons, follow their strategy: keep json-path, but excluding json-smart part of it, and include json-mart of the proper version separately.

Picking up version of json-smart from the OS core, they added in the recent PR https://github.com/opensearch-project/OpenSearch/pull/17569

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1222

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [X] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
