### PR TITLE
[Performance Improvement] Add custom bulk scorer for hybrid query (2-3x faster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Semantic Field] Add semantic ingest processor. ([#1309](https://github.com/opensearch-project/neural-search/pull/1309))
 
 ### Enhancements
+- [Performance Improvement] Add custom bulk scorer for hybrid query (2-3x faster) ([#1289](https://github.com/opensearch-project/neural-search/pull/1289))
 
 ### Bug Fixes
 - Fix score value as null for single shard when sorting is not done on score field ([#1277](https://github.com/opensearch-project/neural-search/pull/1277))

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchRelevancyIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchRelevancyIT.java
@@ -2,9 +2,9 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package org.opensearch.neuralsearch.bwc.rolling;
 
+import org.opensearch.common.Randomness;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
@@ -34,58 +34,58 @@ public class HybridSearchRelevancyIT extends AbstractRollingUpgradeTestCase {
 
     // Arrays of words to generate random meaningful content
     private static final String[] SUBJECTS = {
-            "Machine learning",
-            "Deep learning",
-            "Neural networks",
-            "Artificial intelligence",
-            "Data science",
-            "Natural language processing",
-            "Computer vision",
-            "Robotics",
-            "Big data",
-            "Cloud computing",
-            "Edge computing",
-            "Internet of Things" };
+        "Machine learning",
+        "Deep learning",
+        "Neural networks",
+        "Artificial intelligence",
+        "Data science",
+        "Natural language processing",
+        "Computer vision",
+        "Robotics",
+        "Big data",
+        "Cloud computing",
+        "Edge computing",
+        "Internet of Things" };
 
     private static final String[] VERBS = {
-            "analyzes",
-            "processes",
-            "transforms",
-            "improves",
-            "optimizes",
-            "enhances",
-            "revolutionizes",
-            "accelerates",
-            "streamlines",
-            "powers",
-            "enables",
-            "drives" };
+        "analyzes",
+        "processes",
+        "transforms",
+        "improves",
+        "optimizes",
+        "enhances",
+        "revolutionizes",
+        "accelerates",
+        "streamlines",
+        "powers",
+        "enables",
+        "drives" };
 
     private static final String[] OBJECTS = {
-            "data processing",
-            "pattern recognition",
-            "decision making",
-            "business operations",
-            "computational tasks",
-            "system performance",
-            "automation processes",
-            "data analysis",
-            "resource utilization",
-            "technological innovation",
-            "software development",
-            "cloud infrastructure" };
+        "data processing",
+        "pattern recognition",
+        "decision making",
+        "business operations",
+        "computational tasks",
+        "system performance",
+        "automation processes",
+        "data analysis",
+        "resource utilization",
+        "technological innovation",
+        "software development",
+        "cloud infrastructure" };
 
     private static final String[] MODIFIERS = {
-            "efficiently",
-            "rapidly",
-            "intelligently",
-            "automatically",
-            "significantly",
-            "dramatically",
-            "consistently",
-            "reliably",
-            "effectively",
-            "seamlessly" };
+        "efficiently",
+        "rapidly",
+        "intelligently",
+        "automatically",
+        "significantly",
+        "dramatically",
+        "consistently",
+        "reliably",
+        "effectively",
+        "seamlessly" };
 
     public void testSearchHitsAfterNormalization_whenIndexWithMultipleShards_E2EFlow() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
@@ -97,19 +97,19 @@ public class HybridSearchRelevancyIT extends AbstractRollingUpgradeTestCase {
                 loadModel(modelId);
                 createPipelineProcessor(modelId, PIPELINE_NAME);
                 createIndexWithConfiguration(
-                        indexName,
-                        Files.readString(Path.of(classLoader.getResource("processor/IndexMappings.json").toURI())),
-                        PIPELINE_NAME
+                    indexName,
+                    Files.readString(Path.of(classLoader.getResource("processor/IndexMappings.json").toURI())),
+                    PIPELINE_NAME
                 );
                 // ingest test documents
                 for (int i = 0; i < testDocuments.length; i++) {
                     addDocument(indexName, String.valueOf(i), TEST_FIELD, testDocuments[i], null, null);
                 }
                 createSearchPipeline(
-                        SEARCH_PIPELINE_NAME,
-                        "l2",
-                        "arithmetic_mean",
-                        Map.of("weights", Arrays.toString(new float[] { 0.5f, 0.5f }))
+                    SEARCH_PIPELINE_NAME,
+                    "l2",
+                    "arithmetic_mean",
+                    Map.of("weights", Arrays.toString(new float[] { 0.5f, 0.5f }))
                 );
 
                 // execute hybrid query and store results
@@ -150,7 +150,7 @@ public class HybridSearchRelevancyIT extends AbstractRollingUpgradeTestCase {
 
     private String[] generateTestDocuments(int count) {
         String[] documents = new String[count];
-        Random random = new Random();
+        Random random = Randomness.get();
 
         for (int i = 0; i < count; i++) {
             String subject = SUBJECTS[random.nextInt(SUBJECTS.length)];
@@ -162,19 +162,19 @@ public class HybridSearchRelevancyIT extends AbstractRollingUpgradeTestCase {
             boolean includeModifier = random.nextDouble() < 0.7;
 
             documents[i] = includeModifier
-                    ? String.format("%s %s %s %s", subject, verb, object, modifier)
-                    : String.format("%s %s %s", subject, verb, object);
+                ? String.format(Locale.ROOT, "%s %s %s %s", subject, verb, object, modifier)
+                : String.format(Locale.ROOT, "%s %s %s", subject, verb, object);
         }
         return documents;
     }
 
     private HybridQueryBuilder createHybridQuery(String modelId, String queryText) {
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
-                .fieldName(VECTOR_EMBEDDING_FIELD)
-                .modelId(modelId)
-                .queryText(queryText)
-                .k(10 * NUM_DOCS)
-                .build();
+            .fieldName(VECTOR_EMBEDDING_FIELD)
+            .modelId(modelId)
+            .queryText(queryText)
+            .k(10 * NUM_DOCS)
+            .build();
 
         MatchQueryBuilder matchQueryBuilder = new MatchQueryBuilder("text", queryText);
 
@@ -188,11 +188,11 @@ public class HybridSearchRelevancyIT extends AbstractRollingUpgradeTestCase {
     private void getAndAssertQueryResults(HybridQueryBuilder queryBuilder, String modelId, int queryResultSize) throws Exception {
         loadModel(modelId);
         Map<String, Object> searchResponseAsMap = search(
-                getIndexNameForTest(),
-                queryBuilder,
-                null,
-                queryResultSize,
-                Map.of("search_pipeline", SEARCH_PIPELINE_NAME)
+            getIndexNameForTest(),
+            queryBuilder,
+            null,
+            queryResultSize,
+            Map.of("search_pipeline", SEARCH_PIPELINE_NAME)
         );
         int hits = getHitCount(searchResponseAsMap);
         assertEquals(queryResultSize, hits);

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchRelevancyIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchRelevancyIT.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.neuralsearch.bwc.rolling;
+
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.opensearch.neuralsearch.util.TestUtils.NODES_BWC_CLUSTER;
+import static org.opensearch.neuralsearch.util.TestUtils.TEXT_EMBEDDING_PROCESSOR;
+import static org.opensearch.neuralsearch.util.TestUtils.getModelId;
+
+public class HybridSearchRelevancyIT extends AbstractRollingUpgradeTestCase {
+    private static final String PIPELINE_NAME = "neural-pipeline";
+    private static final String SEARCH_PIPELINE_NAME = "hybrid-search-pipeline";
+    private static final String TEST_FIELD = "passage_text";
+    private static final int NUM_DOCS = 100;
+    private static final String VECTOR_EMBEDDING_FIELD = "passage_embedding";
+    private static final String QUERY_TEXT = "machine learning patterns";
+    private String modelId;
+
+    // Arrays of words to generate random meaningful content
+    private static final String[] SUBJECTS = {
+            "Machine learning",
+            "Deep learning",
+            "Neural networks",
+            "Artificial intelligence",
+            "Data science",
+            "Natural language processing",
+            "Computer vision",
+            "Robotics",
+            "Big data",
+            "Cloud computing",
+            "Edge computing",
+            "Internet of Things" };
+
+    private static final String[] VERBS = {
+            "analyzes",
+            "processes",
+            "transforms",
+            "improves",
+            "optimizes",
+            "enhances",
+            "revolutionizes",
+            "accelerates",
+            "streamlines",
+            "powers",
+            "enables",
+            "drives" };
+
+    private static final String[] OBJECTS = {
+            "data processing",
+            "pattern recognition",
+            "decision making",
+            "business operations",
+            "computational tasks",
+            "system performance",
+            "automation processes",
+            "data analysis",
+            "resource utilization",
+            "technological innovation",
+            "software development",
+            "cloud infrastructure" };
+
+    private static final String[] MODIFIERS = {
+            "efficiently",
+            "rapidly",
+            "intelligently",
+            "automatically",
+            "significantly",
+            "dramatically",
+            "consistently",
+            "reliably",
+            "effectively",
+            "seamlessly" };
+
+    public void testSearchHitsAfterNormalization_whenIndexWithMultipleShards_E2EFlow() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        String indexName = getIndexNameForTest();
+        String[] testDocuments = generateTestDocuments(NUM_DOCS);
+        switch (getClusterType()) {
+            case OLD:
+                modelId = uploadTextEmbeddingModel();
+                loadModel(modelId);
+                createPipelineProcessor(modelId, PIPELINE_NAME);
+                createIndexWithConfiguration(
+                        indexName,
+                        Files.readString(Path.of(classLoader.getResource("processor/IndexMappings.json").toURI())),
+                        PIPELINE_NAME
+                );
+                // ingest test documents
+                for (int i = 0; i < testDocuments.length; i++) {
+                    addDocument(indexName, String.valueOf(i), TEST_FIELD, testDocuments[i], null, null);
+                }
+                createSearchPipeline(
+                        SEARCH_PIPELINE_NAME,
+                        "l2",
+                        "arithmetic_mean",
+                        Map.of("weights", Arrays.toString(new float[] { 0.5f, 0.5f }))
+                );
+
+                // execute hybrid query and store results
+                HybridQueryBuilder hybridQueryBuilder = createHybridQuery(modelId, QUERY_TEXT);
+                getAndAssertQueryResults(hybridQueryBuilder, modelId, NUM_DOCS);
+                break;
+            case MIXED:
+                modelId = getModelId(getIngestionPipeline(PIPELINE_NAME), TEXT_EMBEDDING_PROCESSOR);
+                HybridQueryBuilder mixedClusterQuery = createHybridQuery(modelId, QUERY_TEXT);
+                if (isFirstMixedRound()) {
+                    getAndAssertQueryResults(mixedClusterQuery, modelId, NUM_DOCS);
+                    String[] testDocumentsAfterMixedUpgrade = generateTestDocuments(NUM_DOCS);
+                    for (int i = 0; i < testDocumentsAfterMixedUpgrade.length; i++) {
+                        addDocument(indexName, String.valueOf(NUM_DOCS + i), TEST_FIELD, testDocumentsAfterMixedUpgrade[i], null, null);
+                    }
+                } else {
+                    getAndAssertQueryResults(mixedClusterQuery, modelId, 2 * NUM_DOCS);
+                }
+                break;
+            case UPGRADED:
+                try {
+                    modelId = getModelId(getIngestionPipeline(PIPELINE_NAME), TEXT_EMBEDDING_PROCESSOR);
+                    loadModel(modelId);
+                    String[] testDocumentsAfterFullUpgrade = generateTestDocuments(NUM_DOCS);
+                    for (int i = 0; i < testDocumentsAfterFullUpgrade.length; i++) {
+                        addDocument(indexName, String.valueOf(2 * NUM_DOCS + i), TEST_FIELD, testDocumentsAfterFullUpgrade[i], null, null);
+                    }
+                    HybridQueryBuilder upgradedClusterQuery = createHybridQuery(modelId, QUERY_TEXT);
+                    getAndAssertQueryResults(upgradedClusterQuery, modelId, 3 * NUM_DOCS);
+                } finally {
+                    wipeOfTestResources(getIndexNameForTest(), PIPELINE_NAME, modelId, SEARCH_PIPELINE_NAME);
+                }
+                break;
+            default:
+                throw new IllegalStateException(String.format(Locale.ROOT, "Unexpected value: %s", getClusterType()));
+        }
+    }
+
+    private String[] generateTestDocuments(int count) {
+        String[] documents = new String[count];
+        Random random = new Random();
+
+        for (int i = 0; i < count; i++) {
+            String subject = SUBJECTS[random.nextInt(SUBJECTS.length)];
+            String verb = VERBS[random.nextInt(VERBS.length)];
+            String object = OBJECTS[random.nextInt(OBJECTS.length)];
+            String modifier = MODIFIERS[random.nextInt(MODIFIERS.length)];
+
+            // randomly decide whether to add a modifier (70% chance)
+            boolean includeModifier = random.nextDouble() < 0.7;
+
+            documents[i] = includeModifier
+                    ? String.format("%s %s %s %s", subject, verb, object, modifier)
+                    : String.format("%s %s %s", subject, verb, object);
+        }
+        return documents;
+    }
+
+    private HybridQueryBuilder createHybridQuery(String modelId, String queryText) {
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(VECTOR_EMBEDDING_FIELD)
+                .modelId(modelId)
+                .queryText(queryText)
+                .k(10 * NUM_DOCS)
+                .build();
+
+        MatchQueryBuilder matchQueryBuilder = new MatchQueryBuilder("text", queryText);
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(matchQueryBuilder);
+        hybridQueryBuilder.add(neuralQueryBuilder);
+
+        return hybridQueryBuilder;
+    }
+
+    private void getAndAssertQueryResults(HybridQueryBuilder queryBuilder, String modelId, int queryResultSize) throws Exception {
+        loadModel(modelId);
+        Map<String, Object> searchResponseAsMap = search(
+                getIndexNameForTest(),
+                queryBuilder,
+                null,
+                queryResultSize,
+                Map.of("search_pipeline", SEARCH_PIPELINE_NAME)
+        );
+        int hits = getHitCount(searchResponseAsMap);
+        assertEquals(queryResultSize, hits);
+
+        List<Double> normalizedScores = getNormalizationScoreList(searchResponseAsMap);
+        assertQueryScores(normalizedScores, queryResultSize);
+        List<String> normalizedDocIds = getNormalizationDocIdList(searchResponseAsMap);
+        assertQueryDocIds(normalizedDocIds, queryResultSize);
+    }
+
+    private void assertQueryScores(List<Double> queryScores, int queryResultSize) {
+        assertNotNull(queryScores);
+        assertEquals(queryResultSize, queryScores.size());
+
+        // check scores are in descending order
+        for (int i = 0; i < queryScores.size() - 1; i++) {
+            double currentScore = queryScores.get(i);
+            double nextScore = queryScores.get(i + 1);
+            assertTrue("scores not in descending order", currentScore >= nextScore);
+        }
+    }
+
+    private void assertQueryDocIds(List<String> querDocIds, int queryResultSize) {
+        assertNotNull(querDocIds);
+        assertEquals(queryResultSize, querDocIds.size());
+
+        // check document IDs are unique
+        Set<String> uniqueDocIds = new HashSet<>();
+        for (String docId : querDocIds) {
+            assertTrue("duplicate document ID found", uniqueDocIds.add(docId));
+        }
+        assertEquals("number of unique document IDs doesn't match expected count", queryResultSize, uniqueDocIds.size());
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridBulkScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridBulkScorer.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.Getter;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Bulk scorer for hybrid query
+ */
+public class HybridBulkScorer extends BulkScorer {
+    private static final int SHIFT = 12;
+    private static final int WINDOW_SIZE = 1 << SHIFT;
+    private static final int MASK = WINDOW_SIZE - 1;
+
+    private final long cost;
+    private final Scorer[] scorers;
+    @Getter
+    private final HybridSubQueryScorer hybridSubQueryScorer;
+    private final boolean needsScores;
+    @Getter
+    private final FixedBitSet matching;
+    @Getter
+    private final float[][] windowScores;
+    private final HybridQueryDocIdStream hybridQueryDocIdStream;
+    private final int maxDoc;
+
+    /**
+     * Constructor for HybridBulkScorer
+     * @param scorers list of scorers for each sub query
+     * @param needsScores whether the scorer needs scores
+     * @param maxDoc maximum document id
+     */
+    public HybridBulkScorer(List<Scorer> scorers, boolean needsScores, int maxDoc) {
+        long cost = 0;
+        this.scorers = new Scorer[scorers.size()];
+        for (int subQueryIndex = 0; subQueryIndex < scorers.size(); subQueryIndex++) {
+            Scorer scorer = scorers.get(subQueryIndex);
+            if (Objects.isNull(scorer)) {
+                continue;
+            }
+            cost += scorer.iterator().cost();
+            this.scorers[subQueryIndex] = scorer;
+        }
+        this.cost = cost;
+        this.hybridSubQueryScorer = new HybridSubQueryScorer(scorers.size());
+        this.needsScores = needsScores;
+        this.matching = new FixedBitSet(WINDOW_SIZE);
+        this.windowScores = new float[this.scorers.length][WINDOW_SIZE];
+        this.maxDoc = maxDoc;
+        this.hybridQueryDocIdStream = new HybridQueryDocIdStream(this);
+    }
+
+    @Override
+    public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+        collector.setScorer(hybridSubQueryScorer);
+        // making sure we are not going over the global limit defined by maxDoc
+        max = Math.min(max, maxDoc);
+        int[] docsIds = advance(min, scorers);
+        while (allDocIdsUsed(docsIds, max) == false) {
+            scoreWindow(collector, acceptDocs, min, max, docsIds);
+        }
+        return getNextDocIdCandidate(docsIds);
+    }
+
+    private void scoreWindow(LeafCollector collector, Bits acceptDocs, int min, int max, int[] docIds) throws IOException {
+        // pick the lowest out of all not yet used doc ids
+        int topDoc = -1;
+        for (int docId : docIds) {
+            if (docId < max) {
+                topDoc = docId;
+                break;
+            }
+        }
+
+        final int windowBase = topDoc & ~MASK; // take the next match (at random) and find the window where it belongs
+        final int windowMin = Math.max(min, windowBase);
+        final int windowMax = Math.min(max, windowBase + WINDOW_SIZE);
+
+        scoreWindowIntoBitSetWithSubqueryScorers(collector, acceptDocs, max, docIds, windowMin, windowMax, windowBase);
+    }
+
+    private void scoreWindowIntoBitSetWithSubqueryScorers(
+        LeafCollector collector,
+        Bits acceptDocs,
+        int max,
+        int[] docIds,
+        int windowMin,
+        int windowMax,
+        int windowBase
+    ) throws IOException {
+        for (int subQueryIndex = 0; subQueryIndex < scorers.length; subQueryIndex++) {
+            if (Objects.isNull(scorers[subQueryIndex]) || docIds[subQueryIndex] >= max) {
+                continue;
+            }
+            DocIdSetIterator it = scorers[subQueryIndex].iterator();
+            int doc = docIds[subQueryIndex];
+            if (doc < windowMin) {
+                doc = it.advance(windowMin);
+            }
+            while (doc < windowMax) {
+                if (Objects.isNull(acceptDocs) || acceptDocs.get(doc)) {
+                    int d = doc & MASK;
+                    if (needsScores) {
+                        float score = scorers[subQueryIndex].score();
+                        // collect score only in case it's gt competitive score
+                        if (score > hybridSubQueryScorer.getMinScores()[subQueryIndex]) {
+                            matching.set(d);
+                            windowScores[subQueryIndex][d] = score;
+                        }
+                    } else {
+                        matching.set(d);
+                    }
+                }
+                doc = it.nextDoc();
+            }
+            docIds[subQueryIndex] = doc;
+        }
+
+        hybridQueryDocIdStream.setBase(windowBase);
+        collector.collect(hybridQueryDocIdStream);
+
+        resetWindowState();
+    }
+
+    private int[] advance(int min, Scorer[] scorers) throws IOException {
+        int[] docIds = new int[scorers.length];
+        for (int subQueryIndex = 0; subQueryIndex < scorers.length; subQueryIndex++) {
+            if (Objects.isNull(scorers[subQueryIndex])) {
+                docIds[subQueryIndex] = DocIdSetIterator.NO_MORE_DOCS;
+                continue;
+            }
+            DocIdSetIterator it = scorers[subQueryIndex].iterator();
+            int doc = it.docID();
+            if (doc < min) {
+                doc = it.advance(min);
+            }
+            docIds[subQueryIndex] = doc;
+        }
+        return docIds;
+    }
+
+    private boolean allDocIdsUsed(int[] docsIds, int max) {
+        for (int docId : docsIds) {
+            if (docId < max) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private int getNextDocIdCandidate(final int[] docsIds) {
+        int nextDoc = -1;
+        for (int doc : docsIds) {
+            if (doc != DocIdSetIterator.NO_MORE_DOCS) {
+                nextDoc = Math.max(nextDoc, doc);
+            }
+        }
+        return nextDoc == -1 ? DocIdSetIterator.NO_MORE_DOCS : nextDoc;
+    }
+
+    /**
+     * Reset the internal state for the next window of documents
+     */
+    private void resetWindowState() {
+        matching.clear();
+
+        for (float[] windowScore : windowScores) {
+            Arrays.fill(windowScore, 0.0f);
+        }
+    }
+
+    @Override
+    public long cost() {
+        return cost;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.lucene.search.CheckedIntConsumer;
+import org.apache.lucene.search.DocIdStream;
+import org.apache.lucene.util.FixedBitSet;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * This class is used to create a DocIdStream for HybridQuery
+ */
+@RequiredArgsConstructor
+public class HybridQueryDocIdStream extends DocIdStream {
+    private final HybridBulkScorer hybridBulkScorer;
+    @Setter
+    private int base;
+
+    /**
+     * Iterate over all doc ids and collect each doc id with leaf collector
+     * @param consumer consumer that is called for each accepted doc id
+     * @throws IOException in case of IO exception
+     */
+    @Override
+    public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
+        // bitset that represents matching documents, bit is set (1) if doc id is a match
+        FixedBitSet matchingBitSet = hybridBulkScorer.getMatching();
+        long[] bitArray = matchingBitSet.getBits();
+        // iterate through each block of 64 documents (since each long contains 64 bits)
+        for (int idx = 0; idx < bitArray.length; idx++) {
+            long bits = bitArray[idx];
+            while (bits != 0L) {
+                // find position of the rightmost set bit (1)
+                int numberOfTrailingZeros = Long.numberOfTrailingZeros(bits);
+                // calculate actual document ID within the window
+                // idx << 6 is equivalent to idx * 64 (block offset)
+                // numberOfTrailingZeros gives position within the block
+                final int docIndexInWindow = (idx << 6) | numberOfTrailingZeros;
+                float[][] windowScores = hybridBulkScorer.getWindowScores();
+                for (int subQueryIndex = 0; subQueryIndex < windowScores.length; subQueryIndex++) {
+                    if (Objects.isNull(windowScores[subQueryIndex])) {
+                        continue;
+                    }
+                    float scoreOfDocIdForSubQuery = windowScores[subQueryIndex][docIndexInWindow];
+                    hybridBulkScorer.getHybridSubQueryScorer().getSubQueryScores()[subQueryIndex] = scoreOfDocIdForSubQuery;
+                }
+                // process the document with its base offset
+                consumer.accept(base | docIndexInWindow);
+                // reset scores after processing of one doc, this is required because scorer object is re-used
+                hybridBulkScorer.getHybridSubQueryScorer().resetScores();
+                // reset bit for this doc id to indicate that it has been consumed
+                bits ^= 1L << numberOfTrailingZeros;
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
@@ -18,6 +18,7 @@ import java.util.Objects;
  */
 @RequiredArgsConstructor
 public class HybridQueryDocIdStream extends DocIdStream {
+    private static final int BLOCK_SHIFT = 6;
     private final HybridBulkScorer hybridBulkScorer;
     @Setter
     private int base;
@@ -41,7 +42,7 @@ public class HybridQueryDocIdStream extends DocIdStream {
                 // calculate actual document ID within the window
                 // idx << 6 is equivalent to idx * 64 (block offset)
                 // numberOfTrailingZeros gives position within the block
-                final int docIndexInWindow = (idx << 6) | numberOfTrailingZeros;
+                final int docIndexInWindow = (idx << BLOCK_SHIFT) | numberOfTrailingZeros;
                 float[][] windowScores = hybridBulkScorer.getWindowScores();
                 for (int subQueryIndex = 0; subQueryIndex < windowScores.length; subQueryIndex++) {
                     if (Objects.isNull(windowScores[subQueryIndex])) {

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
@@ -14,7 +14,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
-import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.PriorityQueue;
 import org.opensearch.neuralsearch.search.HybridDisiWrapper;
 
@@ -44,11 +43,11 @@ public class HybridQueryScorer extends Scorer {
     private final TwoPhase twoPhase;
     private final int numSubqueries;
 
-    public HybridQueryScorer(final Weight weight, final List<Scorer> subScorers) throws IOException {
-        this(weight, subScorers, ScoreMode.TOP_SCORES);
+    public HybridQueryScorer(final List<Scorer> subScorers) throws IOException {
+        this(subScorers, ScoreMode.TOP_SCORES);
     }
 
-    HybridQueryScorer(final Weight weight, final List<Scorer> subScorers, final ScoreMode scoreMode) throws IOException {
+    HybridQueryScorer(final List<Scorer> subScorers, final ScoreMode scoreMode) throws IOException {
         super();
         this.subScorers = Collections.unmodifiableList(subScorers);
         this.numSubqueries = subScorers.size();
@@ -75,7 +74,7 @@ public class HybridQueryScorer extends Scorer {
                 sumMatchCost += w.matchCost * costWeight;
             }
         }
-        if (!hasApproximation) { // no sub scorer supports approximations
+        if (hasApproximation == false) { // no sub scorer supports approximations
             twoPhase = null;
         } else {
             final float matchCost = sumMatchCost / sumApproxCost;
@@ -284,7 +283,7 @@ public class HybridQueryScorer extends Scorer {
                     wrapper.next = verifiedMatches;
                     verifiedMatches = wrapper;
 
-                    if (!needsScores) {
+                    if (needsScores == false) {
                         // we can stop here
                         return true;
                     }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridScorerSupplier.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridScorerSupplier.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This class is responsible for creating a HybridScorer based on the provided list of ScorerSupplier objects.
+ */
+@RequiredArgsConstructor
+public class HybridScorerSupplier extends ScorerSupplier {
+
+    private long cost = -1;
+    @Getter
+    private final List<ScorerSupplier> scorerSuppliers;
+    private final HybridQueryWeight weight;
+    private final ScoreMode scoreMode;
+    private final LeafReaderContext context;
+
+    @Override
+    public Scorer get(long leadCost) throws IOException {
+        List<Scorer> tScorers = new ArrayList<>();
+        for (ScorerSupplier ss : scorerSuppliers) {
+            if (Objects.nonNull(ss)) {
+                tScorers.add(ss.get(leadCost));
+            } else {
+                tScorers.add(null);
+            }
+        }
+        return new HybridQueryScorer(tScorers, scoreMode);
+    }
+
+    @Override
+    public long cost() {
+        if (cost == -1) {
+            long cost = 0;
+            for (ScorerSupplier ss : scorerSuppliers) {
+                if (Objects.nonNull(ss)) {
+                    cost += ss.cost();
+                }
+            }
+            this.cost = cost;
+        }
+        return cost;
+    }
+
+    @Override
+    public void setTopLevelScoringClause() throws IOException {
+        for (ScorerSupplier ss : scorerSuppliers) {
+            // sub scorers need to be able to skip too as calls to setMinCompetitiveScore get
+            // propagated
+            if (Objects.nonNull(ss)) {
+                ss.setTopLevelScoringClause();
+            }
+        }
+    }
+
+    @Override
+    public BulkScorer bulkScorer() throws IOException {
+        List<Scorer> scorers = new ArrayList<>();
+        for (Weight weight : weight.getWeights()) {
+            Scorer scorer = weight.scorer(context);
+            scorers.add(scorer);
+        }
+        return new HybridBulkScorer(scorers, scoreMode.needsScores(), context.reader().maxDoc());
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridSubQueryScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridSubQueryScorer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.Data;
+import org.apache.lucene.search.Scorable;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Scorer implementation for Hybrid Query. This object is light and expected to be re-used between different doc ids
+ */
+@Data
+public class HybridSubQueryScorer extends Scorable {
+    // array of scores from all sub-queries for a single doc id
+    private final float[] subQueryScores;
+    // array of min competitive scores, score is shard level
+    private final float[] minScores;
+
+    public HybridSubQueryScorer(int numOfSubQueries) {
+        this.minScores = new float[numOfSubQueries];
+        this.subQueryScores = new float[numOfSubQueries];
+    }
+
+    @Override
+    public float score() throws IOException {
+        // for scenarios when scorer is needed (like in aggregations) for one doc id return sum of sub-query scores
+        float totalScore = 0.0f;
+        for (float score : subQueryScores) {
+            totalScore += score;
+        }
+        return totalScore;
+    }
+
+    /**
+     * Reset sub-query scores to 0.0f so this scorer can be reused for next doc id
+     */
+    public void resetScores() {
+        Arrays.fill(subQueryScores, 0.0f);
+    }
+
+    public int getNumOfSubQueries() {
+        return subQueryScores.length;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollector.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * The abstract class for hybrid query collector
+ * The abstract class for hybrid query leaf collector
  */
 @Log4j2
 public abstract class HybridLeafCollector implements LeafCollector {

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollector.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.collector;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.opensearch.neuralsearch.query.HybridSubQueryScorer;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * The abstract class for hybrid query collector
+ */
+@Log4j2
+public abstract class HybridLeafCollector implements LeafCollector {
+    @Getter(AccessLevel.PACKAGE)
+    HybridSubQueryScorer compoundQueryScorer;
+
+    @Override
+    public void setScorer(Scorable scorer) throws IOException {
+        if (scorer instanceof HybridSubQueryScorer) {
+            compoundQueryScorer = (HybridSubQueryScorer) scorer;
+        } else {
+            compoundQueryScorer = getHybridQueryScorer(scorer);
+            if (Objects.isNull(compoundQueryScorer)) {
+                log.error("cannot find scorer of type HybridQueryScorer in a hierarchy of scorer {}", scorer);
+            }
+        }
+    }
+
+    private HybridSubQueryScorer getHybridQueryScorer(final Scorable scorer) throws IOException {
+        if (Objects.isNull(scorer)) {
+            return null;
+        }
+        if (scorer instanceof HybridSubQueryScorer) {
+            return (HybridSubQueryScorer) scorer;
+        }
+        for (Scorable.ChildScorable childScorable : scorer.getChildren()) {
+            HybridSubQueryScorer hybridQueryScorer = getHybridQueryScorer(childScorable.child());
+            if (Objects.nonNull(hybridQueryScorer)) {
+                log.debug("found hybrid query scorer, it's child of scorer {}", childScorable.child().getClass().getSimpleName());
+                return hybridQueryScorer;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.search.collector;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -22,7 +23,6 @@ import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.PriorityQueue;
 
 import lombok.extern.log4j.Log4j2;
-import org.opensearch.neuralsearch.query.HybridQueryScorer;
 import org.opensearch.neuralsearch.search.HitsThresholdChecker;
 
 /**
@@ -38,7 +38,7 @@ public class HybridTopScoreDocCollector implements HybridSearchCollector {
     private int totalHits;
     private int[] collectedHitsPerSubQuery;
     private final int numOfHits;
-    private PriorityQueue<ScoreDoc>[] compoundScores;
+    private List<PriorityQueue<ScoreDoc>> compoundScores;
     @Getter
     private float maxScore = 0.0f;
 
@@ -50,89 +50,7 @@ public class HybridTopScoreDocCollector implements HybridSearchCollector {
     @Override
     public LeafCollector getLeafCollector(LeafReaderContext context) {
         docBase = context.docBase;
-
-        return new LeafCollector() {
-            HybridQueryScorer compoundQueryScorer;
-
-            @Override
-            public void setScorer(Scorable scorer) throws IOException {
-                if (scorer instanceof HybridQueryScorer) {
-                    log.debug("passed scorer is of type HybridQueryScorer, saving it for collecting documents and scores");
-                    compoundQueryScorer = (HybridQueryScorer) scorer;
-                } else {
-                    compoundQueryScorer = getHybridQueryScorer(scorer);
-                    if (Objects.isNull(compoundQueryScorer)) {
-                        log.error(
-                            String.format(Locale.ROOT, "cannot find scorer of type HybridQueryScorer in a hierarchy of scorer %s", scorer)
-                        );
-                    }
-                }
-            }
-
-            private HybridQueryScorer getHybridQueryScorer(final Scorable scorer) throws IOException {
-                if (scorer == null) {
-                    return null;
-                }
-                if (scorer instanceof HybridQueryScorer) {
-                    return (HybridQueryScorer) scorer;
-                }
-                for (Scorable.ChildScorable childScorable : scorer.getChildren()) {
-                    HybridQueryScorer hybridQueryScorer = getHybridQueryScorer(childScorable.child());
-                    if (Objects.nonNull(hybridQueryScorer)) {
-                        log.debug(
-                            String.format(
-                                Locale.ROOT,
-                                "found hybrid query scorer, it's child of scorer %s",
-                                childScorable.child().getClass().getSimpleName()
-                            )
-                        );
-                        return hybridQueryScorer;
-                    }
-                }
-                return null;
-            }
-
-            @Override
-            public void collect(int doc) throws IOException {
-                if (Objects.isNull(compoundQueryScorer)) {
-                    throw new IllegalArgumentException("scorers are null for all sub-queries in hybrid query");
-                }
-                float[] subScoresByQuery = compoundQueryScorer.hybridScores();
-                // iterate over results for each query
-                if (compoundScores == null) {
-                    compoundScores = new PriorityQueue[subScoresByQuery.length];
-                    for (int i = 0; i < subScoresByQuery.length; i++) {
-                        compoundScores[i] = new HitQueue(numOfHits, false);
-                    }
-                    collectedHitsPerSubQuery = new int[subScoresByQuery.length];
-                }
-                // Increment total hit count which represents unique doc found on the shard
-                totalHits++;
-                hitsThresholdChecker.incrementHitCount();
-                for (int i = 0; i < subScoresByQuery.length; i++) {
-                    float score = subScoresByQuery[i];
-                    // if score is 0.0 there is no hits for that sub-query
-                    if (score == 0) {
-                        continue;
-                    }
-                    if (hitsThresholdChecker.isThresholdReached() && totalHitsRelation == TotalHits.Relation.EQUAL_TO) {
-                        log.info(
-                            "hit count threshold reached: total hits={}, threshold={}, action=updating_results",
-                            totalHits,
-                            hitsThresholdChecker.getTotalHitsThreshold()
-                        );
-                        totalHitsRelation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
-                    }
-                    collectedHitsPerSubQuery[i]++;
-                    PriorityQueue<ScoreDoc> pq = compoundScores[i];
-                    ScoreDoc currentDoc = new ScoreDoc(doc + docBase, score);
-                    maxScore = Math.max(currentDoc.score, maxScore);
-                    // this way we're inserting into heap and do nothing else unless we reach the capacity
-                    // after that we pull out the lowest score element on each insert
-                    pq.insertWithOverflow(currentDoc);
-                }
-            }
-        };
+        return new HybridTopScoreLeafCollector();
     }
 
     @Override
@@ -149,12 +67,12 @@ public class HybridTopScoreDocCollector implements HybridSearchCollector {
             return new ArrayList<>();
         }
         final List<TopDocs> topDocs = new ArrayList<>();
-        for (int i = 0; i < compoundScores.length; i++) {
+        for (int i = 0; i < compoundScores.size(); i++) {
             topDocs.add(
                 topDocsPerQuery(
                     0,
-                    Math.min(collectedHitsPerSubQuery[i], compoundScores[i].size()),
-                    compoundScores[i],
+                    Math.min(collectedHitsPerSubQuery[i], compoundScores.get(i).size()),
+                    compoundScores.get(i),
                     collectedHitsPerSubQuery[i]
                 )
             );
@@ -196,4 +114,75 @@ public class HybridTopScoreDocCollector implements HybridSearchCollector {
             }
         }
     }
+
+    /**
+     * Leaf collector to collect top docs for each sub query
+     */
+    protected class HybridTopScoreLeafCollector extends HybridLeafCollector {
+        float[] minScoreThresholds;
+
+        @Override
+        public void setScorer(Scorable scorer) throws IOException {
+            super.setScorer(scorer);
+            if (Objects.isNull(minScoreThresholds)) {
+                minScoreThresholds = new float[getCompoundQueryScorer().getNumOfSubQueries()];
+                Arrays.fill(minScoreThresholds, Float.MIN_VALUE);
+            }
+        }
+
+        @Override
+        public void collect(int doc) throws IOException {
+            if (Objects.isNull(getCompoundQueryScorer())) {
+                return;
+            }
+            ensureSubQueryScoreQueues();
+            // Increment total hit count which represents unique doc found on the shard
+            totalHits++;
+            float[] scores = getCompoundQueryScorer().getSubQueryScores();
+            int docWithBase = doc + docBase;
+            for (int subQueryIndex = 0; subQueryIndex < scores.length; subQueryIndex++) {
+                float score = scores[subQueryIndex];
+                // if score is 0.0 there is no hits for that sub-query
+                if (score <= 0) {
+                    continue;
+                }
+
+                if (score < minScoreThresholds[subQueryIndex]) {
+                    continue;
+                }
+
+                if (hitsThresholdChecker.isThresholdReached() && totalHitsRelation == TotalHits.Relation.EQUAL_TO) {
+                    totalHitsRelation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
+                }
+                collectedHitsPerSubQuery[subQueryIndex]++;
+                PriorityQueue<ScoreDoc> pq = compoundScores.get(subQueryIndex);
+                ScoreDoc currentDoc = new ScoreDoc(docWithBase, score);
+                maxScore = Math.max(currentDoc.score, maxScore);
+                // this way we're inserting into heap and do nothing else unless we reach the capacity
+                // after that we pull out the lowest score element on each insert
+                ScoreDoc evictedScoreDoc = pq.insertWithOverflow(currentDoc);
+                if (Objects.nonNull(evictedScoreDoc)) {
+                    float newThresholdScore = evictedScoreDoc.score;
+                    minScoreThresholds[subQueryIndex] = Math.max(minScoreThresholds[subQueryIndex], newThresholdScore);
+                    compoundQueryScorer.getMinScores()[subQueryIndex] = Math.max(
+                        compoundQueryScorer.getMinScores()[subQueryIndex],
+                        newThresholdScore
+                    );
+                }
+            }
+        }
+
+        /**
+         * Initialize compound score queues for each sub query if it's not initialized already
+         */
+        private void ensureSubQueryScoreQueues() {
+            if (Objects.isNull(compoundScores)) {
+                compoundScores = new ArrayList<>(compoundQueryScorer.getNumOfSubQueries());
+                for (int i = 0; i < compoundQueryScorer.getNumOfSubQueries(); i++) {
+                    compoundScores.add(new HitQueue(numOfHits, false));
+                }
+                collectedHitsPerSubQuery = new int[compoundQueryScorer.getNumOfSubQueries()];
+            }
+        }
+    };
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/PagingFieldCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/PagingFieldCollector.java
@@ -36,7 +36,7 @@ public final class PagingFieldCollector extends HybridTopFieldDocSortCollector {
                 if (Objects.isNull(compoundQueryScorer)) {
                     throw new IllegalArgumentException("scorers are null for all sub-queries in hybrid query");
                 }
-                float[] subScoresByQuery = compoundQueryScorer.hybridScores();
+                float[] subScoresByQuery = compoundQueryScorer.getSubQueryScores();
                 initializePriorityQueuesWithComparators(context, subScoresByQuery.length);
                 incrementTotalHitCount();
                 for (int i = 0; i < subScoresByQuery.length; i++) {

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/SimpleFieldCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/SimpleFieldCollector.java
@@ -31,7 +31,7 @@ public final class SimpleFieldCollector extends HybridTopFieldDocSortCollector {
                 if (Objects.isNull(compoundQueryScorer)) {
                     throw new IllegalArgumentException("scorers are null for all sub-queries in hybrid query");
                 }
-                float[] subScoresByQuery = compoundQueryScorer.hybridScores();
+                float[] subScoresByQuery = compoundQueryScorer.getSubQueryScores();
                 initializePriorityQueuesWithComparators(context, subScoresByQuery.length);
                 incrementTotalHitCount();
                 for (int i = 0; i < subScoresByQuery.length; i++) {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridBulkScorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridBulkScorerTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.util.FixedBitSet;
+import org.junit.Before;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HybridBulkScorerTests extends OpenSearchTestCase {
+
+    private static final int MAX_DOC = 1000;
+    private Scorer mockScorer1;
+    private Scorer mockScorer2;
+    private DocIdSetIterator mockIterator1;
+    private DocIdSetIterator mockIterator2;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        mockScorer1 = mock(Scorer.class);
+        mockScorer2 = mock(Scorer.class);
+        mockIterator1 = mock(DocIdSetIterator.class);
+        mockIterator2 = mock(DocIdSetIterator.class);
+
+        when(mockIterator1.cost()).thenReturn(1L);
+        when(mockIterator2.cost()).thenReturn(1L);
+
+        when(mockScorer1.iterator()).thenReturn(mockIterator1);
+        when(mockScorer2.iterator()).thenReturn(mockIterator2);
+    }
+
+    public void testHybridBulkScorerCreation() {
+        List<Scorer> scorers = Arrays.asList(mockScorer1, mockScorer2);
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        assertNotNull(bulkScorer);
+        assertNotNull(bulkScorer.getHybridSubQueryScorer());
+        assertNotNull(bulkScorer.getMatching());
+        assertNotNull(bulkScorer.getWindowScores());
+    }
+
+    public void testHybridBulkScorerWithEmptyScorers() {
+        List<Scorer> scorers = Collections.emptyList();
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        assertNotNull(bulkScorer);
+        assertEquals(0, bulkScorer.getWindowScores().length);
+    }
+
+    public void testHybridBulkScorerWithSingleScorer() {
+        List<Scorer> scorers = Collections.singletonList(mockScorer1);
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        assertNotNull(bulkScorer);
+        assertEquals(1, bulkScorer.getWindowScores().length);
+    }
+
+    public void testWindowScoresInitialization() {
+        List<Scorer> scorers = Arrays.asList(mockScorer1, mockScorer2);
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        float[][] windowScores = bulkScorer.getWindowScores();
+        assertEquals(2, windowScores.length);
+        assertEquals(4096, windowScores[0].length); // 2^12 (WINDOW_SIZE)
+    }
+
+    public void testMatchingBitSetInitialization() {
+        List<Scorer> scorers = Arrays.asList(mockScorer1, mockScorer2);
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        FixedBitSet matching = bulkScorer.getMatching();
+        assertNotNull(matching);
+        assertEquals(4096, matching.length()); // 2^12 (WINDOW_SIZE)
+    }
+
+    public void testScoreWithInvalidRange() throws IOException {
+        // Setup scorers
+        List<Scorer> scorers = Arrays.asList(mockScorer1, mockScorer2);
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        LeafCollector mockLeafCollector = mock(LeafCollector.class);
+
+        // setup iterator behavior to prevent infinite loop
+        when(mockIterator1.docID()).thenReturn(-1, MAX_DOC); // Return -1 first, then MAX_DOC
+        when(mockIterator1.nextDoc()).thenReturn(MAX_DOC);   // Return MAX_DOC to indicate end
+        when(mockIterator2.docID()).thenReturn(-1, MAX_DOC);
+        when(mockIterator2.nextDoc()).thenReturn(MAX_DOC);
+
+        when(mockScorer1.score()).thenReturn(1.0f);
+        when(mockScorer2.score()).thenReturn(1.0f);
+
+        // test with max value greater than maxDoc
+        int result = bulkScorer.score(mockLeafCollector, null, 0, MAX_DOC + 100);
+        assertEquals(MAX_DOC, result);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStreamTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStreamTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.util.FixedBitSet;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HybridQueryDocIdStreamTests extends OpenSearchTestCase {
+
+    private static final int DOC_ID_1 = 1;
+    private static final int DOC_ID_2 = 2;
+    private static final int DOC_ID_3 = 3;
+    private static final int NUM_DOCS = 5;
+
+    @SneakyThrows
+    public void testForEach_whenNoMatchingDocs_thenNoDocumentsProcessed() {
+        // setup
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        HybridBulkScorer mockScorer = mock(HybridBulkScorer.class);
+        when(mockScorer.getMatching()).thenReturn(matchingDocs);
+
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        List<Integer> processedDocs = new ArrayList<>();
+
+        // execute
+        stream.forEach(docId -> processedDocs.add(docId));
+
+        // verify
+        assertTrue(processedDocs.isEmpty());
+    }
+
+    @SneakyThrows
+    public void testForEach_whenSingleMatchingDoc_thenProcessed() {
+        // setup
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        matchingDocs.set(DOC_ID_1);
+
+        HybridBulkScorer mockScorer = createMockScorerWithDocs(matchingDocs);
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        List<Integer> processedDocs = new ArrayList<>();
+
+        // execute
+        stream.forEach(docId -> processedDocs.add(docId));
+
+        // verify
+        assertEquals(1, processedDocs.size());
+        assertEquals(DOC_ID_1, processedDocs.get(0).intValue());
+    }
+
+    @SneakyThrows
+    public void testForEach_whenMultipleMatchingDocs_thenAllProcessed() {
+        // setup
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        matchingDocs.set(DOC_ID_1);
+        matchingDocs.set(DOC_ID_2);
+        matchingDocs.set(DOC_ID_3);
+
+        HybridBulkScorer mockScorer = createMockScorerWithDocs(matchingDocs);
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        List<Integer> processedDocs = new ArrayList<>();
+
+        // execute
+        stream.forEach(docId -> processedDocs.add(docId));
+
+        // verify
+        assertEquals(3, processedDocs.size());
+        assertTrue(processedDocs.contains(DOC_ID_1));
+        assertTrue(processedDocs.contains(DOC_ID_2));
+        assertTrue(processedDocs.contains(DOC_ID_3));
+    }
+
+    @SneakyThrows
+    public void testForEach_whenBaseOffsetProvided_thenDocIdsAdjusted() {
+        // setup
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        matchingDocs.set(DOC_ID_1);
+        matchingDocs.set(DOC_ID_2);
+
+        HybridBulkScorer mockScorer = createMockScorerWithDocs(matchingDocs);
+        int baseOffset = 100;
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        List<Integer> processedDocs = new ArrayList<>();
+        stream.setBase(baseOffset);
+
+        // execute
+        stream.forEach(docId -> processedDocs.add(docId));
+
+        // verify
+        assertEquals(2, processedDocs.size());
+        assertTrue(processedDocs.contains(baseOffset | DOC_ID_1));
+        assertTrue(processedDocs.contains(baseOffset | DOC_ID_2));
+    }
+
+    @SneakyThrows
+    public void testForEach_whenCrossing64BitBoundary_thenAllDocsProcessed() {
+        // setup
+        int numDocs = 128; // Two longs worth of bits
+        FixedBitSet matchingDocs = new FixedBitSet(numDocs);
+        matchingDocs.set(63);  // Last bit in first long
+        matchingDocs.set(64);  // First bit in second long
+
+        HybridBulkScorer mockScorer = createMockScorerWithDocs(matchingDocs, numDocs);
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        List<Integer> processedDocs = new ArrayList<>();
+
+        // execute
+        stream.forEach(docId -> processedDocs.add(docId));
+
+        // verify
+        assertEquals(2, processedDocs.size());
+        assertTrue(processedDocs.contains(63));
+        assertTrue(processedDocs.contains(64));
+    }
+
+    private HybridBulkScorer createMockScorerWithDocs(FixedBitSet matchingDocs, int numDocs) {
+        HybridBulkScorer mockScorer = mock(HybridBulkScorer.class);
+        when(mockScorer.getMatching()).thenReturn(matchingDocs);
+
+        // setup window scores with the specified number of docs
+        float[][] windowScores = new float[2][numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            windowScores[0][i] = random().nextFloat();
+            windowScores[1][i] = random().nextFloat();
+        }
+        when(mockScorer.getWindowScores()).thenReturn(windowScores);
+
+        // setup hybrid sub-query scorer
+        HybridSubQueryScorer mockSubQueryScorer = mock(HybridSubQueryScorer.class);
+        when(mockSubQueryScorer.getSubQueryScores()).thenReturn(new float[2]);
+        when(mockScorer.getHybridSubQueryScorer()).thenReturn(mockSubQueryScorer);
+
+        return mockScorer;
+    }
+
+    private HybridBulkScorer createMockScorerWithDocs(FixedBitSet matchingDocs) {
+        HybridBulkScorer mockScorer = mock(HybridBulkScorer.class);
+        when(mockScorer.getMatching()).thenReturn(matchingDocs);
+
+        // setup window scores
+        float[][] windowScores = new float[2][NUM_DOCS]; // 2 sub-queries
+        for (int i = 0; i < NUM_DOCS; i++) {
+            windowScores[0][i] = random().nextFloat();
+            windowScores[1][i] = random().nextFloat();
+        }
+        when(mockScorer.getWindowScores()).thenReturn(windowScores);
+
+        // setup hybrid sub-query scorer
+        HybridSubQueryScorer mockSubQueryScorer = mock(HybridSubQueryScorer.class);
+        when(mockSubQueryScorer.getSubQueryScores()).thenReturn(new float[2]);
+        when(mockScorer.getHybridSubQueryScorer()).thenReturn(mockSubQueryScorer);
+
+        return mockScorer;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridScorerSupplierTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridScorerSupplierTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.query.HybridQueryBuilderTests.TEXT_FIELD_NAME;
+
+public class HybridScorerSupplierTests extends OpenSearchQueryTestCase {
+
+    static final String TERM_QUERY_TEXT = "keyword";
+
+    private HybridQueryWeight weight;
+    private LeafReaderContext context;
+    private ScoreMode scoreMode;
+
+    private Directory directory;
+    private IndexWriter w;
+    private IndexReader reader;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        directory = newDirectory();
+        w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+        int docId = RandomizedTest.randomInt();
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId, TERM_QUERY_TEXT, ft));
+        w.commit();
+
+        reader = DirectoryReader.open(w);
+        HybridQuery hybridQuery = new HybridQuery(
+            List.of(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT).toQuery(mockQueryShardContext)),
+            new HybridQueryContext(10)
+        );
+        IndexSearcher searcher = newSearcher(reader);
+        weight = (HybridQueryWeight) hybridQuery.createWeight(searcher, ScoreMode.TOP_SCORES, 1.0f);
+        context = searcher.getIndexReader().leaves().get(0);
+        scoreMode = ScoreMode.COMPLETE;
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        w.close();
+        reader.close();
+        directory.close();
+    }
+
+    public void testGetWithEmptyScorers() throws IOException {
+        HybridScorerSupplier hybridScorerSupplier = new HybridScorerSupplier(Collections.emptyList(), weight, scoreMode, context);
+
+        Scorer scorer = hybridScorerSupplier.get(randomLong());
+        assertNotNull(scorer);
+        assertTrue(scorer instanceof HybridQueryScorer);
+    }
+
+    public void testGetWithNullScorer() throws IOException {
+        List<ScorerSupplier> scorerSuppliers = Arrays.asList(null, createMockScorerSupplier());
+
+        HybridScorerSupplier hybridScorerSupplier = new HybridScorerSupplier(scorerSuppliers, weight, scoreMode, context);
+
+        Scorer scorer = hybridScorerSupplier.get(randomLong());
+        assertNotNull(scorer);
+        assertTrue(scorer instanceof HybridQueryScorer);
+    }
+
+    public void testGetWithValidScorers() throws IOException {
+        List<ScorerSupplier> scorerSuppliers = Arrays.asList(createMockScorerSupplier(), createMockScorerSupplier());
+
+        HybridScorerSupplier hybridScorerSupplier = new HybridScorerSupplier(scorerSuppliers, weight, scoreMode, context);
+
+        Scorer scorer = hybridScorerSupplier.get(randomLong());
+        assertNotNull(scorer);
+        assertTrue(scorer instanceof HybridQueryScorer);
+    }
+
+    public void testCostCalculation() {
+        ScorerSupplier supplier1 = createMockScorerSupplier(100L);
+        ScorerSupplier supplier2 = createMockScorerSupplier(200L);
+        List<ScorerSupplier> scorerSuppliers = Arrays.asList(supplier1, supplier2);
+
+        HybridScorerSupplier hybridScorerSupplier = new HybridScorerSupplier(scorerSuppliers, weight, scoreMode, context);
+
+        assertEquals(300L, hybridScorerSupplier.cost());
+        // assert caching - should return same value without recalculating
+        assertEquals(300L, hybridScorerSupplier.cost());
+    }
+
+    public void testCostCalculationWithNullScorer() {
+        ScorerSupplier supplier = createMockScorerSupplier(100L);
+        List<ScorerSupplier> scorerSuppliers = Arrays.asList(null, supplier);
+
+        HybridScorerSupplier hybridScorerSupplier = new HybridScorerSupplier(scorerSuppliers, weight, scoreMode, context);
+
+        assertEquals(100L, hybridScorerSupplier.cost());
+    }
+
+    private ScorerSupplier createMockScorerSupplier() throws IOException {
+        return createMockScorerSupplier(randomLong());
+    }
+
+    private ScorerSupplier createMockScorerSupplier(long cost) {
+        ScorerSupplier scorerSupplier = mock(ScorerSupplier.class);
+        try {
+            when(scorerSupplier.get(randomLong())).thenReturn(mock(Scorer.class));
+            when(scorerSupplier.cost()).thenReturn(cost);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return scorerSupplier;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridSubQueryScorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridSubQueryScorerTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class HybridSubQueryScorerTests extends OpenSearchTestCase {
+
+    private static final int NUM_SUB_QUERIES = 2;
+
+    public void testGetSubQueryScores_whenInitialized_thenReturnCorrectSize() {
+        HybridSubQueryScorer scorer = new HybridSubQueryScorer(NUM_SUB_QUERIES);
+        float[] scores = scorer.getSubQueryScores();
+
+        assertEquals(NUM_SUB_QUERIES, scores.length);
+        assertEquals(NUM_SUB_QUERIES, scorer.getNumOfSubQueries());
+    }
+
+    public void testResetScores_whenScoresSet_thenAllScoresZero() {
+        HybridSubQueryScorer scorer = new HybridSubQueryScorer(NUM_SUB_QUERIES);
+        float[] scores = scorer.getSubQueryScores();
+        scores[0] = 0.5f;
+        scores[1] = 1.0f;
+
+        scorer.resetScores();
+
+        // verify all scores are reset to 0
+        for (float score : scorer.getSubQueryScores()) {
+            assertEquals(0.0f, score, 0.0f);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollectorTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollectorTestCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.collector;
+
+import org.apache.lucene.search.LeafCollector;
+import org.opensearch.neuralsearch.query.HybridSubQueryScorer;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Base class for HybridCollector test cases
+ */
+public class HybridCollectorTestCase extends OpenSearchQueryTestCase {
+    /**
+     * Collect docs and scores for each sub-query scorer and add them to the leaf collector
+     * @param scorer HybridSubQueryScorer object
+     * @param scores1 List of scores for the first sub-query
+     * @param leafCollector LeafCollector object
+     * @param subQueryIndex Index of the sub-query
+     * @param docsIds Array of document IDs
+     * @throws IOException
+     */
+    void collectDocsAndScores(
+        HybridSubQueryScorer scorer,
+        List<Float> scores1,
+        LeafCollector leafCollector,
+        int subQueryIndex,
+        int[] docsIds
+    ) throws IOException {
+        for (int i = 0; i < docsIds.length; i++) {
+            scorer.getSubQueryScores()[subQueryIndex] = scores1.get(i);
+            leafCollector.collect(docsIds[i]);
+            scorer.resetScores();
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -875,10 +875,18 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         assertEquals(6, scoreDocs.length);
         assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[0].score, DELTA_FOR_ASSERTION);
         assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[1].score, DELTA_FOR_ASSERTION);
-        assertTrue(maxScore >= scoreDocs[2].score);
         assertEquals(MAGIC_NUMBER_DELIMITER, scoreDocs[3].score, DELTA_FOR_ASSERTION);
-        assertEquals(maxScore, scoreDocs[4].score, DELTA_FOR_ASSERTION);
         assertEquals(MAGIC_NUMBER_START_STOP, scoreDocs[5].score, DELTA_FOR_ASSERTION);
+
+        if (Math.abs(scoreDocs[2].score - maxScore) <= DELTA_FOR_ASSERTION) {
+            assertEquals(maxScore, scoreDocs[2].score, DELTA_FOR_ASSERTION);
+            assertTrue(scoreDocs[4].score <= maxScore);
+        } else if (Math.abs(scoreDocs[4].score - maxScore) <= DELTA_FOR_ASSERTION) {
+            assertTrue(scoreDocs[2].score <= maxScore);
+            assertEquals(maxScore, scoreDocs[4].score, DELTA_FOR_ASSERTION);
+        } else {
+            fail("neither scoreDocs[2] nor scoreDocs[4] equals maxScore");
+        }
 
         w.close();
         reader.close();

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1289,6 +1289,18 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         return scores;
     }
 
+    @SuppressWarnings("unchecked")
+    protected List<String> getNormalizationDocIdList(final Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hits1map = (Map<String, Object>) searchResponseAsMap.get("hits");
+        List<Object> hitsList = (List<Object>) hits1map.get("hits");
+        List<String> docIds = new ArrayList<>();
+        for (Object hit : hitsList) {
+            Map<String, Object> searchHit = (Map<String, Object>) hit;
+            docIds.add(searchHit.get("_id").toString());
+        }
+        return docIds;
+    }
+
     protected List<Map<String, Object>> getListOfValues(Map<String, Object> searchResponseAsMap, String key) {
         return (List<Map<String, Object>>) searchResponseAsMap.get(key);
     }


### PR DESCRIPTION
### Description
Adding custom implementation of bulk scorer for hybrid query, mainly design that is highlighted in this [RFC](https://github.com/opensearch-project/neural-search/issues/1290). This improves score collection process and overall response times for query. 

After running benchmarks using released 3.0 as baseline these are following results in terms of response time and system throughput:

<h4>NOAA dataset, keyword search)</h4>

https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/noaa_semantic_search

**Benchmark Mode Performance**

Query Type | New solution (ops/s) | Base 3.0 (ops/s) | Improvement
-- | -- | -- | --
Simple Range | 91.2 | 93.8 | -2.80%
Medium Subset | 91.2 | 70 | 30.30%
Large Subset | 60.2 | 28 | 115%
3 Sub-queries | 39.6 | 11.2 | 253.60%

**Response times**

Query Type | Metric | New solution (ms) | Base 3.0 (ms) | Improvement
-- | -- | -- | -- | --
Medium Subset | p50 | 81.2 | 107.7 | 24.6%
  | p90 | 86.6 | 116.6 | 25.7%
  | p99 | 92.5 | 128.5 | 28.0%
Large Subset | p50 | 126.6 | 278.7 | 54.6%
  | p90 | 132.9 | 304.7 | 56.4%
  | p99 | 141.1 | 337.8 | 58.2%
3 Sub-queries | p50 | 184.5 | 656.7 | 71.9%
  | p90 | 214.9 | 880.5 | 75.6%
  | p99 | 231.6 | 1042.6 | 77.8%

<h4>Quora dataset, keyword + semantic search</h4>

Based on [neural_search](https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/neural_search) and [PR](https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/624) 

**Benchmark Mode Performance**

Query Type | New solution (ops/s) | Base 3.0 (ops/s) | Improvement
-- | -- | -- | --
Hybrid Search | 41.3 | 38.8 | 6.40%
Complex Hybrid | 34.9 | 33.2 | 5.10%
Complex with Aggs | 31.2 | 26.4 | 18.20%

**Response Time Metrics**

Query Type | Metric | New solution (ms) | Base 3.0 (ms) | Improvement
-- | -- | -- | -- | --
Hybrid Search | p50 | 179.9 | 197.1 | 8.70%
  | p90 | 202.4 | 224.9 | 10%
  | p99 | 229.2 | 251.1 | 8.70%
Complex Hybrid | p50 | 210.6 | 231.5 | 9%
  | p90 | 248.2 | 282.9 | 12.30%
  | p99 | 285.5 | 329.4 | 13.30%
Complex with Aggs | p50 | 217.7 | 291 | 25.20%
  | p90 | 254.9 | 379.6 | 32.90%
  | p99 | 292.4 | 448.8 | 34.80%

Cluster setup: 
- 3 data nodes cluster
- C5.2xlarge instance type (8 vCPU, 16Gb RAM)
- 6 shards
- 8 segments per shard, force merged before running search queries

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1234
https://github.com/opensearch-project/neural-search/issues/1236 (partially)

### Check List
- [X] New functionality includes testing.
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
