### PR TITLE
Remove validation on text and image field for text_image_embedding processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Remove validations for unmapped fields (text and image) in TextImageEmbeddingProcessor ([#1230](https://github.com/opensearch-project/neural-search/pull/1230))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -17,7 +17,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
-import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.AbstractProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
@@ -25,7 +24,6 @@ import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import com.google.common.annotations.VisibleForTesting;
 
 import lombok.extern.log4j.Log4j2;
-import org.opensearch.neuralsearch.util.ProcessorDocumentUtils;
 
 /**
  * This processor is used for user input data text and image embedding processing, model_id can be used to indicate which model user use,
@@ -107,7 +105,6 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
     @Override
     public void execute(final IngestDocument ingestDocument, final BiConsumer<IngestDocument, Exception> handler) {
         try {
-            validateEmbeddingFieldsValue(ingestDocument);
             Map<String, String> knnMap = buildMapWithKnnKeyAndOriginalValue(ingestDocument);
             Map<String, String> inferenceMap = createInferences(knnMap);
             if (inferenceMap.isEmpty()) {
@@ -168,20 +165,6 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put(knnKey, modelTensorList);
         return result;
-    }
-
-    private void validateEmbeddingFieldsValue(final IngestDocument ingestDocument) {
-        Map<String, Object> sourceAndMetadataMap = ingestDocument.getSourceAndMetadata();
-        String indexName = sourceAndMetadataMap.get(IndexFieldMapper.NAME).toString();
-        ProcessorDocumentUtils.validateMapTypeValue(
-            FIELD_MAP_FIELD,
-            sourceAndMetadataMap,
-            fieldMap,
-            indexName,
-            clusterService,
-            environment,
-            false
-        );
     }
 
     @Override

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
@@ -185,7 +185,9 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
         sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("my_text_field", "value2");
-        sourceAndMetadata.put("key3", "value3");
+        sourceAndMetadata.put("text", "");
+        sourceAndMetadata.put("image", null);
+        sourceAndMetadata.put("key5", Map.of("inner_field", "innerValue1"));
         sourceAndMetadata.put("image_field", "base64_of_image_1234567890");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
         TextImageEmbeddingProcessor processor = createInstance();


### PR DESCRIPTION
### This PR is to manually backport this [change](https://github.com/opensearch-project/neural-search/pull/1230) to 2.19, as the automatic backport failed

* Remove validation on text and image field for text_image_embedding processor

Signed-off-by: Weijia Zhao <zweijia@amazon.com>

* Add Changelog

Signed-off-by: Weijia Zhao <zweijia@amazon.com>

---------

Signed-off-by: Weijia Zhao <zweijia@amazon.com>
(cherry picked from commit 8506daa6b62fcc2085f701685779828a22a4bd66)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
