### PR TITLE
Add include_individual_nodes param to stats API

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/rest/RestNeuralStatsAction.java
+++ b/src/main/java/org/opensearch/neuralsearch/rest/RestNeuralStatsAction.java
@@ -61,6 +61,11 @@ public class RestNeuralStatsAction extends BaseRestHandler {
     public static final String INCLUDE_METADATA_PARAM = "include_metadata";
 
     /**
+     * Query parameter name to include individual nodes data
+     */
+    public static final String INCLUDE_INDIVIDUAL_NODES_PARAM = "include_individual_nodes";
+
+    /**
      * Regex for valid params, containing only alphanumeric, -, or _
      */
     public static final String PARAM_REGEX = "^[A-Za-z0-9-_]+$";
@@ -91,7 +96,13 @@ public class RestNeuralStatsAction extends BaseRestHandler {
         new Route(RestRequest.Method.GET, NEURAL_BASE_URI + "/stats/{stat}")
     );
 
-    private static final Set<String> RESPONSE_PARAMS = ImmutableSet.of(NODE_ID_PARAM, STAT_PARAM, INCLUDE_METADATA_PARAM, FLATTEN_PARAM);
+    private static final Set<String> RESPONSE_PARAMS = ImmutableSet.of(
+        NODE_ID_PARAM,
+        STAT_PARAM,
+        INCLUDE_METADATA_PARAM,
+        FLATTEN_PARAM,
+        INCLUDE_INDIVIDUAL_NODES_PARAM
+    );
 
     /**
      * Validates a param string if its under the max length and matches simple string pattern
@@ -168,6 +179,9 @@ public class RestNeuralStatsAction extends BaseRestHandler {
 
         boolean includeMetadata = request.paramAsBoolean(INCLUDE_METADATA_PARAM, false);
         neuralStatsInput.setIncludeMetadata(includeMetadata);
+
+        boolean includeIndividualNodes = request.paramAsBoolean(INCLUDE_INDIVIDUAL_NODES_PARAM, true);
+        neuralStatsInput.setIncludeIndividualNodes(includeIndividualNodes);
 
         // Process requested stats parameters
         processStatsRequestParameters(request, neuralStatsInput);

--- a/src/main/java/org/opensearch/neuralsearch/stats/NeuralStatsInput.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/NeuralStatsInput.java
@@ -60,6 +60,12 @@ public class NeuralStatsInput implements ToXContentObject, Writeable {
     @Setter
     private boolean flatten;
 
+    @Setter
+    /**
+     * Controls whether the response will include individual nodes
+     */
+    private boolean includeIndividualNodes;
+
     /**
      * Builder constructor for creating NeuralStatsInput with specific filtering parameters.
      *
@@ -75,13 +81,15 @@ public class NeuralStatsInput implements ToXContentObject, Writeable {
         EnumSet<EventStatName> eventStatNames,
         EnumSet<InfoStatName> infoStatNames,
         boolean includeMetadata,
-        boolean flatten
+        boolean flatten,
+        boolean includeIndividualNodes
     ) {
         this.nodeIds = nodeIds;
         this.eventStatNames = eventStatNames;
         this.infoStatNames = infoStatNames;
         this.includeMetadata = includeMetadata;
         this.flatten = flatten;
+        this.includeIndividualNodes = includeIndividualNodes;
     }
 
     /**
@@ -94,6 +102,7 @@ public class NeuralStatsInput implements ToXContentObject, Writeable {
         this.infoStatNames = EnumSet.noneOf(InfoStatName.class);
         this.includeMetadata = false;
         this.flatten = false;
+        this.includeIndividualNodes = true;
     }
 
     /**
@@ -108,6 +117,7 @@ public class NeuralStatsInput implements ToXContentObject, Writeable {
         infoStatNames = input.readOptionalEnumSet(InfoStatName.class);
         includeMetadata = input.readBoolean();
         flatten = input.readBoolean();
+        includeIndividualNodes = input.readBoolean();
     }
 
     /**
@@ -123,6 +133,7 @@ public class NeuralStatsInput implements ToXContentObject, Writeable {
         out.writeOptionalEnumSet(infoStatNames);
         out.writeBoolean(includeMetadata);
         out.writeBoolean(flatten);
+        out.writeBoolean(includeIndividualNodes);
     }
 
     /**
@@ -147,6 +158,7 @@ public class NeuralStatsInput implements ToXContentObject, Writeable {
         }
         builder.field(RestNeuralStatsAction.INCLUDE_METADATA_PARAM, includeMetadata);
         builder.field(RestNeuralStatsAction.FLATTEN_PARAM, flatten);
+        builder.field(RestNeuralStatsAction.INCLUDE_INDIVIDUAL_NODES_PARAM, includeIndividualNodes);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/org/opensearch/neuralsearch/transport/NeuralStatsResponse.java
+++ b/src/main/java/org/opensearch/neuralsearch/transport/NeuralStatsResponse.java
@@ -34,6 +34,7 @@ public class NeuralStatsResponse extends BaseNodesResponse<NeuralStatsNodeRespon
     private Map<String, Map<String, StatSnapshot<?>>> nodeIdToNodeEventStats;
     private boolean flatten;
     private boolean includeMetadata;
+    private boolean includeIndividualNodes;
 
     /**
      * Constructor
@@ -53,6 +54,7 @@ public class NeuralStatsResponse extends BaseNodesResponse<NeuralStatsNodeRespon
         this.nodeIdToNodeEventStats = castedNodeIdToNodeEventStats;
         this.flatten = in.readBoolean();
         this.includeMetadata = in.readBoolean();
+        this.includeIndividualNodes = in.readBoolean();
     }
 
     /**
@@ -75,7 +77,8 @@ public class NeuralStatsResponse extends BaseNodesResponse<NeuralStatsNodeRespon
         Map<String, StatSnapshot<?>> aggregatedNodeStats,
         Map<String, Map<String, StatSnapshot<?>>> nodeIdToNodeEventStats,
         boolean flatten,
-        boolean includeMetadata
+        boolean includeMetadata,
+        boolean includeIndividualNodes
     ) {
         super(clusterName, nodes, failures);
         this.infoStats = infoStats;
@@ -83,6 +86,7 @@ public class NeuralStatsResponse extends BaseNodesResponse<NeuralStatsNodeRespon
         this.nodeIdToNodeEventStats = nodeIdToNodeEventStats;
         this.flatten = flatten;
         this.includeMetadata = includeMetadata;
+        this.includeIndividualNodes = includeIndividualNodes;
     }
 
     @Override
@@ -97,6 +101,7 @@ public class NeuralStatsResponse extends BaseNodesResponse<NeuralStatsNodeRespon
         out.writeMap(downcastedNodeIdToNodeEventStats);
         out.writeBoolean(flatten);
         out.writeBoolean(includeMetadata);
+        out.writeBoolean(includeIndividualNodes);
     }
 
     @Override
@@ -121,10 +126,12 @@ public class NeuralStatsResponse extends BaseNodesResponse<NeuralStatsNodeRespon
         builder.mapContents(formattedAggregatedNodeStats);
         builder.endObject();
 
-        Map<String, Object> formattedNodeEventStats = formatNodeEventStats(nodeIdToNodeEventStats);
-        builder.startObject(NODES_KEY_PREFIX);
-        builder.mapContents(formattedNodeEventStats);
-        builder.endObject();
+        if (includeIndividualNodes) {
+            Map<String, Object> formattedNodeEventStats = formatNodeEventStats(nodeIdToNodeEventStats);
+            builder.startObject(NODES_KEY_PREFIX);
+            builder.mapContents(formattedNodeEventStats);
+            builder.endObject();
+        }
 
         return builder;
     }

--- a/src/main/java/org/opensearch/neuralsearch/transport/NeuralStatsTransportAction.java
+++ b/src/main/java/org/opensearch/neuralsearch/transport/NeuralStatsTransportAction.java
@@ -77,9 +77,6 @@ public class NeuralStatsTransportAction extends TransportNodesAction<
         List<NeuralStatsNodeResponse> responses,
         List<FailedNodeException> failures
     ) {
-        // Final object that will hold the stats in format Map<ResponsePath, Value>
-        Map<String, StatSnapshot<?>> resultStats = new HashMap<>();
-
         // Convert node level stats to map
         Map<String, Map<String, StatSnapshot<?>>> nodeIdToEventStats = processorNodeEventStatsIntoMap(responses);
 
@@ -105,7 +102,8 @@ public class NeuralStatsTransportAction extends TransportNodesAction<
             aggregatedNodeStats,
             nodeIdToEventStats,
             request.getNeuralStatsInput().isFlatten(),
-            request.getNeuralStatsInput().isIncludeMetadata()
+            request.getNeuralStatsInput().isIncludeMetadata(),
+            request.getNeuralStatsInput().isIncludeIndividualNodes()
         );
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/rest/RestNeuralStatsActionTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/rest/RestNeuralStatsActionTests.java
@@ -71,7 +71,7 @@ public class RestNeuralStatsActionTests extends InferenceProcessorTestCase {
         client.close();
     }
 
-    public void test_execute() throws Exception {
+    public void test_execute_defaultParams() throws Exception {
         when(settingsAccessor.isStatsEnabled()).thenReturn(true);
         RestNeuralStatsAction restNeuralStatsAction = new RestNeuralStatsAction(settingsAccessor);
 
@@ -84,6 +84,32 @@ public class RestNeuralStatsActionTests extends InferenceProcessorTestCase {
         NeuralStatsInput capturedInput = argumentCaptor.getValue().getNeuralStatsInput();
         assertEquals(capturedInput.getEventStatNames(), EnumSet.allOf(EventStatName.class));
         assertEquals(capturedInput.getInfoStatNames(), EnumSet.allOf(InfoStatName.class));
+        assertFalse(capturedInput.isFlatten());
+        assertFalse(capturedInput.isIncludeMetadata());
+        assertTrue(capturedInput.isIncludeIndividualNodes());
+    }
+
+    public void test_execute_customParams() throws Exception {
+        when(settingsAccessor.isStatsEnabled()).thenReturn(true);
+        RestNeuralStatsAction restNeuralStatsAction = new RestNeuralStatsAction(settingsAccessor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put(RestNeuralStatsAction.FLATTEN_PARAM, "true");
+        params.put(RestNeuralStatsAction.INCLUDE_METADATA_PARAM, "true");
+        params.put(RestNeuralStatsAction.INCLUDE_INDIVIDUAL_NODES_PARAM, "false");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
+
+        restNeuralStatsAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<NeuralStatsRequest> argumentCaptor = ArgumentCaptor.forClass(NeuralStatsRequest.class);
+        verify(client, times(1)).execute(eq(NeuralStatsAction.INSTANCE), argumentCaptor.capture(), any());
+
+        NeuralStatsInput capturedInput = argumentCaptor.getValue().getNeuralStatsInput();
+        assertEquals(capturedInput.getEventStatNames(), EnumSet.allOf(EventStatName.class));
+        assertEquals(capturedInput.getInfoStatNames(), EnumSet.allOf(InfoStatName.class));
+        assertTrue(capturedInput.isFlatten());
+        assertTrue(capturedInput.isIncludeMetadata());
+        assertFalse(capturedInput.isIncludeIndividualNodes());
     }
 
     public void test_handleRequest_disabledForbidden() throws Exception {

--- a/src/test/java/org/opensearch/neuralsearch/stats/NeuralStatsInputTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/stats/NeuralStatsInputTests.java
@@ -42,6 +42,7 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
         assertTrue(input.getInfoStatNames().isEmpty());
         assertFalse(input.isIncludeMetadata());
         assertFalse(input.isFlatten());
+        assertTrue(input.isIncludeIndividualNodes());
     }
 
     public void test_builderWithAllFields() {
@@ -55,6 +56,7 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
             .infoStatNames(infoStats)
             .includeMetadata(true)
             .flatten(true)
+            .includeIndividualNodes(false)
             .build();
 
         assertEquals(nodeIds, input.getNodeIds());
@@ -69,7 +71,8 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
 
         // Have to return the readByte since readBoolean can't be mocked
         when(mockInput.readByte()).thenReturn((byte) 1)   // true for includeMetadata
-            .thenReturn((byte) 1);  // true for flatten
+            .thenReturn((byte) 1)  // true for flatten
+            .thenReturn((byte) 0);  // false for includeIndividualNodes
 
         when(mockInput.readOptionalStringList()).thenReturn(Arrays.asList(NODE_ID_1, NODE_ID_2));
         when(mockInput.readOptionalEnumSet(EventStatName.class)).thenReturn(EnumSet.of(EVENT_STAT));
@@ -82,8 +85,9 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
         assertEquals(EnumSet.of(STATE_STAT), input.getInfoStatNames());
         assertTrue(input.isIncludeMetadata());
         assertTrue(input.isFlatten());
+        assertFalse(input.isIncludeIndividualNodes());
 
-        verify(mockInput, times(2)).readByte();
+        verify(mockInput, times(3)).readByte();
         verify(mockInput, times(1)).readOptionalStringList();
         verify(mockInput, times(2)).readOptionalEnumSet(any());
     }
@@ -99,6 +103,7 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
             .infoStatNames(infoStats)
             .includeMetadata(true)
             .flatten(true)
+            .includeIndividualNodes(false)
             .build();
 
         StreamOutput mockOutput = mock(StreamOutput.class);
@@ -108,8 +113,8 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
         verify(mockOutput).writeOptionalEnumSet(eventStats);
         verify(mockOutput).writeOptionalEnumSet(infoStats);
 
-        // 2 boolean writes, 1 for flatten, 1 for include metadata
         verify(mockOutput, times(2)).writeBoolean(true);
+        verify(mockOutput, times(1)).writeBoolean(false);
     }
 
     public void test_toXContent() throws IOException {
@@ -123,6 +128,7 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
             .infoStatNames(infoStats)
             .includeMetadata(true)
             .flatten(true)
+            .includeIndividualNodes(true)
             .build();
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
@@ -134,6 +140,7 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
         assertEquals(Collections.singletonList(STATE_STAT.getNameString()), responseMap.get("state_stats"));
         assertEquals(true, responseMap.get(RestNeuralStatsAction.INCLUDE_METADATA_PARAM));
         assertEquals(true, responseMap.get(RestNeuralStatsAction.FLATTEN_PARAM));
+        assertEquals(true, responseMap.get(RestNeuralStatsAction.INCLUDE_INDIVIDUAL_NODES_PARAM));
     }
 
     public void test_writeToHandlesEmptyCollections() throws IOException {
@@ -144,8 +151,7 @@ public class NeuralStatsInputTests extends OpenSearchTestCase {
 
         verify(mockOutput).writeOptionalStringCollection(any(List.class));
         verify(mockOutput, times(2)).writeOptionalEnumSet(any(EnumSet.class));
-
-        // 4 boolean writes, 2 for each enum set, 1 for flatten, 1 for include metadata
         verify(mockOutput, times(2)).writeBoolean(false);
+        verify(mockOutput, times(1)).writeBoolean(true);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/transport/NeuralStatsResponseTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/transport/NeuralStatsResponseTests.java
@@ -89,7 +89,8 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
             aggregatedNodeStats,
             nodeIdToNodeEventStats,
             true,
-            false
+            false,
+            true
         );
 
         response.writeTo(mockStreamOutput);
@@ -102,8 +103,9 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
         // 2 calls, one by BaseNodesResponse, one by class under test
         verify(mockStreamOutput, times(2)).writeList(failures);
         verify(mockStreamOutput, times(3)).writeMap(any());
-        verify(mockStreamOutput).writeBoolean(true);
-        verify(mockStreamOutput).writeBoolean(false);
+
+        verify(mockStreamOutput, times(2)).writeBoolean(true);
+        verify(mockStreamOutput, times(1)).writeBoolean(false);
     }
 
     public void test_toXContent_emptyStats() throws IOException {
@@ -115,6 +117,7 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
             aggregatedNodeStats,
             nodeIdToNodeEventStats,
             false,
+            true,
             true
         );
         XContentBuilder builder = XContentFactory.jsonBuilder();
@@ -142,7 +145,8 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
             aggregatedNodeStats,
             nodeIdToNodeEventStats,
             false,
-            false
+            false,
+            true
         );
         XContentBuilder builder = XContentFactory.jsonBuilder();
 
@@ -170,7 +174,8 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
             aggregatedNodeStats,
             nodeIdToNodeEventStats,
             true,
-            false
+            false,
+            true
         );
         XContentBuilder builder = XContentFactory.jsonBuilder();
 
@@ -198,7 +203,8 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
             aggregatedNodeStats,
             nodeIdToNodeEventStats,
             false,
-            false
+            false,
+            true
         );
         XContentBuilder builder = XContentFactory.jsonBuilder();
 
@@ -211,6 +217,44 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
         Map<String, Object> node1Stats = (Map<String, Object>) nodesMap.get("node1");
         Map<String, Object> node1StatsTest = (Map<String, Object>) node1Stats.get("test");
         assertEquals(42, node1StatsTest.get("stat"));
+    }
+
+    public void test_toXContent_withIncludeIndividualNodeStats_false() throws IOException {
+        StatSnapshot<Long> mockSnapshot = mock(StatSnapshot.class);
+        when(mockSnapshot.getValue()).thenReturn(42L);
+        Map<String, StatSnapshot<?>> nodeStats = new HashMap<>();
+        nodeStats.put("test.stat", mockSnapshot);
+        nodeIdToNodeEventStats.put("node1", nodeStats);
+
+        // This is a mock aggregated node stats
+        aggregatedNodeStats.put("test.stat", mockSnapshot);
+
+        NeuralStatsResponse response = new NeuralStatsResponse(
+            clusterName,
+            nodes,
+            failures,
+            infoStats,
+            aggregatedNodeStats,
+            nodeIdToNodeEventStats,
+            false,
+            false,
+            false
+        );
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+
+        builder.startObject();
+        response.toXContent(builder, null);
+        builder.endObject();
+        Map<String, Object> responseMap = xContentBuilderToMap(builder);
+
+        // Shouldn't contain individual nodes
+        assertFalse(responseMap.containsKey(NeuralStatsResponse.NODES_KEY_PREFIX));
+
+        // Should still contain aggregated nodes info
+        Map<String, Object> aggregatedNodesMap = (Map<String, Object>) responseMap.get(NeuralStatsResponse.AGGREGATED_NODES_KEY_PREFIX);
+        Map<String, Object> nodeStatsTest = (Map<String, Object>) aggregatedNodesMap.get("test");
+
+        assertEquals(42, nodeStatsTest.get("stat"));
     }
 
     public void test_toXContent_withNodeStats_flattened() throws IOException {
@@ -228,7 +272,8 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
             aggregatedNodeStats,
             nodeIdToNodeEventStats,
             true,
-            false
+            false,
+            true
         );
         XContentBuilder builder = XContentFactory.jsonBuilder();
 
@@ -259,8 +304,10 @@ public class NeuralStatsResponseTests extends OpenSearchTestCase {
             aggregatedNodeStats,
             nodeIdToNodeEventStats,
             false,
+            true,
             true
         );
+
         XContentBuilder builder = XContentFactory.jsonBuilder();
 
         builder.startObject();


### PR DESCRIPTION
### Description
Adds a new parameter to stats API, `include_individual_nodes`, default `true`. When set to `false`, includes individual node-level stats from the stats response (but still includes aggregated `all_nodes` response)


## With flag disabled (default true)
```
GET /_plugins/_neural/stats?include_individual_nodes=false

{
	"_nodes": {
		"total": 1,
		"successful": 1,
		"failed": 0
	},
	"cluster_name": "integTest",
	"info": {
		"cluster_version": "3.1.0",
		"processors": {
			"ingest": {
				"text_chunking_delimiter_processors": 0,
				"text_chunking_fixed_length_processors": 0,
				"text_embedding_processors_in_pipelines": 0,
				"text_chunking_processors": 0
			}
		}
	},
	"all_nodes": {
		"semantic_highlighting": {
			"semantic_highlighting_request_count": 0
		},
		"processors": {
			"ingest": {
				"text_chunking_executions": 0,
				"text_embedding_executions": 0,
				"text_chunking_fixed_length_executions": 0,
				"text_chunking_delimiter_executions": 0
			}
		}
	}
}
```

## With flag enabled (default true)
```
GET /_plugins/_neural/stats
{
	"_nodes": {
		"total": 1,
		"successful": 1,
		"failed": 0
	},
	"cluster_name": "integTest",
	"info": {
		"cluster_version": "3.1.0",
		"processors": {
			"ingest": {
				"text_chunking_delimiter_processors": 0,
				"text_chunking_fixed_length_processors": 0,
				"text_embedding_processors_in_pipelines": 0,
				"text_chunking_processors": 0
			}
		}
	},
	"all_nodes": {
		"semantic_highlighting": {
			"semantic_highlighting_request_count": 0
		},
		"processors": {
			"ingest": {
				"text_chunking_executions": 0,
				"text_embedding_executions": 0,
				"text_chunking_fixed_length_executions": 0,
				"text_chunking_delimiter_executions": 0
			}
		}
	},
	"nodes": {
		"9XVcfxaHTjeuK1I65oZmPg": {
			"semantic_highlighting": {
				"semantic_highlighting_request_count": 0
			},
			"processors": {
				"ingest": {
					"text_chunking_executions": 0,
					"text_embedding_executions": 0,
					"text_chunking_fixed_length_executions": 0,
					"text_chunking_delimiter_executions": 0
				}
			}
		}
	}
}
```


### Related Issues
Related to #1104 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).


API spec issue: https://github.com/opensearch-project/opensearch-api-specification/issues/890
Documentation issue: https://github.com/opensearch-project/documentation-website/issues/9943



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
