### PR TITLE
Fixed score value as null for single shard for sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 - Add validations to prevent empty input_text_field and input_image_field in TextImageEmbeddingProcessor ([#1257](https://github.com/opensearch-project/neural-search/pull/1257))
+- Fix score value as null for single shard when sorting is not done on score field ([#1277](https://github.com/opensearch-project/neural-search/pull/1277))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -86,6 +86,7 @@ public class NormalizationProcessorWorkflow {
             .querySearchResults(querySearchResults)
             .sort(evaluateSortCriteria(querySearchResults, queryTopDocs))
             .fromValueForSingleShard(getFromValueIfSingleShard(request))
+            .isSingleShard(getIsSingleShard(request))
             .build();
 
         // combine
@@ -101,6 +102,11 @@ public class NormalizationProcessorWorkflow {
             unprocessedDocIds,
             combineScoresDTO.getFromValueForSingleShard()
         );
+    }
+
+    private boolean getIsSingleShard(final NormalizationProcessorWorkflowExecuteRequest request) {
+        final SearchPhaseContext searchPhaseContext = request.getSearchPhaseContext();
+        return searchPhaseContext.getNumShards() == 1;
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -106,7 +106,7 @@ public class NormalizationProcessorWorkflow {
 
     private boolean getIsSingleShard(final NormalizationProcessorWorkflowExecuteRequest request) {
         final SearchPhaseContext searchPhaseContext = request.getSearchPhaseContext();
-        return searchPhaseContext.getNumShards() == 1;
+        return searchPhaseContext.getNumShards() == 1 || request.fetchSearchResultOptional.isEmpty() == false;
     }
 
     /**
@@ -116,7 +116,7 @@ public class NormalizationProcessorWorkflow {
      */
     private int getFromValueIfSingleShard(final NormalizationProcessorWorkflowExecuteRequest request) {
         final SearchPhaseContext searchPhaseContext = request.getSearchPhaseContext();
-        if (searchPhaseContext.getNumShards() > 1 || request.fetchSearchResultOptional.isEmpty()) {
+        if (getIsSingleShard(request) == false) {
             return -1;
         }
         int from = searchPhaseContext.getRequest().source().from();

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/CombineScoresDto.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/CombineScoresDto.java
@@ -30,4 +30,5 @@ public class CombineScoresDto {
     @Nullable
     private Sort sort;
     private int fromValueForSingleShard;
+    private boolean isSingleShard;
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
@@ -261,7 +261,7 @@ public class ScoreCombiner {
         final boolean isSortEnabled = sort != null;
         final boolean isSortByScore = isSortOrderByScore(sort);
         // Case when sort is enabled on single shard and sorting is not done on score field
-        if (isSortEnabled && !isSortByScore && isSingleShard) {
+        if (isSortEnabled && isSortByScore == false && isSingleShard) {
             return new FieldDoc(docId, Float.NaN, docIdSortFieldMap.get(docId), shardId);
         }
         if (isSortEnabled && docIdSortFieldMap != null) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
@@ -228,7 +228,7 @@ public class ScoreCombiner {
         final Collection<Integer> sortedScores,
         final long maxHits,
         final Map<Integer, Object[]> docIdSortFieldMap,
-        Sort sort,
+        final Sort sort,
         final boolean isSingleShard
     ) {
 
@@ -251,7 +251,7 @@ public class ScoreCombiner {
     }
 
     private ScoreDoc getScoreDoc(
-        Sort sort,
+        final Sort sort,
         final int docId,
         final int shardId,
         final Map<Integer, Float> combinedNormalizedScoresByDocId,
@@ -301,7 +301,7 @@ public class ScoreCombiner {
         final Map<Integer, Float> combinedNormalizedScoresByDocId,
         final Collection<Integer> sortedScores,
         Map<Integer, Object[]> docIdSortFieldMap,
-        Sort sort,
+        final Sort sort,
         final boolean isSingleShard
     ) {
         // - max number of hits will be the same which are passed from QueryPhase

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
@@ -72,14 +72,16 @@ public class ScoreCombiner {
         // multiple sub queries, doc ids may repeat for each sub query results
         ScoreCombinationTechnique scoreCombinationTechnique = combineScoresDTO.getScoreCombinationTechnique();
         Sort sort = combineScoresDTO.getSort();
+        boolean isSingleShard = combineScoresDTO.isSingleShard();
         combineScoresDTO.getQueryTopDocs()
-            .forEach(compoundQueryTopDocs -> combineShardScores(scoreCombinationTechnique, compoundQueryTopDocs, sort));
+            .forEach(compoundQueryTopDocs -> combineShardScores(scoreCombinationTechnique, compoundQueryTopDocs, sort, isSingleShard));
     }
 
     private void combineShardScores(
         final ScoreCombinationTechnique scoreCombinationTechnique,
         final CompoundTopDocs compoundQueryTopDocs,
-        final Sort sort
+        final Sort sort,
+        final boolean isSingleShard
     ) {
         if (Objects.isNull(compoundQueryTopDocs) || compoundQueryTopDocs.getTotalHits().value() == 0) {
             return;
@@ -106,7 +108,8 @@ public class ScoreCombiner {
             combinedNormalizedScoresByDocId,
             sortedDocsIds,
             getDocIdSortFieldsMap(compoundQueryTopDocs, combinedNormalizedScoresByDocId, sort),
-            sort != null
+            sort,
+            isSingleShard
         );
     }
 
@@ -225,8 +228,10 @@ public class ScoreCombiner {
         final Collection<Integer> sortedScores,
         final long maxHits,
         final Map<Integer, Object[]> docIdSortFieldMap,
-        boolean isSortingEnabled
+        Sort sort,
+        final boolean isSingleShard
     ) {
+
         // ShardId will be -1 when index has multiple shards
         int shardId = -1;
         // ShardId will not be -1 in when index has single shard because Fetch phase gets executed before Normalization
@@ -239,19 +244,26 @@ public class ScoreCombiner {
             if (hitCount == maxHits) {
                 break;
             }
-            scoreDocs.add(getScoreDoc(isSortingEnabled, docId, shardId, combinedNormalizedScoresByDocId, docIdSortFieldMap));
+            scoreDocs.add(getScoreDoc(sort, docId, shardId, combinedNormalizedScoresByDocId, docIdSortFieldMap, isSingleShard));
             hitCount++;
         }
         return scoreDocs;
     }
 
     private ScoreDoc getScoreDoc(
-        final boolean isSortEnabled,
+        Sort sort,
         final int docId,
         final int shardId,
         final Map<Integer, Float> combinedNormalizedScoresByDocId,
-        final Map<Integer, Object[]> docIdSortFieldMap
+        final Map<Integer, Object[]> docIdSortFieldMap,
+        final boolean isSingleShard
     ) {
+        final boolean isSortEnabled = sort != null;
+        final boolean isSortByScore = isSortOrderByScore(sort);
+        // Case when sort is enabled on single shard and sorting is not done on score field
+        if (isSortEnabled && !isSortByScore && isSingleShard) {
+            return new FieldDoc(docId, Float.NaN, docIdSortFieldMap.get(docId), shardId);
+        }
         if (isSortEnabled && docIdSortFieldMap != null) {
             return new FieldDoc(docId, combinedNormalizedScoresByDocId.get(docId), docIdSortFieldMap.get(docId), shardId);
         }
@@ -289,7 +301,8 @@ public class ScoreCombiner {
         final Map<Integer, Float> combinedNormalizedScoresByDocId,
         final Collection<Integer> sortedScores,
         Map<Integer, Object[]> docIdSortFieldMap,
-        boolean isSortingEnabled
+        Sort sort,
+        final boolean isSingleShard
     ) {
         // - max number of hits will be the same which are passed from QueryPhase
         long maxHits = compoundQueryTopDocs.getTotalHits().value();
@@ -301,7 +314,8 @@ public class ScoreCombiner {
                 sortedScores,
                 maxHits,
                 docIdSortFieldMap,
-                isSortingEnabled
+                sort,
+                isSingleShard
             )
         );
         compoundQueryTopDocs.setTotalHits(getTotalHits(topDocsPerSubQuery, maxHits));


### PR DESCRIPTION
### Description
Fixed score value as null for single shard for sorting when sort field is not score. This mimics the current OpenSearch behavior 

```json
{
    "took": 3291,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 5,
            "relation": "eq"
        },
        "max_score": null,
        "hits": [
            {
                "_index": "my-test1",
                "_id": "5",
                "_score": null,
                "_source": {
                    "content_text": "zoo exhibits",
                    "content_vector": [
                        0.11,
                        0.44
                    ]
                },
                "sort": [
                    "5"
                ]
            },
            {
                "_index": "my-test1",
                "_id": "4",
                "_score": null,
                "_source": {
                    "content_text": "wildlife park",
                    "content_vector": [
                        0.14,
                        0.42
                    ]
                },
                "sort": [
                    "4"
                ]
            },
            {
                "_index": "my-test1",
                "_id": "3",
                "_score": null,
                "_source": {
                    "content_text": "zoo keeper",
                    "content_vector": [
                        0.15,
                        0.48
                    ]
                },
                "sort": [
                    "3"
                ]
            },
            {
                "_index": "my-test1",
                "_id": "2",
                "_score": null,
                "_source": {
                    "content_text": "aquarium fish",
                    "content_vector": [
                        0.12,
                        -0.34
                    ]
                },
                "sort": [
                    "2"
                ]
            },
            {
                "_index": "my-test1",
                "_id": "1",
                "_score": null,
                "_source": {
                    "content_text": "zoo animals",
                    "content_vector": [
                        0.13,
                        0.45
                    ]
                },
                "sort": [
                    "1"
                ]
            }
        ]
    }
}
```

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/1274

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
