### PR TITLE
Update semantic highlighter test model

### DIFF
--- a/src/test/resources/highlight/UploadSentenceHighlightingModelRequestBody.json
+++ b/src/test/resources/highlight/UploadSentenceHighlightingModelRequestBody.json
@@ -5,7 +5,7 @@
   "description": "Sentence highlighting question answering model for testing",
   "model_format": "TORCH_SCRIPT",
   "model_group_id": "%s",
-  "model_content_hash_value": "84eddafdc1b23c13b2e4bbeb9d137aa7ae6b1aab37b91f99f4d9f9beb322a049",
+  "model_content_hash_value": "15e97d44ca59f6cd3e977398e38a9cea401eb87f360b92ca9dd8b30afd41f926",
   "url": "https://github.com/opensearch-project/ml-commons/blob/main/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/question_answering/sentence_highlighting_qa_model_pt.zip?raw=true",
   "model_config": {
     "model_type": "sentence_highlighting",

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -304,7 +304,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     @SneakyThrows
     protected String prepareSentenceHighlightingModel() {
         String requestBody = Files.readString(
-            Path.of(Objects.requireNonNull(classLoader.getResource("processor/UploadSentenceHighlightingModelRequestBody.json")).toURI())
+            Path.of(Objects.requireNonNull(classLoader.getResource("highlight/UploadSentenceHighlightingModelRequestBody.json")).toURI())
         );
         String modelId = registerModelGroupAndUploadModel(requestBody);
         loadModel(modelId);


### PR DESCRIPTION
### Description
Once after https://github.com/opensearch-project/ml-commons/pull/3699 merged, we need update the new model's hash value  for semantic highlighter integ test by this PR. Meanwhile moving the model config location to highlight resource folder.

~~Pending merge this PR util https://github.com/opensearch-project/ml-commons/pull/3699 merged. Current CI will be failed as expected.~~

https://github.com/opensearch-project/ml-commons/pull/3699 merged


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
