### PR TITLE
Return bad request for invalid stat parameters in stats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 - Add validations to prevent empty input_text_field and input_image_field in TextImageEmbeddingProcessor ([#1257](https://github.com/opensearch-project/neural-search/pull/1257))
 - Fix score value as null for single shard when sorting is not done on score field ([#1277](https://github.com/opensearch-project/neural-search/pull/1277))
+- Return bad request for stats API calls with invalid stat names instead of ignoring them ([#1291](https://github.com/opensearch-project/neural-search/pull/1291))
+
 
 ### Infrastructure
 

--- a/src/test/java/org/opensearch/neuralsearch/rest/RestNeuralStatsActionTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/rest/RestNeuralStatsActionTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.rest;
+
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.neuralsearch.processor.InferenceProcessorTestCase;
+import org.opensearch.neuralsearch.settings.NeuralSearchSettingsAccessor;
+import org.opensearch.neuralsearch.stats.NeuralStatsInput;
+import org.opensearch.neuralsearch.stats.events.EventStatName;
+import org.opensearch.neuralsearch.stats.info.InfoStatName;
+import org.opensearch.neuralsearch.transport.NeuralStatsAction;
+import org.opensearch.neuralsearch.transport.NeuralStatsRequest;
+import org.opensearch.neuralsearch.transport.NeuralStatsResponse;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RestNeuralStatsActionTests extends InferenceProcessorTestCase {
+    private NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Mock
+    private NeuralSearchSettingsAccessor settingsAccessor;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<NeuralStatsResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(NeuralStatsAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void test_execute() throws Exception {
+        when(settingsAccessor.isStatsEnabled()).thenReturn(true);
+        RestNeuralStatsAction restNeuralStatsAction = new RestNeuralStatsAction(settingsAccessor);
+
+        RestRequest request = getRestRequest();
+        restNeuralStatsAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<NeuralStatsRequest> argumentCaptor = ArgumentCaptor.forClass(NeuralStatsRequest.class);
+        verify(client, times(1)).execute(eq(NeuralStatsAction.INSTANCE), argumentCaptor.capture(), any());
+
+        NeuralStatsInput capturedInput = argumentCaptor.getValue().getNeuralStatsInput();
+        assertEquals(capturedInput.getEventStatNames(), EnumSet.allOf(EventStatName.class));
+        assertEquals(capturedInput.getInfoStatNames(), EnumSet.allOf(InfoStatName.class));
+    }
+
+    public void test_handleRequest_disabledForbidden() throws Exception {
+        when(settingsAccessor.isStatsEnabled()).thenReturn(false);
+        RestNeuralStatsAction restNeuralStatsAction = new RestNeuralStatsAction(settingsAccessor);
+
+        RestRequest request = getRestRequest();
+        restNeuralStatsAction.handleRequest(request, channel, client);
+
+        verify(client, never()).execute(eq(NeuralStatsAction.INSTANCE), any(), any());
+
+        ArgumentCaptor<BytesRestResponse> responseCaptor = ArgumentCaptor.forClass(BytesRestResponse.class);
+        verify(channel).sendResponse(responseCaptor.capture());
+
+        BytesRestResponse response = responseCaptor.getValue();
+        assertEquals(RestStatus.FORBIDDEN, response.status());
+    }
+
+    public void test_handleRequest_invalidStatParameter() throws Exception {
+        when(settingsAccessor.isStatsEnabled()).thenReturn(true);
+        RestNeuralStatsAction restNeuralStatsAction = new RestNeuralStatsAction(settingsAccessor);
+
+        // Create request with invalid stat parameter
+        Map<String, String> params = new HashMap<>();
+        params.put("stat", "INVALID_STAT");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+                .withParams(params)
+                .build();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> restNeuralStatsAction.handleRequest(request, channel, client)
+        );
+
+        verify(client, never()).execute(eq(NeuralStatsAction.INSTANCE), any(), any());
+    }
+
+    private RestRequest getRestRequest() {
+        Map<String, String> params = new HashMap<>();
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+    }
+}


### PR DESCRIPTION
### Description
Fixes bug in parsing stat names while calling the stats API. Currently it will log every stat specified when API is called. We change this to return a 400 bad request instead.

Technically this could be a breaking change, but only for users that are purposefully calling the API with invalid stat names, which doesn't have any valid use case.


Example 400:
```
GET /_plugins/_neural/stats/text_embedding
{
	"error": {
		"root_cause": [
			{
				"type": "illegal_argument_exception",
				"reason": "request [/_plugins/_neural/stats/text_embedding] contains unrecognized stat: [text_embedding] -> did you mean [text_embedding_executions]?"
			}
		],
		"type": "illegal_argument_exception",
		"reason": "request [/_plugins/_neural/stats/text_embedding] contains unrecognized stat: [text_embedding] -> did you mean [text_embedding_executions]?"
	},
	"status": 400
}
```
### Related Issues
n/a

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
