### PR TITLE
Add IT for neural sparse query + bert-uncased mbert-uncased analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.x](https://github.com/opensearch-project/neural-search/compare/main...HEAD)
 
 ### Features
-- Implement analyzer based neural sparse query ([#1088](https://github.com/opensearch-project/neural-search/pull/1088))
+- Implement analyzer based neural sparse query ([#1088](https://github.com/opensearch-project/neural-search/pull/1088) [#1279](https://github.com/opensearch-project/neural-search/pull/1279))
 - [Semantic Field] Add semantic field mapper. ([#1225](https://github.com/opensearch-project/neural-search/pull/1225)).
 
 ### Enhancements

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralSparseQueryIT.java
@@ -100,6 +100,24 @@ public class NeuralSparseQueryIT extends BaseNeuralSearchIT {
             assertEquals("1", firstInnerHit.get("_id"));
             float expectedScore = 2 * computeExpectedScore(testRankFeaturesDoc, Map.of("hello", 1f, "world", 1f, "a", 1f, "b", 1f));
             assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
+
+            sparseEncodingQueryBuilder.analyzer("bert-uncased");
+            Map<String, Object> searchResponseAsMap2 = search(TEST_BASIC_INDEX_NAME, sparseEncodingQueryBuilder, 1);
+            Map<String, Object> firstInnerHit2 = getFirstInnerHit(searchResponseAsMap2);
+            expectedScore = 2 * computeExpectedScore(
+                testRankFeaturesDoc,
+                Map.of("hello", 6.937756538391113f, "world", 3.4208686351776123f, "a", 0.4022789001464844f, "b", 3.7727110385894775f)
+            );
+            assertEquals(expectedScore, objectToFloat(firstInnerHit2.get("_score")), DELTA);
+
+            sparseEncodingQueryBuilder.analyzer("mbert-uncased");
+            Map<String, Object> searchResponseAsMap3 = search(TEST_BASIC_INDEX_NAME, sparseEncodingQueryBuilder, 1);
+            Map<String, Object> firstInnerHit3 = getFirstInnerHit(searchResponseAsMap3);
+            expectedScore = 2 * computeExpectedScore(
+                testRankFeaturesDoc,
+                Map.of("hello", 3.848525285720825f, "world", 1.5188000202178955f, "a", 1.054316759109497f, "b", 2.0035440921783447f)
+            );
+            assertEquals(expectedScore, objectToFloat(firstInnerHit3.get("_score")), DELTA);
         } finally {
             wipeOfTestResources(TEST_BASIC_INDEX_NAME, null, null, null);
         }


### PR DESCRIPTION
### Description
The [PR](https://github.com/opensearch-project/ml-commons/pull/3719) to add `bert-uncased` and `mbert-uncased` analyzer is merged.

Add IT of neural sparse + these 2 analyzers.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
