### PR TITLE
Fix for merging scoreDocs when totalHits are greater than 1 and fieldDocs are 0

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
@@ -46,14 +46,13 @@ class HybridQueryScoreDocsMerger<T extends ScoreDoc> {
         // then the newTopFieldDocs method in the HybridCollectorManager will set the fieldDocs as TopFieldDocs(totalHits, new FieldDoc[0],
         // sortFields).
         // In this case the size of fieldDocs is 0 with no delimiters.
-        if (sourceScoreDocs.length == 0) {
+        if (Objects.requireNonNull(sourceScoreDocs, "score docs cannot be null").length == 0) {
             return newScoreDocs;
         }
-        if (newScoreDocs.length == 0) {
+        if (Objects.requireNonNull(newScoreDocs, "score docs cannot be null").length == 0) {
             return sourceScoreDocs;
         }
-        if (Objects.requireNonNull(sourceScoreDocs, "score docs cannot be null").length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC
-            || Objects.requireNonNull(newScoreDocs, "score docs cannot be null").length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC) {
+        if (sourceScoreDocs.length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC || newScoreDocs.length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC) {
             throw new IllegalArgumentException("cannot merge top docs because it does not have enough elements");
         }
         // we overshoot and preallocate more than we need - length of both top docs combined.

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryScoreDocsMerger.java
@@ -37,6 +37,21 @@ class HybridQueryScoreDocsMerger<T extends ScoreDoc> {
      * @return merged array of ScoreDocs objects
      */
     public T[] merge(final T[] sourceScoreDocs, final T[] newScoreDocs, final Comparator<T> comparator, final boolean isSortEnabled) {
+        // The length of sourceScoreDocs or newScoreDocs can be 0 in the following conditions
+        // 1. When concurrent segment search is enabled then there can be multiple collector instances that can have search results.
+        // 2. The total hits count of every collector instance represent the actual count of search results present in the shard
+        // irrespective of pagination.
+        // 3. If the PagingFieldCollector removes the search results as per `search_after` criteria and totalHits added in the collector is
+        // greater than 0,
+        // then the newTopFieldDocs method in the HybridCollectorManager will set the fieldDocs as TopFieldDocs(totalHits, new FieldDoc[0],
+        // sortFields).
+        // In this case the size of fieldDocs is 0 with no delimiters.
+        if (sourceScoreDocs.length == 0) {
+            return newScoreDocs;
+        }
+        if (newScoreDocs.length == 0) {
+            return sourceScoreDocs;
+        }
         if (Objects.requireNonNull(sourceScoreDocs, "score docs cannot be null").length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC
             || Objects.requireNonNull(newScoreDocs, "score docs cannot be null").length < MIN_NUMBER_OF_ELEMENTS_IN_SCORE_DOC) {
             throw new IllegalArgumentException("cannot merge top docs because it does not have enough elements");


### PR DESCRIPTION
### Description
The PR contains the bug fix when The length of sourceScoreDocs or newScoreDocs can be 0 in following conditions:
1.   When concurrent segment search is enabled then there can be multiple collector instances that can have search results.
2.   The total hits count of every collector instance represent the actual count of search results present in the shard irrespective of pagination.
3. If the PagingFieldCollector removes the search results as per `search_after` criteria and totalHits added in the collector is greater than 0, then the newTopFieldDocs method in the HybridCollectorManager will set the fieldDocs as TopFieldDocs(totalHits, new FieldDoc[0],sortFields). In this case the size of fieldDocs is 0 with no delimiters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
