### PR TITLE
Hybrid query should call rewrite before creating weight

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
@@ -47,7 +47,7 @@ public final class HybridQueryWeight extends Weight {
         super(hybridQuery);
         weights = hybridQuery.getSubQueries().stream().map(q -> {
             try {
-                return searcher.createWeight(q.rewrite(searcher), scoreMode, boost);
+                return searcher.createWeight(searcher.rewrite(q), scoreMode, boost);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
@@ -47,7 +47,7 @@ public final class HybridQueryWeight extends Weight {
         super(hybridQuery);
         weights = hybridQuery.getSubQueries().stream().map(q -> {
             try {
-                return searcher.createWeight(q, scoreMode, boost);
+                return searcher.createWeight(q.rewrite(searcher), scoreMode, boost);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -117,6 +117,7 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
         assertTrue(querySpecs.stream().anyMatch(spec -> HybridQueryBuilder.NAME.equals(spec.getName().getPreferredName())));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/neural-search/pull/1268")
     public void testQueryPhaseSearcher() {
         Optional<QueryPhaseSearcher> queryPhaseSearcherWithFeatureFlagDisabled = plugin.getQueryPhaseSearcher();
 

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -117,7 +117,7 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
         assertTrue(querySpecs.stream().anyMatch(spec -> HybridQueryBuilder.NAME.equals(spec.getName().getPreferredName())));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/neural-search/pull/1268")
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/17940")
     public void testQueryPhaseSearcher() {
         Optional<QueryPhaseSearcher> queryPhaseSearcherWithFeatureFlagDisabled = plugin.getQueryPhaseSearcher();
 


### PR DESCRIPTION
### Description
We should always be calling `#rewrite` before we create query weight from `IndexSearcher`

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
