### PR TITLE
Remove validation on text and image field for text_image_embedding processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Lower bound for min-max normalization technique in hybrid query ([#1195](https://github.com/opensearch-project/neural-search/pull/1195))
 ### Enhancements
 ### Bug Fixes
+- Remove validations for unmapped fields (text and image) in TextImageEmbeddingProcessor ([#1230](https://github.com/opensearch-project/neural-search/pull/1230))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -17,7 +17,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
-import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
@@ -25,7 +24,6 @@ import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import com.google.common.annotations.VisibleForTesting;
 
 import lombok.extern.log4j.Log4j2;
-import org.opensearch.neuralsearch.util.ProcessorDocumentUtils;
 
 /**
  * This processor is used for user input data text and image embedding processing, model_id can be used to indicate which model user use,
@@ -107,7 +105,6 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
     @Override
     public void execute(final IngestDocument ingestDocument, final BiConsumer<IngestDocument, Exception> handler) {
         try {
-            validateEmbeddingFieldsValue(ingestDocument);
             Map<String, String> knnMap = buildMapWithKnnKeyAndOriginalValue(ingestDocument);
             Map<String, String> inferenceMap = createInferences(knnMap);
             if (inferenceMap.isEmpty()) {
@@ -171,20 +168,6 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put(knnKey, modelTensorList);
         return result;
-    }
-
-    private void validateEmbeddingFieldsValue(final IngestDocument ingestDocument) {
-        Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
-        String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
-        ProcessorDocumentUtils.validateMapTypeValue(
-            FIELD_MAP_FIELD,
-            sourceAndMetadataMap,
-            fieldMap,
-            indexName,
-            clusterService,
-            environment,
-            false
-        );
     }
 
     @Override

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorIT.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.Before;
+import org.opensearch.client.ResponseException;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
 
 /**
@@ -21,17 +22,13 @@ public class TextImageEmbeddingProcessorIT extends BaseNeuralSearchIT {
     private static final String INGEST_DOCUMENT = "{\n"
         + "  \"title\": \"This is a good day\",\n"
         + "  \"description\": \"daily logging\",\n"
-        + "  \"passage_text\": \"A very nice day today\",\n"
+        + "  \"passage_text\": \"passage_text_value\",\n"
+        + "  \"text\": \"\",\n"
+        + "  \"image\": null,\n"
         + "  \"favorites\": {\n"
         + "    \"game\": \"overwatch\",\n"
         + "    \"movie\": null\n"
         + "  }\n"
-        + "}\n";
-
-    private static final String INGEST_DOCUMENT_UNMAPPED_FIELDS = "{\n"
-        + "  \"title\": \"This is a good day\",\n"
-        + "  \"description\": \"daily logging\",\n"
-        + "  \"some_random_field\": \"Today is a sunny weather\"\n"
         + "}\n";
 
     @Before
@@ -49,8 +46,19 @@ public class TextImageEmbeddingProcessorIT extends BaseNeuralSearchIT {
         ingestDocument(INDEX_NAME, INGEST_DOCUMENT);
         assertEquals(1, getDocCount(INDEX_NAME));
         // verify doc without mapping
-        ingestDocument(INDEX_NAME, INGEST_DOCUMENT_UNMAPPED_FIELDS);
+        String documentWithUnmappedFields;
+        documentWithUnmappedFields = INGEST_DOCUMENT.replace("passage_text", "random_field_1");
+        ingestDocument(INDEX_NAME, documentWithUnmappedFields);
         assertEquals(2, getDocCount(INDEX_NAME));
+    }
+
+    public void testEmbeddingProcessor_whenIngestingDocumentWithNullMappingValue_thenThrowException() throws Exception {
+        String modelId = uploadModel();
+        loadModel(modelId);
+        createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_IMAGE_EMBEDDING);
+        createIndexWithPipeline(INDEX_NAME, "IndexMappings.json", PIPELINE_NAME);
+
+        expectThrows(ResponseException.class, () -> ingestDocument(INDEX_NAME, INGEST_DOCUMENT.replace("\"passage_text_value\"", "null")));
     }
 
     private String uploadModel() throws Exception {

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
@@ -185,7 +185,9 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
         sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("my_text_field", "value2");
-        sourceAndMetadata.put("key3", "value3");
+        sourceAndMetadata.put("text", "");
+        sourceAndMetadata.put("image", null);
+        sourceAndMetadata.put("key5", Map.of("inner_field", "innerValue1"));
         sourceAndMetadata.put("image_field", "base64_of_image_1234567890");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
         TextImageEmbeddingProcessor processor = createInstance();


### PR DESCRIPTION
### Description
This PR removes the text and image field validation for text_image_processor

### Related Issues
Resolves #1221
<!-- List any other related issues here -->

### Code Bug
Request:
```
POST nlp-index/_doc/1?pipeline=nlp-ingest-pipeline
{
  "text": ""
}
```
Response:
```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "map type field [text] has empty string value, cannot process it"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "map type field [text] has empty string value, cannot process it"
  },
  "status": 400
}
```

#### Code Bug Deep Dive
When create a text_image_processor, we need to pass a `field_map` that at least contains `text` or `image` field, see doc [here](https://opensearch.org/docs/latest/ingest-pipelines/processors/text-image-embedding/). During document ingestion, the processor will read the actual value from `input_text_field` and `input_image_field`, NOT from `text` or `image`. 

However it's possible that some document contain the `text` or `image` field, as well as `input_text_field` and `input_image_field`. Since the processor reads the actual values from `input_text_field` and `input_image_field` and create embeddings against them,  these `text` or `image` fields should be treated as unmapped fields. We should allow users to ingest whatever value `text` or `image` field has.

Currently there's a [validation](https://github.com/opensearch-project/neural-search/blob/5f25d6c5e4f64e05b6c17a2eb2ec9e1f467f1974/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java#L78) for creating the processor to ensure the `field_map` is valid.

During ingestion, there's another [validation](https://github.com/opensearch-project/neural-search/blob/5f25d6c5e4f64e05b6c17a2eb2ec9e1f467f1974/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java#L176) to validate the embedding field values (from `input_text_field` and `input_image_field`). However this method is wrong, it checks the field values with `text` or `image` field, we should remove this method entirely. As for validating the actual embedding field values, it is already covered [here](https://github.com/opensearch-project/neural-search/blob/5f25d6c5e4f64e05b6c17a2eb2ec9e1f467f1974/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java#L111C42-L111C76) 

### Check List
- [N] New functionality includes testing.
- [N/A] New functionality has been documented.
- [N] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [Y] Commits are signed per the DCO using `--signoff`.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
