### PR TITLE
Feat: Add `chunk_size` parameter to DelimiterChunker

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunkerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/chunker/DelimiterChunkerTests.java
@@ -4,17 +4,18 @@
  */
 package org.opensearch.neuralsearch.processor.chunker;
 
+import org.junit.Assert;
+import org.opensearch.test.OpenSearchTestCase;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.opensearch.test.OpenSearchTestCase;
-
 import static org.opensearch.neuralsearch.processor.chunker.Chunker.MAX_CHUNK_LIMIT_FIELD;
 import static org.opensearch.neuralsearch.processor.chunker.Chunker.CHUNK_STRING_COUNT_FIELD;
 import static org.opensearch.neuralsearch.processor.chunker.DelimiterChunker.DELIMITER_FIELD;
+import static org.opensearch.neuralsearch.processor.chunker.DelimiterChunker.CHUNK_SIZE_FIELD;
 
 public class DelimiterChunkerTests extends OpenSearchTestCase {
 
@@ -34,6 +35,22 @@ public class DelimiterChunkerTests extends OpenSearchTestCase {
     public void testCreate_withDelimiterFieldEmptyString_thenFail() {
         Exception exception = assertThrows(IllegalArgumentException.class, () -> new DelimiterChunker(Map.of(DELIMITER_FIELD, "")));
         Assert.assertEquals(String.format(Locale.ROOT, "Parameter [%s] should not be empty.", DELIMITER_FIELD), exception.getMessage());
+    }
+
+    public void testCreate_withChunkSizeInvalidType_thenFail() {
+        Exception exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> new DelimiterChunker(Map.of(CHUNK_SIZE_FIELD, "not-an-integer"))
+        );
+        Assert.assertEquals(
+            String.format(Locale.ROOT, "Parameter [%s] must be of %s type", CHUNK_SIZE_FIELD, Integer.class.getName()),
+            exception.getMessage()
+        );
+    }
+
+    public void testCreate_withValidChunkSize_thenSucceed() {
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(CHUNK_SIZE_FIELD, 100, DELIMITER_FIELD, "\n"));
+        assertNotNull(chunker);
     }
 
     public void testChunk_withNewlineDelimiter_thenSucceed() {
@@ -72,6 +89,13 @@ public class DelimiterChunkerTests extends OpenSearchTestCase {
         assertEquals(List.of("a.", "b.", "cc.", "d."), chunkResult);
     }
 
+    public void testChunk_WithPeriodDelimitersAndChunkSize_thenSucceed() {
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, ".", CHUNK_SIZE_FIELD, 3));
+        String content = "aa.bb.cc c.dd.";
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
+        assertEquals(List.of("aa.", "bb.", "cc ", "c.", "dd."), chunkResult);
+    }
+
     public void testChunk_withDoubleNewlineDelimiter_thenSucceed() {
         DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n"));
         String content = "\n\na\n\n\n";
@@ -108,5 +132,118 @@ public class DelimiterChunkerTests extends OpenSearchTestCase {
         );
         List<String> expectedPassages = List.of("\n\na\n\n\n");
         assertEquals(expectedPassages, passages);
+    }
+
+    public void testChunk_whenOnlyDelimitersPresent_withChunkSizeTooSmall_thenEachDelimiterIsOwnChunk() {
+        String content = "\n\n\n\n";
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n", CHUNK_SIZE_FIELD, 1));
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
+        assertEquals(List.of("\n\n", "\n\n"), chunkResult);
+    }
+
+    public void testChunk_whenOnlyDelimiterPresent_withChunkSizeLargerThanContent_thenSingleChunkReturned() {
+        String content = "\n\n";
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n", CHUNK_SIZE_FIELD, 3));
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
+        assertEquals(List.of("\n\n"), chunkResult);
+    }
+
+    public void testChunk_whenNewlineDelimiterUsed_andChunkSizeIsLimited_thenSplitAtNewlineAndChunkSize() {
+        String content = """
+            OpenSearch is a community-driven project.
+            It consists of a search engine and visualization tools.
+            Contributions are welcome!
+            """;
+
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n", CHUNK_SIZE_FIELD, 50));
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
+
+        assertEquals(
+            List.of(
+                "OpenSearch is a community-driven project.\n",
+                "It consists of a search engine and visualization t",
+                "ools.\n",
+                "Contributions are welcome!\n"
+            ),
+            chunkResult
+        );
+    }
+
+    public void testChunk_whenSpaceDelimiterUsed_andChunkSizeIsSmall_thenSplitAtSpacesRespectingSize() {
+        String content = "This is a sample text that includes several words.";
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, " ", CHUNK_SIZE_FIELD, 10));
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
+
+        assertEquals(List.of("This ", "is ", "a ", "sample ", "text ", "that ", "includes ", "several ", "words."), chunkResult);
+    }
+
+    public void testChunk_whenParagraphDelimiterUsed_andParagraphExceedsChunkSize_thenSplitWithinParagraphBySize() {
+        String content = """
+            Paragraph one is short.
+
+            Paragraph two is significantly longer and contains multiple sentences. \
+            This should be split properly if it exceeds the specified chunk size.
+
+            Third para.
+            """;
+
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, "\n\n", CHUNK_SIZE_FIELD, 60));
+        List<String> chunkResult = chunker.chunk(content, runtimeParameters);
+
+        assertEquals(
+            List.of(
+                "Paragraph one is short.\n\n",
+                "Paragraph two is significantly longer and contains multiple ",
+                "sentences. This should be split properly if it exceeds the s",
+                "pecified chunk size.\n\n",
+                "Third para.\n"
+            ),
+            chunkResult
+        );
+    }
+
+    public void testChunk_whenExceedMaxChunkLimit_withDelimiterSegments_thenRemainingContentAppendedToLastChunk() {
+        String content = "one. two. three. four. five six.";
+
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, ".", CHUNK_SIZE_FIELD, 6));
+
+        int runtimeMaxChunkLimit = 2, chunkStringCount = 1;
+
+        List<String> result = chunker.chunk(
+            content,
+            Map.of(MAX_CHUNK_LIMIT_FIELD, runtimeMaxChunkLimit, CHUNK_STRING_COUNT_FIELD, chunkStringCount)
+        );
+
+        assertEquals(List.of("one.", " two. three. four. five six."), result);
+    }
+
+    public void testChunk_whenExceedMaxChunkLimit_withChunkSizeSplit_thenRemainingContentAppendedToLastChunk() {
+        String content = "one, two. three. four. five six.";
+
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, ".", CHUNK_SIZE_FIELD, 6));
+
+        int runtimeMaxChunkLimit = 3, chunkStringCount = 1;
+
+        List<String> result = chunker.chunk(
+            content,
+            Map.of(MAX_CHUNK_LIMIT_FIELD, runtimeMaxChunkLimit, CHUNK_STRING_COUNT_FIELD, chunkStringCount)
+        );
+
+        assertEquals(List.of("one, t", "wo.", " three. four. five six."), result);
+    }
+
+    public void testChunk_WhenChunkIsSubdividedByChunkSize_AndMaxLimitIsHit_ShouldMergeRemainder() {
+        String content = "abcd.efgh";
+
+        DelimiterChunker chunker = new DelimiterChunker(Map.of(DELIMITER_FIELD, ".", CHUNK_SIZE_FIELD, 2));
+
+        int runtimeMaxChunkLimit = 2, chunkStringCount = 1;
+
+        List<String> result = chunker.chunk(
+            content,
+            Map.of(MAX_CHUNK_LIMIT_FIELD, runtimeMaxChunkLimit, CHUNK_STRING_COUNT_FIELD, chunkStringCount)
+        );
+
+        assertEquals(List.of("ab", "cd.efgh"), result);
     }
 }


### PR DESCRIPTION
### Description
The existing implementation only splits input based on the given delimiter. However, in many cases, the segment between two delimiters can exceed a reasonable memory or display size (especially in UIs, summarization tasks, or embeddings). In such cases, enforcing a maximum `chunk_size` is necessary.

This PR enhances the `DelimiterChunker.chunk()` method to support:
- `chunk_size`-based splitting in addition to delimiter-based splitting.
- Smarter handling of content exceeding `chunk_size`.
- Better runtime chunk limit enforcement.
- Improved naming and inline documentation for clarity and maintainability.

The logic has been restructured to gracefully split large segments while preserving delimiters and avoiding OOM or excessive chunk generation when upper limits are reached.

<br>

### Related Issues
-  #1261
- https://github.com/opensearch-project/neural-search/pull/1312#issuecomment-2865631495

<br>

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
