### PR TITLE
Support custom tags in semantic highlighter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Optimize embedding generation in Sparse Encoding Processor ([#1246](https://github.com/opensearch-project/neural-search/pull/1246))
 - Optimize embedding generation in Text/Image Embedding Processor ([#1249](https://github.com/opensearch-project/neural-search/pull/1249))
 - Inner hits support with hybrid query ([#1253](https://github.com/opensearch-project/neural-search/pull/1253))
+- Support custom tags in semantic highlighter ([#1254](https://github.com/opensearch-project/neural-search/pull/1254))
 
 ### Enhancements
 

--- a/src/main/java/org/opensearch/neuralsearch/highlight/SemanticHighlighter.java
+++ b/src/main/java/org/opensearch/neuralsearch/highlight/SemanticHighlighter.java
@@ -60,8 +60,18 @@ public class SemanticHighlighter implements Highlighter {
             return null;
         }
 
+        // The pre- and post- tags are provided by the user or defaulted to <em> and </em>
+        String[] preTags = fieldContext.field.fieldOptions().preTags();
+        String[] postTags = fieldContext.field.fieldOptions().postTags();
+
         // Get highlighted text - allow any exceptions from this call to propagate
-        String highlightedResponse = semanticHighlighterEngine.getHighlightedSentences(modelId, originalQueryText, fieldText);
+        String highlightedResponse = semanticHighlighterEngine.getHighlightedSentences(
+            modelId,
+            originalQueryText,
+            fieldText,
+            preTags[0],
+            postTags[0]
+        );
 
         if (highlightedResponse == null || highlightedResponse.isEmpty()) {
             log.warn("No highlighted text found for field {}", fieldContext.fieldName);

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -114,7 +114,10 @@ public class NeuralSearch extends Plugin implements ActionPlugin, SearchPlugin, 
         NeuralQueryBuilder.initialize(clientAccessor);
         NeuralSparseQueryBuilder.initialize(clientAccessor);
         QueryTextExtractorRegistry queryTextExtractorRegistry = new QueryTextExtractorRegistry();
-        SemanticHighlighterEngine semanticHighlighterEngine = new SemanticHighlighterEngine(clientAccessor, queryTextExtractorRegistry);
+        SemanticHighlighterEngine semanticHighlighterEngine = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(clientAccessor)
+            .queryTextExtractorRegistry(queryTextExtractorRegistry)
+            .build();
         semanticHighlighter.initialize(semanticHighlighterEngine);
         HybridQueryExecutor.initialize(threadPool);
         normalizationProcessorWorkflow = new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner());

--- a/src/test/java/org/opensearch/neuralsearch/highlight/SemanticHighlighterIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/highlight/SemanticHighlighterIT.java
@@ -33,6 +33,10 @@ public class SemanticHighlighterIT extends BaseNeuralSearchIT {
     private static final String TEST_CONTENT = "Machine learning is a field of artificial intelligence that uses statistical techniques. "
         + "Natural language processing is a branch of artificial intelligence that helps computers understand human language. "
         + "Deep learning is a subset of machine learning that uses neural networks with many layers.";
+    private static final String DEFAULT_PRE_TAG = "<em>";
+    private static final String DEFAULT_POST_TAG = "</em>";
+    private static final String CUSTOM_PRE_TAG = "<test>";
+    private static final String CUSTOM_POST_TAG = "</test>";
     private final float[] testVector = createRandomVector(TEST_DIMENSION);
 
     @Before
@@ -73,7 +77,7 @@ public class SemanticHighlighterIT extends BaseNeuralSearchIT {
      * 5. Neural Query
      * 6. Hybrid Query
      */
-    public void testQueriesWithSemanticHighlighter() throws Exception {
+    public void testQueriesWithSemanticHighlighter() {
         // Set up models for the test
         String textEmbeddingModelId = prepareModel();
         String sentenceHighlightingModelId = prepareSentenceHighlightingModel();
@@ -255,8 +259,8 @@ public class SemanticHighlighterIT extends BaseNeuralSearchIT {
             10,
             customHighlightFields,
             customHighlightOptions,
-            new String[] { "<test>" },
-            new String[] { "</test>" }
+            new String[] { CUSTOM_PRE_TAG },
+            new String[] { CUSTOM_POST_TAG }
         );
 
         // Verify results with custom tags
@@ -273,10 +277,10 @@ public class SemanticHighlighterIT extends BaseNeuralSearchIT {
         assertFalse("Highlighted fields should not be empty", customHighlightedFields.isEmpty());
 
         String customHighlightedText = customHighlightedFields.getFirst();
-        assertTrue("Text should contain custom opening tag", customHighlightedText.contains("<test>"));
-        assertTrue("Text should contain custom closing tag", customHighlightedText.contains("</test>"));
-        assertFalse("Text should not contain default opening tag", customHighlightedText.contains("<em>"));
-        assertFalse("Text should not contain default closing tag", customHighlightedText.contains("</em>"));
+        assertTrue("Text should contain custom opening tag", customHighlightedText.contains(CUSTOM_PRE_TAG));
+        assertTrue("Text should contain custom closing tag", customHighlightedText.contains(CUSTOM_POST_TAG));
+        assertFalse("Text should not contain default opening tag", customHighlightedText.contains(DEFAULT_PRE_TAG));
+        assertFalse("Text should not contain default closing tag", customHighlightedText.contains(DEFAULT_POST_TAG));
         verifyHighlightResults(searchResponse, TEST_QUERY_TEXT);
 
         // 6. Test Hybrid Query
@@ -361,10 +365,9 @@ public class SemanticHighlighterIT extends BaseNeuralSearchIT {
 
         assertTrue("Highlighted text should contain semantically relevant content for query: " + expectedContent, hasRelevantContent);
 
-        // Verify the highlight tags are present
-        assertTrue(
-            "Highlighted text should contain proper highlight tags",
-            highlightedText.contains("<em>") && highlightedText.contains("</em>")
-        );
+        // Verify the highlight tags are present - either default tags or custom tags
+        boolean hasDefaultTags = highlightedText.contains(DEFAULT_PRE_TAG) && highlightedText.contains(DEFAULT_POST_TAG);
+        boolean hasCustomTags = highlightedText.contains(CUSTOM_PRE_TAG) && highlightedText.contains(CUSTOM_POST_TAG);
+        assertTrue("Highlighted text should contain either default or custom highlight tags", hasDefaultTags || hasCustomTags);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/highlight/SemanticHighlighterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/highlight/SemanticHighlighterTests.java
@@ -57,7 +57,10 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         super.setUp();
         mlCommonsClientAccessor = mock(MLCommonsClientAccessor.class);
         queryTextExtractorRegistry = new QueryTextExtractorRegistry();
-        highlighterEngine = new SemanticHighlighterEngine(mlCommonsClientAccessor, queryTextExtractorRegistry);
+        highlighterEngine = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(mlCommonsClientAccessor)
+            .queryTextExtractorRegistry(queryTextExtractorRegistry)
+            .build();
 
         highlighter = new SemanticHighlighter();
         highlighter.initialize(highlighterEngine);
@@ -116,6 +119,12 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         return mockResponse;
     }
 
+    private void setupDefaultHighlightTags(FieldHighlightContext context) {
+        // In the real OpenSearch environment, these default tags are provided by the core
+        when(context.field.fieldOptions().preTags()).thenReturn(new String[] { "<em>" });
+        when(context.field.fieldOptions().postTags()).thenReturn(new String[] { "</em>" });
+    }
+
     // Tests for the SemanticHighlighter class
 
     public void testCanHighlight() {
@@ -134,6 +143,7 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         // Create a context with a TermQuery instead of a mocked Query
         TermQuery termQuery = new TermQuery(new Term(TEST_FIELD, "test"));
         FieldHighlightContext context = createHighlightContext(TEST_CONTENT, termQuery);
+        setupDefaultHighlightTags(context);
 
         HighlightField result = highlighter.highlight(context);
 
@@ -161,6 +171,8 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         NeuralKNNQuery neuralQuery = new NeuralKNNQuery(new TermQuery(new Term(TEST_FIELD, "dummy")), queryText);
 
         FieldHighlightContext context = createHighlightContext(TEST_CONTENT, neuralQuery);
+        setupDefaultHighlightTags(context);
+
         HighlightField result = highlighter.highlight(context);
 
         assertNotNull("Should return highlight field with semantic query", result);
@@ -172,7 +184,10 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         // Setup a custom mock for this test that simulates an error
         MLCommonsClientAccessor errorMlClient = mock(MLCommonsClientAccessor.class);
         QueryTextExtractorRegistry errorRegistry = new QueryTextExtractorRegistry();
-        SemanticHighlighterEngine errorEngine = new SemanticHighlighterEngine(errorMlClient, errorRegistry);
+        SemanticHighlighterEngine errorEngine = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(errorMlClient)
+            .queryTextExtractorRegistry(errorRegistry)
+            .build();
 
         SemanticHighlighter customHighlighter = new SemanticHighlighter();
         customHighlighter.initialize(errorEngine);
@@ -187,6 +202,7 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         // Create a context with a TermQuery instead of a mocked Query
         TermQuery termQuery = new TermQuery(new Term(TEST_FIELD, "test"));
         FieldHighlightContext context = createHighlightContext(TEST_CONTENT, termQuery);
+        setupDefaultHighlightTags(context);
 
         // Should throw an exception due to the model error
         OpenSearchException exception = expectThrows(OpenSearchException.class, () -> customHighlighter.highlight(context));
@@ -197,11 +213,17 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
     public void testMultipleInitialization() {
         MLCommonsClientAccessor mlClient1 = mock(MLCommonsClientAccessor.class);
         QueryTextExtractorRegistry registry1 = new QueryTextExtractorRegistry();
-        SemanticHighlighterEngine engine1 = new SemanticHighlighterEngine(mlClient1, registry1);
+        SemanticHighlighterEngine engine1 = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(mlClient1)
+            .queryTextExtractorRegistry(registry1)
+            .build();
 
         MLCommonsClientAccessor mlClient2 = mock(MLCommonsClientAccessor.class);
         QueryTextExtractorRegistry registry2 = new QueryTextExtractorRegistry();
-        SemanticHighlighterEngine engine2 = new SemanticHighlighterEngine(mlClient2, registry2);
+        SemanticHighlighterEngine engine2 = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(mlClient2)
+            .queryTextExtractorRegistry(registry2)
+            .build();
 
         SemanticHighlighter testHighlighter = new SemanticHighlighter();
         testHighlighter.initialize(engine1);
@@ -257,7 +279,7 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
     }
 
     public void testGetHighlightedSentences() {
-        String result = highlighterEngine.getHighlightedSentences(MODEL_ID, TEST_QUERY, TEST_CONTENT);
+        String result = highlighterEngine.getHighlightedSentences(MODEL_ID, TEST_QUERY, TEST_CONTENT, "<em>", "</em>");
 
         assertNotNull("Should return highlighted text", result);
         assertTrue("Should contain highlighting tags", result.contains("<em>") && result.contains("</em>"));
@@ -283,15 +305,33 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         resultMap.put("highlights", highlightsList);
 
         String text = "This is a test string";
-        String result = highlighterEngine.applyHighlighting(text, resultMap);
+        String result = highlighterEngine.applyHighlighting(text, resultMap, "<em>", "</em>");
 
         assertEquals("Should apply highlights correctly", "<em>This</em> is <em>a te</em>st string", result);
+    }
+
+    public void testCustomTags() {
+        // Test with custom tags
+        String result = highlighterEngine.getHighlightedSentences(MODEL_ID, TEST_QUERY, TEST_CONTENT, "<mark>", "</mark>");
+        assertNotNull("Should return highlighted text", result);
+        assertTrue("Should contain custom highlighting tags", result.contains("<mark>") && result.contains("</mark>"));
+        assertFalse("Should not contain default highlighting tags", result.contains("<em>") || result.contains("</em>"));
+
+        // Test with different custom tags
+        result = highlighterEngine.getHighlightedSentences(MODEL_ID, TEST_QUERY, TEST_CONTENT, "<span class='highlight'>", "</span>");
+        assertNotNull("Should return highlighted text", result);
+        assertTrue(
+            "Should contain new custom highlighting tags",
+            result.contains("<span class='highlight'>") && result.contains("</span>")
+        );
+        assertFalse("Should not contain previous highlighting tags", result.contains("<mark>") || result.contains("</mark>"));
     }
 
     public void testIntegrationWithTermQuery() {
         // Integration test logic for term queries
         TermQuery query = new TermQuery(new Term(TEST_FIELD, "test"));
         FieldHighlightContext context = createHighlightContext(TEST_CONTENT, query);
+        setupDefaultHighlightTags(context);
 
         HighlightField result = highlighter.highlight(context);
         assertNotNull("Should return highlight field", result);
@@ -309,6 +349,7 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         BooleanQuery query = builder.build();
 
         FieldHighlightContext context = createHighlightContext(TEST_CONTENT, query);
+        setupDefaultHighlightTags(context);
 
         HighlightField result = highlighter.highlight(context);
         assertNotNull("Should return highlight field", result);
@@ -323,6 +364,7 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         NeuralKNNQuery query = new NeuralKNNQuery(mock(Query.class), "semantic test");
 
         FieldHighlightContext context = createHighlightContext(TEST_CONTENT, query);
+        setupDefaultHighlightTags(context);
 
         HighlightField result = highlighter.highlight(context);
         assertNotNull("Should return highlight field", result);
@@ -336,7 +378,10 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         // Error handling logic for null model response
         MLCommonsClientAccessor nullResponseClient = mock(MLCommonsClientAccessor.class);
         QueryTextExtractorRegistry nullRegistry = new QueryTextExtractorRegistry();
-        SemanticHighlighterEngine nullResponseEngine = new SemanticHighlighterEngine(nullResponseClient, nullRegistry);
+        SemanticHighlighterEngine nullResponseEngine = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(nullResponseClient)
+            .queryTextExtractorRegistry(nullRegistry)
+            .build();
 
         SemanticHighlighter testHighlighter = new SemanticHighlighter();
         testHighlighter.initialize(nullResponseEngine);
@@ -351,6 +396,7 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         // Create a context with a TermQuery instead of a mocked Query
         TermQuery termQuery = new TermQuery(new Term(TEST_FIELD, "test"));
         FieldHighlightContext context = createHighlightContext(TEST_CONTENT, termQuery);
+        setupDefaultHighlightTags(context);
 
         // The highlight method should return null when model returns null
         HighlightField result = testHighlighter.highlight(context);
@@ -361,7 +407,10 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         // Error handling logic for empty model response
         MLCommonsClientAccessor emptyResponseClient = mock(MLCommonsClientAccessor.class);
         QueryTextExtractorRegistry emptyRegistry = new QueryTextExtractorRegistry();
-        SemanticHighlighterEngine emptyResponseEngine = new SemanticHighlighterEngine(emptyResponseClient, emptyRegistry);
+        SemanticHighlighterEngine emptyResponseEngine = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(emptyResponseClient)
+            .queryTextExtractorRegistry(emptyRegistry)
+            .build();
 
         SemanticHighlighter testHighlighter = new SemanticHighlighter();
         testHighlighter.initialize(emptyResponseEngine);
@@ -375,10 +424,89 @@ public class SemanticHighlighterTests extends OpenSearchTestCase {
         // Create a context with a TermQuery instead of a mocked Query
         TermQuery termQuery = new TermQuery(new Term(TEST_FIELD, "test"));
         FieldHighlightContext context = createHighlightContext(TEST_CONTENT, termQuery);
+        setupDefaultHighlightTags(context);
 
         // The highlight method should return null when model returns empty list
         HighlightField result = testHighlighter.highlight(context);
         assertNull("Result should be null when model returns empty list", result);
+    }
+
+    public void testHighlightWithCustomTags() {
+        // Create a context with custom tags
+        TermQuery termQuery = new TermQuery(new Term(TEST_FIELD, "test"));
+        FieldHighlightContext context = createHighlightContext(TEST_CONTENT, termQuery);
+        when(context.field.fieldOptions().preTags()).thenReturn(new String[] { "<mark>" });
+        when(context.field.fieldOptions().postTags()).thenReturn(new String[] { "</mark>" });
+
+        HighlightField result = highlighter.highlight(context);
+
+        assertNotNull("Should return highlight field", result);
+        String highlightedText = result.fragments()[0].string();
+        assertTrue("Text should contain custom tags", highlightedText.contains("<mark>") && highlightedText.contains("</mark>"));
+        assertFalse("Text should not contain default tags", highlightedText.contains("<em>") || highlightedText.contains("</em>"));
+    }
+
+    public void testHighlightWithPartialTags() {
+        // Since OpenSearch core doesn't allow setting only one of preTags or postTags,
+        // we're skipping this test as it's not a valid use case.
+    }
+
+    public void testHighlightWithNullResponse() {
+        // Setup a custom mock for this test that returns null
+        MLCommonsClientAccessor nullResponseClient = mock(MLCommonsClientAccessor.class);
+        QueryTextExtractorRegistry nullRegistry = new QueryTextExtractorRegistry();
+        SemanticHighlighterEngine nullResponseEngine = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(nullResponseClient)
+            .queryTextExtractorRegistry(nullRegistry)
+            .build();
+
+        SemanticHighlighter customHighlighter = new SemanticHighlighter();
+        customHighlighter.initialize(nullResponseEngine);
+
+        // Mock response that calls the listener with null
+        doAnswer(invocation -> {
+            ActionListener<List<Map<String, Object>>> listener = invocation.getArgument(1);
+            listener.onResponse(null);
+            return null;
+        }).when(nullResponseClient).inferenceSentenceHighlighting(any(SentenceHighlightingRequest.class), any());
+
+        // Create a context with a TermQuery instead of a mocked Query
+        TermQuery termQuery = new TermQuery(new Term(TEST_FIELD, "test"));
+        FieldHighlightContext context = createHighlightContext(TEST_CONTENT, termQuery);
+        setupDefaultHighlightTags(context);
+
+        // Should return null due to null response
+        HighlightField result = customHighlighter.highlight(context);
+        assertNull("Should return null for null response", result);
+    }
+
+    public void testHighlightWithEmptyResponse() {
+        // Setup a custom mock for this test that returns empty list
+        MLCommonsClientAccessor emptyResponseClient = mock(MLCommonsClientAccessor.class);
+        QueryTextExtractorRegistry emptyRegistry = new QueryTextExtractorRegistry();
+        SemanticHighlighterEngine emptyResponseEngine = SemanticHighlighterEngine.builder()
+            .mlCommonsClient(emptyResponseClient)
+            .queryTextExtractorRegistry(emptyRegistry)
+            .build();
+
+        SemanticHighlighter customHighlighter = new SemanticHighlighter();
+        customHighlighter.initialize(emptyResponseEngine);
+
+        // Mock response that calls the listener with empty list
+        doAnswer(invocation -> {
+            ActionListener<List<Map<String, Object>>> listener = invocation.getArgument(1);
+            listener.onResponse(new ArrayList<>());
+            return null;
+        }).when(emptyResponseClient).inferenceSentenceHighlighting(any(SentenceHighlightingRequest.class), any());
+
+        // Create a context with a TermQuery instead of a mocked Query
+        TermQuery termQuery = new TermQuery(new Term(TEST_FIELD, "test"));
+        FieldHighlightContext context = createHighlightContext(TEST_CONTENT, termQuery);
+        setupDefaultHighlightTags(context);
+
+        // Should return null due to empty response
+        HighlightField result = customHighlighter.highlight(context);
+        assertNull("Should return null for empty response", result);
     }
 
     private FieldHighlightContext createHighlightContext(String fieldContent, String queryText) {

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -2288,4 +2288,44 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             null
         );
     }
+
+    /**
+     * Execute a search request with highlighting and custom tags
+     *
+     * @param index Index to search against
+     * @param queryBuilder queryBuilder to produce source of query
+     * @param resultSize number of results to return in the search
+     * @param highlightFields map of field names to highlight configurations
+     * @param highlightOptions global highlight options
+     * @param preTags array of pre-tags for highlighting
+     * @param postTags array of post-tags for highlighting
+     * @return Search results represented as a map
+     */
+    protected Map<String, Object> searchWithHighlight(
+        final String index,
+        final QueryBuilder queryBuilder,
+        final int resultSize,
+        final Map<String, Map<String, Object>> highlightFields,
+        final Map<String, Object> highlightOptions,
+        final String[] preTags,
+        final String[] postTags
+    ) {
+        return search(
+            index,
+            queryBuilder,
+            null,
+            resultSize,
+            Map.of(),
+            null,
+            null,
+            null,
+            false,
+            null,
+            0,
+            highlightFields,
+            highlightOptions,
+            Arrays.asList(preTags),
+            Arrays.asList(postTags)
+        );
+    }
 }

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -653,8 +653,8 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
      * @param from from parameter for pagination
      * @param highlightFields map of field names to highlight configurations
      * @param highlightOptions global highlight options
-     * @param sourceIncludes list of fields to include in _source
-     * @param sourceExcludes list of fields to exclude from _source
+     * @param preTags pre tag for highlight
+     * @param postTags post tag for highlight
      * @return Search results represented as a map
      */
     @SneakyThrows
@@ -672,8 +672,8 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         int from,
         Map<String, Map<String, Object>> highlightFields,
         Map<String, Object> highlightOptions,
-        List<String> sourceIncludes,
-        List<String> sourceExcludes
+        List<String> preTags,
+        List<String> postTags
     ) {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         builder.field("from", from);
@@ -739,7 +739,20 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
                 builder.field("options");
                 builder.map(highlightOptions);
             }
-
+            if (preTags != null && !preTags.isEmpty()) {
+                builder.startArray("pre_tags");
+                for (String preTag : preTags) {
+                    builder.value(preTag);
+                }
+                builder.endArray();
+            }
+            if (postTags != null && !postTags.isEmpty()) {
+                builder.startArray("post_tags");
+                for (String postTag : postTags) {
+                    builder.value(postTag);
+                }
+                builder.endArray();
+            }
             builder.endObject();
         }
 


### PR DESCRIPTION
### Description
This PR adds support for custom highlighting tags in the semantic highlighter, allowing users to specify their own pre and post tags for highlighting text while default tags are`<em>` and `</em>` if these parameter are not provided. These parameters schema are already supported in OpenSearch highlighter framework.

### Example API
```
curl -X POST "localhost:9200/neural-search-index/_search?pretty" -H 'Content-Type: application/json' -d '{
  "_source": {
    "excludes": ["text_embedding"]
  },
  "query": {
    "neural": {
      "text_embedding": {
        "query_text": "AI systems that can learn",
        "model_id": "'$text_embedding_model_id'",
        "k": 5
      }
    }
  },
  "highlight": {
    "fields": {
      "text": {
        "type": "semantic"
      }
    },
    "options": {
      "model_id": "'$sentence_model_id'"
    },
    "pre_tags": [
      "<strong>"
    ],
    "post_tags": [
      "</strong>"
    ]
  }
}'
```

### Related Issues
Part of https://github.com/opensearch-project/neural-search/issues/1182

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
