### PR TITLE
Switch guava deps from compileOnly to implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,7 +257,7 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
     secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
     compileOnly fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
-    compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
+    implementation group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     compileOnly group: 'commons-lang', name: 'commons-lang', version: '2.6'
     api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
@@ -284,7 +284,7 @@ dependencies {
     runtimeOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testFixturesImplementation "org.opensearch:common-utils:${version}"
     testFixturesImplementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
-    testFixturesCompileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
+    testFixturesImplementation group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     testFixturesImplementation fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
     testImplementation fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
     testImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"


### PR DESCRIPTION
### Description
In https://github.com/opensearch-project/job-scheduler/pull/773, guava was removed from JS which means these deps are no longer available to AD at runtime. This PR to change the guava deps from compileOnly to implementation to ensure they are included in the assembly and available at runtime.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
