### PR TITLE
add stats for text embedding processors with flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Stats] Add stats for text chunking processor algorithms ([#1308](https://github.com/opensearch-project/neural-search/pull/1308))
 - Support custom weights in RRF normalization processor ([#1322](https://github.com/opensearch-project/neural-search/pull/1322))
 - [Stats] Add stats tracking for semantic highlighting ([#1327](https://github.com/opensearch-project/neural-search/pull/1327))
-
+- [Stats] Add stats for text embedding processor with different settings ([#1332](https://github.com/opensearch-project/neural-search/pull/1332))
 ### Bug Fixes
 - Fix score value as null for single shard when sorting is not done on score field ([#1277](https://github.com/opensearch-project/neural-search/pull/1277))
 - Return bad request for stats API calls with invalid stat names instead of ignoring them ([#1291](https://github.com/opensearch-project/neural-search/pull/1291))

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -72,6 +72,7 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
             generateAndSetInference(ingestDocument, processMap, inferenceList, handler);
             return;
         }
+        EventStatsManager.increment(EventStatName.TEXT_EMBEDDING_PROCESSOR_SKIP_EXISTING_EXECUTIONS);
         // if skipExisting flag is turned on, eligible inference texts will be compared and filtered after embeddings are copied
         Object index = ingestDocument.getSourceAndMetadata().get(INDEX_FIELD);
         Object id = ingestDocument.getSourceAndMetadata().get(ID_FIELD);
@@ -109,6 +110,7 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
     @Override
     public void subBatchExecute(List<IngestDocumentWrapper> ingestDocumentWrappers, Consumer<List<IngestDocumentWrapper>> handler) {
         try {
+            EventStatsManager.increment(EventStatName.TEXT_EMBEDDING_PROCESSOR_EXECUTIONS);
             if (CollectionUtils.isEmpty(ingestDocumentWrappers)) {
                 handler.accept(ingestDocumentWrappers);
                 return;
@@ -126,6 +128,7 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
             }
             // skipExisting flag is turned on, eligible inference texts in dataForInferences will be compared and filtered after embeddings
             // are copied
+            EventStatsManager.increment(EventStatName.TEXT_EMBEDDING_PROCESSOR_SKIP_EXISTING_EXECUTIONS);
             openSearchClient.execute(
                 MultiGetAction.INSTANCE,
                 buildMultiGetRequest(dataForInferences),

--- a/src/main/java/org/opensearch/neuralsearch/stats/events/EventStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/events/EventStatName.java
@@ -19,6 +19,11 @@ import java.util.stream.Collectors;
 @Getter
 public enum EventStatName implements StatName {
     TEXT_EMBEDDING_PROCESSOR_EXECUTIONS("text_embedding_executions", "processors.ingest", EventStatType.TIMESTAMPED_EVENT_COUNTER),
+    TEXT_EMBEDDING_PROCESSOR_SKIP_EXISTING_EXECUTIONS(
+        "text_embedding_skip_existing_executions",
+        "processors.ingest",
+        EventStatType.TIMESTAMPED_EVENT_COUNTER
+    ),
     TEXT_CHUNKING_PROCESSOR_EXECUTIONS("text_chunking_executions", "processors.ingest", EventStatType.TIMESTAMPED_EVENT_COUNTER),
     TEXT_CHUNKING_FIXED_LENGTH_EXECUTIONS(
         "text_chunking_fixed_length_executions",

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
@@ -21,6 +21,7 @@ public enum InfoStatName implements StatName {
     // Cluster info
     CLUSTER_VERSION("cluster_version", "", InfoStatType.INFO_STRING),
     TEXT_EMBEDDING_PROCESSORS("text_embedding_processors_in_pipelines", "processors.ingest", InfoStatType.INFO_COUNTER),
+    TEXT_EMBEDDING_SKIP_EXISTING_PROCESSORS("text_embedding_skip_existing_processors", "processors.ingest", InfoStatType.INFO_COUNTER),
     TEXT_CHUNKING_PROCESSORS("text_chunking_processors", "processors.ingest", InfoStatType.INFO_COUNTER),
     TEXT_CHUNKING_DELIMITER_PROCESSORS("text_chunking_delimiter_processors", "processors.ingest", InfoStatType.INFO_COUNTER),
     TEXT_CHUNKING_FIXED_LENGTH_PROCESSORS("text_chunking_fixed_length_processors", "processors.ingest", InfoStatType.INFO_COUNTER);

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
@@ -17,6 +17,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -130,7 +131,7 @@ public class InfoStatsManager {
                     Map<String, Object> processorConfig = asMap(entry.getValue());
                     switch (processorType) {
                         case TextEmbeddingProcessor.TYPE:
-                            increment(stats, InfoStatName.TEXT_EMBEDDING_PROCESSORS);
+                            countTextEmbeddingProcessorStats(stats, processorConfig);
                             break;
                         case TextChunkingProcessor.TYPE:
                             countTextChunkingProcessorStats(stats, processorConfig);
@@ -138,6 +139,19 @@ public class InfoStatsManager {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Counts text embedding processor stats based on processor config
+     * @param stats map containing the stat to increment
+     * @param processorConfig map of the processor config, parsed to add stats
+     */
+    private void countTextEmbeddingProcessorStats(Map<InfoStatName, CountableInfoStatSnapshot> stats, Map<String, Object> processorConfig) {
+        increment(stats, InfoStatName.TEXT_EMBEDDING_PROCESSORS);
+        Object skipExisting = processorConfig.get(TextEmbeddingProcessor.SKIP_EXISTING);
+        if (Objects.nonNull(skipExisting) && skipExisting.equals(Boolean.TRUE)) {
+            increment(stats, InfoStatName.TEXT_EMBEDDING_SKIP_EXISTING_PROCESSORS);
         }
     }
 


### PR DESCRIPTION
### Description
Enhance Stats for Text Embedding Processor, including stats for `skip_existing` option enabled

### Updated Response

```
{
	"_nodes": {
		"total": 1,
		"successful": 1,
		"failed": 0
	},
	"cluster_name": "integTest",
	"info": {
		"cluster_version": "3.1.0",
		"processors": {
			"ingest": {
				"text_chunking_delimiter_processors": 0,
				"text_chunking_fixed_length_processors": 0,
				"text_embedding_processors_in_pipelines": 1,
				"text_embedding_skip_existing_processors": 1,
				"text_chunking_processors": 0
			}
		}
	},
	"all_nodes": {
		"processors": {
			"ingest": {
				"text_chunking_executions": 0,
				"text_embedding_executions": 2,
				"text_embedding_skip_existing_executions": 2,
				"text_chunking_fixed_length_executions": 0,
				"text_chunking_delimiter_executions": 0
			}
		}
	},
	"nodes": {
		"rMyVPGp2SsWL-sLQ3HSjCQ": {
			"processors": {
				"ingest": {
					"text_chunking_executions": 0,
					"text_embedding_executions": 2,
					"text_embedding_skip_existing_executions": 2,
					"text_chunking_fixed_length_executions": 0,
					"text_chunking_delimiter_executions": 0
				}
			}
		}
	}
}
```

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
