### PR TITLE
Add semantic field mapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.x](https://github.com/opensearch-project/neural-search/compare/main...HEAD)
 
 ### Features
+- [Semantic Field] Add semantic field mapper. ([#1225](https://github.com/opensearch-project/neural-search/pull/1225)).
 
 ### Enhancements
 

--- a/build.gradle
+++ b/build.gradle
@@ -251,6 +251,7 @@ def knnJarDirectory = "$buildDir/dependencies/opensearch-knn"
 
 dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
+    implementation group: 'org.opensearch.plugin', name:'mapper-extras-client', version: "${opensearch_version}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchWithRescoreIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchWithRescoreIT.java
@@ -105,7 +105,13 @@ public class HybridSearchWithRescoreIT extends AbstractRollingUpgradeTestCase {
     ) throws Exception {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
-        loadModel(modelId);
+        // In rolling upgrade tests we will not clean up the resources created in old and mix
+        // so check if the model is already deployed then no need to deploy it again.
+        if (!isModelAlreadyDeployed(modelId)) {
+            loadModel(modelId);
+        }
+        // Try to ensure all nodes are green before we do the search.
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
         Map<String, Object> searchResponseAsMap = search(
             getIndexNameForTest(),
             hybridQueryBuilder,

--- a/src/main/java/org/opensearch/neuralsearch/constants/MappingConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/MappingConstants.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.constants;
+
+/**
+ * Constants related to the index mapping.
+ */
+public class MappingConstants {
+    /**
+     * Name for the field type. In index mapping we use this key to define the field type.
+     */
+    public static final String TYPE = "type";
+}

--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.constants;
+
+/**
+ * Constants for semantic field
+ */
+public class SemanticFieldConstants {
+    /**
+     * Name of the model id parameter. We use this key to define the id of the ML model that we will use for the
+     * semantic field.
+     */
+    public static final String MODEL_ID = "model_id";
+
+    /**
+     * Name of the search model id parameter. We use this key to define the id of the ML model that we will use to
+     * inference the query text during the search. If this parameter is not defined we will use the model_id instead.
+     */
+    public static final String SEARCH_MODEL_ID = "search_model_id";
+
+    /**
+     * Name of the raw field type parameter. We use this key to define the field type for the raw data. It will control
+     * how to store and query the raw data.
+     */
+    public static final String RAW_FIELD_TYPE = "raw_field_type";
+
+    /**
+     * Name of the raw field type parameter. We use this key to define a custom field name for the semantic info.
+     */
+    public static final String SEMANTIC_INFO_FIELD_NAME = "semantic_info_field_name";
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.FilterFieldType;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.mapper.TokenCountFieldMapper;
+import org.opensearch.index.mapper.WildcardFieldMapper;
+import org.opensearch.neuralsearch.constants.MappingConstants;
+import org.opensearch.neuralsearch.mapper.dto.SemanticParameters;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
+
+/**
+ * FieldMapper for the semantic field. It will hold a delegate field mapper to delegate the data parsing and query work
+ * based on the raw_field_type.
+ */
+public class SemanticFieldMapper extends ParametrizedFieldMapper {
+    public static final String CONTENT_TYPE = "semantic";
+    private final SemanticParameters semanticParameters;
+
+    @Setter
+    @Getter
+    private ParametrizedFieldMapper delegateFieldMapper;
+
+    protected SemanticFieldMapper(
+        String simpleName,
+        MappedFieldType mappedFieldType,
+        MultiFields multiFields,
+        CopyTo copyTo,
+        ParametrizedFieldMapper delegateFieldMapper,
+        SemanticParameters semanticParameters
+    ) {
+        super(simpleName, mappedFieldType, multiFields, copyTo);
+        this.delegateFieldMapper = delegateFieldMapper;
+        this.semanticParameters = semanticParameters;
+    }
+
+    @Override
+    public Builder getMergeBuilder() {
+        Builder semanticFieldMapperBuilder = (Builder) new Builder(simpleName()).init(this);
+        ParametrizedFieldMapper.Builder delegateBuilder = delegateFieldMapper.getMergeBuilder();
+        semanticFieldMapperBuilder.setDelegateBuilder(delegateBuilder);
+        return semanticFieldMapperBuilder;
+    }
+
+    @Override
+    public final ParametrizedFieldMapper merge(Mapper mergeWith) {
+        if (mergeWith instanceof SemanticFieldMapper) {
+            try {
+                delegateFieldMapper = delegateFieldMapper.merge(((SemanticFieldMapper) mergeWith).delegateFieldMapper);
+            } catch (IllegalArgumentException e) {
+                final String err = String.format(
+                    Locale.ROOT,
+                    "Failed to update the mapper %s because failed to update the delegate mapper for the raw_field_type %s due to %s",
+                    this.name(),
+                    this.semanticParameters.getRawFieldType(),
+                    e.getMessage()
+                );
+                throw new IllegalArgumentException(err, e);
+            }
+        }
+        return super.merge(mergeWith);
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context) throws IOException {
+        delegateFieldMapper.parse(context);
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    public static class Builder extends ParametrizedFieldMapper.Builder {
+        @Getter
+        protected final Parameter<String> modelId = Parameter.stringParam(
+            MODEL_ID,
+            true,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getModelId(),
+            null
+        );
+        @Getter
+        protected final Parameter<String> searchModelId = Parameter.stringParam(
+            SEARCH_MODEL_ID,
+            true,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getSearchModelId(),
+            null
+        );
+        @Getter
+        protected final Parameter<String> rawFieldType = Parameter.stringParam(
+            RAW_FIELD_TYPE,
+            false,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getRawFieldType(),
+            TextFieldMapper.CONTENT_TYPE
+        );
+        @Getter
+        protected final Parameter<String> semanticInfoFieldName = Parameter.stringParam(
+            SEMANTIC_INFO_FIELD_NAME,
+            false,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getSemanticInfoFieldName(),
+            null
+        );
+
+        @Setter
+        protected ParametrizedFieldMapper.Builder delegateBuilder;
+
+        protected Builder(String name) {
+            super(name);
+        }
+
+        @Override
+        protected List<Parameter<?>> getParameters() {
+            return List.of(modelId, searchModelId, rawFieldType, semanticInfoFieldName);
+        }
+
+        @Override
+        public SemanticFieldMapper build(BuilderContext context) {
+            final ParametrizedFieldMapper delegateMapper = delegateBuilder.build(context);
+
+            final SemanticParameters semanticParameters = this.getSemanticParameters();
+            final MappedFieldType semanticFieldType = new SemanticFieldType(delegateMapper.fieldType(), semanticParameters);
+
+            return new SemanticFieldMapper(
+                name,
+                semanticFieldType,
+                multiFieldsBuilder.build(this, context),
+                copyTo.build(),
+                delegateMapper,
+                semanticParameters
+            );
+        }
+
+        public SemanticParameters getSemanticParameters() {
+            return new SemanticParameters(
+                modelId.getValue(),
+                searchModelId.getValue(),
+                rawFieldType.getValue(),
+                semanticInfoFieldName.getValue()
+            );
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+
+        private final static Set<String> SUPPORTED_RAW_FIELD_TYPE = Set.of(
+            TextFieldMapper.CONTENT_TYPE,
+            KeywordFieldMapper.CONTENT_TYPE,
+            MatchOnlyTextFieldMapper.CONTENT_TYPE,
+            WildcardFieldMapper.CONTENT_TYPE,
+            TokenCountFieldMapper.CONTENT_TYPE,
+            BinaryFieldMapper.CONTENT_TYPE
+        );
+
+        @Override
+        public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            final String rawFieldType = (String) node.getOrDefault(RAW_FIELD_TYPE, TextFieldMapper.CONTENT_TYPE);
+
+            validateRawFieldType(rawFieldType);
+
+            final ParametrizedFieldMapper.TypeParser typeParser = (ParametrizedFieldMapper.TypeParser) parserContext.typeParser(
+                rawFieldType
+            );
+            final Builder semanticFieldMapperBuilder = new Builder(name);
+
+            // semantic field mapper builder parse semantic fields
+            Map<String, Object> semanticConfig = extractSemanticConfig(node, semanticFieldMapperBuilder.getParameters(), rawFieldType);
+            semanticFieldMapperBuilder.parse(name, parserContext, semanticConfig);
+
+            // delegate field mapper builder parse remaining fields
+            ParametrizedFieldMapper.Builder delegateBuilder = typeParser.parse(name, node, parserContext);
+            semanticFieldMapperBuilder.setDelegateBuilder(delegateBuilder);
+
+            return semanticFieldMapperBuilder;
+        }
+
+        private void validateRawFieldType(final String rawFieldType) {
+            if (rawFieldType == null || !SUPPORTED_RAW_FIELD_TYPE.contains(rawFieldType)) {
+                final String err = String.format(
+                    Locale.ROOT,
+                    "raw_field_type %s is not supported. It should be one of [%s]",
+                    rawFieldType,
+                    String.join(", ", SUPPORTED_RAW_FIELD_TYPE)
+                );
+                throw new IllegalArgumentException(err);
+            }
+        }
+
+        /**
+         * In this function we will extract all the parameters defined in the semantic field mapper builder and parse it
+         * later. The remaining parameters will be processed by the type parser of the raw field type. Here we cannot
+         * pass the parameters defined by semantic field to the delegate type parser of the raw field type because it
+         * cannot recognize them.
+         * @param node field config
+         * @param parameters parameters for semantic field
+         * @param rawFieldType field type of the raw data
+         * @return semantic field config
+         */
+        private Map<String, Object> extractSemanticConfig(Map<String, Object> node, List<Parameter<?>> parameters, String rawFieldType) {
+            final Map<String, Object> semanticConfig = new HashMap<>();
+            for (Parameter<?> parameter : parameters) {
+                Object config = node.get(parameter.name);
+                if (config != null) {
+                    semanticConfig.put(parameter.name, config);
+                    node.remove(parameter.name);
+                }
+            }
+            semanticConfig.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+            node.put(MappingConstants.TYPE, rawFieldType);
+            return semanticConfig;
+        }
+    }
+
+    public static class SemanticFieldType extends FilterFieldType {
+        @Getter
+        private SemanticParameters semanticParameters;
+
+        public SemanticFieldType(@NonNull final MappedFieldType delegate, @NonNull final SemanticParameters semanticParameters) {
+            super(delegate);
+            this.semanticParameters = semanticParameters;
+        }
+
+        @Override
+        public String typeName() {
+            return SemanticFieldMapper.CONTENT_TYPE;
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        builder.field(MappingConstants.TYPE, contentType());
+
+        // semantic parameters
+        final List<Parameter<?>> parameters = getMergeBuilder().getParameters();
+        for (Parameter<?> parameter : parameters) {
+            // By default, we will not return the default value. But raw_field_type is useful info to let users know how
+            // we will handle the raw data. So we explicitly return it even it is using the default value.
+            if (RAW_FIELD_TYPE.equals(parameter.name)) {
+                parameter.toXContent(builder, true);
+            } else {
+                parameter.toXContent(builder, includeDefaults);
+            }
+        }
+
+        // non-semantic parameters
+        // semantic field mapper itself does not handle multi fields or copy to. The delegate field mapper will handle it.
+        delegateFieldMapper.multiFields().toXContent(builder, params);
+        delegateFieldMapper.copyTo().toXContent(builder, params);
+        delegateFieldMapper.getMergeBuilder().toXContent(builder, includeDefaults);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/dto/SemanticParameters.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/dto/SemanticParameters.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.dto;
+
+import lombok.Getter;
+
+/**
+ * A DTO to hold all the semantic parameters.
+ */
+@Getter
+public class SemanticParameters {
+    private final String modelId;
+    private final String searchModelId;
+    private final String rawFieldType;
+    private final String semanticInfoFieldName;
+
+    public SemanticParameters(String modelId, String searchModelId, String rawFieldType, String semanticInfoFieldName) {
+        this.modelId = modelId;
+        this.searchModelId = searchModelId;
+        this.semanticInfoFieldName = semanticInfoFieldName;
+        this.rawFieldType = rawFieldType;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
+++ b/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
@@ -16,17 +16,6 @@ import lombok.NoArgsConstructor;
 public final class NeuralSearchSettings {
 
     /**
-     * Gates the functionality of hybrid search
-     * Currently query phase searcher added with hybrid search will conflict with concurrent search in core.
-     * Once that problem is resolved this feature flag can be removed.
-     */
-    public static final Setting<Boolean> NEURAL_SEARCH_HYBRID_SEARCH_DISABLED = Setting.boolSetting(
-        "plugins.neural_search.hybrid_search_disabled",
-        false,
-        Setting.Property.NodeScope
-    );
-
-    /**
      * Limits the number of document fields that can be passed to the reranker.
      */
     public static final Setting<Integer> RERANKER_MAX_DOC_FIELDS = Setting.intSetting(

--- a/src/main/java/org/opensearch/neuralsearch/util/FeatureFlagUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/FeatureFlagUtil.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import java.util.Map;
+
+public class FeatureFlagUtil {
+    public static final String SEMANTIC_FIELD_ENABLED = "semantic_field_enabled";
+    private static final Map<String, Boolean> featureFlagMap = Map.of(SEMANTIC_FIELD_ENABLED, Boolean.FALSE);
+
+    public static Boolean isEnabled(String name) {
+        return featureFlagMap.getOrDefault(name, Boolean.FALSE);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTestUtil.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTestUtil.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper;
+
+import lombok.NonNull;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.analysis.AnalyzerScope;
+import org.opensearch.index.analysis.IndexAnalyzers;
+import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.mapper.ContentPath;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.TextFieldMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.when;
+import static org.opensearch.Version.CURRENT;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
+import static org.opensearch.test.OpenSearchTestCase.settings;
+
+public class SemanticFieldMapperTestUtil {
+    public static final String fieldName = "testField";
+    public static final String modelId = "modelId";
+    public static final String searchModelId = "searchModelId";
+    public static final String semanticInfoFieldName = "semanticInfoFieldName";
+
+    public static final SemanticFieldMapper.TypeParser TYPE_PARSER = new SemanticFieldMapper.TypeParser();
+    private static final IndexAnalyzers indexAnalyzers = new IndexAnalyzers(
+        singletonMap("default", new NamedAnalyzer("default", AnalyzerScope.INDEX, new StandardAnalyzer())),
+        emptyMap(),
+        emptyMap()
+    );
+
+    public static Map<String, Object> createFieldConfig(final String rawFieldType) {
+        Map<String, Object> node = new HashMap<>();
+        node.put(TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        node.put(RAW_FIELD_TYPE, rawFieldType);
+        node.put(MODEL_ID, modelId);
+        node.put(SEARCH_MODEL_ID, searchModelId);
+        node.put(SEMANTIC_INFO_FIELD_NAME, semanticInfoFieldName);
+        return node;
+    }
+
+    public static void mockParserContext(@NonNull final String rawFieldType, @NonNull final ParametrizedFieldMapper.TypeParser parser, @NonNull final Mapper.TypeParser.ParserContext parserContext) {
+        when(parserContext.typeParser(rawFieldType)).thenReturn(parser);
+        when(parserContext.getIndexAnalyzers()).thenReturn(indexAnalyzers);
+        when(parserContext.indexVersionCreated()).thenReturn(CURRENT);
+    }
+
+    public static SemanticFieldMapper buildSemanticFieldMapperWithTextAsRawFieldType(
+        final @NonNull Mapper.TypeParser.ParserContext parserContext
+    ) {
+        final Map<String, Object> node = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        return buildSemanticFieldMapperWithTextAsRawFieldType(node, parserContext);
+    }
+
+    public static SemanticFieldMapper buildSemanticFieldMapperWithTextAsRawFieldType(
+        final @NonNull Map<String, Object> fieldConfig,
+        final @NonNull Mapper.TypeParser.ParserContext parserContext
+    ) {
+        return buildSemanticFieldMapper(fieldConfig, TextFieldMapper.CONTENT_TYPE, TextFieldMapper.PARSER, parserContext);
+
+    }
+
+    public static SemanticFieldMapper buildSemanticFieldMapper(
+        final @NonNull String rawFieldType,
+        final @NonNull ParametrizedFieldMapper.TypeParser typeParser,
+        final @NonNull Mapper.TypeParser.ParserContext parserContext
+    ) {
+        final Map<String, Object> fieldConfig = createFieldConfig(rawFieldType);
+        return buildSemanticFieldMapper(fieldConfig, rawFieldType, typeParser, parserContext);
+    }
+
+    public static SemanticFieldMapper buildSemanticFieldMapper(
+        final @NonNull Map<String, Object> fieldConfig,
+        final @NonNull String rawFieldType,
+        final @NonNull ParametrizedFieldMapper.TypeParser typeParser,
+        final @NonNull Mapper.TypeParser.ParserContext parserContext
+    ) {
+        mockParserContext(rawFieldType, typeParser, parserContext);
+
+        final SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, fieldConfig, parserContext);
+
+        final Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        final ParametrizedFieldMapper.BuilderContext builderContext = new ParametrizedFieldMapper.BuilderContext(
+            settings,
+            new ContentPath()
+        );
+
+        return builder.build(builderContext);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTests.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper;
+
+import lombok.NonNull;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.mapper.WildcardFieldMapper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.buildSemanticFieldMapperWithTextAsRawFieldType;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.mockParserContext;
+import static org.opensearch.neuralsearch.mapper.SemanticFieldMapperTestUtil.TYPE_PARSER;
+import static org.opensearch.neuralsearch.util.TestUtils.xContentBuilderToMap;
+
+public class SemanticFieldMapperTests extends OpenSearchTestCase {
+
+    @Mock
+    private ParametrizedFieldMapper.TypeParser.ParserContext parserContext;
+    @Mock
+    private ParseContext parseContext;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void testTypeParser_parse_whenTextRawFieldType_thenDelegateTextFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(TextFieldMapper.CONTENT_TYPE, TextFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(TextFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof TextFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenMatchOnlyTextRawFieldType_thenDelegateTextOnlyFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(MatchOnlyTextFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(MatchOnlyTextFieldMapper.CONTENT_TYPE, MatchOnlyTextFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(MatchOnlyTextFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof MatchOnlyTextFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenKeywordRawFieldType_thenDelegateKeywordFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(KeywordFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(KeywordFieldMapper.CONTENT_TYPE, KeywordFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(KeywordFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof KeywordFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenWildcardRawFieldType_thenDelegateWildcardFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(WildcardFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(WildcardFieldMapper.CONTENT_TYPE, WildcardFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(WildcardFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof WildcardFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenBinaryRawFieldType_thenDelegateBinaryFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(BinaryFieldMapper.CONTENT_TYPE);
+
+        mockParserContext(BinaryFieldMapper.CONTENT_TYPE, BinaryFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(BinaryFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof BinaryFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenNoRawFieldType_thenDelegateTextFieldMapper() {
+        final Map<String, Object> node = createFieldConfig(null);
+        node.remove(RAW_FIELD_TYPE);
+
+        mockParserContext(TextFieldMapper.CONTENT_TYPE, TextFieldMapper.PARSER, parserContext);
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext);
+
+        assertBuilderParseParametersSuccessfully(TextFieldMapper.CONTENT_TYPE, builder);
+        assertTrue(builder.delegateBuilder instanceof TextFieldMapper.Builder);
+    }
+
+    public void testTypeParser_parse_whenNullRawFieldType_thenException() {
+        final Map<String, Object> node = createFieldConfig(null);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext)
+        );
+        final String expectedError = "raw_field_type null is not supported. It should be one of";
+        assertTrue(exception.getMessage().contains(expectedError));
+    }
+
+    public void testTypeParser_parse_whenUnsupportedRawFieldType_thenException() {
+        final Map<String, Object> node = createFieldConfig("unsupported");
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> TYPE_PARSER.parse(SemanticFieldMapperTestUtil.fieldName, node, parserContext)
+        );
+        final String expectedError = "raw_field_type unsupported is not supported. It should be one of";
+        assertTrue(exception.getMessage().contains(expectedError));
+    }
+
+    private void assertBuilderParseParametersSuccessfully(
+        @NonNull final String rawFieldType,
+        @NonNull final SemanticFieldMapper.Builder builder
+    ) {
+        assertEquals(rawFieldType, builder.rawFieldType.getValue());
+        assertEquals(SemanticFieldMapperTestUtil.modelId, builder.modelId.getValue());
+        assertEquals(SemanticFieldMapperTestUtil.searchModelId, builder.searchModelId.getValue());
+        assertEquals(SemanticFieldMapperTestUtil.semanticInfoFieldName, builder.semanticInfoFieldName.getValue());
+    }
+
+    private Map<String, Object> createFieldConfig(final String rawFieldType) {
+        Map<String, Object> node = new HashMap<>();
+        node.put(TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        node.put(RAW_FIELD_TYPE, rawFieldType);
+        node.put(MODEL_ID, SemanticFieldMapperTestUtil.modelId);
+        node.put(SEARCH_MODEL_ID, SemanticFieldMapperTestUtil.searchModelId);
+        node.put(SEMANTIC_INFO_FIELD_NAME, SemanticFieldMapperTestUtil.semanticInfoFieldName);
+        return node;
+    }
+
+    public void testBuilder_getParameters() {
+        final SemanticFieldMapper.Builder builder = new SemanticFieldMapper.Builder(SemanticFieldMapperTestUtil.fieldName);
+        assertEquals(4, builder.getParameters().size());
+        List<String> actualParams = builder.getParameters().stream().map(a -> a.name).collect(Collectors.toList());
+        List<String> expectedParams = Arrays.asList(MODEL_ID, SEARCH_MODEL_ID, RAW_FIELD_TYPE, SEMANTIC_INFO_FIELD_NAME);
+        assertEquals(expectedParams, actualParams);
+    }
+
+    public void testBuilder_build_shouldBuildDelegateFieldMapper() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        assertTrue(semanticFieldMapper.getDelegateFieldMapper() instanceof TextFieldMapper);
+        assertTrue(semanticFieldMapper.fieldType() instanceof SemanticFieldMapper.SemanticFieldType);
+    }
+
+    public void testFieldMapper_getMergeBuilder_shouldSetDelegateMergeBuilder() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        final SemanticFieldMapper.Builder mergeBuilder = semanticFieldMapper.getMergeBuilder();
+        assertTrue(mergeBuilder.delegateBuilder instanceof TextFieldMapper.Builder);
+    }
+
+    public void testFieldMapper_merge_shouldMergeDelegateFieldMapper() {
+        final String newModelId = "newModelId";
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        final Map<String, Object> updatedConfig = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        updatedConfig.put(MODEL_ID, newModelId);
+        final SemanticFieldMapper semanticFieldMapperToMerge = buildSemanticFieldMapperWithTextAsRawFieldType(updatedConfig, parserContext);
+
+        final SemanticFieldMapper mergedSemanticFieldMapper = (SemanticFieldMapper) semanticFieldMapper.merge(semanticFieldMapperToMerge);
+
+        assertEquals(newModelId, mergedSemanticFieldMapper.getMergeBuilder().modelId.getValue());
+        // A new delegate field mapper should be created after the merge and it's still a text field mapper
+        assertNotEquals(semanticFieldMapper.getDelegateFieldMapper(), mergedSemanticFieldMapper.getDelegateFieldMapper());
+        assertTrue(mergedSemanticFieldMapper.getDelegateFieldMapper() instanceof TextFieldMapper);
+    }
+
+    public void testFieldMapper_merge_whenConflictWithSemanticParameters_thenException() {
+        final String newSemanticInfoFieldName = "newSemanticInfoFieldName";
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        final Map<String, Object> updatedConfig = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        updatedConfig.put(SEMANTIC_INFO_FIELD_NAME, newSemanticInfoFieldName);
+        when(parserContext.typeParser(KeywordFieldMapper.CONTENT_TYPE)).thenReturn(KeywordFieldMapper.PARSER);
+        final SemanticFieldMapper semanticFieldMapperToMerge = buildSemanticFieldMapperWithTextAsRawFieldType(updatedConfig, parserContext);
+
+        final IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> semanticFieldMapper.merge(semanticFieldMapperToMerge)
+        );
+
+        final String expectedError = "Mapper for [testField] conflicts with existing mapper:\n"
+            + "\tCannot update parameter [semantic_info_field_name] from [semanticInfoFieldName] to [newSemanticInfoFieldName]";
+        assertEquals(expectedError, exception.getMessage());
+    }
+
+    public void testFieldMapper_merge_whenConflictWithDelegateMapperParameters_thenException() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+
+        final Map<String, Object> updatedConfig = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        updatedConfig.put(RAW_FIELD_TYPE, KeywordFieldMapper.CONTENT_TYPE);
+        when(parserContext.typeParser(KeywordFieldMapper.CONTENT_TYPE)).thenReturn(KeywordFieldMapper.PARSER);
+        final SemanticFieldMapper semanticFieldMapperToMerge = buildSemanticFieldMapperWithTextAsRawFieldType(updatedConfig, parserContext);
+
+        final IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> semanticFieldMapper.merge(semanticFieldMapperToMerge)
+        );
+
+        final String expectedError = "Failed to update the mapper testField because failed to update the delegate "
+            + "mapper for the raw_field_type text due to mapper [testField] cannot be changed from type [text] to "
+            + "[keyword]";
+        assertEquals(expectedError, exception.getMessage());
+    }
+
+    public void testFieldMapper_parseCreateField_shouldDelegateToDelegateMapper() throws IOException {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        ParametrizedFieldMapper delegateMapper = mock(ParametrizedFieldMapper.class);
+        semanticFieldMapper.setDelegateFieldMapper(delegateMapper);
+
+        semanticFieldMapper.parseCreateField(parseContext);
+
+        verify(delegateMapper, times(1)).parse(parseContext);
+    }
+
+    public void testFieldMapper_contentType_shouldReturnSemantic() {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        assertEquals(SemanticFieldMapper.CONTENT_TYPE, semanticFieldMapper.contentType());
+    }
+
+    public void testFieldMapper_doXContentBody_shouldReturnParameters() throws IOException {
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(parserContext);
+        final XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        semanticFieldMapper.doXContentBody(xContentBuilder, false, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        final Map<String, Object> out = xContentBuilderToMap(xContentBuilder);
+
+        final Map<String, Object> expected = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+
+        assertEquals(expected, out);
+    }
+
+    public void testFieldMapper_doXContentBody_withDefaultRawFieldType_shouldReturnDefaultValue() throws IOException {
+        final Map<String, Object> config = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+        config.remove(RAW_FIELD_TYPE);
+
+        final SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapperWithTextAsRawFieldType(config, parserContext);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        semanticFieldMapper.doXContentBody(xContentBuilder, false, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        Map<String, Object> out = xContentBuilderToMap(xContentBuilder);
+
+        Map<String, Object> expected = createFieldConfig(TextFieldMapper.CONTENT_TYPE);
+
+        assertEquals(expected, out);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -12,7 +12,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.Before;
 import org.mockito.Mock;
@@ -37,7 +36,6 @@ import org.opensearch.neuralsearch.processor.rerank.RerankProcessor;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
-import org.opensearch.neuralsearch.search.query.HybridQueryPhaseSearcher;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettings;
 import org.opensearch.plugins.SearchPipelinePlugin;
 import org.opensearch.plugins.SearchPlugin;
@@ -47,7 +45,6 @@ import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
 import org.opensearch.search.pipeline.SearchPipelineService;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.SearchResponseProcessor;
-import org.opensearch.search.query.QueryPhaseSearcher;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
@@ -117,22 +114,6 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
         assertTrue(querySpecs.stream().anyMatch(spec -> HybridQueryBuilder.NAME.equals(spec.getName().getPreferredName())));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/17940")
-    public void testQueryPhaseSearcher() {
-        Optional<QueryPhaseSearcher> queryPhaseSearcherWithFeatureFlagDisabled = plugin.getQueryPhaseSearcher();
-
-        assertNotNull(queryPhaseSearcherWithFeatureFlagDisabled);
-        assertFalse(queryPhaseSearcherWithFeatureFlagDisabled.isEmpty());
-        assertTrue(queryPhaseSearcherWithFeatureFlagDisabled.get() instanceof HybridQueryPhaseSearcher);
-
-        initFeatureFlags();
-
-        Optional<QueryPhaseSearcher> queryPhaseSearcher = plugin.getQueryPhaseSearcher();
-
-        assertNotNull(queryPhaseSearcher);
-        assertTrue(queryPhaseSearcher.isEmpty());
-    }
-
     public void testProcessors() {
         Settings settings = Settings.builder().build();
         Environment environment = mock(Environment.class);
@@ -176,7 +157,7 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
     public void testGetSettings() {
         List<Setting<?>> settings = plugin.getSettings();
 
-        assertEquals(3, settings.size());
+        assertEquals(2, settings.size());
     }
 
     public void testRequestProcessors() {
@@ -210,5 +191,9 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
         assertFalse(executorBuilders.isEmpty());
         assertEquals("Unexpected number of executor builders are registered", 1, executorBuilders.size());
         assertTrue(executorBuilders.get(0) instanceof FixedExecutorBuilder);
+    }
+
+    public void testGetMappers_shouldReturnEmptyMap() {
+        assertTrue(plugin.getMappers().isEmpty());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessorTests.java
@@ -519,7 +519,8 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
         int requestedSize = 2;
         PriorityQueue<SearchHit> priorityQueue = new PriorityQueue<>(new SearchHitComparator(null));
         TotalHits.Relation totalHitsRelation = randomFrom(TotalHits.Relation.values());
-        TotalHits totalHits = new TotalHits(randomLongBetween(1, 1000), totalHitsRelation);
+        // At least need 2 total hits since later in getCombinedExplainDetails we will try to process two hits.
+        TotalHits totalHits = new TotalHits(randomLongBetween(2, 1000), totalHitsRelation);
 
         final int numDocs = totalHits.value() >= requestedSize ? requestedSize : (int) totalHits.value();
         int scoreFactor = randomIntBetween(1, numResponses);

--- a/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/OpenSearchQueryTestCase.java
@@ -16,7 +16,6 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.BooleanClause;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
-import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.NEURAL_SEARCH_HYBRID_SEARCH_DISABLED;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -32,7 +31,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.CheckedConsumer;
-import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -230,11 +228,6 @@ public abstract class OpenSearchQueryTestCase extends OpenSearchTestCase {
                 return Float.MAX_VALUE;
             }
         };
-    }
-
-    @SuppressForbidden(reason = "manipulates system properties for testing")
-    protected static void initFeatureFlags() {
-        System.setProperty(NEURAL_SEARCH_HYBRID_SEARCH_DISABLED.getKey(), "true");
     }
 
     protected static QueryBuilderVisitor createTestVisitor(List<QueryBuilder> visitedQueries) {


### PR DESCRIPTION
### Description
Add semantic field mapper to support the semantic field type.

Also remove the incorrect FF NEURAL_SEARCH_HYBRID_SEARCH_DISABLED.

### Related Issues
Resolves [#[803]](https://github.com/opensearch-project/neural-search/issues/803)
Resolves part of the issue [#1226](https://github.com/opensearch-project/neural-search/issues/1226)


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
