### PR TITLE
Implement Optimized embedding generation in sparse encoding processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add Z Score normalization technique ([#1224](https://github.com/opensearch-project/neural-search/pull/1224))
 - Support semantic sentence highlighter ([#1193](https://github.com/opensearch-project/neural-search/pull/1193))
 - Optimize embedding generation in Text Embedding Processor ([#1191](https://github.com/opensearch-project/neural-search/pull/1191))
+- Optimize embedding generation in Sparse Encoding Processor ([#1246](https://github.com/opensearch-project/neural-search/pull/1246))
 
 ### Enhancements
 

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -147,7 +147,12 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
                 parameters.ingestService.getClusterService()
             ),
             SparseEncodingProcessor.TYPE,
-            new SparseEncodingProcessorFactory(clientAccessor, parameters.env, parameters.ingestService.getClusterService()),
+            new SparseEncodingProcessorFactory(
+                parameters.client,
+                clientAccessor,
+                parameters.env,
+                parameters.ingestService.getClusterService()
+            ),
             TextImageEmbeddingProcessor.TYPE,
             new TextImageEmbeddingProcessorFactory(clientAccessor, parameters.env, parameters.ingestService.getClusterService()),
             TextChunkingProcessor.TYPE,

--- a/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
@@ -6,20 +6,29 @@ package org.opensearch.neuralsearch.processor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
+import org.opensearch.action.get.GetAction;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.MultiGetAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.IngestDocumentWrapper;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.processor.optimization.TextEmbeddingInferenceFilter;
 import org.opensearch.neuralsearch.util.prune.PruneType;
 import org.opensearch.neuralsearch.util.TokenWeightUtil;
 
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.neuralsearch.util.prune.PruneUtils;
+import org.opensearch.transport.client.OpenSearchClient;
 
 /**
  * This processor is used for user input data text sparse encoding processing, model_id can be used to indicate which model user use,
@@ -30,6 +39,10 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
 
     public static final String TYPE = "sparse_encoding";
     public static final String LIST_TYPE_NESTED_MAP_KEY = "sparse_encoding";
+    private final OpenSearchClient openSearchClient;
+    private final boolean skipExisting;
+    private final TextEmbeddingInferenceFilter textEmbeddingInferenceFilter;
+
     @Getter
     private final PruneType pruneType;
     @Getter
@@ -41,8 +54,11 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
         int batchSize,
         String modelId,
         Map<String, Object> fieldMap,
+        boolean skipExisting,
+        TextEmbeddingInferenceFilter textEmbeddingInferenceFilter,
         PruneType pruneType,
         float pruneRatio,
+        OpenSearchClient openSearchClient,
         MLCommonsClientAccessor clientAccessor,
         Environment environment,
         ClusterService clusterService
@@ -50,26 +66,52 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
         super(tag, description, batchSize, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
         this.pruneType = pruneType;
         this.pruneRatio = pruneRatio;
+        this.skipExisting = skipExisting;
+        this.textEmbeddingInferenceFilter = textEmbeddingInferenceFilter;
+        this.openSearchClient = openSearchClient;
     }
 
     @Override
     public void doExecute(
         IngestDocument ingestDocument,
-        Map<String, Object> ProcessMap,
+        Map<String, Object> processMap,
         List<String> inferenceList,
         BiConsumer<IngestDocument, Exception> handler
     ) {
-        mlCommonsClientAccessor.inferenceSentencesWithMapResult(
-            TextInferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
-            ActionListener.wrap(resultMaps -> {
-                List<Map<String, Float>> sparseVectors = TokenWeightUtil.fetchListOfTokenWeightMap(resultMaps)
-                    .stream()
-                    .map(vector -> PruneUtils.pruneSparseVector(pruneType, pruneRatio, vector))
-                    .toList();
-                setVectorFieldsToDocument(ingestDocument, ProcessMap, sparseVectors);
+        if (skipExisting == false) {
+            generateAndSetMapInference(ingestDocument, processMap, inferenceList, pruneType, pruneRatio, handler);
+            return;
+        }
+        // if skipExisting flag is turned on, eligible inference texts will be compared and filtered after embeddings are copied
+        Object index = ingestDocument.getSourceAndMetadata().get(INDEX_FIELD);
+        Object id = ingestDocument.getSourceAndMetadata().get(ID_FIELD);
+        if (Objects.isNull(index) || Objects.isNull(id)) {
+            generateAndSetMapInference(ingestDocument, processMap, inferenceList, pruneType, pruneRatio, handler);
+            return;
+        }
+        openSearchClient.execute(GetAction.INSTANCE, new GetRequest(index.toString(), id.toString()), ActionListener.wrap(response -> {
+            final Map<String, Object> existingDocument = response.getSourceAsMap();
+            if (existingDocument == null || existingDocument.isEmpty()) {
+                generateAndSetMapInference(ingestDocument, processMap, inferenceList, pruneType, pruneRatio, handler);
+                return;
+            }
+            // filter given ProcessMap by comparing existing document with ingestDocument
+            Map<String, Object> filteredProcessMap = textEmbeddingInferenceFilter.filterAndCopyExistingEmbeddings(
+                existingDocument,
+                ingestDocument.getSourceAndMetadata(),
+                processMap
+            );
+            // create inference list based on filtered ProcessMap
+            List<String> filteredInferenceList = createInferenceList(filteredProcessMap).stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+            if (filteredInferenceList.isEmpty()) {
                 handler.accept(ingestDocument, null);
-            }, e -> { handler.accept(null, e); })
-        );
+            } else {
+                generateAndSetMapInference(ingestDocument, filteredProcessMap, filteredInferenceList, pruneType, pruneRatio, handler);
+            }
+
+        }, e -> { handler.accept(null, e); }));
     }
 
     @Override
@@ -84,5 +126,48 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
                 handler.accept(sparseVectors);
             }, onException)
         );
+    }
+
+    @Override
+    public void subBatchExecute(List<IngestDocumentWrapper> ingestDocumentWrappers, Consumer<List<IngestDocumentWrapper>> handler) {
+        try {
+            if (CollectionUtils.isEmpty(ingestDocumentWrappers)) {
+                handler.accept(ingestDocumentWrappers);
+                return;
+            }
+            List<DataForInference> dataForInferences = getDataForInference(ingestDocumentWrappers);
+            List<String> inferenceList = constructInferenceTexts(dataForInferences);
+            if (inferenceList.isEmpty()) {
+                handler.accept(ingestDocumentWrappers);
+                return;
+            }
+            // skip existing flag is turned off. Call doSubBatchExecute without filtering
+            if (skipExisting == false) {
+                doSubBatchExecute(ingestDocumentWrappers, inferenceList, dataForInferences, handler);
+                return;
+            }
+            // skipExisting flag is turned on, eligible inference texts in dataForInferences will be compared and filtered after embeddings
+            // are copied
+            openSearchClient.execute(
+                MultiGetAction.INSTANCE,
+                buildMultiGetRequest(dataForInferences),
+                ActionListener.wrap(
+                    response -> reuseOrGenerateEmbedding(
+                        response,
+                        ingestDocumentWrappers,
+                        inferenceList,
+                        dataForInferences,
+                        handler,
+                        textEmbeddingInferenceFilter
+                    ),
+                    e -> {
+                        // When exception is thrown in for MultiGetAction, set exception to all ingestDocumentWrappers
+                        updateWithExceptions(getIngestDocumentWrappers(dataForInferences), handler, e);
+                    }
+                )
+            );
+        } catch (Exception e) {
+            updateWithExceptions(ingestDocumentWrappers, handler, e);
+        }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/optimization/InferenceFilter.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/optimization/InferenceFilter.java
@@ -113,12 +113,12 @@ public abstract class InferenceFilter {
      * @param processMap The current map being processed.
      * @return A filtered map containing only elements that require new embeddings.
      */
-    public Map<String, Object> filter(
+    public Map<String, Object> filterAndCopyExistingEmbeddings(
         Map<String, Object> existingSourceAndMetadataMap,
         Map<String, Object> sourceAndMetadataMap,
         Map<String, Object> processMap
     ) {
-        return filter(existingSourceAndMetadataMap, sourceAndMetadataMap, processMap, "");
+        return filterAndCopyExistingEmbeddings(existingSourceAndMetadataMap, sourceAndMetadataMap, processMap, "");
     }
 
     /**
@@ -135,7 +135,7 @@ public abstract class InferenceFilter {
      * traversedPath would be dot-separated string of level1.level2.level3
      * @return A filtered map containing only elements that require new embeddings
      */
-    private Map<String, Object> filter(
+    private Map<String, Object> filterAndCopyExistingEmbeddings(
         Map<String, Object> existingSourceAndMetadataMap,
         Map<String, Object> sourceAndMetadataMap,
         Map<String, Object> processMap,
@@ -148,7 +148,7 @@ public abstract class InferenceFilter {
             Object value = entry.getValue();
             String currentPath = traversedPath.isEmpty() ? key : traversedPath + "." + key;
             if (value instanceof Map) {
-                Map<String, Object> filteredInnerMap = filter(
+                Map<String, Object> filteredInnerMap = filterAndCopyExistingEmbeddings(
                     existingSourceAndMetadataMap,
                     sourceAndMetadataMap,
                     ProcessorUtils.unsafeCastToObjectMap(value),

--- a/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import static org.mockito.Mockito.verify;
@@ -32,9 +33,16 @@ import java.util.stream.IntStream;
 
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.action.get.GetAction;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.get.MultiGetAction;
+import org.opensearch.action.get.MultiGetRequest;
+import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
@@ -52,13 +60,21 @@ import com.google.common.collect.ImmutableMap;
 
 import lombok.SneakyThrows;
 import org.opensearch.neuralsearch.util.prune.PruneType;
+import org.opensearch.transport.client.OpenSearchClient;
 
 public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
+
+    @Mock
+    private OpenSearchClient openSearchClient;
+
     @Mock
     private MLCommonsClientAccessor mlCommonsClientAccessor;
 
     @Mock
     private Environment environment;
+
+    @Captor
+    private ArgumentCaptor<TextInferenceRequest> inferenceRequestCaptor;
 
     private ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
 
@@ -75,30 +91,46 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
     }
 
     @SneakyThrows
-    private SparseEncodingProcessor createInstance() {
+    private SparseEncodingProcessor createInstance(boolean skipExisting) {
         Map<String, Processor.Factory> registry = new HashMap<>();
         Map<String, Object> config = new HashMap<>();
         config.put(SparseEncodingProcessor.MODEL_ID_FIELD, "mockModelId");
         config.put(SparseEncodingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1Mapped", "key2", "key2Mapped"));
+        config.put(SparseEncodingProcessor.SKIP_EXISTING, skipExisting);
         return (SparseEncodingProcessor) sparseEncodingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
     }
 
     @SneakyThrows
-    private SparseEncodingProcessor createInstance(int batchSize) {
+    private SparseEncodingProcessor createInstance(int batchSize, boolean skipExisting) {
         Map<String, Processor.Factory> registry = new HashMap<>();
         Map<String, Object> config = new HashMap<>();
         config.put(SparseEncodingProcessor.MODEL_ID_FIELD, "mockModelId");
         config.put(SparseEncodingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1Mapped", "key2", "key2Mapped"));
         config.put(AbstractBatchingProcessor.BATCH_SIZE_FIELD, batchSize);
+        config.put(SparseEncodingProcessor.SKIP_EXISTING, skipExisting);
         return (SparseEncodingProcessor) sparseEncodingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
     }
 
     @SneakyThrows
-    private SparseEncodingProcessor createInstance(PruneType pruneType, float pruneRatio) {
+    private SparseEncodingProcessor createNestedTypeInstance(boolean skipExisting) {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(SparseEncodingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(SparseEncodingProcessor.SKIP_EXISTING, skipExisting);
+        config.put(
+            SparseEncodingProcessor.FIELD_MAP_FIELD,
+            ImmutableMap.of("key1", Map.of("test1", "test1_knn"), "key2", Map.of("test4", "test4_knn"))
+        );
+        return (SparseEncodingProcessor) sparseEncodingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
+    }
+
+    @SneakyThrows
+    private SparseEncodingProcessor createInstance(PruneType pruneType, float pruneRatio, boolean skipExisting) {
         Map<String, Processor.Factory> registry = new HashMap<>();
         Map<String, Object> config = new HashMap<>();
         config.put(SparseEncodingProcessor.MODEL_ID_FIELD, "mockModelId");
         config.put(SparseEncodingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1Mapped", "key2", "key2Mapped"));
+        config.put(SparseEncodingProcessor.SKIP_EXISTING, skipExisting);
         config.put("prune_type", pruneType.getValue());
         config.put("prune_ratio", pruneRatio);
         return (SparseEncodingProcessor) sparseEncodingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
@@ -110,7 +142,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        SparseEncodingProcessor processor = createInstance();
+        SparseEncodingProcessor processor = createInstance(false);
 
         List<Map<String, ?>> dataAsMapList = createMockMapResult(2);
         doAnswer(invocation -> {
@@ -133,6 +165,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         Map<String, Processor.Factory> registry = new HashMap<>();
         MLCommonsClientAccessor accessor = mock(MLCommonsClientAccessor.class);
         SparseEncodingProcessorFactory sparseEncodingProcessorFactory = new SparseEncodingProcessorFactory(
+            openSearchClient,
             accessor,
             environment,
             clusterService
@@ -162,7 +195,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         sourceAndMetadata.put("key1", list1);
         sourceAndMetadata.put("key2", list2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        SparseEncodingProcessor processor = createInstance();
+        SparseEncodingProcessor processor = createInstance(false);
 
         List<Map<String, ?>> dataAsMapList = createMockMapResult(6);
         doAnswer(invocation -> {
@@ -183,7 +216,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         sourceAndMetadata.put("key1", "value1");
         sourceAndMetadata.put("key2", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        SparseEncodingProcessor processor = createInstance();
+        SparseEncodingProcessor processor = createInstance(false);
 
         doAnswer(invocation -> {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
@@ -208,19 +241,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         sourceAndMetadata.put("key1", map1);
         sourceAndMetadata.put("key2", map2);
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
-        Map<String, Processor.Factory> registry = new HashMap<>();
-        Map<String, Object> config = new HashMap<>();
-        config.put(SparseEncodingProcessor.MODEL_ID_FIELD, "mockModelId");
-        config.put(
-            SparseEncodingProcessor.FIELD_MAP_FIELD,
-            ImmutableMap.of("key1", Map.of("test1", "test1_knn"), "key2", Map.of("test4", "test4_knn"))
-        );
-        SparseEncodingProcessor processor = (SparseEncodingProcessor) sparseEncodingProcessorFactory.create(
-            registry,
-            PROCESSOR_TAG,
-            DESCRIPTION,
-            config
-        );
+        SparseEncodingProcessor processor = createNestedTypeInstance(false);
 
         List<Map<String, ?>> dataAsMapList = createMockMapResult(2);
         doAnswer(invocation -> {
@@ -239,7 +260,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
     public void test_batchExecute_successful() {
         final int docCount = 5;
         List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
-        SparseEncodingProcessor processor = createInstance(docCount);
+        SparseEncodingProcessor processor = createInstance(docCount, false);
         List<Map<String, ?>> dataAsMapList = createMockMapResult(10);
         doAnswer(invocation -> {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
@@ -262,7 +283,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
     public void test_batchExecute_exception() {
         final int docCount = 5;
         List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
-        SparseEncodingProcessor processor = createInstance(docCount);
+        SparseEncodingProcessor processor = createInstance(docCount, false);
         doAnswer(invocation -> {
             ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
             listener.onFailure(new RuntimeException());
@@ -289,7 +310,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         sourceAndMetadata.put("key2", "value2");
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
 
-        SparseEncodingProcessor processor = createInstance(PruneType.MAX_RATIO, 0.5f);
+        SparseEncodingProcessor processor = createInstance(PruneType.MAX_RATIO, 0.5f, false);
 
         List<Map<String, ?>> dataAsMapList = Collections.singletonList(
             Map.of("response", Arrays.asList(ImmutableMap.of("hello", 1.0f, "world", 0.1f), ImmutableMap.of("test", 0.8f, "low", 0.4f)))
@@ -326,7 +347,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
     }
 
     public void test_batchExecute_withPrune_successful() {
-        SparseEncodingProcessor processor = createInstance(PruneType.MAX_RATIO, 0.5f);
+        SparseEncodingProcessor processor = createInstance(PruneType.MAX_RATIO, 0.5f, false);
 
         List<Map<String, ?>> mockMLResponse = Collections.singletonList(
             Map.of(
@@ -372,11 +393,481 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         assertFalse(secondResult.containsKey("token5"));
     }
 
+    public void testIngest_skip_existing_flag_successful() {
+        Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        sourceAndMetadata.put("_id", "1");
+        sourceAndMetadata.put("key1", "value1");
+        sourceAndMetadata.put("key2", "value2");
+        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
+        SparseEncodingProcessor processor = createInstance(true);
+        mockUpdateDocument(ingestDocument);
+        List<Map<String, ?>> dataAsMapList = createMockMapResult(2);
+        doAnswer(invocation -> {
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
+            listener.onResponse(dataAsMapList);
+            return null;
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        verify(handler).accept(any(IngestDocument.class), isNull());
+    }
+
+    public void testExecute_skip_existing_flag_null_id_successful() {
+        Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        sourceAndMetadata.put("key1", "value1");
+        sourceAndMetadata.put("key2", "value2");
+        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
+        SparseEncodingProcessor processor = createInstance(true);
+        mockUpdateDocument(ingestDocument);
+        List<Map<String, ?>> dataAsMapList = createMockMapResult(2);
+        doAnswer(invocation -> {
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
+            listener.onResponse(dataAsMapList);
+            return null;
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(argThat(request -> request.getInputTexts() != null), isA(ActionListener.class));
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        verify(handler).accept(any(IngestDocument.class), isNull());
+    }
+
+    public void testExecute_with_no_update_with_skip_existing_flag_successful() {
+        Map<String, Object> ingestSourceAndMetadata = new HashMap<>();
+        ingestSourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        ingestSourceAndMetadata.put("_id", "1");
+        ingestSourceAndMetadata.put("key1", "value1");
+        ingestSourceAndMetadata.put("key2", "value2");
+        IngestDocument ingestDocument = new IngestDocument(ingestSourceAndMetadata, new HashMap<>());
+        SparseEncodingProcessor processor = createInstance(true);
+        List<String> inferenceList = Arrays.asList("value1", "value2");
+        TextInferenceRequest ingestRequest = TextInferenceRequest.builder().modelId("mockModelId").inputTexts(inferenceList).build();
+        Map<String, Object> updateSourceAndMetadata = deepCopy(ingestSourceAndMetadata); // no change
+        IngestDocument updateDocument = new IngestDocument(updateSourceAndMetadata, new HashMap<>());
+        mockUpdateDocument(ingestDocument);
+        mockVectorCreation(ingestRequest, null);
+
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        processor.execute(updateDocument, handler); // update document
+        verify(handler, times(2)).accept(any(IngestDocument.class), isNull());
+        verify(openSearchClient, times(2)).execute(isA(GetAction.class), isA(GetRequest.class), isA(ActionListener.class));
+        verify(mlCommonsClientAccessor, times(1)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        assertEquals(ingestRequest.getInputTexts(), inferenceRequestCaptor.getValue().getInputTexts());
+        Map key1insert = (Map) ingestDocument.getSourceAndMetadata().get("key1Mapped");
+        Map key1update = (Map) updateDocument.getSourceAndMetadata().get("key1Mapped");
+        Map key2insert = (Map) ingestDocument.getSourceAndMetadata().get("key2Mapped");
+        Map key2update = (Map) updateDocument.getSourceAndMetadata().get("key2Mapped");
+        assertEquals(((Number) key1insert.get("hello")).floatValue(), ((Number) key1update.get("hello")).floatValue(), 0.001f);
+        assertEquals(((Number) key1insert.get("world")).floatValue(), ((Number) key1update.get("world")).floatValue(), 0.001f);
+        assertEquals(((Number) key2insert.get("hello")).floatValue(), ((Number) key2update.get("hello")).floatValue(), 0.001f);
+        assertEquals(((Number) key2insert.get("world")).floatValue(), ((Number) key2update.get("world")).floatValue(), 0.001f);
+    }
+
+    public void testExecute_with_update_with_skip_existing_flag_successful() {
+        Map<String, Object> ingestSourceAndMetadata = new HashMap<>();
+        ingestSourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        ingestSourceAndMetadata.put("_id", "1");
+        ingestSourceAndMetadata.put("key1", "value1");
+        ingestSourceAndMetadata.put("key2", "value2");
+        IngestDocument ingestDocument = new IngestDocument(ingestSourceAndMetadata, new HashMap<>());
+        SparseEncodingProcessor processor = createInstance(true);
+        List<String> inferenceList = Arrays.asList("value1", "value2");
+        TextInferenceRequest ingestRequest = TextInferenceRequest.builder().modelId("mockModelId").inputTexts(inferenceList).build();
+        Map<String, Object> updateSourceAndMetadata = deepCopy(ingestSourceAndMetadata); // updated
+        updateSourceAndMetadata.put("key2", "newValue"); // updated
+        List<String> filteredInferenceList = List.of("newValue");
+        TextInferenceRequest updateRequest = TextInferenceRequest.builder()
+            .modelId("mockModelId")
+            .inputTexts(filteredInferenceList)
+            .build();
+        IngestDocument updateDocument = new IngestDocument(updateSourceAndMetadata, new HashMap<>());
+        mockUpdateDocument(ingestDocument);
+        mockVectorCreation(ingestRequest, updateRequest);
+
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        processor.execute(updateDocument, handler); // update document
+        verify(handler, times(2)).accept(any(IngestDocument.class), isNull());
+        verify(openSearchClient, times(2)).execute(isA(GetAction.class), isA(GetRequest.class), isA(ActionListener.class));
+        verify(mlCommonsClientAccessor, times(2)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        List<TextInferenceRequest> requests = inferenceRequestCaptor.getAllValues();
+        assertEquals(ingestRequest.getInputTexts(), requests.get(0).getInputTexts());
+        assertEquals(updateRequest.getInputTexts(), requests.get(1).getInputTexts());
+        Map key1insert = (Map) ingestDocument.getSourceAndMetadata().get("key1Mapped");
+        Map key1update = (Map) updateDocument.getSourceAndMetadata().get("key1Mapped");
+        Map key2insert = (Map) ingestDocument.getSourceAndMetadata().get("key2Mapped");
+        Map key2update = (Map) updateDocument.getSourceAndMetadata().get("key2Mapped");
+        assertEquals(((Number) key1insert.get("hello")).floatValue(), ((Number) key1update.get("hello")).floatValue(), 0.001f);
+        assertEquals(((Number) key1insert.get("world")).floatValue(), ((Number) key1update.get("world")).floatValue(), 0.001f);
+        assertTrue(key2insert.containsKey("hello"));
+        assertTrue(key2insert.containsKey("world"));
+        assertTrue(key2update.containsKey("hello"));
+        assertTrue(key2update.containsKey("world"));
+    }
+
+    public void testExecute_withListTypeInput_no_update_skip_existing_flag_successful() {
+        List<String> list1 = ImmutableList.of("test1", "test2", "test3");
+        List<String> list2 = ImmutableList.of("test4", "test5", "test6");
+        Map<String, Object> ingestSourceAndMetadata = new HashMap<>();
+        ingestSourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        ingestSourceAndMetadata.put("_id", "1");
+        ingestSourceAndMetadata.put("key1", list1);
+        ingestSourceAndMetadata.put("key2", list2);
+        List<String> inferenceList = Arrays.asList("test1", "test2", "test3", "test4", "test5", "test6");
+        TextInferenceRequest ingestRequest = TextInferenceRequest.builder().modelId("mockModelId").inputTexts(inferenceList).build();
+        IngestDocument ingestDocument = new IngestDocument(ingestSourceAndMetadata, new HashMap<>());
+
+        Map<String, Object> updateSourceAndMetadata = deepCopy(ingestSourceAndMetadata);
+        IngestDocument updateDocument = new IngestDocument(updateSourceAndMetadata, new HashMap<>());
+
+        SparseEncodingProcessor processor = createInstance(true);
+        mockUpdateDocument(ingestDocument);
+        mockVectorCreation(ingestRequest, null);
+
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        processor.execute(updateDocument, handler);
+
+        verify(handler, times(2)).accept(any(IngestDocument.class), isNull());
+        verify(openSearchClient, times(2)).execute(isA(GetAction.class), isA(GetRequest.class), isA(ActionListener.class));
+        verify(mlCommonsClientAccessor, times(1)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        assertEquals(ingestRequest.getInputTexts(), inferenceRequestCaptor.getValue().getInputTexts());
+        List key1insert = (List) ingestDocument.getSourceAndMetadata().get("key1Mapped");
+        List key1update = (List) updateDocument.getSourceAndMetadata().get("key1Mapped");
+        List key2insert = (List) ingestDocument.getSourceAndMetadata().get("key2Mapped");
+        List key2update = (List) updateDocument.getSourceAndMetadata().get("key2Mapped");
+        verifyEqualEmbeddingInMap(key1insert, key1update);
+        verifyEqualEmbeddingInMap(key2insert, key2update);
+    }
+
+    public void testExecute_withListTypeInput_with_update_skip_existing_flag_successful() {
+        List<String> list1 = ImmutableList.of("test1", "test2", "test3");
+        List<String> list2 = ImmutableList.of("test4", "test5", "test6");
+        Map<String, Object> ingestSourceAndMetadata = new HashMap<>();
+        ingestSourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        ingestSourceAndMetadata.put("_id", "1");
+        ingestSourceAndMetadata.put("key1", list1);
+        ingestSourceAndMetadata.put("key2", list2);
+        List<String> inferenceList = Arrays.asList("test1", "test2", "test3", "test4", "test5", "test6");
+        IngestDocument ingestDocument = new IngestDocument(ingestSourceAndMetadata, new HashMap<>());
+        TextInferenceRequest ingestRequest = TextInferenceRequest.builder().modelId("mockModelId").inputTexts(inferenceList).build();
+
+        Map<String, Object> updateSourceAndMetadata = deepCopy(ingestSourceAndMetadata);
+        updateSourceAndMetadata.put("key1", ImmutableList.of("test1", "newValue1", "newValue2"));
+        updateSourceAndMetadata.put("key2", ImmutableList.of("newValue3", "test5", "test6"));
+        List<String> filteredInferenceList = Arrays.asList("test1", "newValue1", "newValue2", "newValue3", "test5", "test6");
+        IngestDocument updateDocument = new IngestDocument(updateSourceAndMetadata, new HashMap<>());
+        TextInferenceRequest updateRequest = TextInferenceRequest.builder()
+            .modelId("mockModelId")
+            .inputTexts(filteredInferenceList)
+            .build();
+
+        SparseEncodingProcessor processor = createInstance(true);
+        mockUpdateDocument(ingestDocument);
+        mockVectorCreation(ingestRequest, updateRequest);
+
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        processor.execute(updateDocument, handler);
+
+        verify(handler, times(2)).accept(any(IngestDocument.class), isNull());
+        verify(openSearchClient, times(2)).execute(isA(GetAction.class), isA(GetRequest.class), isA(ActionListener.class));
+        verify(mlCommonsClientAccessor, times(2)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        List<TextInferenceRequest> requests = inferenceRequestCaptor.getAllValues();
+        assertEquals(ingestRequest.getInputTexts(), requests.get(0).getInputTexts());
+        assertEquals(updateRequest.getInputTexts(), requests.get(1).getInputTexts());
+        List key1insert = (List) ingestDocument.getSourceAndMetadata().get("key1Mapped");
+        List key1update = (List) updateDocument.getSourceAndMetadata().get("key1Mapped");
+        List key2insert = (List) ingestDocument.getSourceAndMetadata().get("key2Mapped");
+        List key2update = (List) updateDocument.getSourceAndMetadata().get("key2Mapped");
+        assertEquals(key1insert.size(), key1update.size());
+        assertEquals(key2insert.size(), key2update.size());
+    }
+
+    public void testExecute_withMapTypeInput_no_update_skip_existing_flag_successful() {
+        Map<String, String> map1 = new HashMap<>();
+        map1.put("test1", "test2");
+        Map<String, String> map2 = new HashMap<>();
+        map2.put("test4", "test5");
+        Map<String, Object> ingestSourceAndMetadata = new HashMap<>();
+        ingestSourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        ingestSourceAndMetadata.put("_id", "1");
+        ingestSourceAndMetadata.put("key1", map1);
+        ingestSourceAndMetadata.put("key2", map2);
+        List<String> inferenceList = Arrays.asList("test2", "test5");
+        TextInferenceRequest request = TextInferenceRequest.builder().modelId("mockModelId").inputTexts(inferenceList).build();
+        IngestDocument ingestDocument = new IngestDocument(ingestSourceAndMetadata, new HashMap<>());
+        SparseEncodingProcessor processor = createNestedTypeInstance(true);
+        Map<String, Object> updateSourceAndMetadata = deepCopy(ingestSourceAndMetadata);
+        IngestDocument updateDocument = new IngestDocument(updateSourceAndMetadata, new HashMap<>());
+
+        mockUpdateDocument(ingestDocument);
+        mockVectorCreation(request, null);
+
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        processor.execute(updateDocument, handler);
+
+        verify(handler, times(2)).accept(any(IngestDocument.class), isNull());
+        verify(openSearchClient, times(2)).execute(isA(GetAction.class), isA(GetRequest.class), isA(ActionListener.class));
+        verify(mlCommonsClientAccessor, times(1)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        assertEquals(request.getInputTexts(), inferenceRequestCaptor.getValue().getInputTexts());
+        Map key1insert = (Map) ((Map) ingestDocument.getSourceAndMetadata().get("key1")).get("test1_knn");
+        Map key1update = (Map) ((Map) updateDocument.getSourceAndMetadata().get("key1")).get("test1_knn");
+        Map key2insert = (Map) ((Map) ingestDocument.getSourceAndMetadata().get("key2")).get("test4_knn");
+        Map key2update = (Map) ((Map) updateDocument.getSourceAndMetadata().get("key2")).get("test4_knn");
+        assertEquals(((Number) key1insert.get("hello")).floatValue(), ((Number) key1update.get("hello")).floatValue(), 0.001f);
+        assertEquals(((Number) key1insert.get("world")).floatValue(), ((Number) key1update.get("world")).floatValue(), 0.001f);
+        assertEquals(((Number) key2insert.get("hello")).floatValue(), ((Number) key2update.get("hello")).floatValue(), 0.001f);
+        assertEquals(((Number) key2insert.get("world")).floatValue(), ((Number) key2update.get("world")).floatValue(), 0.001f);
+    }
+
+    public void testExecute_withMapTypeInput_with_update_skip_existing_flag_successful() {
+        Map<String, String> map1 = new HashMap<>();
+        map1.put("test1", "test2");
+        Map<String, String> map2 = new HashMap<>();
+        map2.put("test4", "test5");
+        Map<String, Object> ingestSourceAndMetadata = new HashMap<>();
+        ingestSourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        ingestSourceAndMetadata.put("_id", "1");
+        ingestSourceAndMetadata.put("key1", map1);
+        ingestSourceAndMetadata.put("key2", map2);
+        List<String> inferenceList = Arrays.asList("test2", "test5");
+        TextInferenceRequest ingestRequest = TextInferenceRequest.builder().modelId("mockModelId").inputTexts(inferenceList).build();
+        IngestDocument ingestDocument = new IngestDocument(ingestSourceAndMetadata, new HashMap<>());
+        SparseEncodingProcessor processor = createNestedTypeInstance(true);
+        Map<String, Object> updateSourceAndMetadata = deepCopy(ingestSourceAndMetadata);
+        IngestDocument updateDocument = new IngestDocument(updateSourceAndMetadata, new HashMap<>());
+        ((Map) updateSourceAndMetadata.get("key1")).put("test1", "newValue1");
+        List<String> filteredInferenceList = Arrays.asList("newValue1");
+        TextInferenceRequest updateRequest = TextInferenceRequest.builder()
+            .modelId("mockModelId")
+            .inputTexts(filteredInferenceList)
+            .build();
+
+        mockUpdateDocument(ingestDocument);
+        mockVectorCreation(ingestRequest, updateRequest);
+
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        processor.execute(updateDocument, handler);
+
+        verify(handler, times(2)).accept(any(IngestDocument.class), isNull());
+        verify(openSearchClient, times(2)).execute(isA(GetAction.class), isA(GetRequest.class), isA(ActionListener.class));
+        verify(mlCommonsClientAccessor, times(2)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        List<TextInferenceRequest> requests = inferenceRequestCaptor.getAllValues();
+        assertEquals(ingestRequest.getInputTexts(), requests.get(0).getInputTexts());
+        assertEquals(updateRequest.getInputTexts(), requests.get(1).getInputTexts());
+        Map key1insert = (Map) ((Map) ingestDocument.getSourceAndMetadata().get("key1")).get("test1_knn");
+        Map key1update = (Map) ((Map) updateDocument.getSourceAndMetadata().get("key1")).get("test1_knn");
+        Map key2insert = (Map) ((Map) ingestDocument.getSourceAndMetadata().get("key2")).get("test4_knn");
+        Map key2update = (Map) ((Map) updateDocument.getSourceAndMetadata().get("key2")).get("test4_knn");
+        assertEquals(key1insert.size(), key1update.size());
+        assertEquals(key2insert.size(), key2update.size());
+    }
+
+    public void test_batchExecute_no_update_successful() {
+        final int docCount = 5;
+        List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
+        List<IngestDocumentWrapper> updateDocumentWrappers = createIngestDocumentWrappers(docCount);
+        SparseEncodingProcessor processor = createInstance(docCount, true);
+        Consumer resultHandler = mock(Consumer.class);
+        TextInferenceRequest ingestRequest = TextInferenceRequest.builder()
+            .modelId("mockModelID")
+            .inputTexts(List.of("value1", "value1", "value1", "value1", "value1"))
+            .build();
+        mockVectorCreation(ingestRequest, null);
+        mockUpdateMultipleDocuments(ingestDocumentWrappers);
+        processor.batchExecute(ingestDocumentWrappers, resultHandler);
+        processor.batchExecute(updateDocumentWrappers, resultHandler);
+        for (int i = 0; i < docCount; ++i) {
+            assertEquals(
+                ingestDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1"),
+                updateDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1")
+            );
+            assertEquals(
+                ((Number) ((Map) ingestDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1Mapped")).get("hello"))
+                    .floatValue(),
+                ((Number) ((Map) updateDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1Mapped")).get("hello"))
+                    .floatValue(),
+                0.001f
+            );
+            assertEquals(
+                ((Number) ((Map) ingestDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1Mapped")).get("world"))
+                    .floatValue(),
+                ((Number) ((Map) updateDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1Mapped")).get("world"))
+                    .floatValue(),
+                0.001f
+            );
+        }
+        verify(openSearchClient, times(2)).execute(isA(MultiGetAction.class), isA(MultiGetRequest.class), isA(ActionListener.class));
+        verify(mlCommonsClientAccessor, times(1)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        assertEquals(ingestRequest.getInputTexts(), inferenceRequestCaptor.getValue().getInputTexts());
+    }
+
+    public void test_batchExecute_with_update_successful() {
+        final int docCount = 5;
+        List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
+        List<IngestDocumentWrapper> updateDocumentWrappers = createIngestDocumentWrappers(docCount, "newValue");
+        SparseEncodingProcessor processor = createInstance(docCount, true);
+        Consumer resultHandler = mock(Consumer.class);
+        TextInferenceRequest ingestRequest = TextInferenceRequest.builder()
+            .modelId("mockModelID")
+            .inputTexts(List.of("value1", "value1", "value1", "value1", "value1"))
+            .build();
+        TextInferenceRequest updateRequest = TextInferenceRequest.builder()
+            .modelId("mockModelID")
+            .inputTexts(List.of("newValue", "newValue", "newValue", "newValue", "newValue"))
+            .build();
+        mockVectorCreation(ingestRequest, updateRequest);
+        mockUpdateMultipleDocuments(ingestDocumentWrappers);
+        processor.batchExecute(ingestDocumentWrappers, resultHandler);
+        processor.batchExecute(updateDocumentWrappers, resultHandler);
+        for (int i = 0; i < docCount; ++i) {
+            assertEquals(
+                ((Map) ingestDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1Mapped")).size(),
+                ((Map) updateDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1Mapped")).size()
+            );
+            assertEquals(
+                ((Map) ingestDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1Mapped")).size(),
+                ((Map) updateDocumentWrappers.get(i).getIngestDocument().getSourceAndMetadata().get("key1Mapped")).size()
+            );
+        }
+        verify(openSearchClient, times(2)).execute(isA(MultiGetAction.class), isA(MultiGetRequest.class), isA(ActionListener.class));
+        verify(mlCommonsClientAccessor, times(2)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        List<TextInferenceRequest> requests = inferenceRequestCaptor.getAllValues();
+        assertEquals(ingestRequest.getInputTexts(), requests.get(0).getInputTexts());
+        assertEquals(updateRequest.getInputTexts(), requests.get(1).getInputTexts());
+    }
+
+    public void test_subBatchExecute_emptyIngestDocumentWrapper_successful() {
+        List<IngestDocumentWrapper> ingestDocumentWrappers = Collections.emptyList();
+        SparseEncodingProcessor processor = createInstance(false);
+        Consumer resultHandler = mock(Consumer.class);
+        processor.subBatchExecute(ingestDocumentWrappers, resultHandler);
+        ArgumentCaptor<List<IngestDocumentWrapper>> resultCallback = ArgumentCaptor.forClass(List.class);
+        verify(resultHandler).accept(resultCallback.capture());
+    }
+
+    public void test_subBatchExecute_emptyInferenceList_successful() {
+        List<IngestDocumentWrapper> ingestDocumentWrappers = new ArrayList<>();
+        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, null, null));
+        SparseEncodingProcessor processor = createInstance(false);
+        Consumer resultHandler = mock(Consumer.class);
+        processor.subBatchExecute(ingestDocumentWrappers, resultHandler);
+        ArgumentCaptor<List<IngestDocumentWrapper>> resultCallback = ArgumentCaptor.forClass(List.class);
+        verify(resultHandler).accept(resultCallback.capture());
+    }
+
+    public void test_execute_emptyInferenceList_successful() {
+        List<IngestDocumentWrapper> ingestDocumentWrappers = new ArrayList<>();
+        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, null, null));
+        SparseEncodingProcessor processor = createInstance(false);
+        Consumer resultHandler = mock(Consumer.class);
+        processor.subBatchExecute(ingestDocumentWrappers, resultHandler);
+        ArgumentCaptor<List<IngestDocumentWrapper>> resultCallback = ArgumentCaptor.forClass(List.class);
+        verify(resultHandler).accept(resultCallback.capture());
+    }
+
     private List<Map<String, ?>> createMockMapResult(int number) {
         List<Map<String, Float>> mockSparseEncodingResult = new ArrayList<>();
-        IntStream.range(0, number).forEachOrdered(x -> mockSparseEncodingResult.add(ImmutableMap.of("hello", 1.0f, "world", 0.1f)));
+        IntStream.range(0, number)
+            .forEachOrdered(x -> mockSparseEncodingResult.add(ImmutableMap.of("hello", randomFloat(), "world", randomFloat())));
 
         List<Map<String, ?>> mockMapResult = Collections.singletonList(Map.of("response", mockSparseEncodingResult));
         return mockMapResult;
+    }
+
+    private void mockUpdateDocument(IngestDocument ingestDocument) {
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockEmptyGetResponse()); // returns empty result for ingest action
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(convertToGetResponse(ingestDocument)); // returns previously ingested document for update action
+            return null;
+        }).when(openSearchClient).execute(isA(GetAction.class), isA(GetRequest.class), isA(ActionListener.class));
+    }
+
+    private void mockVectorCreation(TextInferenceRequest ingestRequest, TextInferenceRequest updateRequest) {
+        doAnswer(invocation -> {
+            int numVectors = ingestRequest.getInputTexts().size();
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
+            listener.onResponse(createMockMapResult(numVectors));
+            return null;
+        }).doAnswer(invocation -> {
+            int numVectors = updateRequest.getInputTexts().size();
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
+            listener.onResponse(createMockMapResult(numVectors));
+            return null;
+        }).when(mlCommonsClientAccessor).inferenceSentencesWithMapResult(isA(TextInferenceRequest.class), isA(ActionListener.class));
+    }
+
+    private void verifyEqualEmbeddingInMap(List<Map> insertVectors, List<Map> updateVectors) {
+        assertEquals(insertVectors.size(), updateVectors.size());
+
+        for (int i = 0; i < insertVectors.size(); i++) {
+            Map<String, Map<String, Number>> insertMap = insertVectors.get(i);
+            Map<String, Map<String, Number>> updateMap = updateVectors.get(i);
+            for (Map.Entry<String, Map<String, Number>> entry : insertMap.entrySet()) {
+                Map<String, Number> insertValue = entry.getValue();
+                Map<String, Number> updateValue = updateMap.get(entry.getKey());
+                for (String key : insertValue.keySet()) {
+                    assertEquals(insertValue.get(key).floatValue(), updateValue.get(key).floatValue(), 0.001f);
+                }
+            }
+        }
+    }
+
+    private void mockUpdateMultipleDocuments(List<IngestDocumentWrapper> ingestDocuments) {
+        doAnswer(invocation -> {
+            ActionListener<MultiGetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockEmptyMultiGetItemResponse()); // returns empty result for ingest action
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<MultiGetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(convertToMultiGetItemResponse(ingestDocuments)); // returns previously ingested document for update action
+            return null;
+        }).when(openSearchClient).execute(isA(MultiGetAction.class), isA(MultiGetRequest.class), isA(ActionListener.class));
+    }
+
+    private void mockFailedUpdateMultipleDocuments(List<IngestDocumentWrapper> ingestDocuments) {
+        doAnswer(invocation -> {
+            ActionListener<MultiGetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockEmptyMultiGetItemResponse()); // returns empty result for ingest action
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<MultiGetResponse> listener = invocation.getArgument(2);
+            listener.onFailure(new RuntimeException()); // throw exception on update
+            return null;
+        }).when(openSearchClient).execute(isA(MultiGetAction.class), isA(MultiGetRequest.class), isA(ActionListener.class));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -1219,6 +1219,25 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
     }
 
     @SneakyThrows
+    public void testExecute_when_initial_ingest_null_id_with_skip_existing_flag_successful() {
+        Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        sourceAndMetadata.put("key1", "value1");
+        sourceAndMetadata.put("key2", "value2");
+        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(true);
+        List<List<Float>> modelTensorList = createMockVectorResult();
+        doAnswer(invocation -> {
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
+            listener.onResponse(modelTensorList);
+            return null;
+        }).when(mlCommonsClientAccessor).inferenceSentences(isA(TextInferenceRequest.class), isA(ActionListener.class));
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+        verify(handler).accept(any(IngestDocument.class), isNull());
+    }
+
+    @SneakyThrows
     public void testExecute_with_no_update_with_skip_existing_flag_successful() {
         Map<String, Object> ingestSourceAndMetadata = new HashMap<>();
         ingestSourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");

--- a/src/test/java/org/opensearch/neuralsearch/processor/optimization/TextEmbeddingInferenceFilterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/optimization/TextEmbeddingInferenceFilterTests.java
@@ -164,7 +164,11 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
         Map<String, Object> existingMap = new HashMap<>();
         existingMap.put("outerField", existingNestedMap);
 
-        Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filter(existingMap, sourceAndMetadataMap, processMap);
+        Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filterAndCopyExistingEmbeddings(
+            existingMap,
+            sourceAndMetadataMap,
+            processMap
+        );
 
         assertNull(((Map) result.get("outerField")).get("embeddingField"));
         assertEquals(Arrays.asList(0.1, 0.2, 0.3), ((Map) sourceAndMetadataMap.get("outerField")).get("embeddingField"));
@@ -182,7 +186,11 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
         Map<String, Object> existingMap = new HashMap<>();
         existingMap.put("outerField", existingNestedMap);
 
-        Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filter(existingMap, sourceAndMetadataMap, processMap);
+        Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filterAndCopyExistingEmbeddings(
+            existingMap,
+            sourceAndMetadataMap,
+            processMap
+        );
 
         assertFalse(result.isEmpty());
         assertEquals("New Text", ((Map<String, Object>) result.get("outerField")).get("embeddingField"));
@@ -202,7 +210,11 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
         Map<String, Object> existingMap = new HashMap<>();
         existingMap.put("outerField", existingNestedMap);
 
-        Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filter(existingMap, sourceAndMetadataMap, processMap);
+        Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filterAndCopyExistingEmbeddings(
+            existingMap,
+            sourceAndMetadataMap,
+            processMap
+        );
 
         assertNull(((Map) result.get("outerField")).get("embeddingField"));
         assertEquals(Arrays.asList(0.1, 0.2, 0.3), ((List) ((Map) sourceAndMetadataMap.get("outerField")).get("embeddingField")).get(0));
@@ -222,7 +234,11 @@ public class TextEmbeddingInferenceFilterTests extends OpenSearchTestCase {
         Map<String, Object> existingMap = new HashMap<>();
         existingMap.put("outerField", existingNestedMap);
 
-        Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filter(existingMap, sourceAndMetadataMap, processMap);
+        Map<String, Object> result = nestedTextEmbeddingInferenceFilter.filterAndCopyExistingEmbeddings(
+            existingMap,
+            sourceAndMetadataMap,
+            processMap
+        );
 
         assertEquals(2, ((List) ((Map) result.get("outerField")).get("embeddingField")).size());
         assertNull(sourceAndMetadataMap.get("outerField"));

--- a/src/test/resources/processor/SparseEncodingPipelineConfigurationWithSkipExisting.json
+++ b/src/test/resources/processor/SparseEncodingPipelineConfigurationWithSkipExisting.json
@@ -1,0 +1,20 @@
+{
+  "description": "An example sparse Encoding pipeline",
+  "processors" : [
+    {
+      "sparse_encoding": {
+        "model_id": "%s",
+        "batch_size": "%d",
+        "field_map": {
+          "title": "title_sparse",
+          "favor_list": "favor_list_sparse",
+          "favorites": {
+            "game": "game_sparse",
+            "movie": "movie_sparse"
+          }
+        },
+        "skip_existing": true
+      }
+    }
+  ]
+}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -104,6 +104,8 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         "processor/PipelineConfiguration.json",
         ProcessorType.SPARSE_ENCODING,
         "processor/SparseEncodingPipelineConfiguration.json",
+        ProcessorType.SPARSE_ENCODING_WITH_SKIP_EXISTING,
+        "processor/SparseEncodingPipelineConfigurationWithSkipExisting.json",
         ProcessorType.TEXT_IMAGE_EMBEDDING,
         "processor/PipelineForTextImageEmbeddingProcessorConfiguration.json",
         ProcessorType.TEXT_EMBEDDING_WITH_NESTED_FIELDS_MAPPING,
@@ -1963,6 +1965,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         TEXT_EMBEDDING_WITH_NESTED_FIELDS_MAPPING_WITH_SKIP_EXISTING,
         TEXT_IMAGE_EMBEDDING,
         SPARSE_ENCODING,
+        SPARSE_ENCODING_WITH_SKIP_EXISTING,
         SPARSE_ENCODING_PRUNE
     }
 


### PR DESCRIPTION
### Description
This PR implements embedding optimization for sparse encoding processor. This PR contains similar changes as previously merged PR for optimizing text embedding processor. 

Text Embedding Processor Optimization PR: [link](https://github.com/opensearch-project/neural-search/pull/1238)
Related RFC: https://github.com/opensearch-project/neural-search/issues/1138

### Sparse Encoding Benchmarking Results

### Setup

**Version**: OS 3.0 alpha
**Cluster**: 4 r6g.2xlarge nodes (1 coordinator node 3 data nodes)

**Dataset:** Trec-covid (https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/trec-covid.zip)
**Inference Model:** amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v2-distill



**Pipeline:** 

```
{
  "description": "A sparse encoding pipeline",
  "processors": [
    {
      "sparse_encoding": {
        "model_id": "nHXUzpUBA788_009ga9N",
        "prune_type": "max_ratio",
        "prune_ratio": 0.1,
        "field_map": {
          "passage_text": "passage_embedding"
        },
        "skip_existing": true/false
      }
    }
  ]
}
```

**Index:**

```
{
  "settings": {
    "index.knn": true,
    "number_of_shards": 3,
    "default_pipeline": "nlp-ingest-pipeline"
  },
  "mappings": {
    "properties": {
      "id": {
        "type": "text"
      },
      "passage_embedding": {
        "type": "rank_features"
      },
      "passage_text": {
        "type": "text"
      }
    }
  }
}
```

**Ingest Latency**

The following table presents latency measurements of initial ingest operation (in milliseconds) with *skip_existing* feature enabled and disabled. The Percent difference columns show the relative performance impact between the two.


|Operation	|Prune Type	|Prune Ratio	|Doc Size	|Batch Size	|skip_existing_off latency (ms)	|skip_existing_on latency (ms)	|Difference (ms)	|Percent Difference	|
|---	|---	|---	|---	|---	|---	|---	|---	|---	|
|Single Ingest 	|max_ratio	|0.1	|1000	|1	|623172.06	|655658.66	|32486.6	|5.21%	|
|Single Ingest	|max_ratio	|0.1	|2000	|1	|1241234.59	|1310683.17	|69448.58	|5.60%	|
|Single Ingest 	|max_ratio	|0.1	|3000	|1	|1942907.49	|1965918.53	|23011.04	|1.18%	|
|Batch Ingest 	|max_ratio	|0.1	|171332	|200	|3077040.12	|3101697.22	|24657.1	|0.80%	|
|Batch Ingest 	|max_ratio	|0.1	|171332	|500	|2889452.28	|2905052.15	|15599.87	|0.54%	|

**Update Latency**

The following table presents the latency measurements of update operation after identical ingest operation (in milliseconds) with *skip_existing* feature enabled and disabled. The Percent difference columns show the relative performance impact between the two.


|Operation	|Prune Type	|Prune Ratio	|Doc Size	|Batch Size	|skip_existing_off latency (ms)	|skip_existing_on latency (ms)	|Difference (ms)	|Percent Difference	|
|---	|---	|---	|---	|---	|---	|---	|---	|---	|
|Single Update 	|max_ratio	|0.1	|1000	|1	|623172.06	|111144.76	|-512027.3	|-82.16%	|
|Single Update 	|max_ratio	|0.1	|2000	|1	|1241234.59	|213015.48	|-1028219.11	|-82.84%	|
|Single Update	|max_ratio	|0.1	|3000	|1	|1942907.49	|306765.73	|-1636141.76	|-84.21%	|
|Batch Update 	|max_ratio	|0.1	|171332	|200	|3077040.12	|475197.34	|-2601842.78	|-84.56%	|
|Batch Update 	|max_ratio	|0.1	|171332	|500	|2889452.28	|437750.26	|-2451702.02	|-84.85%	|






### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
