### PR TITLE
Support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ apply plugin: 'java-test-fixtures'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.pluginzip'
+apply plugin: 'opensearch.java-agent'
 apply plugin: 'jacoco'
 apply plugin: "com.diffplug.spotless"
 apply plugin: 'io.freefair.lombok'

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
@@ -47,7 +47,7 @@ public final class HybridQueryWeight extends Weight {
         super(hybridQuery);
         weights = hybridQuery.getSubQueries().stream().map(q -> {
             try {
-                return searcher.createWeight(q, scoreMode, boost);
+                return searcher.createWeight(q.rewrite(searcher), scoreMode, boost);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -4,4 +4,9 @@ grant {
     permission java.lang.RuntimePermission "accessDeclaredMembers";
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.lang.RuntimePermission "setContextClassLoader";
+
+    // for accessing Unix domain socket on windows
+    permission java.net.NetPermission "accessUnixDomainSocket";
+    // temporary for testing..
+    permission java.net.SocketPermission "*", "connect,resolve";
 };


### PR DESCRIPTION
### Description

Support phasing off SecurityManager usage in favor of Java Agent

This commit allows passing a JVM argument to allow plugins test execute under Java Agent.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
