### PR TITLE
Fix the edge case when the value of a fieldMap key in ingestDocument is empty String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+- Add validations to prevent empty input_text_field and input_image_field in TextImageEmbeddingProcessor ([#1257](https://github.com/opensearch-project/neural-search/pull/1257))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -183,8 +183,26 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
             if (!sourceAndMetadataMap.containsKey(originalKey)) {
                 continue;
             }
-            if (!(sourceAndMetadataMap.get(originalKey) instanceof String)) {
-                throw new IllegalArgumentException("Unsupported format of the field in the document, value must be a string");
+
+            Object metaValue = sourceAndMetadataMap.get(originalKey);
+            if (Objects.isNull(metaValue)) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.getDefault(),
+                        "Unsupported format of the field in the document, %s value must be a non-empty string. Currently it is null",
+                        originalKey
+                    )
+                );
+            } else if ((metaValue instanceof String) == false || Objects.isNull(metaValue) || StringUtils.isBlank((String) metaValue)) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.getDefault(),
+                        "Unsupported format of the field in the document, %s value must be a non-empty string. Currently it is '%s'. Type is %s",
+                        originalKey,
+                        metaValue,
+                        metaValue.getClass()
+                    )
+                );
             }
             mapWithKnnKeys.put(originalKey, (String) sourceAndMetadataMap.get(originalKey));
         }


### PR DESCRIPTION
### Description
Currently if we create an ingest pipeline like this: 

```
{
  "description": "A text/image embedding pipeline",
  "processors": [
    {
      "text_image_embedding": {
        "model_id": "NXTU_pUBDuT6AlC02kKK",
        "embedding": "vector_embedding",
        "field_map": {
          "text": "input_text_field",
          "image": "input_image_field"
        }
      }
    }
  ]
}
```

And we simulate the pipeline like 

```
{
  "docs": [
    {
      "_index": "nlp-index-2",
      "_id": "1",
      "_source":{
	 "input_text_field": ""
         "input_image_field": ""
      }
    }
  ]
}
```

The MultiModal BedRock model actually would throw status exception

```
{
	"docs": [
		{
			"error": {
				"root_cause": [
					{
						"type": "status_exception",
						"reason": "Error from remote service: {\"message\":\"Malformed input request: #/inputText: expected minLength: 1, actual: 0, #/inputImage: expected minLength: 1, actual: 0, #: required key [requests] not found, #: extraneous key [inputText] is not permitted, #: extraneous key [inputImage] is not permitted, please reformat your input and try again.\"}"
					}
				],
				"type": "status_exception",
				"reason": "Error from remote service: {\"message\":\"Malformed input request: #/inputText: expected minLength: 1, actual: 0, #/inputImage: expected minLength: 1, actual: 0, #: required key [requests] not found, #: extraneous key [inputText] is not permitted, #: extraneous key [inputImage] is not permitted, please reformat your input and try again.\"}"
			}
		}
	]
}
``` 

So we would like to throw exception for such unhandled empty string value edge case.

#### After the Change

##### Input

```
{
  "docs": [
    {
      "_index": "nlp-index-2",
      "_id": "1",
      "_source":{
	"input_text_field": "",
        "input_image_field": "iVBORw0K..."
      }
    }
  ]
}
```

##### Output

```
{
	"docs": [
		{
			"error": {
				"root_cause": [
					{
						"type": "illegal_argument_exception",
						"reason": "Unsupported format of the field in the document, input_text_field value must be a non-empty string. Currently it is ''. Type is class java.lang.String"
					}
				],
				"type": "illegal_argument_exception",
				"reason": "Unsupported format of the field in the document, input_text_field value must be a non-empty string. Currently it is ''. Type is class java.lang.String"
			}
		}
	]
}
```

### Related Issues
Resolves #1239

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
