### PR TITLE
Support sub query raw scores in Hybrid Search Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Features
 - [Hybrid Query] Add upper bound parameter for min-max normalization technique ([#1431](https://github.com/opensearch-project/neural-search/pull/1431))
+- [Hybrid] Support Sub Query Scores for Hybrid Search ([#1369](https://github.com/opensearch-project/neural-search/pull/1369))
 
 ### Enhancements
 - [Semantic Field] Support configuring the auto-generated knn_vector field through the semantic field. ([#1420](https://github.com/opensearch-project/neural-search/pull/1420))

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/restart/HybridSearchIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/restart/HybridSearchIT.java
@@ -105,7 +105,8 @@ public class HybridSearchIT extends AbstractRestartUpgradeRestTestCase {
             pipelineName,
             DEFAULT_NORMALIZATION_METHOD,
             DEFAULT_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
+            false
         );
     }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/restart/HybridSearchWithRescoreIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/restart/HybridSearchWithRescoreIT.java
@@ -55,7 +55,8 @@ public class HybridSearchWithRescoreIT extends AbstractRestartUpgradeRestTestCas
                 SEARCH_PIPELINE_NAME,
                 DEFAULT_NORMALIZATION_METHOD,
                 DEFAULT_COMBINATION_METHOD,
-                Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f }))
+                Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
+                false
             );
         } else {
             String modelId = null;

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -67,6 +67,7 @@ def versionsBelow2_19 = versionsBelow2_18 + "2.18"
 def versionsBelow2_20 = versionsBelow2_19 + "2.19"
 def versionsBelow3_0 = versionsBelow2_20 + "2.20"
 def versionsBelow3_1 = versionsBelow3_0 + "3.0"
+def versionsBelow3_2 = versionsBelow3_1 + "3.1"
 
 // Task to run BWC tests against the old cluster
 task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
@@ -92,6 +93,13 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
     if (versionsBelow3_1.any { ext.neural_search_bwc_version.startsWith(it) }){
         filter {
             excludeTestsMatching "org.opensearch.neuralsearch.bwc.rolling.SemanticFieldIT.*"
+        }
+    }
+
+    // Excluding sub query scores tests because we introduce this feature in 3.2
+    if (versionsBelow3_2.any { ext.neural_search_bwc_version.startsWith(it) }){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.rolling.HybridSearchSubQueryScoresIT.*"
         }
     }
 
@@ -142,6 +150,13 @@ task testAgainstOneThirdUpgradedCluster(type: StandaloneRestIntegTestTask) {
         }
     }
 
+    // Excluding sub query scores tests because we introduce this feature in 3.2
+    if (versionsBelow3_2.any { ext.neural_search_bwc_version.startsWith(it) }){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.rolling.HybridSearchSubQueryScoresIT.*"
+        }
+    }
+
     // Excluding KnnRadialSearchIT for 3.0.0 due to known radial search shard failure issue
     // https://github.com/opensearch-project/neural-search/issues/1392
     if (ext.neural_search_bwc_version == "3.0.0") {
@@ -188,6 +203,13 @@ task testAgainstTwoThirdsUpgradedCluster(type: StandaloneRestIntegTestTask) {
         }
     }
 
+    // Excluding sub query scores tests because we introduce this feature in 3.2
+    if (versionsBelow3_2.any { ext.neural_search_bwc_version.startsWith(it) }){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.rolling.HybridSearchSubQueryScoresIT.*"
+        }
+    }
+
     // Excluding KnnRadialSearchIT for 3.0.0 due to known radial search shard failure issue
     // https://github.com/opensearch-project/neural-search/issues/1392
     if (ext.neural_search_bwc_version == "3.0.0") {
@@ -231,6 +253,13 @@ task testRollingUpgrade(type: StandaloneRestIntegTestTask) {
     if (versionsBelow3_1.any { ext.neural_search_bwc_version.startsWith(it) }){
         filter {
             excludeTestsMatching "org.opensearch.neuralsearch.bwc.rolling.SemanticFieldIT.*"
+        }
+    }
+
+    // Excluding sub query scores tests because we introduce this feature in 3.2
+    if (versionsBelow3_2.any { ext.neural_search_bwc_version.startsWith(it) }){
+        filter {
+            excludeTestsMatching "org.opensearch.neuralsearch.bwc.rolling.HybridSearchSubQueryScoresIT.*"
         }
     }
 

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchIT.java
@@ -57,7 +57,8 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
                     SEARCH_PIPELINE_NAME,
                     DEFAULT_NORMALIZATION_METHOD,
                     DEFAULT_COMBINATION_METHOD,
-                    Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f }))
+                    Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
+                    false
                 );
                 break;
             case MIXED:

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchRelevancyIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchRelevancyIT.java
@@ -108,7 +108,8 @@ public class HybridSearchRelevancyIT extends AbstractRollingUpgradeTestCase {
                     SEARCH_PIPELINE_NAME,
                     "l2",
                     "arithmetic_mean",
-                    Map.of("weights", Arrays.toString(new float[] { 0.5f, 0.5f }))
+                    Map.of("weights", Arrays.toString(new float[] { 0.5f, 0.5f })),
+                    false
                 );
 
                 // execute hybrid query and store results

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchSubQueryScoresIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchSubQueryScoresIT.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.bwc.rolling;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opensearch.index.query.MatchQueryBuilder;
+import static org.opensearch.neuralsearch.util.TestUtils.NODES_BWC_CLUSTER;
+import static org.opensearch.neuralsearch.util.TestUtils.PARAM_NAME_WEIGHTS;
+import static org.opensearch.neuralsearch.util.TestUtils.TEXT_EMBEDDING_PROCESSOR;
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_NORMALIZATION_METHOD;
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_COMBINATION_METHOD;
+import static org.opensearch.neuralsearch.util.TestUtils.getModelId;
+import static org.opensearch.neuralsearch.util.TestUtils.getNestedHits;
+
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+
+public class HybridSearchSubQueryScoresIT extends AbstractRollingUpgradeTestCase {
+
+    private static final String PIPELINE_NAME = "nlp-hybrid-pipeline";
+    private static final String SEARCH_PIPELINE_NAME = "nlp-search-pipeline";
+    private static final String TEST_FIELD = "passage_text";
+    private static final String TEXT = "Hello world";
+    private static final String TEXT_MIXED = "Hi planet";
+    private static final String TEXT_UPGRADED = "Hi earth";
+    private static final String QUERY = "Hi world";
+    private static final int NUM_DOCS_PER_ROUND = 1;
+    private static final String VECTOR_EMBEDDING_FIELD = "passage_embedding";
+    protected static final String RESCORE_QUERY = "hi";
+    private static String modelId = "";
+
+    public void testHybridizationScoresFieldInMixedCluster() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        switch (getClusterType()) {
+            case OLD:
+                modelId = uploadTextEmbeddingModel();
+                createPipelineProcessor(modelId, PIPELINE_NAME);
+                createIndexWithConfiguration(
+                    getIndexNameForTest(),
+                    Files.readString(Path.of(classLoader.getResource("processor/IndexMappings.json").toURI())),
+                    PIPELINE_NAME
+                );
+                // Add documents to spread across shards
+                for (int i = 0; i < NUM_DOCS_PER_ROUND; i++) {
+                    addDocument(getIndexNameForTest(), String.valueOf(i), TEST_FIELD, TEXT + i, null, null);
+                }
+                createSearchPipeline(
+                    SEARCH_PIPELINE_NAME,
+                    DEFAULT_NORMALIZATION_METHOD,
+                    DEFAULT_COMBINATION_METHOD,
+                    Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
+                    false
+                );
+                break;
+
+            case MIXED:
+                modelId = getModelId(getIngestionPipeline(PIPELINE_NAME), TEXT_EMBEDDING_PROCESSOR);
+                loadAndWaitForModelToBeReady(modelId);
+
+                if (isFirstMixedRound()) {
+                    HybridQueryBuilder query = getQueryBuilder(modelId, null, null, null, null);
+                    validateTestIndexOnUpgrade(NUM_DOCS_PER_ROUND, modelId, query, null);
+                    addDocument(getIndexNameForTest(), "mixed_1", TEST_FIELD, TEXT_MIXED, null, null);
+                } else {
+                    HybridQueryBuilder query = getQueryBuilder(modelId, null, null, null, null);
+                    validateTestIndexOnUpgrade(NUM_DOCS_PER_ROUND + 1, modelId, query, null);
+                }
+                break;
+
+            case UPGRADED:
+                try {
+                    modelId = getModelId(getIngestionPipeline(PIPELINE_NAME), TEXT_EMBEDDING_PROCESSOR);
+                    loadAndWaitForModelToBeReady(modelId);
+
+                    // Add a doc to trigger fetch on upgraded node
+                    addDocument(getIndexNameForTest(), "upgraded", TEST_FIELD, TEXT_UPGRADED, null, null);
+
+                    HybridQueryBuilder hybridQueryBuilder = getQueryBuilder(
+                        modelId,
+                        Boolean.FALSE,
+                        Map.of("ef_search", 100),
+                        RescoreContext.getDefault(),
+                        new MatchQueryBuilder("_id", "upgraded")
+                    );
+
+                    createSearchPipeline(
+                        SEARCH_PIPELINE_NAME,
+                        DEFAULT_NORMALIZATION_METHOD,
+                        DEFAULT_COMBINATION_METHOD,
+                        Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
+                        true
+                    );
+
+                    Map<String, Object> searchResponseAsMap = search(
+                        getIndexNameForTest(),
+                        hybridQueryBuilder,
+                        null,
+                        1,
+                        Map.of("search_pipeline", SEARCH_PIPELINE_NAME + "1")
+                    );
+                    assertNotNull(searchResponseAsMap);
+                    assertHybridizationSubQueryScores(searchResponseAsMap, 2);
+                } finally {
+                    wipeOfTestResources(getIndexNameForTest(), PIPELINE_NAME, modelId, SEARCH_PIPELINE_NAME);
+                }
+                break;
+
+            default:
+                throw new IllegalStateException("Unexpected value: " + getClusterType());
+        }
+    }
+
+    private void validateTestIndexOnUpgrade(
+        final int numberOfDocs,
+        final String modelId,
+        HybridQueryBuilder hybridQueryBuilder,
+        QueryBuilder rescorer
+    ) throws Exception {
+        int docCount = getDocCount(getIndexNameForTest());
+        assertEquals(numberOfDocs, docCount);
+        Map<String, Object> searchResponseAsMap = search(
+            getIndexNameForTest(),
+            hybridQueryBuilder,
+            rescorer,
+            1,
+            Map.of("search_pipeline", SEARCH_PIPELINE_NAME)
+        );
+        assertNotNull(searchResponseAsMap);
+        int hits = getHitCount(searchResponseAsMap);
+        assertEquals(1, hits);
+        List<Double> scoresList = getNormalizationScoreList(searchResponseAsMap);
+        for (Double score : scoresList) {
+            assertTrue(0 <= score && score <= 2);
+        }
+    }
+
+    private void assertHybridizationSubQueryScores(Map<String, Object> searchResponseAsMap, int expectedSubQueryCount) {
+        List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
+
+        for (Map<String, Object> hit : hitsNestedList) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> fields = (Map<String, Object>) hit.get("fields");
+            assertNotNull(fields);
+            @SuppressWarnings("unchecked")
+            List<Double> subQueryScores = (List<Double>) fields.get("hybridization_sub_query_scores");
+            assertNotNull(subQueryScores);
+            assertEquals(expectedSubQueryCount, subQueryScores.size());
+            for (Double score : subQueryScores) {
+                assertNotNull(score);
+                assertTrue(score >= 0.0);
+                assertTrue(score <= 1.0);
+            }
+        }
+    }
+
+    private HybridQueryBuilder getQueryBuilder(
+        final String modelId,
+        final Boolean expandNestedDocs,
+        final Map<String, ?> methodParameters,
+        final RescoreContext rescoreContextForNeuralQuery,
+        final QueryBuilder filter
+    ) {
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(VECTOR_EMBEDDING_FIELD)
+            .modelId(modelId)
+            .queryText(QUERY)
+            .k(5)
+            .build();
+        if (expandNestedDocs != null) {
+            neuralQueryBuilder.expandNested(expandNestedDocs);
+        }
+        if (methodParameters != null) {
+            neuralQueryBuilder.methodParameters(methodParameters);
+        }
+        if (Objects.nonNull(rescoreContextForNeuralQuery)) {
+            neuralQueryBuilder.rescoreContext(rescoreContextForNeuralQuery);
+        }
+
+        MatchQueryBuilder matchQueryBuilder = new MatchQueryBuilder("text", QUERY);
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(matchQueryBuilder);
+        hybridQueryBuilder.add(neuralQueryBuilder);
+
+        if (filter != null) {
+            hybridQueryBuilder.filter(filter);
+        }
+
+        return hybridQueryBuilder;
+    }
+}

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchWithRescoreIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchWithRescoreIT.java
@@ -58,7 +58,8 @@ public class HybridSearchWithRescoreIT extends AbstractRollingUpgradeTestCase {
                     SEARCH_PIPELINE_NAME,
                     DEFAULT_NORMALIZATION_METHOD,
                     DEFAULT_COMBINATION_METHOD,
-                    Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f }))
+                    Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
+                    false
                 );
                 break;
             case MIXED:

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticFieldIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticFieldIT.java
@@ -33,17 +33,17 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
             case OLD:
                 modelId = uploadSparseEncodingModel();
                 prepareSemanticIndex(
-                        getIndexNameForTest(),
-                        Collections.singletonList(new SemanticFieldConfig(TEST_SEMANTIC_TEXT_FIELD)),
-                        modelId,
-                        null
+                    getIndexNameForTest(),
+                    Collections.singletonList(new SemanticFieldConfig(TEST_SEMANTIC_TEXT_FIELD)),
+                    modelId,
+                    null
                 );
                 addSemanticDoc(
-                        getIndexNameForTest(),
-                        "0",
-                        String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
-                        List.of(SEMANTIC_EMBEDDING_FIELD),
-                        List.of(testRankFeaturesDoc)
+                    getIndexNameForTest(),
+                    "0",
+                    String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
+                    List.of(SEMANTIC_EMBEDDING_FIELD),
+                    List.of(testRankFeaturesDoc)
                 );
                 break;
             case MIXED:
@@ -54,11 +54,11 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
                     totalDocsCountMixed = NUM_DOCS_PER_ROUND;
                     validateTestIndex(totalDocsCountMixed);
                     addSemanticDoc(
-                            getIndexNameForTest(),
-                            "1",
-                            String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
-                            List.of(SEMANTIC_EMBEDDING_FIELD),
-                            List.of(testRankFeaturesDoc)
+                        getIndexNameForTest(),
+                        "1",
+                        String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
+                        List.of(SEMANTIC_EMBEDDING_FIELD),
+                        List.of(testRankFeaturesDoc)
                     );
                 } else {
                     totalDocsCountMixed = 2 * NUM_DOCS_PER_ROUND;
@@ -71,11 +71,11 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
                     modelId = getModelId(getIndexMapping(getIndexNameForTest()), getIndexNameForTest(), TEST_SEMANTIC_TEXT_FIELD_PATH);
                     loadAndWaitForModelToBeReady(modelId);
                     addSemanticDoc(
-                            getIndexNameForTest(),
-                            "2",
-                            String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
-                            List.of(SEMANTIC_EMBEDDING_FIELD),
-                            List.of(testRankFeaturesDoc)
+                        getIndexNameForTest(),
+                        "2",
+                        String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
+                        List.of(SEMANTIC_EMBEDDING_FIELD),
+                        List.of(testRankFeaturesDoc)
                     );
                     validateTestIndex(totalDocsCountUpgraded);
                 } finally {
@@ -91,10 +91,10 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
-                .fieldName(TEST_SEMANTIC_TEXT_FIELD)
-                .queryText(TEST_QUERY_TEXT)
-                .boost(2.0f)
-                .build();
+            .fieldName(TEST_SEMANTIC_TEXT_FIELD)
+            .queryText(TEST_QUERY_TEXT)
+            .boost(2.0f)
+            .build();
 
         Map<String, Object> searchResponseAsMap = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertEquals(1, getHitCount(searchResponseAsMap));

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticFieldIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticFieldIT.java
@@ -33,17 +33,17 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
             case OLD:
                 modelId = uploadSparseEncodingModel();
                 prepareSemanticIndex(
-                    getIndexNameForTest(),
-                    Collections.singletonList(new SemanticFieldConfig(TEST_SEMANTIC_TEXT_FIELD)),
-                    modelId,
-                    null
+                        getIndexNameForTest(),
+                        Collections.singletonList(new SemanticFieldConfig(TEST_SEMANTIC_TEXT_FIELD)),
+                        modelId,
+                        null
                 );
                 addSemanticDoc(
-                    getIndexNameForTest(),
-                    "0",
-                    String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
-                    List.of(SEMANTIC_EMBEDDING_FIELD),
-                    List.of(testRankFeaturesDoc)
+                        getIndexNameForTest(),
+                        "0",
+                        String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
+                        List.of(SEMANTIC_EMBEDDING_FIELD),
+                        List.of(testRankFeaturesDoc)
                 );
                 break;
             case MIXED:
@@ -54,11 +54,11 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
                     totalDocsCountMixed = NUM_DOCS_PER_ROUND;
                     validateTestIndex(totalDocsCountMixed);
                     addSemanticDoc(
-                        getIndexNameForTest(),
-                        "1",
-                        String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
-                        List.of(SEMANTIC_EMBEDDING_FIELD),
-                        List.of(testRankFeaturesDoc)
+                            getIndexNameForTest(),
+                            "1",
+                            String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
+                            List.of(SEMANTIC_EMBEDDING_FIELD),
+                            List.of(testRankFeaturesDoc)
                     );
                 } else {
                     totalDocsCountMixed = 2 * NUM_DOCS_PER_ROUND;
@@ -71,11 +71,11 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
                     modelId = getModelId(getIndexMapping(getIndexNameForTest()), getIndexNameForTest(), TEST_SEMANTIC_TEXT_FIELD_PATH);
                     loadAndWaitForModelToBeReady(modelId);
                     addSemanticDoc(
-                        getIndexNameForTest(),
-                        "2",
-                        String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
-                        List.of(SEMANTIC_EMBEDDING_FIELD),
-                        List.of(testRankFeaturesDoc)
+                            getIndexNameForTest(),
+                            "2",
+                            String.format(LOCALE, "%s_%s", TEST_SEMANTIC_TEXT_FIELD, SEMANTIC_INFO_FIELD),
+                            List.of(SEMANTIC_EMBEDDING_FIELD),
+                            List.of(testRankFeaturesDoc)
                     );
                     validateTestIndex(totalDocsCountUpgraded);
                 } finally {
@@ -91,10 +91,10 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
-            .fieldName(TEST_SEMANTIC_TEXT_FIELD)
-            .queryText(TEST_QUERY_TEXT)
-            .boost(2.0f)
-            .build();
+                .fieldName(TEST_SEMANTIC_TEXT_FIELD)
+                .queryText(TEST_QUERY_TEXT)
+                .boost(2.0f)
+                .build();
 
         Map<String, Object> searchResponseAsMap = search(getIndexNameForTest(), neuralQueryBuilder, 1);
         assertEquals(1, getHitCount(searchResponseAsMap));

--- a/src/main/java/org/opensearch/neuralsearch/common/MinClusterVersionUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/common/MinClusterVersionUtil.java
@@ -32,6 +32,7 @@ public final class MinClusterVersionUtil {
 
     // Constant for neural_knn_query version check
     public static final String NEURAL_KNN_QUERY = "neural_knn_query";
+    public static final Version MINIMAL_SUPPORTED_VERSION_SUB_QUERY_SCORES = Version.V_3_1_0;
 
     // Note this minimal version will act as an override
     private static final Map<String, Version> MINIMAL_VERSION_NEURAL = ImmutableMap.<String, Version>builder()
@@ -56,6 +57,10 @@ public final class MinClusterVersionUtil {
 
     public static boolean isClusterOnOrAfterMinReqVersionForStatCategoryFiltering() {
         return NeuralSearchClusterUtil.instance().getClusterMinVersion().onOrAfter(MINIMAL_SUPPORTED_VERSION_STATS_CATEGORY_FILTERING);
+    }
+
+    public static boolean isClusterOnOrAfterMinReqVersionForSubQuerySupport() {
+        return NeuralSearchClusterUtil.instance().getClusterMinVersion().onOrAfter(MINIMAL_SUPPORTED_VERSION_SUB_QUERY_SCORES);
     }
 
     public static boolean isClusterOnOrAfterMinReqVersion(String key) {

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -31,6 +31,7 @@ import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
 import org.opensearch.neuralsearch.mappingtransformer.SemanticMappingTransformer;
 import org.opensearch.neuralsearch.processor.factory.SemanticFieldProcessorFactory;
 import org.opensearch.plugins.MapperPlugin;
+import org.opensearch.search.fetch.FetchSubPhase;
 import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -70,6 +71,7 @@ import org.opensearch.neuralsearch.processor.factory.RRFProcessorFactory;
 import org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
+import org.opensearch.neuralsearch.processor.HybridizationFetchSubPhase;
 import org.opensearch.neuralsearch.processor.rerank.RerankProcessor;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
@@ -260,6 +262,11 @@ public class NeuralSearch extends Plugin
             NeuralSparseTwoPhaseProcessor.TYPE,
             new NeuralSparseTwoPhaseProcessor.Factory()
         );
+    }
+
+    @Override
+    public List<FetchSubPhase> getFetchSubPhases(FetchPhaseConstructionContext context) {
+        return List.of(new HybridizationFetchSubPhase());
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
@@ -6,8 +6,8 @@ package org.opensearch.neuralsearch.processor;
 
 import org.opensearch.action.search.SearchPhaseContext;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 /**
  * Registry to store hybrid score for each search phase context

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
@@ -9,17 +9,34 @@ import org.opensearch.search.internal.SearchContext;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Registry to store hybrid score for each search context
+ */
 public class HybridScoreRegistry {
     private static final Map<SearchContext, Map<Integer, float[]>> contextToHolder = new HashMap<>();
 
+    /**
+     * Store hybrid score for each search context
+     * @param context
+     * @param scoreMap
+     */
     public static void store(SearchContext context, Map<Integer, float[]> scoreMap) {
         contextToHolder.put(context, scoreMap);
     }
 
+    /**
+     * Get hybrid score for each search context
+     * @param context
+     * @return map of hybrid score
+     */
     public static Map<Integer, float[]> get(SearchContext context) {
         return contextToHolder.get(context);
     }
 
+    /**
+     * Remove hybrid score for each search context
+     * @param context
+     */
     public static void remove(SearchContext context) {
         contextToHolder.remove(context);
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
@@ -13,14 +13,14 @@ import java.util.Map;
  * Registry to store hybrid score for each search context
  */
 public class HybridScoreRegistry {
-    private static final Map<SearchPhaseContext, Map<Integer, float[]>> contextToHolder = new HashMap<>();
+    private static final Map<SearchPhaseContext, Map<String, float[]>> contextToHolder = new HashMap<>();
 
     /**
      * Store hybrid score for each search context
      * @param context
      * @param scoreMap
      */
-    public static void store(SearchPhaseContext context, Map<Integer, float[]> scoreMap) {
+    public static void store(SearchPhaseContext context, Map<String, float[]> scoreMap) {
         contextToHolder.put(context, scoreMap);
     }
 
@@ -29,7 +29,7 @@ public class HybridScoreRegistry {
      * @param context
      * @return map of hybrid score
      */
-    public static Map<Integer, float[]> get(SearchPhaseContext context) {
+    public static Map<String, float[]> get(SearchPhaseContext context) {
         return contextToHolder.get(context);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
@@ -4,7 +4,7 @@
  */
 package org.opensearch.neuralsearch.processor;
 
-import org.opensearch.search.internal.SearchContext;
+import org.opensearch.action.search.SearchPhaseContext;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,14 +13,14 @@ import java.util.Map;
  * Registry to store hybrid score for each search context
  */
 public class HybridScoreRegistry {
-    private static final Map<SearchContext, Map<Integer, float[]>> contextToHolder = new HashMap<>();
+    private static final Map<SearchPhaseContext, Map<Integer, float[]>> contextToHolder = new HashMap<>();
 
     /**
      * Store hybrid score for each search context
      * @param context
      * @param scoreMap
      */
-    public static void store(SearchContext context, Map<Integer, float[]> scoreMap) {
+    public static void store(SearchPhaseContext context, Map<Integer, float[]> scoreMap) {
         contextToHolder.put(context, scoreMap);
     }
 
@@ -29,7 +29,7 @@ public class HybridScoreRegistry {
      * @param context
      * @return map of hybrid score
      */
-    public static Map<Integer, float[]> get(SearchContext context) {
+    public static Map<Integer, float[]> get(SearchPhaseContext context) {
         return contextToHolder.get(context);
     }
 
@@ -37,7 +37,7 @@ public class HybridScoreRegistry {
      * Remove hybrid score for each search context
      * @param context
      */
-    public static void remove(SearchContext context) {
+    public static void remove(SearchPhaseContext context) {
         contextToHolder.remove(context);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import org.opensearch.search.internal.SearchContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HybridScoreRegistry {
+    private static final Map<SearchContext, Map<Integer, float[]>> contextToHolder = new HashMap<>();
+
+    public static void store(SearchContext context, Map<Integer, float[]> scoreMap) {
+        contextToHolder.put(context, scoreMap);
+    }
+
+    public static Map<Integer, float[]> get(SearchContext context) {
+        return contextToHolder.get(context);
+    }
+
+    public static void remove(SearchContext context) {
+        contextToHolder.remove(context);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridScoreRegistry.java
@@ -6,17 +6,17 @@ package org.opensearch.neuralsearch.processor;
 
 import org.opensearch.action.search.SearchPhaseContext;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Registry to store hybrid score for each search context
+ * Registry to store hybrid score for each search phase context
  */
 public class HybridScoreRegistry {
-    private static final Map<SearchPhaseContext, Map<String, float[]>> contextToHolder = new HashMap<>();
+    private static final ConcurrentHashMap<SearchPhaseContext, Map<String, float[]>> contextToHolder = new ConcurrentHashMap<>();
 
     /**
-     * Store hybrid score for each search context
+     * Store hybrid score for each search phase context
      * @param context
      * @param scoreMap
      */
@@ -25,7 +25,7 @@ public class HybridScoreRegistry {
     }
 
     /**
-     * Get hybrid score for each search context
+     * Get hybrid score for each search phase context
      * @param context
      * @return map of hybrid score
      */
@@ -34,7 +34,7 @@ public class HybridScoreRegistry {
     }
 
     /**
-     * Remove hybrid score for each search context
+     * Remove hybrid score for each search phase context
      * @param context
      */
     public static void remove(SearchPhaseContext context) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhase.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhase.java
@@ -48,7 +48,7 @@ public class HybridizationFetchSubPhase implements FetchSubPhase {
                     && isClusterOnOrAfterMinReqVersionForSubQuerySupport()
                     && hasInnerHits == false;
                 if (shouldAddHybridScores) {
-                    Map<String, float[]> scoreMap = HybridScoreRegistry.get(context);
+                    Map<String, float[]> scoreMap = context == null ? null : HybridScoreRegistry.get(context);
                     if (scoreMap == null) {
                         log.debug("No sub query scores found");
                         return;

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhase.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.opensearch.common.document.DocumentField;
+import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
+import org.opensearch.search.fetch.FetchContext;
+import org.opensearch.search.fetch.FetchSubPhase;
+import org.opensearch.search.fetch.FetchSubPhaseProcessor;
+import org.opensearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class HybridizationFetchSubPhase implements FetchSubPhase {
+
+    public HybridizationFetchSubPhase() {}
+
+    @Override
+    public FetchSubPhaseProcessor getProcessor(FetchContext fetchContext) throws IOException {
+        SearchContext context = ScoreNormalizer.getSearchContext();
+
+        return new FetchSubPhaseProcessor() {
+            LeafReaderContext ctx;
+
+            @Override
+            public void setNextReader(LeafReaderContext leafReaderContext) throws IOException {
+                this.ctx = leafReaderContext;
+            }
+
+            @Override
+            public void process(HitContext hitContext) {
+                Map<Integer, float[]> scoreMap = HybridScoreRegistry.get(context);
+                if (scoreMap == null) {
+                    return;
+                }
+                int docId = hitContext.docId();
+                float[] subqueryScores = scoreMap.get(docId);
+
+                if (subqueryScores != null) {
+                    // Add it as a field rather than modifying _source
+                    hitContext.hit().setDocumentField("_hybridization", new DocumentField("_hybridization", List.of(subqueryScores)));
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhase.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhase.java
@@ -24,7 +24,7 @@ import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isCluster
  */
 public class HybridizationFetchSubPhase implements FetchSubPhase {
 
-    private static final String NAME = "hybridization_sub_query_scores";
+    private static final String SUB_QUERY_SCORES_NAME = "hybridization_sub_query_scores";
 
     @Override
     public FetchSubPhaseProcessor getProcessor(FetchContext fetchContext) throws IOException {
@@ -58,7 +58,7 @@ public class HybridizationFetchSubPhase implements FetchSubPhase {
                         for (float score : subqueryScores) {
                             hybridScores.add(score);
                         }
-                        hitContext.hit().setDocumentField(NAME, new DocumentField(NAME, hybridScores));
+                        hitContext.hit().setDocumentField(SUB_QUERY_SCORES_NAME, new DocumentField(SUB_QUERY_SCORES_NAME, hybridScores));
                     }
                 }
             }

--- a/src/main/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhase.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhase.java
@@ -16,9 +16,14 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isClusterOnOrAfterMinReqVersionForSubQuerySupport;
+
+/**
+ * Fetch sub phase to add hybridization scores to the search response
+ */
 public class HybridizationFetchSubPhase implements FetchSubPhase {
 
-    public HybridizationFetchSubPhase() {}
+    private static final String NAME = "hybridization";
 
     @Override
     public FetchSubPhaseProcessor getProcessor(FetchContext fetchContext) throws IOException {
@@ -34,16 +39,18 @@ public class HybridizationFetchSubPhase implements FetchSubPhase {
 
             @Override
             public void process(HitContext hitContext) {
-                Map<Integer, float[]> scoreMap = HybridScoreRegistry.get(context);
-                if (scoreMap == null) {
-                    return;
-                }
-                int docId = hitContext.docId();
-                float[] subqueryScores = scoreMap.get(docId);
+                if (isClusterOnOrAfterMinReqVersionForSubQuerySupport()) {
+                    Map<Integer, float[]> scoreMap = HybridScoreRegistry.get(context);
+                    if (scoreMap == null) {
+                        return;
+                    }
+                    int docId = hitContext.docId();
+                    float[] subqueryScores = scoreMap.get(docId);
 
-                if (subqueryScores != null) {
-                    // Add it as a field rather than modifying _source
-                    hitContext.hit().setDocumentField("_hybridization", new DocumentField("_hybridization", List.of(subqueryScores)));
+                    if (subqueryScores != null) {
+                        // Add it as a field rather than modifying _source
+                        hitContext.hit().setDocumentField(NAME, new DocumentField(NAME, List.of(subqueryScores)));
+                    }
                 }
             }
         };

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessor.java
@@ -48,6 +48,7 @@ public class NormalizationProcessor extends AbstractScoreHybridizationProcessor 
     private final ScoreNormalizationTechnique normalizationTechnique;
     private final ScoreCombinationTechnique combinationTechnique;
     private final NormalizationProcessorWorkflow normalizationWorkflow;
+    private final boolean subQueryScores;
 
     private final Map<String, Runnable> normTechniqueIncrementers = Map.of(
         L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
@@ -87,6 +88,7 @@ public class NormalizationProcessor extends AbstractScoreHybridizationProcessor 
             .fetchSearchResultOptional(fetchSearchResult)
             .normalizationTechnique(normalizationTechnique)
             .combinationTechnique(combinationTechnique)
+            .subQueryScores(subQueryScores)
             .explain(explain)
             .pipelineProcessingContext(requestContextOptional.orElse(null))
             .searchPhaseContext(searchPhaseContext)

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -79,6 +79,7 @@ public class NormalizationProcessorWorkflow {
         NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(request.getNormalizationTechnique())
+            .subQueryScores(request.isSubQueryScores())
             .build();
 
         // normalize

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -56,7 +56,7 @@ public class NormalizationProcessorWorkflow {
 
     private final ScoreNormalizer scoreNormalizer;
     private final ScoreCombiner scoreCombiner;
-    private static final String NAME = "hybridization_sub_query_scores";
+    private static final String SUB_QUERY_SCORES_NAME = "hybridization_sub_query_scores";
 
     /**
      * Start execution of this workflow
@@ -353,7 +353,7 @@ public class NormalizationProcessorWorkflow {
 
             // Check for all the conditions
             boolean shouldAddHybridScores = subqueryScores != null
-                && documentFields.containsKey(NAME) == false
+                && documentFields.containsKey(SUB_QUERY_SCORES_NAME) == false
                 && isClusterOnOrAfterMinReqVersionForSubQuerySupport()
                 && hasInnerHits == false;
 
@@ -363,7 +363,7 @@ public class NormalizationProcessorWorkflow {
                 for (float score : subqueryScores) {
                     hybridScores.add(score);
                 }
-                searchHit.setDocumentField(NAME, new DocumentField(NAME, hybridScores));
+                searchHit.setDocumentField(SUB_QUERY_SCORES_NAME, new DocumentField(SUB_QUERY_SCORES_NAME, hybridScores));
             }
             updatedSearchHitArray[i] = searchHit;
         }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -342,7 +342,8 @@ public class NormalizationProcessorWorkflow {
 
             float[] subqueryScores = scoreMap.get(scoreDoc.doc);
 
-            if (subqueryScores != null && searchHit.getDocumentFields() == null) {
+            Map<String, DocumentField> documentFields = searchHit.getDocumentFields();
+            if (subqueryScores != null && !documentFields.containsKey("_hybridization")) {
                 // Add it as a field rather than modifying _source
                 searchHit.setDocumentField("_hybridization", new DocumentField("_hybridization", List.of(subqueryScores)));
             }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -43,6 +43,7 @@ import org.opensearch.search.query.QuerySearchResult;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
+import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isClusterOnOrAfterMinReqVersionForSubQuerySupport;
 import static org.opensearch.neuralsearch.plugin.NeuralSearch.EXPLANATION_RESPONSE_KEY;
 import static org.opensearch.neuralsearch.search.util.HybridSearchSortUtil.evaluateSortCriteria;
 
@@ -343,7 +344,9 @@ public class NormalizationProcessorWorkflow {
             float[] subqueryScores = scoreMap.get(scoreDoc.doc);
 
             Map<String, DocumentField> documentFields = searchHit.getDocumentFields();
-            if (subqueryScores != null && !documentFields.containsKey("_hybridization")) {
+            if (subqueryScores != null
+                && !documentFields.containsKey("_hybridization")
+                && isClusterOnOrAfterMinReqVersionForSubQuerySupport()) {
                 // Add it as a field rather than modifying _source
                 searchHit.setDocumentField("_hybridization", new DocumentField("_hybridization", List.of(subqueryScores)));
             }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowExecuteRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowExecuteRequest.java
@@ -28,6 +28,7 @@ public class NormalizationProcessorWorkflowExecuteRequest {
     final Optional<FetchSearchResult> fetchSearchResultOptional;
     final ScoreNormalizationTechnique normalizationTechnique;
     final ScoreCombinationTechnique combinationTechnique;
+    final boolean subQueryScores;
     boolean explain;
     final PipelineProcessingContext pipelineProcessingContext;
     final SearchPhaseContext searchPhaseContext;

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowExecuteRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowExecuteRequest.java
@@ -10,9 +10,7 @@ import lombok.Getter;
 import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
-import org.opensearch.search.fetch.FetchContext;
 import org.opensearch.search.fetch.FetchSearchResult;
-import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.query.QuerySearchResult;
 
@@ -33,6 +31,4 @@ public class NormalizationProcessorWorkflowExecuteRequest {
     boolean explain;
     final PipelineProcessingContext pipelineProcessingContext;
     final SearchPhaseContext searchPhaseContext;
-    final SearchContext searchContext;
-    final FetchContext fetchContext;
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowExecuteRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowExecuteRequest.java
@@ -10,7 +10,9 @@ import lombok.Getter;
 import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
+import org.opensearch.search.fetch.FetchContext;
 import org.opensearch.search.fetch.FetchSearchResult;
+import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.query.QuerySearchResult;
 
@@ -31,4 +33,6 @@ public class NormalizationProcessorWorkflowExecuteRequest {
     boolean explain;
     final PipelineProcessingContext pipelineProcessingContext;
     final SearchPhaseContext searchPhaseContext;
+    final SearchContext searchContext;
+    final FetchContext fetchContext;
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizeScoresDTO.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizeScoresDTO.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
 
 import java.util.List;
@@ -25,4 +26,5 @@ public class NormalizeScoresDTO {
     private ScoreNormalizationTechnique normalizationTechnique;
     @NonNull
     private boolean subQueryScores;
+    private SearchPhaseContext searchPhaseContext;
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizeScoresDTO.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizeScoresDTO.java
@@ -23,4 +23,6 @@ public class NormalizeScoresDTO {
     private List<CompoundTopDocs> queryTopDocs;
     @NonNull
     private ScoreNormalizationTechnique normalizationTechnique;
+    @NonNull
+    private boolean subQueryScores;
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/RRFProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/RRFProcessor.java
@@ -53,6 +53,7 @@ public class RRFProcessor extends AbstractScoreHybridizationProcessor {
     private final ScoreNormalizationTechnique normalizationTechnique;
     private final ScoreCombinationTechnique combinationTechnique;
     private final NormalizationProcessorWorkflow normalizationWorkflow;
+    private final boolean subQueryScores;
 
     private final Map<String, Runnable> combTechniqueIncrementers = Map.of(
         RRFScoreCombinationTechnique.TECHNIQUE_NAME,
@@ -87,6 +88,7 @@ public class RRFProcessor extends AbstractScoreHybridizationProcessor {
             .fetchSearchResultOptional(fetchSearchResult)
             .normalizationTechnique(normalizationTechnique)
             .combinationTechnique(combinationTechnique)
+            .subQueryScores(subQueryScores)
             .explain(explain)
             .pipelineProcessingContext(requestContextOptional.orElse(null))
             .searchPhaseContext(searchPhaseContext)

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
@@ -64,11 +64,7 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
                 MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME
             );
             Map<String, Object> normalizationParams = readOptionalMap(NormalizationProcessor.TYPE, tag, normalizationClause, PARAMETERS);
-            normalizationTechnique = scoreNormalizationFactory.createNormalization(
-                normalizationTechniqueName,
-                normalizationParams,
-                subQueryScores
-            );
+            normalizationTechnique = scoreNormalizationFactory.createNormalization(normalizationTechniqueName, normalizationParams);
         }
 
         Map<String, Object> combinationClause = readOptionalMap(NormalizationProcessor.TYPE, tag, config, COMBINATION_CLAUSE);
@@ -105,7 +101,8 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
             description,
             normalizationTechnique,
             scoreCombinationTechnique,
-            normalizationProcessorWorkflow
+            normalizationProcessorWorkflow,
+            subQueryScores
         );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/NormalizationProcessorFactory.java
@@ -53,7 +53,13 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
         final Processor.PipelineContext pipelineContext
     ) throws Exception {
         Map<String, Object> normalizationClause = readOptionalMap(NormalizationProcessor.TYPE, tag, config, NORMALIZATION_CLAUSE);
-        boolean subQueryScores = readBooleanProperty(NormalizationProcessor.TYPE, tag, config, SUB_QUERY_SCORES, DEFAULT_SUB_QUERY_SCORES);
+        boolean subQueryScoresEnabled = readBooleanProperty(
+            NormalizationProcessor.TYPE,
+            tag,
+            config,
+            SUB_QUERY_SCORES,
+            DEFAULT_SUB_QUERY_SCORES
+        );
         ScoreNormalizationTechnique normalizationTechnique = ScoreNormalizationFactory.DEFAULT_METHOD;
         if (Objects.nonNull(normalizationClause)) {
             String normalizationTechniqueName = readStringProperty(
@@ -94,7 +100,7 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
             NormalizationProcessor.TYPE,
             normalizationTechnique,
             scoreCombinationTechnique,
-            subQueryScores
+            subQueryScoresEnabled
         );
         return new NormalizationProcessor(
             tag,
@@ -102,7 +108,7 @@ public class NormalizationProcessorFactory implements Processor.Factory<SearchPh
             normalizationTechnique,
             scoreCombinationTechnique,
             normalizationProcessorWorkflow,
-            subQueryScores
+            subQueryScoresEnabled
         );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
@@ -7,6 +7,7 @@ package org.opensearch.neuralsearch.processor.factory;
 import java.util.Map;
 import java.util.Objects;
 
+import org.opensearch.neuralsearch.processor.NormalizationProcessor;
 import org.opensearch.neuralsearch.processor.RRFProcessor;
 import org.opensearch.neuralsearch.processor.NormalizationProcessorWorkflow;
 import org.opensearch.neuralsearch.processor.combination.RRFScoreCombinationTechnique;
@@ -21,8 +22,14 @@ import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
+import static org.opensearch.ingest.ConfigurationUtils.readBooleanProperty;
 import static org.opensearch.ingest.ConfigurationUtils.readOptionalMap;
 import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.COMBINATION_CLAUSE;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.SUB_QUERY_SCORES;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.DEFAULT_SUB_QUERY_SCORES;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.TECHNIQUE;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.PARAMETERS;
 
 /**
  * Factory class to instantiate RRF processor based on user provided input.
@@ -30,9 +37,6 @@ import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
 @AllArgsConstructor
 @Log4j2
 public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResultsProcessor> {
-    public static final String COMBINATION_CLAUSE = "combination";
-    public static final String TECHNIQUE = "technique";
-    public static final String PARAMETERS = "parameters";
 
     private final NormalizationProcessorWorkflow normalizationProcessorWorkflow;
     private ScoreNormalizationFactory scoreNormalizationFactory;
@@ -54,7 +58,9 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
         ScoreCombinationTechnique scoreCombinationTechnique = scoreCombinationFactory.createCombination(
             RRFScoreCombinationTechnique.TECHNIQUE_NAME
         );
+
         Map<String, Object> combinationClause = readOptionalMap(RRFProcessor.TYPE, tag, config, COMBINATION_CLAUSE);
+        boolean subQueryScores = readBooleanProperty(NormalizationProcessor.TYPE, tag, config, SUB_QUERY_SCORES, DEFAULT_SUB_QUERY_SCORES);
         if (Objects.nonNull(combinationClause)) {
             String combinationTechnique = readStringProperty(
                 RRFProcessor.TYPE,
@@ -68,17 +74,19 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
             if (combinationClause.containsKey(rankConstantParam)) {
                 normalizationTechnique = scoreNormalizationFactory.createNormalization(
                     RRFNormalizationTechnique.TECHNIQUE_NAME,
-                    Map.of(rankConstantParam, combinationClause.get(rankConstantParam))
+                    Map.of(rankConstantParam, combinationClause.get(rankConstantParam)),
+                    subQueryScores
                 );
             }
             Map<String, Object> params = readOptionalMap(RRFProcessor.TYPE, tag, combinationClause, PARAMETERS);
             scoreCombinationTechnique = scoreCombinationFactory.createCombination(combinationTechnique, params);
         }
         log.info(
-            "Creating search phase results processor of type [{}] with normalization [{}] and combination [{}]",
+            "Creating search phase results processor of type [{}] with normalization [{}] and combination [{}] with sub query scores as [{}]",
             RRFProcessor.TYPE,
             normalizationTechnique,
-            scoreCombinationTechnique
+            scoreCombinationTechnique,
+            subQueryScores
         );
         return new RRFProcessor(tag, description, normalizationTechnique, scoreCombinationTechnique, normalizationProcessorWorkflow);
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
@@ -74,8 +74,7 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
             if (combinationClause.containsKey(rankConstantParam)) {
                 normalizationTechnique = scoreNormalizationFactory.createNormalization(
                     RRFNormalizationTechnique.TECHNIQUE_NAME,
-                    Map.of(rankConstantParam, combinationClause.get(rankConstantParam)),
-                    subQueryScores
+                    Map.of(rankConstantParam, combinationClause.get(rankConstantParam))
                 );
             }
             Map<String, Object> params = readOptionalMap(RRFProcessor.TYPE, tag, combinationClause, PARAMETERS);

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
@@ -59,7 +59,7 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
         );
 
         Map<String, Object> combinationClause = readOptionalMap(RRFProcessor.TYPE, tag, config, COMBINATION_CLAUSE);
-        boolean subQueryScores = readBooleanProperty(RRFProcessor.TYPE, tag, config, SUB_QUERY_SCORES, DEFAULT_SUB_QUERY_SCORES);
+        boolean subQueryScoresEnabled = readBooleanProperty(RRFProcessor.TYPE, tag, config, SUB_QUERY_SCORES, DEFAULT_SUB_QUERY_SCORES);
         if (Objects.nonNull(combinationClause)) {
             String combinationTechnique = readStringProperty(
                 RRFProcessor.TYPE,
@@ -84,7 +84,7 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
             RRFProcessor.TYPE,
             normalizationTechnique,
             scoreCombinationTechnique,
-            subQueryScores
+            subQueryScoresEnabled
         );
         return new RRFProcessor(
             tag,
@@ -92,7 +92,7 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
             normalizationTechnique,
             scoreCombinationTechnique,
             normalizationProcessorWorkflow,
-            subQueryScores
+            subQueryScoresEnabled
         );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
@@ -7,7 +7,6 @@ package org.opensearch.neuralsearch.processor.factory;
 import java.util.Map;
 import java.util.Objects;
 
-import org.opensearch.neuralsearch.processor.NormalizationProcessor;
 import org.opensearch.neuralsearch.processor.RRFProcessor;
 import org.opensearch.neuralsearch.processor.NormalizationProcessorWorkflow;
 import org.opensearch.neuralsearch.processor.combination.RRFScoreCombinationTechnique;
@@ -60,7 +59,7 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
         );
 
         Map<String, Object> combinationClause = readOptionalMap(RRFProcessor.TYPE, tag, config, COMBINATION_CLAUSE);
-        boolean subQueryScores = readBooleanProperty(NormalizationProcessor.TYPE, tag, config, SUB_QUERY_SCORES, DEFAULT_SUB_QUERY_SCORES);
+        boolean subQueryScores = readBooleanProperty(RRFProcessor.TYPE, tag, config, SUB_QUERY_SCORES, DEFAULT_SUB_QUERY_SCORES);
         if (Objects.nonNull(combinationClause)) {
             String combinationTechnique = readStringProperty(
                 RRFProcessor.TYPE,
@@ -87,6 +86,13 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
             scoreCombinationTechnique,
             subQueryScores
         );
-        return new RRFProcessor(tag, description, normalizationTechnique, scoreCombinationTechnique, normalizationProcessorWorkflow);
+        return new RRFProcessor(
+            tag,
+            description,
+            normalizationTechnique,
+            scoreCombinationTechnique,
+            normalizationProcessorWorkflow,
+            subQueryScores
+        );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
@@ -50,8 +50,8 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
      * - iterate over each result and update score as per formula above where "score" is raw score returned by Hybrid query
      */
     @Override
-    public Map<Integer, float[]> normalize(final NormalizeScoresDTO normalizeScoresDTO) {
-        Map<Integer, float[]> docIdToSubqueryScores = new HashMap<>();
+    public Map<String, float[]> normalize(final NormalizeScoresDTO normalizeScoresDTO) {
+        Map<String, float[]> docIdToSubqueryScores = new HashMap<>();
         List<CompoundTopDocs> queryTopDocs = normalizeScoresDTO.getQueryTopDocs();
         // get l2 norms for each sub-query
         List<Float> normsPerSubquery = getL2Norm(queryTopDocs);
@@ -67,10 +67,9 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     // Initialize or update subquery scores array per doc
                     if (normalizeScoresDTO.isSubQueryScores()) {
-                        float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(
-                            scoreDoc.doc,
-                            k -> new float[topDocsPerSubQuery.size()]
-                        );
+                        int shardIndex = compoundQueryTopDocs.getSearchShard().getShardId();
+                        String key = shardIndex + "_" + scoreDoc.doc;
+                        float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(key, k -> new float[topDocsPerSubQuery.size()]);
                         scoresArray[j] = scoreDoc.score;
                     }
                     scoreDoc.score = normalizeSingleScore(scoreDoc.score, normsPerSubquery.get(j));

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
@@ -33,19 +33,13 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
     @ToString.Include
     public static final String TECHNIQUE_NAME = "l2";
     private static final float MIN_SCORE = 0.0f;
-    private final boolean subQueryScores;
 
     public L2ScoreNormalizationTechnique() {
-        this(Map.of(), new ScoreNormalizationUtil(), false);
+        this(Map.of(), new ScoreNormalizationUtil());
     }
 
-    public L2ScoreNormalizationTechnique(
-        final Map<String, Object> params,
-        final ScoreNormalizationUtil scoreNormalizationUtil,
-        final boolean subQueryScores
-    ) {
+    public L2ScoreNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
         scoreNormalizationUtil.validateParameters(params, Set.of(), Map.of());
-        this.subQueryScores = subQueryScores;
     }
 
     /**
@@ -72,7 +66,7 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
                 TopDocs subQueryTopDoc = topDocsPerSubQuery.get(j);
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     // Initialize or update subquery scores array per doc
-                    if (subQueryScores) {
+                    if (normalizeScoresDTO.isSubQueryScores()) {
                         float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(
                             scoreDoc.doc,
                             k -> new float[topDocsPerSubQuery.size()]

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechnique.java
@@ -50,7 +50,8 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
      * - iterate over each result and update score as per formula above where "score" is raw score returned by Hybrid query
      */
     @Override
-    public void normalize(final NormalizeScoresDTO normalizeScoresDTO) {
+    public Map<Integer, float[]> normalize(final NormalizeScoresDTO normalizeScoresDTO) {
+        Map<Integer, float[]> docIdToSubqueryScores = new HashMap<>();
         List<CompoundTopDocs> queryTopDocs = normalizeScoresDTO.getQueryTopDocs();
         // get l2 norms for each sub-query
         List<Float> normsPerSubquery = getL2Norm(queryTopDocs);
@@ -64,10 +65,14 @@ public class L2ScoreNormalizationTechnique implements ScoreNormalizationTechniqu
             for (int j = 0; j < topDocsPerSubQuery.size(); j++) {
                 TopDocs subQueryTopDoc = topDocsPerSubQuery.get(j);
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
+                    // Initialize or update subquery scores array per doc
+                    float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(scoreDoc.doc, k -> new float[topDocsPerSubQuery.size()]);
+                    scoresArray[j] = scoreDoc.score;
                     scoreDoc.score = normalizeSingleScore(scoreDoc.score, normsPerSubquery.get(j));
                 }
             }
         }
+        return docIdToSubqueryScores;
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
@@ -84,8 +84,8 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
      * - iterate over each result and update score as per formula above where "score" is raw score returned by Hybrid query
      */
     @Override
-    public Map<Integer, float[]> normalize(final NormalizeScoresDTO normalizeScoresDTO) {
-        Map<Integer, float[]> docIdToSubqueryScores = new HashMap<>();
+    public Map<String, float[]> normalize(final NormalizeScoresDTO normalizeScoresDTO) {
+        Map<String, float[]> docIdToSubqueryScores = new HashMap<>();
         final List<CompoundTopDocs> queryTopDocs = normalizeScoresDTO.getQueryTopDocs();
         MinMaxScores minMaxScores = getMinMaxScoresResult(queryTopDocs);
         // do normalization using actual score and min and max scores for corresponding sub query
@@ -110,10 +110,9 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     // Initialize or update subquery scores array per doc
                     if (normalizeScoresDTO.isSubQueryScores()) {
-                        float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(
-                            scoreDoc.doc,
-                            k -> new float[topDocsPerSubQuery.size()]
-                        );
+                        int shardIndex = compoundQueryTopDocs.getSearchShard().getShardId();
+                        String key = shardIndex + "_" + scoreDoc.doc;
+                        float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(key, k -> new float[topDocsPerSubQuery.size()]);
                         scoresArray[j] = scoreDoc.score;
                     }
                     scoreDoc.score = normalizeSingleScore(

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechnique.java
@@ -62,24 +62,18 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
         PARAM_NAME_UPPER_BOUNDS,
         Set.of(PARAM_NAME_BOUND_MODE, PARAM_NAME_UPPER_BOUND_MAX_SCORE)
     );
-    private final boolean subQueryScores;
 
     private final Optional<List<Map<String, Object>>> lowerBoundsParamsOptional;
     private final Optional<List<Map<String, Object>>> upperBoundsParamsOptional;
 
     public MinMaxScoreNormalizationTechnique() {
-        this(Map.of(), new ScoreNormalizationUtil(), false);
+        this(Map.of(), new ScoreNormalizationUtil());
     }
 
-    public MinMaxScoreNormalizationTechnique(
-        final Map<String, Object> params,
-        final ScoreNormalizationUtil scoreNormalizationUtil,
-        final boolean subQueryScores
-    ) {
+    public MinMaxScoreNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
         scoreNormalizationUtil.validateParameters(params, SUPPORTED_PARAMETERS, NESTED_PARAMETERS);
         lowerBoundsParamsOptional = getBoundsParams(params, PARAM_NAME_LOWER_BOUNDS);
         upperBoundsParamsOptional = getBoundsParams(params, PARAM_NAME_UPPER_BOUNDS);
-        this.subQueryScores = subQueryScores;
     }
 
     /**
@@ -115,7 +109,7 @@ public class MinMaxScoreNormalizationTechnique implements ScoreNormalizationTech
                 UpperBound upperBound = getUpperBound(j);
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     // Initialize or update subquery scores array per doc
-                    if (subQueryScores) {
+                    if (normalizeScoresDTO.isSubQueryScores()) {
                         float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(
                             scoreDoc.doc,
                             k -> new float[topDocsPerSubQuery.size()]

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
@@ -161,8 +161,8 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
             // Initialize or update subquery scores array per doc
             if (subQueryScores) {
                 int shardIndex = searchShard.getShardId();
-                String key = shardIndex + "_" + scoreDoc.doc;
-                float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(key, k -> new float[topDocsSize]);
+                String docKey = String.format(Locale.ROOT, "%d_%d", shardIndex, scoreDoc.doc);
+                float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(docKey, k -> new float[topDocsSize]);
                 scoresArray[topDocsIndex] = scoreDoc.score;
             }
             scoreDoc.score = normalizedScore;

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.Optional;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Abstracts creation of exact score normalization method based on technique name
@@ -24,17 +24,16 @@ public class ScoreNormalizationFactory {
 
     public static final ScoreNormalizationTechnique DEFAULT_METHOD = new MinMaxScoreNormalizationTechnique();
 
-    private static final Map<String, BiFunction<Map<String, Object>, Boolean, ScoreNormalizationTechnique>> SCORE_NORMALIZATION_METHODS =
-        Map.of(
-            MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
-            (params, subQueryScores) -> new MinMaxScoreNormalizationTechnique(params, scoreNormalizationUtil, subQueryScores),
-            L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
-            (params, subQueryScores) -> new L2ScoreNormalizationTechnique(params, scoreNormalizationUtil, subQueryScores),
-            RRFNormalizationTechnique.TECHNIQUE_NAME,
-            (params, subQueryScores) -> new RRFNormalizationTechnique(params, scoreNormalizationUtil, subQueryScores),
-            ZScoreNormalizationTechnique.TECHNIQUE_NAME,
-            (params, subQueryScores) -> new ZScoreNormalizationTechnique(params, scoreNormalizationUtil, subQueryScores)
-        );
+    private static final Map<String, Function<Map<String, Object>, ScoreNormalizationTechnique>> SCORE_NORMALIZATION_METHODS = Map.of(
+        MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
+        params -> new MinMaxScoreNormalizationTechnique(params, scoreNormalizationUtil),
+        L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
+        params -> new L2ScoreNormalizationTechnique(params, scoreNormalizationUtil),
+        RRFNormalizationTechnique.TECHNIQUE_NAME,
+        params -> new RRFNormalizationTechnique(params, scoreNormalizationUtil),
+        ZScoreNormalizationTechnique.TECHNIQUE_NAME,
+        params -> new ZScoreNormalizationTechnique(params, scoreNormalizationUtil)
+    );
 
     private static final Map<String, Set<String>> COMBINATION_TECHNIQUE_FOR_NORMALIZATION_METHODS = Map.of(
         MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
@@ -65,17 +64,13 @@ public class ScoreNormalizationFactory {
      * @return instance of ScoreNormalizationMethod for technique name
      */
     public ScoreNormalizationTechnique createNormalization(final String technique) {
-        return createNormalization(technique, Map.of(), false);
+        return createNormalization(technique, Map.of());
     }
 
-    public ScoreNormalizationTechnique createNormalization(
-        final String technique,
-        final Map<String, Object> params,
-        boolean subQueryScores
-    ) {
+    public ScoreNormalizationTechnique createNormalization(final String technique, final Map<String, Object> params) {
         return Optional.ofNullable(SCORE_NORMALIZATION_METHODS.get(technique))
             .orElseThrow(() -> new IllegalArgumentException("provided normalization technique is not supported"))
-            .apply(params, subQueryScores);
+            .apply(params);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactory.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 /**
  * Abstracts creation of exact score normalization method based on technique name
@@ -24,16 +24,17 @@ public class ScoreNormalizationFactory {
 
     public static final ScoreNormalizationTechnique DEFAULT_METHOD = new MinMaxScoreNormalizationTechnique();
 
-    private static final Map<String, Function<Map<String, Object>, ScoreNormalizationTechnique>> SCORE_NORMALIZATION_METHODS = Map.of(
-        MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new MinMaxScoreNormalizationTechnique(params, scoreNormalizationUtil),
-        L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new L2ScoreNormalizationTechnique(params, scoreNormalizationUtil),
-        RRFNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new RRFNormalizationTechnique(params, scoreNormalizationUtil),
-        ZScoreNormalizationTechnique.TECHNIQUE_NAME,
-        params -> new ZScoreNormalizationTechnique()
-    );
+    private static final Map<String, BiFunction<Map<String, Object>, Boolean, ScoreNormalizationTechnique>> SCORE_NORMALIZATION_METHODS =
+        Map.of(
+            MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
+            (params, subQueryScores) -> new MinMaxScoreNormalizationTechnique(params, scoreNormalizationUtil, subQueryScores),
+            L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
+            (params, subQueryScores) -> new L2ScoreNormalizationTechnique(params, scoreNormalizationUtil, subQueryScores),
+            RRFNormalizationTechnique.TECHNIQUE_NAME,
+            (params, subQueryScores) -> new RRFNormalizationTechnique(params, scoreNormalizationUtil, subQueryScores),
+            ZScoreNormalizationTechnique.TECHNIQUE_NAME,
+            (params, subQueryScores) -> new ZScoreNormalizationTechnique(params, scoreNormalizationUtil, subQueryScores)
+        );
 
     private static final Map<String, Set<String>> COMBINATION_TECHNIQUE_FOR_NORMALIZATION_METHODS = Map.of(
         MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
@@ -64,13 +65,17 @@ public class ScoreNormalizationFactory {
      * @return instance of ScoreNormalizationMethod for technique name
      */
     public ScoreNormalizationTechnique createNormalization(final String technique) {
-        return createNormalization(technique, Map.of());
+        return createNormalization(technique, Map.of(), false);
     }
 
-    public ScoreNormalizationTechnique createNormalization(final String technique, final Map<String, Object> params) {
+    public ScoreNormalizationTechnique createNormalization(
+        final String technique,
+        final Map<String, Object> params,
+        boolean subQueryScores
+    ) {
         return Optional.ofNullable(SCORE_NORMALIZATION_METHODS.get(technique))
             .orElseThrow(() -> new IllegalArgumentException("provided normalization technique is not supported"))
-            .apply(params);
+            .apply(params, subQueryScores);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationTechnique.java
@@ -20,7 +20,7 @@ public interface ScoreNormalizationTechnique {
      * original query results from multiple shards and multiple sub-queries, ScoreNormalizationTechnique,
      * and nullable rankConstant that is only used in RRF technique
      */
-    Map<Integer, float[]> normalize(final NormalizeScoresDTO normalizeScoresDTO);
+    Map<String, float[]> normalize(final NormalizeScoresDTO normalizeScoresDTO);
 
     /**
      * Returns the name of the normalization technique.

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationTechnique.java
@@ -6,6 +6,8 @@ package org.opensearch.neuralsearch.processor.normalization;
 
 import org.opensearch.neuralsearch.processor.NormalizeScoresDTO;
 
+import java.util.Map;
+
 /**
  * Abstracts normalization of scores in query search results.
  */
@@ -18,7 +20,7 @@ public interface ScoreNormalizationTechnique {
      * original query results from multiple shards and multiple sub-queries, ScoreNormalizationTechnique,
      * and nullable rankConstant that is only used in RRF technique
      */
-    void normalize(final NormalizeScoresDTO normalizeScoresDTO);
+    Map<Integer, float[]> normalize(final NormalizeScoresDTO normalizeScoresDTO);
 
     /**
      * Returns the name of the normalization technique.

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizer.java
@@ -49,7 +49,7 @@ public class ScoreNormalizer {
                 HybridScoreRegistry.store(searchPhaseContext, hybridizationScores);
 
                 // clean up later via context.addReleasable()
-                // searchPhaseContext.addReleasable(() -> HybridScoreRegistry.remove(searchPhaseContext));
+                searchPhaseContext.addReleasable(() -> HybridScoreRegistry.remove(searchPhaseContext));
             }
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizer.java
@@ -44,12 +44,14 @@ public class ScoreNormalizer {
             boolean isSortEnabled = isSortEnabled(searchPhaseContext);
 
             if (isExplainEnabled == false && isSortEnabled == false) {
-                // Store in registry
-                setSearchPhaseContext(searchPhaseContext);
-                HybridScoreRegistry.store(searchPhaseContext, hybridizationScores);
-
-                // clean up later via context.addReleasable()
-                searchPhaseContext.addReleasable(() -> HybridScoreRegistry.remove(searchPhaseContext));
+                try {
+                    // Store in registry
+                    setSearchPhaseContext(searchPhaseContext);
+                    HybridScoreRegistry.store(searchPhaseContext, hybridizationScores);
+                } finally {
+                    // clean up later via context.addReleasable()
+                    searchPhaseContext.addReleasable(() -> HybridScoreRegistry.remove(searchPhaseContext));
+                }
             }
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizer.java
@@ -10,18 +10,20 @@ import java.util.Objects;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.neuralsearch.processor.CompoundTopDocs;
 import org.opensearch.neuralsearch.processor.HybridScoreRegistry;
 import org.opensearch.neuralsearch.processor.explain.DocIdAtSearchShard;
 import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
 import org.opensearch.neuralsearch.processor.NormalizeScoresDTO;
-import org.opensearch.search.internal.SearchContext;
+import static org.opensearch.neuralsearch.processor.util.ProcessorUtils.isSortEnabled;
+import static org.opensearch.neuralsearch.processor.util.ProcessorUtils.isExplainEnabled;
 
 public class ScoreNormalizer {
     @Getter
     @Setter
-    private static SearchContext searchContext;
+    private static SearchPhaseContext searchPhaseContext;
 
     /**
      * Performs score normalization based on input normalization technique.
@@ -30,19 +32,24 @@ public class ScoreNormalizer {
      * from multiple shards and multiple sub-queries, scoreNormalizationTechnique exact normalization technique
      * that should be applied, and nullable rankConstant that is only used in RRF technique
      */
-    public void normalizeScores(final NormalizeScoresDTO normalizeScoresDTO, SearchContext searchContext) {
+    public void normalizeScores(final NormalizeScoresDTO normalizeScoresDTO, SearchPhaseContext searchPhaseContext) {
         final List<CompoundTopDocs> queryTopDocs = normalizeScoresDTO.getQueryTopDocs();
         final ScoreNormalizationTechnique scoreNormalizationTechnique = normalizeScoresDTO.getNormalizationTechnique();
         if (canQueryResultsBeNormalized(queryTopDocs)) {
 
             Map<Integer, float[]> hybridizationScores = scoreNormalizationTechnique.normalize(normalizeScoresDTO);
-            // Store in registry
 
-            setSearchContext(searchContext);
-            HybridScoreRegistry.store(searchContext, hybridizationScores);
+            boolean isExplainEnabled = isExplainEnabled(searchPhaseContext);
+            boolean isSortEnabled = isSortEnabled(searchPhaseContext);
 
-            // // // Optional: clean up later via context.addReleasable()
-            // searchContext.addReleasable(() -> HybridScoreRegistry.remove(searchContext));
+            if (isExplainEnabled == false && isSortEnabled == false) {
+                // Store in registry
+                setSearchPhaseContext(searchPhaseContext);
+                HybridScoreRegistry.store(searchPhaseContext, hybridizationScores);
+
+                // clean up later via context.addReleasable()
+                searchPhaseContext.addReleasable(() -> HybridScoreRegistry.remove(searchPhaseContext));
+            }
         }
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizer.java
@@ -32,12 +32,13 @@ public class ScoreNormalizer {
      * from multiple shards and multiple sub-queries, scoreNormalizationTechnique exact normalization technique
      * that should be applied, and nullable rankConstant that is only used in RRF technique
      */
-    public void normalizeScores(final NormalizeScoresDTO normalizeScoresDTO, SearchPhaseContext searchPhaseContext) {
+    public void normalizeScores(final NormalizeScoresDTO normalizeScoresDTO) {
         final List<CompoundTopDocs> queryTopDocs = normalizeScoresDTO.getQueryTopDocs();
         final ScoreNormalizationTechnique scoreNormalizationTechnique = normalizeScoresDTO.getNormalizationTechnique();
+        final SearchPhaseContext searchPhaseContext = normalizeScoresDTO.getSearchPhaseContext();
         if (canQueryResultsBeNormalized(queryTopDocs)) {
 
-            Map<Integer, float[]> hybridizationScores = scoreNormalizationTechnique.normalize(normalizeScoresDTO);
+            Map<String, float[]> hybridizationScores = scoreNormalizationTechnique.normalize(normalizeScoresDTO);
 
             boolean isExplainEnabled = isExplainEnabled(searchPhaseContext);
             boolean isSortEnabled = isSortEnabled(searchPhaseContext);
@@ -48,7 +49,7 @@ public class ScoreNormalizer {
                 HybridScoreRegistry.store(searchPhaseContext, hybridizationScores);
 
                 // clean up later via context.addReleasable()
-                searchPhaseContext.addReleasable(() -> HybridScoreRegistry.remove(searchPhaseContext));
+                // searchPhaseContext.addReleasable(() -> HybridScoreRegistry.remove(searchPhaseContext));
             }
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechnique.java
@@ -36,19 +36,13 @@ public class ZScoreNormalizationTechnique implements ScoreNormalizationTechnique
     public static final String TECHNIQUE_NAME = "z_score";
     private static final float SINGLE_RESULT_SCORE = 1.0f;
     private static final float MIN_SCORE = 0.001f;
-    private final boolean subQueryScores;
 
     public ZScoreNormalizationTechnique() {
-        this(Map.of(), new ScoreNormalizationUtil(), false);
+        this(Map.of(), new ScoreNormalizationUtil());
     }
 
-    public ZScoreNormalizationTechnique(
-        final Map<String, Object> params,
-        final ScoreNormalizationUtil scoreNormalizationUtil,
-        final boolean subQueryScores
-    ) {
+    public ZScoreNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
         scoreNormalizationUtil.validateParameters(params, Set.of(), Map.of());
-        this.subQueryScores = subQueryScores;
     }
 
     /**
@@ -83,7 +77,7 @@ public class ZScoreNormalizationTechnique implements ScoreNormalizationTechnique
                 TopDocs subQueryTopDoc = topDocsPerSubQuery.get(j);
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     // Initialize or update subquery scores array per doc
-                    if (subQueryScores) {
+                    if (normalizeScoresDTO.isSubQueryScores()) {
                         float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(
                             scoreDoc.doc,
                             k -> new float[topDocsPerSubQuery.size()]

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechnique.java
@@ -61,8 +61,8 @@ public class ZScoreNormalizationTechnique implements ScoreNormalizationTechnique
      * and nullable rankConstant that is only used in RRF technique
      */
     @Override
-    public Map<Integer, float[]> normalize(NormalizeScoresDTO normalizeScoresDTO) {
-        Map<Integer, float[]> docIdToSubqueryScores = new HashMap<>();
+    public Map<String, float[]> normalize(NormalizeScoresDTO normalizeScoresDTO) {
+        Map<String, float[]> docIdToSubqueryScores = new HashMap<>();
         List<CompoundTopDocs> queryTopDocs = normalizeScoresDTO.getQueryTopDocs();
 
         ZScores zscores = getZScoreResults(queryTopDocs);
@@ -78,10 +78,9 @@ public class ZScoreNormalizationTechnique implements ScoreNormalizationTechnique
                 for (ScoreDoc scoreDoc : subQueryTopDoc.scoreDocs) {
                     // Initialize or update subquery scores array per doc
                     if (normalizeScoresDTO.isSubQueryScores()) {
-                        float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(
-                            scoreDoc.doc,
-                            k -> new float[topDocsPerSubQuery.size()]
-                        );
+                        int shardIndex = compoundQueryTopDocs.getSearchShard().getShardId();
+                        String key = shardIndex + "_" + scoreDoc.doc;
+                        float[] scoresArray = docIdToSubqueryScores.computeIfAbsent(key, k -> new float[topDocsPerSubQuery.size()]);
                         scoresArray[j] = scoreDoc.score;
                     }
                     scoreDoc.score = normalizeSingleScore(

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/ProcessorUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/ProcessorUtils.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.processor.util;
 
 import lombok.NonNull;
+import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.collect.Tuple;
@@ -14,6 +15,7 @@ import org.opensearch.neuralsearch.processor.CompoundTopDocs;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -302,6 +304,26 @@ public class ProcessorUtils {
         }
 
         return false;
+    }
+
+    /**
+     *
+     * @param searchPhaseContext the search phase context that contains the search request
+     * @return whether sort is enabled in the search request
+     */
+    public static boolean isSortEnabled(SearchPhaseContext searchPhaseContext) {
+        SearchSourceBuilder searchSourceBuilder = searchPhaseContext.getRequest().source();
+        return searchSourceBuilder.sorts() != null && !searchSourceBuilder.sorts().isEmpty();
+    }
+
+    /**
+     *
+     * @param searchPhaseContext the search phase context that contains the search request
+     * @return whether explain is enabled in the search request
+     */
+    public static boolean isExplainEnabled(SearchPhaseContext searchPhaseContext) {
+        SearchSourceBuilder searchSourceBuilder = searchPhaseContext.getRequest().source();
+        return Objects.nonNull(searchSourceBuilder.explain()) && searchSourceBuilder.explain();
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/e2e/HybridCollapseIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/e2e/HybridCollapseIT.java
@@ -32,7 +32,7 @@ public class HybridCollapseIT extends BaseNeuralSearchIT {
         super.setUp();
         createTestIndex();
         indexTestDocuments();
-        createSearchPipeline(SEARCH_PIPELINE, "min_max", "arithmetic_mean", Map.of());
+        createSearchPipeline(SEARCH_PIPELINE, "min_max", "arithmetic_mean", Map.of(), false);
     }
 
     public void testCollapse_whenE2E_thenSuccessful() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/HybridScoreRegistryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/HybridScoreRegistryTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class HybridScoreRegistryTests extends OpenSearchTestCase {
+
+    public void testStoreAndGet() {
+        var mockSearchContext = mock(SearchContext.class);
+        int docId = 1;
+        float[] scores = new float[] { 0.4f, 0.6f };
+        Map<Integer, float[]> expectedScores = Map.of(docId, scores);
+        HybridScoreRegistry.store(mockSearchContext, Map.of(docId, scores));
+        Map<Integer, float[]> actualScores = HybridScoreRegistry.get(mockSearchContext);
+        assertEquals(expectedScores, actualScores);
+    }
+
+    public void testRemove() {
+        var mockSearchContext = mock(SearchContext.class);
+        HybridScoreRegistry.store(mockSearchContext, Map.of(1, new float[] { 0.4f, 0.6f }));
+        HybridScoreRegistry.remove(mockSearchContext);
+        assertNull(HybridScoreRegistry.get(mockSearchContext));
+    }
+
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/HybridScoreRegistryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/HybridScoreRegistryTests.java
@@ -15,17 +15,17 @@ public class HybridScoreRegistryTests extends OpenSearchTestCase {
 
     public void testStoreAndGet() {
         var mockSearchContext = mock(SearchPhaseContext.class);
-        int docId = 1;
+        String key = "0_2";
         float[] scores = new float[] { 0.4f, 0.6f };
-        Map<Integer, float[]> expectedScores = Map.of(docId, scores);
-        HybridScoreRegistry.store(mockSearchContext, Map.of(docId, scores));
-        Map<Integer, float[]> actualScores = HybridScoreRegistry.get(mockSearchContext);
+        Map<String, float[]> expectedScores = Map.of(key, scores);
+        HybridScoreRegistry.store(mockSearchContext, Map.of(key, scores));
+        Map<String, float[]> actualScores = HybridScoreRegistry.get(mockSearchContext);
         assertEquals(expectedScores, actualScores);
     }
 
     public void testRemove() {
         var mockSearchContext = mock(SearchPhaseContext.class);
-        HybridScoreRegistry.store(mockSearchContext, Map.of(1, new float[] { 0.4f, 0.6f }));
+        HybridScoreRegistry.store(mockSearchContext, Map.of("0_2", new float[] { 0.4f, 0.6f }));
         HybridScoreRegistry.remove(mockSearchContext);
         assertNull(HybridScoreRegistry.get(mockSearchContext));
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/HybridScoreRegistryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/HybridScoreRegistryTests.java
@@ -4,7 +4,7 @@
  */
 package org.opensearch.neuralsearch.processor;
 
-import org.opensearch.search.internal.SearchContext;
+import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Map;
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.mock;
 public class HybridScoreRegistryTests extends OpenSearchTestCase {
 
     public void testStoreAndGet() {
-        var mockSearchContext = mock(SearchContext.class);
+        var mockSearchContext = mock(SearchPhaseContext.class);
         int docId = 1;
         float[] scores = new float[] { 0.4f, 0.6f };
         Map<Integer, float[]> expectedScores = Map.of(docId, scores);
@@ -24,7 +24,7 @@ public class HybridScoreRegistryTests extends OpenSearchTestCase {
     }
 
     public void testRemove() {
-        var mockSearchContext = mock(SearchContext.class);
+        var mockSearchContext = mock(SearchPhaseContext.class);
         HybridScoreRegistry.store(mockSearchContext, Map.of(1, new float[] { 0.4f, 0.6f }));
         HybridScoreRegistry.remove(mockSearchContext);
         assertNull(HybridScoreRegistry.get(mockSearchContext));

--- a/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
@@ -175,6 +175,7 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
     }
 
     public void testNoHybridizationFieldWhenDocIdNotInMap() throws IOException {
+        setUpClusterService();
         mockFetchContext = mock(FetchContext.class);
         mockQueryShardContext = mock(QueryShardContext.class);
         try (Directory directory = newDirectory()) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.junit.Before;
+import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.common.document.DocumentField;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
@@ -21,7 +22,6 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.fetch.FetchContext;
 import org.opensearch.search.fetch.FetchSubPhase;
 import org.opensearch.search.fetch.FetchSubPhaseProcessor;
-import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.lookup.SourceLookup;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -66,7 +66,7 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
                 searchHit = new SearchHit(docId);
                 hitContext = new FetchSubPhase.HitContext(searchHit, leafReaderContext, docId, new SourceLookup());
 
-                var mockSearchContext = mock(SearchContext.class);
+                var mockSearchContext = mock(SearchPhaseContext.class);
                 final List<CompoundTopDocs> queryTopDocs = List.of(
                     new CompoundTopDocs(
                         new TotalHits(1, TotalHits.Relation.EQUAL_TO),
@@ -112,7 +112,7 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
                 searchHit = new SearchHit(docId);
                 hitContext = new FetchSubPhase.HitContext(searchHit, leafReaderContext, docId, new SourceLookup());
 
-                var mockSearchContext = mock(SearchContext.class);
+                var mockSearchContext = mock(SearchPhaseContext.class);
 
                 NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
                     .queryTopDocs(List.of())
@@ -144,7 +144,7 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
                 searchHit = new SearchHit(docId);
                 hitContext = new FetchSubPhase.HitContext(searchHit, leafReaderContext, docId, new SourceLookup());
 
-                var mockSearchContext = mock(SearchContext.class);
+                var mockSearchContext = mock(SearchPhaseContext.class);
 
                 // docId 0 not in hit
                 final List<CompoundTopDocs> queryTopDocs = List.of(

--- a/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
@@ -16,10 +16,10 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.document.DocumentField;
+import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
-import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.FetchContext;
@@ -43,11 +43,12 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
     private SearchHit searchHit;
     private FetchSubPhase.HitContext hitContext;
     private static final SearchShard SEARCH_SHARD = new SearchShard("my_index", 0, "12345678");
-    private NeuralSearchClusterUtil clusterUtil;
+    private QueryShardContext mockQueryShardContext;
 
     public void testHybridizationScoreFieldIsSet() throws IOException {
         setUpClusterService();
         mockFetchContext = mock(FetchContext.class);
+        mockQueryShardContext = mock(QueryShardContext.class);
         try (Directory directory = newDirectory()) {
             // Create dummy Lucene doc
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
@@ -75,36 +76,42 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
                         SEARCH_SHARD
                     )
                 );
-                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
-                    .queryTopDocs(queryTopDocs)
-                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
-                    .subQueryScores(true)
-                    .build();
 
                 SearchRequest searchRequest = mock(SearchRequest.class);
                 when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
                 SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
                 when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
 
+                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+                    .queryTopDocs(queryTopDocs)
+                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+                    .subQueryScores(true)
+                    .searchPhaseContext(searchPhaseContext)
+                    .build();
+
                 ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
                 ScoreNormalizationTechnique normalizationTechnique = scoreNormalizationFactory.createNormalization("min_max", Map.of());
 
                 normalizationTechnique.normalize(normalizeScoresDTO);
 
-                scoreNormalizer.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+                scoreNormalizer.normalizeScores(normalizeScoresDTO);
 
                 float[] scores = new float[] { 0.4f, 0.6f };
-                HybridScoreRegistry.store(searchPhaseContext, Map.of(docId, scores));
+                String key = SEARCH_SHARD.getShardId() + "_" + docId;
+                HybridScoreRegistry.store(searchPhaseContext, Map.of(key, scores));
 
                 // Run processor
+                when(mockFetchContext.getQueryShardContext()).thenReturn(mockQueryShardContext);
+                when(mockQueryShardContext.getShardId()).thenReturn(SEARCH_SHARD.getShardId());
                 FetchSubPhaseProcessor processor = subPhase.getProcessor(mockFetchContext);
                 processor.setNextReader(leafReaderContext);
                 processor.process(hitContext);
 
                 DocumentField field = hitContext.hit().field("hybridization_sub_query_scores");
                 assertNotNull(String.valueOf(field), "Expected _hybridization field to be present");
-                assertEquals(1, field.getValues().size());
-                assertSame(scores, field.getValues().get(0));
+                assertEquals(2, field.getValues().size());
+                assertEquals(scores[0], field.getValues().get(0));
+                assertEquals(scores[1], field.getValues().get(1));
             }
         }
     }
@@ -112,6 +119,7 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
     public void testNoHybridizationFieldWhenMapIsNull() throws IOException {
         setUpClusterService();
         mockFetchContext = mock(FetchContext.class);
+        mockQueryShardContext = mock(QueryShardContext.class);
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
                 writer.addDocument(new Document());
@@ -136,24 +144,27 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
                         SEARCH_SHARD
                     )
                 );
-                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
-                    .queryTopDocs(queryTopDocs)
-                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
-                    .subQueryScores(true)
-                    .build();
-
                 SearchRequest searchRequest = mock(SearchRequest.class);
                 when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
                 SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
                 when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
+
+                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+                    .queryTopDocs(queryTopDocs)
+                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+                    .subQueryScores(true)
+                    .searchPhaseContext(searchPhaseContext)
+                    .build();
 
                 ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
                 ScoreNormalizationTechnique normalizationTechnique = scoreNormalizationFactory.createNormalization("min_max", Map.of());
 
                 normalizationTechnique.normalize(normalizeScoresDTO);
 
-                scoreNormalizer.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+                scoreNormalizer.normalizeScores(normalizeScoresDTO);
 
+                when(mockFetchContext.getQueryShardContext()).thenReturn(mockQueryShardContext);
+                when(mockQueryShardContext.getShardId()).thenReturn(SEARCH_SHARD.getShardId());
                 FetchSubPhaseProcessor processor = subPhase.getProcessor(mockFetchContext);
                 processor.setNextReader(leafReaderContext);
                 processor.process(hitContext);
@@ -165,6 +176,7 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
 
     public void testNoHybridizationFieldWhenDocIdNotInMap() throws IOException {
         mockFetchContext = mock(FetchContext.class);
+        mockQueryShardContext = mock(QueryShardContext.class);
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
                 writer.addDocument(new Document());
@@ -174,7 +186,7 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
 
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReaderContext leafReaderContext = reader.leaves().get(0);
-                int docId = 0;
+                int docId = 5;
 
                 searchHit = new SearchHit(docId);
                 hitContext = new FetchSubPhase.HitContext(searchHit, leafReaderContext, docId, new SourceLookup());
@@ -190,27 +202,31 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
                         SEARCH_SHARD
                     )
                 );
-                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
-                    .queryTopDocs(queryTopDocs)
-                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
-                    .subQueryScores(true)
-                    .build();
-
                 SearchRequest searchRequest = mock(SearchRequest.class);
                 when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
                 SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
                 when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
-                scoreNormalizer.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+
+                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+                    .queryTopDocs(queryTopDocs)
+                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+                    .subQueryScores(true)
+                    .searchPhaseContext(searchPhaseContext)
+                    .build();
+                scoreNormalizer.normalizeScores(normalizeScoresDTO);
 
                 float[] scores = new float[] { 0.4f, 0.6f };
-                HybridScoreRegistry.store(searchPhaseContext, Map.of(1, scores));
+                String key = SEARCH_SHARD.getShardId() + "_" + "1";
+                HybridScoreRegistry.store(searchPhaseContext, Map.of(key, scores));
 
+                when(mockFetchContext.getQueryShardContext()).thenReturn(mockQueryShardContext);
+                when(mockQueryShardContext.getShardId()).thenReturn(SEARCH_SHARD.getShardId());
                 FetchSubPhaseProcessor processor = subPhase.getProcessor(mockFetchContext);
                 processor.setNextReader(leafReaderContext);
                 processor.process(hitContext);
 
                 // Check hit context has docId 0 set
-                assertEquals(0, hitContext.hit().docId());
+                assertEquals(5, hitContext.hit().docId());
                 // Check hit does not have _hybridization field as there are no subquery scores for doc 0
                 assertNull(hitContext.hit().field("hybridization_sub_query_scores"));
             }

--- a/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.junit.Before;
+import org.opensearch.common.document.DocumentField;
+import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
+import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.fetch.FetchContext;
+import org.opensearch.search.fetch.FetchSubPhase;
+import org.opensearch.search.fetch.FetchSubPhaseProcessor;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.lookup.SourceLookup;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
+
+    private ScoreNormalizer scoreNormalizer;
+    private HybridScoreRegistry hybridScoreRegistry;
+    private FetchContext mockFetchContext;
+    private SearchHit searchHit;
+    private FetchSubPhase.HitContext hitContext;
+    private static final SearchShard SEARCH_SHARD = new SearchShard("my_index", 0, "12345678");
+
+    @Before
+    public void setUpMocks() {
+        mockFetchContext = mock(FetchContext.class);
+        scoreNormalizer = new ScoreNormalizer();
+        hybridScoreRegistry = new HybridScoreRegistry();
+    }
+
+    public void testHybridizationScoreFieldIsSet() throws IOException {
+        try (Directory directory = newDirectory()) {
+            // Create dummy Lucene doc
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+                Document doc = new Document();
+                doc.add(new NumericDocValuesField("dummy_field", 1));
+                writer.addDocument(doc);
+            }
+
+            // Prepare subphase
+            HybridizationFetchSubPhase subPhase = new HybridizationFetchSubPhase();
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReaderContext leafReaderContext = reader.leaves().get(0);
+                int docId = 0;
+
+                searchHit = new SearchHit(docId);
+                hitContext = new FetchSubPhase.HitContext(searchHit, leafReaderContext, docId, new SourceLookup());
+
+                // Mock ScoreNormalizer and HybridScoreRegistry
+                var mockSearchContext = mock(SearchContext.class);
+                // mockedNormalizer.when(ScoreNormalizer::getSearchContext).thenReturn(mockSearchContext);
+                final List<CompoundTopDocs> queryTopDocs = List.of(
+                    new CompoundTopDocs(
+                        new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                        List.of(new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(1, 2.0f) })),
+                        false,
+                        SEARCH_SHARD
+                    )
+                );
+                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+                    .queryTopDocs(queryTopDocs)
+                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+                    .build();
+                scoreNormalizer.normalizeScores(normalizeScoresDTO, mockSearchContext);
+
+                float[] scores = new float[] { 0.4f, 0.6f };
+                hybridScoreRegistry.store(mockSearchContext, Map.of(docId, scores));
+
+                // Run processor
+                FetchSubPhaseProcessor processor = subPhase.getProcessor(mockFetchContext);
+                processor.setNextReader(leafReaderContext);
+                processor.process(hitContext);
+
+                DocumentField field = hitContext.hit().field("_hybridization");
+                assertNotNull(String.valueOf(field), "Expected _hybridization field to be present");
+                assertEquals(1, field.getValues().size());
+                assertSame(scores, field.getValues().get(0));  // Check reference
+            }
+        }
+    }
+
+    public void testNoHybridizationFieldWhenMapIsNull() throws IOException {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+                writer.addDocument(new Document());
+            }
+
+            HybridizationFetchSubPhase subPhase = new HybridizationFetchSubPhase();
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReaderContext leafReaderContext = reader.leaves().get(0);
+                int docId = 0;
+
+                searchHit = new SearchHit(docId);
+                hitContext = new FetchSubPhase.HitContext(searchHit, leafReaderContext, docId, new SourceLookup());
+
+                var mockSearchContext = mock(SearchContext.class);
+
+                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+                    .queryTopDocs(List.of())
+                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+                    .build();
+                scoreNormalizer.normalizeScores(normalizeScoresDTO, mockSearchContext);
+
+                FetchSubPhaseProcessor processor = subPhase.getProcessor(mockFetchContext);
+                processor.setNextReader(leafReaderContext);
+                processor.process(hitContext);
+
+                assertNull(hitContext.hit().field("_hybridization"));
+            }
+        }
+    }
+
+    public void testNoHybridizationFieldWhenDocIdNotInMap() throws IOException {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), directory)) {
+                writer.addDocument(new Document());
+            }
+
+            HybridizationFetchSubPhase subPhase = new HybridizationFetchSubPhase();
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReaderContext leafReaderContext = reader.leaves().get(0);
+                int docId = 0;
+
+                searchHit = new SearchHit(docId);
+                hitContext = new FetchSubPhase.HitContext(searchHit, leafReaderContext, docId, new SourceLookup());
+
+                var mockSearchContext = mock(SearchContext.class);
+
+                // docId 0 not in hit
+                final List<CompoundTopDocs> queryTopDocs = List.of(
+                    new CompoundTopDocs(
+                        new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                        List.of(new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(docId, 2.0f) })),
+                        false,
+                        SEARCH_SHARD
+                    )
+                );
+                NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+                    .queryTopDocs(queryTopDocs)
+                    .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+                    .build();
+                scoreNormalizer.normalizeScores(normalizeScoresDTO, mockSearchContext);
+
+                float[] scores = new float[] { 0.4f, 0.6f };
+                hybridScoreRegistry.store(mockSearchContext, Map.of(docId, scores));
+
+                FetchSubPhaseProcessor processor = subPhase.getProcessor(mockFetchContext);
+                processor.setNextReader(leafReaderContext);
+                processor.process(hitContext);
+
+                assertEquals(1, hitContext.hit().docId());
+            }
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/HybridizationFetchSubPhaseTests.java
@@ -104,7 +104,7 @@ public class HybridizationFetchSubPhaseTests extends OpenSearchTestCase {
                 DocumentField field = hitContext.hit().field("hybridization_sub_query_scores");
                 assertNotNull(String.valueOf(field), "Expected _hybridization field to be present");
                 assertEquals(1, field.getValues().size());
-                assertSame(scores, field.getValues().get(0));  // Check reference
+                assertSame(scores, field.getValues().get(0));
             }
         }
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -1105,18 +1105,12 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
 
         for (Map<String, Object> hit : hitsNestedList) {
             @SuppressWarnings("unchecked")
-
             Map<String, Object> fields = (Map<String, Object>) hit.get("fields");
-
             assertNotNull(fields);
-
             @SuppressWarnings("unchecked")
             List<Double> subQueryScores = (List<Double>) fields.get("hybridization_sub_query_scores");
-
             assertNotNull(subQueryScores);
-
             assertEquals(expectedSubQueryCount, subQueryScores.size());
-
             for (Double score : subQueryScores) {
                 assertNotNull(score);
                 assertTrue(score >= 0.0);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -22,7 +22,6 @@ import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.Range;
 import org.junit.Before;
-import org.opensearch.common.document.DocumentField;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
@@ -1105,29 +1104,24 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
 
         for (Map<String, Object> hit : hitsNestedList) {
-            // Get fields map from hit
             @SuppressWarnings("unchecked")
 
-            Map<String, DocumentField> fields = hit.getFields();
             Map<String, Object> fields = (Map<String, Object>) hit.get("fields");
 
-            assertNotNull("Fields should not be null", fields);
+            assertNotNull(fields);
 
-            // Get hybridization_sub_query_scores from fields - corrected casting
             @SuppressWarnings("unchecked")
-            List<Double> subQueryScores = ((List<List<Double>>) fields.get("hybridization_sub_query_scores")).get(0);
+            List<Double> subQueryScores = (List<Double>) fields.get("hybridization_sub_query_scores");
+            System.out.println("subquery" + subQueryScores);
 
-            assertNotNull("Hybridization sub query scores should not be null", subQueryScores);
-            assertFalse("Hybridization sub query scores should not be empty", subQueryScores.isEmpty());
+            assertNotNull(subQueryScores);
 
-            // Verify number of scores
-            assertEquals("Should have expected number of sub-query scores", expectedSubQueryCount, subQueryScores.size());
+            assertEquals(expectedSubQueryCount, subQueryScores.size());
 
-            // Verify all scores are within valid range [0.0, 1.0]
             for (Double score : subQueryScores) {
-                assertNotNull("Sub-query score should not be null", score);
-                assertTrue("Sub-query score should be >= 0.0", score >= 0.0);
-                assertTrue("Sub-query score should be <= 1.0", score <= 1.0);
+                assertNotNull(score);
+                assertTrue(score >= 0.0);
+                assertTrue(score <= 1.0);
             }
         }
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -1112,7 +1112,6 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
 
             @SuppressWarnings("unchecked")
             List<Double> subQueryScores = (List<Double>) fields.get("hybridization_sub_query_scores");
-            System.out.println("subquery" + subQueryScores);
 
             assertNotNull(subQueryScores);
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -22,6 +22,7 @@ import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.Range;
 import org.junit.Before;
+import org.opensearch.common.document.DocumentField;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
@@ -270,6 +271,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
         int totalExpectedDocQty = 6;
@@ -337,6 +339,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
 
@@ -387,6 +390,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
         int totalExpectedDocQty = 6;
@@ -454,6 +458,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
 
@@ -776,32 +781,32 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
 
         // Test with both bounds for 2 queries
         createSearchPipeline(
-            "both-bounds-2-queries",
-            DEFAULT_NORMALIZATION_METHOD,
-            Map.of(
-                "lower_bounds",
-                List.of(
-                    Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
-                    Map.of("mode", "clip", "min_score", Float.toString(0.0f))
+                "both-bounds-2-queries",
+                DEFAULT_NORMALIZATION_METHOD,
+                Map.of(
+                        "lower_bounds",
+                        List.of(
+                                Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
+                                Map.of("mode", "clip", "min_score", Float.toString(0.0f))
+                        ),
+                        "upper_bounds",
+                        List.of(
+                                Map.of("mode", "apply", "max_score", Float.toString(0.99f)),
+                                Map.of("mode", "clip", "max_score", Float.toString(1.0f))
+                        )
                 ),
-                "upper_bounds",
-                List.of(
-                    Map.of("mode", "apply", "max_score", Float.toString(0.99f)),
-                    Map.of("mode", "clip", "max_score", Float.toString(1.0f))
-                )
-            ),
-            DEFAULT_COMBINATION_METHOD,
-            Map.of(),
-            false
+                DEFAULT_COMBINATION_METHOD,
+                Map.of(),
+                false
         );
         int totalExpectedDocQty = 5;
 
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
-            .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
-            .queryText(TEST_DOC_TEXT1)
-            .modelId(modelId)
-            .k(5)
-            .build();
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(5)
+                .build();
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
@@ -810,36 +815,36 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         hybridQueryBuilder.add(termQueryBuilder);
 
         Map<String, Object> searchResponseAsMap = search(
-            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
-            hybridQueryBuilder,
-            null,
-            5,
-            Map.of("search_pipeline", "both-bounds-2-queries")
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                hybridQueryBuilder,
+                null,
+                5,
+                Map.of("search_pipeline", "both-bounds-2-queries")
         );
 
         assertQueryResults(searchResponseAsMap, totalExpectedDocQty, false, Range.between(0.01f, 0.99f));
 
         // Test with both bounds for 3 queries
         createSearchPipeline(
-            "both-bounds-3-queries",
-            DEFAULT_NORMALIZATION_METHOD,
-            Map.of(
-                "lower_bounds",
-                List.of(
-                    Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
-                    Map.of("mode", "clip", "min_score", Float.toString(0.0f)),
-                    Map.of("mode", "ignore")
+                "both-bounds-3-queries",
+                DEFAULT_NORMALIZATION_METHOD,
+                Map.of(
+                        "lower_bounds",
+                        List.of(
+                                Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
+                                Map.of("mode", "clip", "min_score", Float.toString(0.0f)),
+                                Map.of("mode", "ignore")
+                        ),
+                        "upper_bounds",
+                        List.of(
+                                Map.of("mode", "apply", "max_score", Float.toString(0.99f)),
+                                Map.of("mode", "clip", "max_score", Float.toString(1.0f)),
+                                Map.of("mode", "ignore")
+                        )
                 ),
-                "upper_bounds",
-                List.of(
-                    Map.of("mode", "apply", "max_score", Float.toString(0.99f)),
-                    Map.of("mode", "clip", "max_score", Float.toString(1.0f)),
-                    Map.of("mode", "ignore")
-                )
-            ),
-            DEFAULT_COMBINATION_METHOD,
-            Map.of(),
-            false
+                DEFAULT_COMBINATION_METHOD,
+                Map.of(),
+                false
         );
 
         // verify case when there are partial matches
@@ -849,11 +854,11 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         hybridQueryBuilderPartialMatch.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT7));
 
         Map<String, Object> searchResponseAsMapPartialMatch = search(
-            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
-            hybridQueryBuilderPartialMatch,
-            null,
-            5,
-            Map.of("search_pipeline", "both-bounds-3-queries")
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                hybridQueryBuilderPartialMatch,
+                null,
+                5,
+                Map.of("search_pipeline", "both-bounds-3-queries")
         );
         assertQueryResults(searchResponseAsMapPartialMatch, 3, false, Range.between(0.33f, 0.99f));
 
@@ -863,13 +868,75 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         hybridQueryBuilderNoMatches.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT7));
 
         Map<String, Object> searchResponseAsMapNoMatches = search(
-            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
-            hybridQueryBuilderNoMatches,
-            null,
-            5,
-            Map.of("search_pipeline", "both-bounds-2-queries")
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                hybridQueryBuilderNoMatches,
+                null,
+                5,
+                Map.of("search_pipeline", "both-bounds-2-queries")
         );
         assertQueryResults(searchResponseAsMapNoMatches, 0, true);
+    }
+
+    @SneakyThrows
+    public void testSubQueryScoresWithSingleShard_thenSuccessful() {
+        String modelId = null;
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME);
+        modelId = prepareModel();
+        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true, false);
+
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(5)
+                .build();
+
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(neuralQueryBuilder);
+        hybridQueryBuilder.add(termQueryBuilder);
+
+        Map<String, Object> searchResponseAsMap = search(
+                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+                hybridQueryBuilder,
+                null,
+                5,
+                Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertQueryResults(searchResponseAsMap, 5, false);
+        assertHybridizationSubQueryScores(searchResponseAsMap, 2);
+    }
+
+    @SneakyThrows
+    public void testSubQueryScoresWithMultipleShards_thenSuccessful() {
+        String modelId = null;
+        initializeIndexIfNotExist(TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME);
+        modelId = prepareModel();
+        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true, false);
+
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+                .queryText(TEST_DOC_TEXT1)
+                .modelId(modelId)
+                .k(5)
+                .build();
+
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(neuralQueryBuilder);
+        hybridQueryBuilder.add(termQueryBuilder);
+
+        Map<String, Object> searchResponseAsMap = search(
+                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+                hybridQueryBuilder,
+                null,
+                6,
+                Map.of("search_pipeline", SEARCH_PIPELINE)
+        );
+        assertQueryResults(searchResponseAsMap, 6, false);
+        assertHybridizationSubQueryScores(searchResponseAsMap, 2);
     }
 
     private void initializeIndexIfNotExist(String indexName) throws IOException {
@@ -1034,6 +1101,37 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         assertEquals(Set.copyOf(ids).size(), ids.size());
     }
 
+    private void assertHybridizationSubQueryScores(Map<String, Object> searchResponseAsMap, int expectedSubQueryCount) {
+        List<Map<String, Object>> hitsNestedList = getNestedHits(searchResponseAsMap);
+
+        for (Map<String, Object> hit : hitsNestedList) {
+            // Get fields map from hit
+            @SuppressWarnings("unchecked")
+
+            Map<String, DocumentField> fields = hit.getFields();
+            Map<String, Object> fields = (Map<String, Object>) hit.get("fields");
+
+            assertNotNull("Fields should not be null", fields);
+
+            // Get hybridization_sub_query_scores from fields - corrected casting
+            @SuppressWarnings("unchecked")
+            List<Double> subQueryScores = ((List<List<Double>>) fields.get("hybridization_sub_query_scores")).get(0);
+
+            assertNotNull("Hybridization sub query scores should not be null", subQueryScores);
+            assertFalse("Hybridization sub query scores should not be empty", subQueryScores.isEmpty());
+
+            // Verify number of scores
+            assertEquals("Should have expected number of sub-query scores", expectedSubQueryCount, subQueryScores.size());
+
+            // Verify all scores are within valid range [0.0, 1.0]
+            for (Double score : subQueryScores) {
+                assertNotNull("Sub-query score should not be null", score);
+                assertTrue("Sub-query score should be >= 0.0", score >= 0.0);
+                assertTrue("Sub-query score should be <= 1.0", score <= 1.0);
+            }
+        }
+    }
+
     @SneakyThrows
     public void testNormalizationProcessor_stats() {
         enableStats();
@@ -1043,19 +1141,22 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             "pipeline1",
             L2ScoreNormalizationTechnique.TECHNIQUE_NAME,
             HarmonicMeanScoreCombinationTechnique.TECHNIQUE_NAME,
-            Map.of()
+            Map.of(),
+            false
         );
         createSearchPipeline(
             "pipeline2",
             MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME,
             GeometricMeanScoreCombinationTechnique.TECHNIQUE_NAME,
-            Map.of()
+            Map.of(),
+            false
         );
         createSearchPipeline(
             "pipeline3",
             ZScoreNormalizationTechnique.TECHNIQUE_NAME,
             ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME,
-            Map.of()
+            Map.of(),
+            false
         );
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorIT.java
@@ -494,6 +494,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
         int totalExpectedDocQty = 6;
@@ -534,6 +535,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
 
@@ -584,6 +586,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
         int totalExpectedDocQty = 6;
@@ -649,6 +652,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
 
@@ -692,6 +696,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
         int totalExpectedDocQty = 6;
@@ -739,6 +744,7 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
 
@@ -780,32 +786,33 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
 
         // Test with both bounds for 2 queries
         createSearchPipeline(
-                "both-bounds-2-queries",
-                DEFAULT_NORMALIZATION_METHOD,
-                Map.of(
-                        "lower_bounds",
-                        List.of(
-                                Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
-                                Map.of("mode", "clip", "min_score", Float.toString(0.0f))
-                        ),
-                        "upper_bounds",
-                        List.of(
-                                Map.of("mode", "apply", "max_score", Float.toString(0.99f)),
-                                Map.of("mode", "clip", "max_score", Float.toString(1.0f))
-                        )
+            "both-bounds-2-queries",
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(
+                "lower_bounds",
+                List.of(
+                    Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
+                    Map.of("mode", "clip", "min_score", Float.toString(0.0f))
                 ),
-                DEFAULT_COMBINATION_METHOD,
-                Map.of(),
-                false
+                "upper_bounds",
+                List.of(
+                    Map.of("mode", "apply", "max_score", Float.toString(0.99f)),
+                    Map.of("mode", "clip", "max_score", Float.toString(1.0f))
+                )
+            ),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            false,
+            false
         );
         int totalExpectedDocQty = 5;
 
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
-                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
-                .queryText(TEST_DOC_TEXT1)
-                .modelId(modelId)
-                .k(5)
-                .build();
+            .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+            .queryText(TEST_DOC_TEXT1)
+            .modelId(modelId)
+            .k(5)
+            .build();
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
@@ -814,36 +821,37 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         hybridQueryBuilder.add(termQueryBuilder);
 
         Map<String, Object> searchResponseAsMap = search(
-                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
-                hybridQueryBuilder,
-                null,
-                5,
-                Map.of("search_pipeline", "both-bounds-2-queries")
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilder,
+            null,
+            5,
+            Map.of("search_pipeline", "both-bounds-2-queries")
         );
 
         assertQueryResults(searchResponseAsMap, totalExpectedDocQty, false, Range.between(0.01f, 0.99f));
 
         // Test with both bounds for 3 queries
         createSearchPipeline(
-                "both-bounds-3-queries",
-                DEFAULT_NORMALIZATION_METHOD,
-                Map.of(
-                        "lower_bounds",
-                        List.of(
-                                Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
-                                Map.of("mode", "clip", "min_score", Float.toString(0.0f)),
-                                Map.of("mode", "ignore")
-                        ),
-                        "upper_bounds",
-                        List.of(
-                                Map.of("mode", "apply", "max_score", Float.toString(0.99f)),
-                                Map.of("mode", "clip", "max_score", Float.toString(1.0f)),
-                                Map.of("mode", "ignore")
-                        )
+            "both-bounds-3-queries",
+            DEFAULT_NORMALIZATION_METHOD,
+            Map.of(
+                "lower_bounds",
+                List.of(
+                    Map.of("mode", "apply", "min_score", Float.toString(0.01f)),
+                    Map.of("mode", "clip", "min_score", Float.toString(0.0f)),
+                    Map.of("mode", "ignore")
                 ),
-                DEFAULT_COMBINATION_METHOD,
-                Map.of(),
-                false
+                "upper_bounds",
+                List.of(
+                    Map.of("mode", "apply", "max_score", Float.toString(0.99f)),
+                    Map.of("mode", "clip", "max_score", Float.toString(1.0f)),
+                    Map.of("mode", "ignore")
+                )
+            ),
+            DEFAULT_COMBINATION_METHOD,
+            Map.of(),
+            false,
+            false
         );
 
         // verify case when there are partial matches
@@ -853,11 +861,11 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         hybridQueryBuilderPartialMatch.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT7));
 
         Map<String, Object> searchResponseAsMapPartialMatch = search(
-                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
-                hybridQueryBuilderPartialMatch,
-                null,
-                5,
-                Map.of("search_pipeline", "both-bounds-3-queries")
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderPartialMatch,
+            null,
+            5,
+            Map.of("search_pipeline", "both-bounds-3-queries")
         );
         assertQueryResults(searchResponseAsMapPartialMatch, 3, false, Range.between(0.33f, 0.99f));
 
@@ -867,11 +875,11 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         hybridQueryBuilderNoMatches.add(QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT7));
 
         Map<String, Object> searchResponseAsMapNoMatches = search(
-                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
-                hybridQueryBuilderNoMatches,
-                null,
-                5,
-                Map.of("search_pipeline", "both-bounds-2-queries")
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilderNoMatches,
+            null,
+            5,
+            Map.of("search_pipeline", "both-bounds-2-queries")
         );
         assertQueryResults(searchResponseAsMapNoMatches, 0, true);
     }
@@ -884,11 +892,11 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true, false);
 
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
-                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
-                .queryText(TEST_DOC_TEXT1)
-                .modelId(modelId)
-                .k(5)
-                .build();
+            .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+            .queryText(TEST_DOC_TEXT1)
+            .modelId(modelId)
+            .k(5)
+            .build();
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
@@ -897,11 +905,11 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         hybridQueryBuilder.add(termQueryBuilder);
 
         Map<String, Object> searchResponseAsMap = search(
-                TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
-                hybridQueryBuilder,
-                null,
-                5,
-                Map.of("search_pipeline", SEARCH_PIPELINE)
+            TEST_MULTI_DOC_INDEX_ONE_SHARD_NAME,
+            hybridQueryBuilder,
+            null,
+            5,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
         );
         assertQueryResults(searchResponseAsMap, 5, false);
         assertHybridizationSubQueryScores(searchResponseAsMap, 2);
@@ -915,11 +923,11 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true, false);
 
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
-                .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
-                .queryText(TEST_DOC_TEXT1)
-                .modelId(modelId)
-                .k(5)
-                .build();
+            .fieldName(TEST_KNN_VECTOR_FIELD_NAME_1)
+            .queryText(TEST_DOC_TEXT1)
+            .modelId(modelId)
+            .k(5)
+            .build();
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
 
@@ -928,11 +936,11 @@ public class NormalizationProcessorIT extends BaseNeuralSearchIT {
         hybridQueryBuilder.add(termQueryBuilder);
 
         Map<String, Object> searchResponseAsMap = search(
-                TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
-                hybridQueryBuilder,
-                null,
-                6,
-                Map.of("search_pipeline", SEARCH_PIPELINE)
+            TEST_MULTI_DOC_INDEX_THREE_SHARDS_NAME,
+            hybridQueryBuilder,
+            null,
+            6,
+            Map.of("search_pipeline", SEARCH_PIPELINE)
         );
         assertQueryResults(searchResponseAsMap, 6, false);
         assertHybridizationSubQueryScores(searchResponseAsMap, 2);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorTests.java
@@ -112,7 +112,8 @@ public class NormalizationProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             new ScoreNormalizationFactory().createNormalization(NORMALIZATION_METHOD),
             new ScoreCombinationFactory().createCombination(COMBINATION_METHOD),
-            new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner())
+            new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
+            false
         );
 
         assertEquals(DESCRIPTION, normalizationProcessor.getDescription());
@@ -131,7 +132,8 @@ public class NormalizationProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             new ScoreNormalizationFactory().createNormalization(NORMALIZATION_METHOD),
             new ScoreCombinationFactory().createCombination(COMBINATION_METHOD),
-            normalizationProcessorWorkflow
+            normalizationProcessorWorkflow,
+            false
         );
 
         SearchRequest searchRequest = new SearchRequest(INDEX_NAME);
@@ -201,7 +203,8 @@ public class NormalizationProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             new ScoreNormalizationFactory().createNormalization(NORMALIZATION_METHOD),
             new ScoreCombinationFactory().createCombination(COMBINATION_METHOD),
-            normalizationProcessorWorkflow
+            normalizationProcessorWorkflow,
+            false
         );
 
         SearchRequest searchRequest = new SearchRequest(INDEX_NAME);
@@ -270,7 +273,8 @@ public class NormalizationProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             new ScoreNormalizationFactory().createNormalization(NORMALIZATION_METHOD),
             new ScoreCombinationFactory().createCombination(ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME),
-            normalizationProcessorWorkflow
+            normalizationProcessorWorkflow,
+            false
         );
         SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
         normalizationProcessor.process(null, searchPhaseContext);
@@ -286,7 +290,8 @@ public class NormalizationProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             new ScoreNormalizationFactory().createNormalization(NORMALIZATION_METHOD),
             new ScoreCombinationFactory().createCombination(COMBINATION_METHOD),
-            normalizationProcessorWorkflow
+            normalizationProcessorWorkflow,
+            false
         );
 
         SearchRequest searchRequest = new SearchRequest(INDEX_NAME);
@@ -341,7 +346,8 @@ public class NormalizationProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             new ScoreNormalizationFactory().createNormalization(NORMALIZATION_METHOD),
             new ScoreCombinationFactory().createCombination(COMBINATION_METHOD),
-            normalizationProcessorWorkflow
+            normalizationProcessorWorkflow,
+            false
         );
 
         SearchRequest searchRequest = new SearchRequest(INDEX_NAME);
@@ -432,7 +438,8 @@ public class NormalizationProcessorTests extends OpenSearchTestCase {
             DESCRIPTION,
             new ScoreNormalizationFactory().createNormalization(NORMALIZATION_METHOD),
             new ScoreCombinationFactory().createCombination(COMBINATION_METHOD),
-            normalizationProcessorWorkflow
+            normalizationProcessorWorkflow,
+            false
         );
 
         SearchRequest searchRequest = new SearchRequest(INDEX_NAME);

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowTests.java
@@ -510,6 +510,7 @@ public class NormalizationProcessorWorkflowTests extends OpenSearchTestCase {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.from(17);
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+        when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
 
         NormalizationProcessorWorkflowExecuteRequest normalizationExecuteDto = NormalizationProcessorWorkflowExecuteRequest.builder()
             .querySearchResults(querySearchResults)

--- a/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflowTests.java
@@ -506,6 +506,7 @@ public class NormalizationProcessorWorkflowTests extends OpenSearchTestCase {
         SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
         when(searchPhaseContext.getNumShards()).thenReturn(4);
         SearchRequest searchRequest = mock(SearchRequest.class);
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.from(17);
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);

--- a/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorTests.java
@@ -71,7 +71,14 @@ public class RRFProcessorTests extends OpenSearchTestCase {
     public void setUp() {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        rrfProcessor = new RRFProcessor(TAG, DESCRIPTION, mockNormalizationTechnique, mockCombinationTechnique, mockNormalizationWorkflow);
+        rrfProcessor = new RRFProcessor(
+            TAG,
+            DESCRIPTION,
+            mockNormalizationTechnique,
+            mockCombinationTechnique,
+            mockNormalizationWorkflow,
+            false
+        );
         when(mockCombinationTechnique.techniqueName()).thenReturn(RRFScoreCombinationTechnique.TECHNIQUE_NAME);
         TestUtils.initializeEventStatsManager();
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreCombinationIT.java
@@ -91,7 +91,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             DEFAULT_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.4f, 0.3f, 0.3f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.4f, 0.3f, 0.3f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -115,7 +116,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             DEFAULT_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.233f, 0.666f, 0.1f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.233f, 0.666f, 0.1f })),
+            false
         );
 
         Map<String, Object> searchResponseWithWeights2AsMap = search(
@@ -135,7 +137,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             DEFAULT_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 1.0f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 1.0f })),
+            false
         );
 
         ResponseException exception1 = expectThrows(
@@ -158,7 +161,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             DEFAULT_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.25f, 0.25f, 0.2f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.25f, 0.25f, 0.2f })),
+            false
         );
 
         ResponseException exception2 = expectThrows(
@@ -202,7 +206,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             HARMONIC_MEAN_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
@@ -227,7 +232,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             L2_NORMALIZATION_METHOD,
             HARMONIC_MEAN_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();
@@ -275,7 +281,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             GEOMETRIC_MEAN_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderDefaultNorm = new HybridQueryBuilder();
@@ -301,7 +308,8 @@ public class ScoreCombinationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             L2_NORMALIZATION_METHOD,
             GEOMETRIC_MEAN_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderL2Norm = new HybridQueryBuilder();

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationIT.java
@@ -83,7 +83,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             L2_NORMALIZATION_METHOD,
             DEFAULT_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
@@ -108,7 +109,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             L2_NORMALIZATION_METHOD,
             HARMONIC_MEAN_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
@@ -133,7 +135,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             L2_NORMALIZATION_METHOD,
             GEOMETRIC_MEAN_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
@@ -179,7 +182,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             DEFAULT_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
@@ -204,7 +208,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             HARMONIC_MEAN_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderHarmonicMean = new HybridQueryBuilder();
@@ -229,7 +234,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             DEFAULT_NORMALIZATION_METHOD,
             GEOMETRIC_MEAN_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderGeometricMean = new HybridQueryBuilder();
@@ -275,7 +281,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
             SEARCH_PIPELINE,
             Z_SCORE_NORMALIZATION_METHOD,
             DEFAULT_COMBINATION_METHOD,
-            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+            Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilderArithmeticMean = new HybridQueryBuilder();
@@ -304,7 +311,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
                 SEARCH_PIPELINE,
                 Z_SCORE_NORMALIZATION_METHOD,
                 HARMONIC_MEAN_COMBINATION_METHOD,
-                Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+                Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+                false
             )
         );
 
@@ -326,7 +334,8 @@ public class ScoreNormalizationIT extends BaseNeuralSearchIT {
                 SEARCH_PIPELINE,
                 Z_SCORE_NORMALIZATION_METHOD,
                 GEOMETRIC_MEAN_COMBINATION_METHOD,
-                Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f }))
+                Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.533f, 0.466f })),
+                false
             )
         );
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
@@ -48,16 +48,17 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
                 SEARCH_SHARD
             )
         );
-        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
-            .queryTopDocs(queryTopDocs)
-            .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
-            .build();
 
         SearchRequest searchRequest = mock(SearchRequest.class);
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
+
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(queryTopDocs)
+            .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+            .searchPhaseContext(searchPhaseContext)
+            .build();
 
         scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
         assertNotNull(queryTopDocs);
@@ -92,15 +93,18 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
                 SEARCH_SHARD
             )
         );
-        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
-            .queryTopDocs(queryTopDocs)
-            .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
-            .build();
 
         SearchRequest searchRequest = mock(SearchRequest.class);
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
+
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(queryTopDocs)
+            .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+            .searchPhaseContext(searchPhaseContext)
+            .build();
+
         scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
 
         scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
@@ -142,15 +146,18 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
                 SEARCH_SHARD
             )
         );
-        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
-            .queryTopDocs(queryTopDocs)
-            .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
-            .build();
 
         SearchRequest searchRequest = mock(SearchRequest.class);
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
+
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(queryTopDocs)
+            .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+            .searchPhaseContext(searchPhaseContext)
+            .build();
+
         scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
 
         scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
@@ -225,15 +232,18 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
                 SEARCH_SHARD
             )
         );
-        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
-            .queryTopDocs(queryTopDocs)
-            .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
-            .build();
 
         SearchRequest searchRequest = mock(SearchRequest.class);
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
+
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(queryTopDocs)
+            .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
+            .searchPhaseContext(searchPhaseContext)
+            .build();
+
         scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
         assertNotNull(queryTopDocs);
         assertEquals(3, queryTopDocs.size());

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
@@ -13,9 +13,12 @@ import org.apache.lucene.search.TotalHits;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
 
+import org.opensearch.search.internal.SearchContext;
 import org.opensearch.test.OpenSearchTestCase;
 
 import lombok.SneakyThrows;
+
+import static org.mockito.Mockito.mock;
 
 public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
@@ -23,16 +26,18 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testEmptyResults_whenEmptyResultsAndDefaultMethod_thenNoProcessing() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
+        SearchContext searchContext = mock(SearchContext.class);
         NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
             .queryTopDocs(List.of())
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
     }
 
     @SneakyThrows
     public void testNormalization_whenOneSubqueryAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
+        SearchContext searchContext = mock(SearchContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(1, TotalHits.Relation.EQUAL_TO),
@@ -45,7 +50,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
         CompoundTopDocs resultDoc = queryTopDocs.get(0);
@@ -64,6 +69,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
     @SneakyThrows
     public void testNormalization_whenOneSubqueryMultipleHitsAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
+        SearchContext searchContext = mock(SearchContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -81,7 +87,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
         CompoundTopDocs resultDoc = queryTopDocs.get(0);
@@ -102,6 +108,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testNormalization_whenMultipleSubqueriesMultipleHitsAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
+        SearchContext searchContext = mock(SearchContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -123,7 +130,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
 
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
@@ -156,6 +163,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testNormalization_whenMultipleSubqueriesMultipleHitsMultipleShardsAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
+        SearchContext searchContext = mock(SearchContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -198,7 +206,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
         assertNotNull(queryTopDocs);
         assertEquals(3, queryTopDocs.size());
         // shard one

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
@@ -11,14 +11,17 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
 
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import lombok.SneakyThrows;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
@@ -37,7 +40,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
     @SneakyThrows
     public void testNormalization_whenOneSubqueryAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
+        SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(1, TotalHits.Relation.EQUAL_TO),
@@ -50,7 +53,14 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
+
+        SearchRequest searchRequest = mock(SearchRequest.class);
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
         CompoundTopDocs resultDoc = queryTopDocs.get(0);
@@ -69,7 +79,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
     @SneakyThrows
     public void testNormalization_whenOneSubqueryMultipleHitsAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
+        SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -87,7 +97,14 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
+
+        SearchRequest searchRequest = mock(SearchRequest.class);
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
         CompoundTopDocs resultDoc = queryTopDocs.get(0);
@@ -108,7 +125,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testNormalization_whenMultipleSubqueriesMultipleHitsAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
+        SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -130,7 +147,14 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
+
+        SearchRequest searchRequest = mock(SearchRequest.class);
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
 
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
@@ -163,7 +187,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testNormalization_whenMultipleSubqueriesMultipleHitsMultipleShardsAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
+        SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -206,7 +230,12 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
             .queryTopDocs(queryTopDocs)
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
+
+        SearchRequest searchRequest = mock(SearchRequest.class);
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
         assertNotNull(queryTopDocs);
         assertEquals(3, queryTopDocs.size());
         // shard one

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
@@ -10,10 +10,10 @@ import org.apache.commons.lang3.Range;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
 
-import org.opensearch.search.internal.SearchContext;
 import org.opensearch.test.OpenSearchTestCase;
 
 import lombok.SneakyThrows;
@@ -26,7 +26,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testEmptyResults_whenEmptyResultsAndDefaultMethod_thenNoProcessing() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchContext searchContext = mock(SearchContext.class);
+        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
         NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
             .queryTopDocs(List.of())
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
@@ -37,7 +37,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
     @SneakyThrows
     public void testNormalization_whenOneSubqueryAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchContext searchContext = mock(SearchContext.class);
+        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(1, TotalHits.Relation.EQUAL_TO),
@@ -69,7 +69,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
     @SneakyThrows
     public void testNormalization_whenOneSubqueryMultipleHitsAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchContext searchContext = mock(SearchContext.class);
+        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -108,7 +108,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testNormalization_whenMultipleSubqueriesMultipleHitsAndOneShardAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchContext searchContext = mock(SearchContext.class);
+        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -163,7 +163,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testNormalization_whenMultipleSubqueriesMultipleHitsMultipleShardsAndDefaultMethod_thenScoreNormalized() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchContext searchContext = mock(SearchContext.class);
+        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
         final List<CompoundTopDocs> queryTopDocs = List.of(
             new CompoundTopDocs(
                 new TotalHits(3, TotalHits.Relation.EQUAL_TO),

--- a/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ScoreNormalizationTechniqueTests.java
@@ -29,12 +29,11 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
 
     public void testEmptyResults_whenEmptyResultsAndDefaultMethod_thenNoProcessing() {
         ScoreNormalizer scoreNormalizationMethod = new ScoreNormalizer();
-        SearchPhaseContext searchContext = mock(SearchPhaseContext.class);
         NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
             .queryTopDocs(List.of())
             .normalizationTechnique(ScoreNormalizationFactory.DEFAULT_METHOD)
             .build();
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchContext);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
     }
 
     @SneakyThrows
@@ -58,9 +57,9 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
 
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
         CompoundTopDocs resultDoc = queryTopDocs.get(0);
@@ -102,9 +101,9 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
 
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
         CompoundTopDocs resultDoc = queryTopDocs.get(0);
@@ -152,9 +151,9 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
 
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
 
         assertNotNull(queryTopDocs);
         assertEquals(1, queryTopDocs.size());
@@ -235,7 +234,7 @@ public class ScoreNormalizationTechniqueTests extends OpenSearchTestCase {
         when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         when(searchPhaseContext.getRequest().source()).thenReturn(searchSourceBuilder);
-        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO, searchPhaseContext);
+        scoreNormalizationMethod.normalizeScores(normalizeScoresDTO);
         assertNotNull(queryTopDocs);
         assertEquals(3, queryTopDocs.size());
         // shard one

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactoryTests.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import static org.mockito.Mockito.mock;
 
 import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.NORMALIZATION_CLAUSE;
-import static org.opensearch.neuralsearch.processor.factory.RRFProcessorFactory.PARAMETERS;
-import static org.opensearch.neuralsearch.processor.factory.RRFProcessorFactory.COMBINATION_CLAUSE;
-import static org.opensearch.neuralsearch.processor.factory.RRFProcessorFactory.TECHNIQUE;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.COMBINATION_CLAUSE;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.TECHNIQUE;
+import static org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFactory.PARAMETERS;
 
 public class RRFProcessorFactoryTests extends OpenSearchTestCase {
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
@@ -370,7 +370,7 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
             .normalizationTechnique(normalizationTechnique)
             .subQueryScores(true)
             .build();
-        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+        Map<String, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
 
         CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
             new TotalHits(2, TotalHits.Relation.EQUAL_TO),
@@ -386,17 +386,17 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
             SEARCH_SHARD
         );
 
-        Map<Integer, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
-            Map.entry(2, new float[] { 0.5f }),
-            Map.entry(4, new float[] { 0.2f })
+        Map<String, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
+            Map.entry(SEARCH_SHARD.getShardId() + "_" + "2", new float[] { 0.5f }),
+            Map.entry(SEARCH_SHARD.getShardId() + "_" + "4", new float[] { 0.2f })
         );
         assertEquals(expectedDocIdToSubqueryScores.size(), docIdToSubqueryScores.size());
-        for (Map.Entry<Integer, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
-            int docId = entry.getKey();
+        for (Map.Entry<String, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
+            String key = entry.getKey();
             float[] expectedScores = entry.getValue();
-            float[] actualScores = docIdToSubqueryScores.get(docId);
+            float[] actualScores = docIdToSubqueryScores.get(key);
 
-            assertArrayEquals("Scores don't match for docId: " + docId, expectedScores, actualScores, 0.0001f);
+            assertArrayEquals(expectedScores, actualScores, 0.0001f);
         }
 
         assertNotNull(compoundTopDocs);
@@ -428,7 +428,7 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
             .normalizationTechnique(normalizationTechnique)
             .subQueryScores(false)
             .build();
-        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+        Map<String, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
 
         assertTrue(docIdToSubqueryScores.isEmpty());
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
@@ -330,7 +330,7 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
         parameters.put("lower_bounds", lowerBoundsList);
 
         try {
-            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false);
+            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
             fail("expected IllegalArgumentException was not thrown");
         } catch (IllegalArgumentException e) {
             assertEquals("unrecognized parameters in normalization technique", e.getMessage());
@@ -342,7 +342,7 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
         parameters.put("invalid_top_level_param", "value"); // Adding an invalid top-level parameter
 
         try {
-            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false);
+            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
             fail("expected IllegalArgumentException was not thrown");
         } catch (IllegalArgumentException e) {
             assertEquals("unrecognized parameters in normalization technique", e.getMessage());

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/L2ScoreNormalizationTechniqueTests.java
@@ -330,7 +330,7 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
         parameters.put("lower_bounds", lowerBoundsList);
 
         try {
-            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false);
             fail("expected IllegalArgumentException was not thrown");
         } catch (IllegalArgumentException e) {
             assertEquals("unrecognized parameters in normalization technique", e.getMessage());
@@ -342,7 +342,7 @@ public class L2ScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase 
         parameters.put("invalid_top_level_param", "value"); // Adding an invalid top-level parameter
 
         try {
-            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            new L2ScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false);
             fail("expected IllegalArgumentException was not thrown");
         } catch (IllegalArgumentException e) {
             assertEquals("unrecognized parameters in normalization technique", e.getMessage());

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -634,6 +634,86 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         assertEquals(expectedCompoundDocsOne, compoundTopDocsOne);
     }
 
+    public void testSubQueryScores_whenSubQueryScoreIsEnabled_thenSuccessful() {
+        MinMaxScoreNormalizationTechnique normalizationTechnique = new MinMaxScoreNormalizationTechnique();
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    )
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(normalizationTechnique)
+            .subQueryScores(true)
+            .build();
+        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+
+        CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(2, 1.0f), new ScoreDoc(4, DELTA_FOR_SCORE_ASSERTION) }
+                )
+            ),
+            false,
+            SEARCH_SHARD
+        );
+
+        Map<Integer, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
+            Map.entry(2, new float[] { 0.5f }),
+            Map.entry(4, new float[] { 0.2f })
+        );
+        assertEquals(expectedDocIdToSubqueryScores.size(), docIdToSubqueryScores.size());
+        for (Map.Entry<Integer, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
+            int docId = entry.getKey();
+            float[] expectedScores = entry.getValue();
+            float[] actualScores = docIdToSubqueryScores.get(docId);
+
+            assertArrayEquals("Scores don't match for docId: " + docId, expectedScores, actualScores, 0.0001f);
+        }
+        assertNotNull(compoundTopDocs);
+        assertEquals(1, compoundTopDocs.size());
+        assertNotNull(compoundTopDocs.get(0).getTopDocs());
+        assertCompoundTopDocs(
+            new TopDocs(expectedCompoundDocs.getTotalHits(), expectedCompoundDocs.getScoreDocs().toArray(new ScoreDoc[0])),
+            compoundTopDocs.get(0).getTopDocs().get(0)
+        );
+    }
+
+    public void testSubQueryScores_whenSubQueryScoreIsDisabled_thenSuccessful() {
+        MinMaxScoreNormalizationTechnique normalizationTechnique = new MinMaxScoreNormalizationTechnique();
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    )
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(normalizationTechnique)
+            .subQueryScores(false)
+            .build();
+        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+
+        assertTrue(docIdToSubqueryScores.isEmpty());
+    }
+
     public void testInvalidParameters() {
         Map<String, Object> parameters = new HashMap<>();
         List<Map<String, Object>> lowerBoundsList = List.of(

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -451,7 +451,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
 
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil())
+            () -> new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false)
         );
 
         assertEquals(
@@ -475,7 +475,8 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parameters.put("lower_bounds", lowerBounds);
         MinMaxScoreNormalizationTechnique techniqueWithBounds = new MinMaxScoreNormalizationTechnique(
             parameters,
-            new ScoreNormalizationUtil()
+            new ScoreNormalizationUtil(),
+            false
         );
         assertEquals("min_max, lower bounds [(apply, 0.2), (clip, 0.1)]", techniqueWithBounds.describe());
 
@@ -483,7 +484,8 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         Map<String, Object> emptyParameters = new HashMap<>();
         MinMaxScoreNormalizationTechnique techniqueWithoutBounds = new MinMaxScoreNormalizationTechnique(
             emptyParameters,
-            new ScoreNormalizationUtil()
+            new ScoreNormalizationUtil(),
+            false
         );
         assertEquals("min_max", techniqueWithoutBounds.describe());
 
@@ -495,7 +497,8 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parametersMissingMode.put("lower_bounds", lowerBoundsMissingMode);
         MinMaxScoreNormalizationTechnique techniqueMissingMode = new MinMaxScoreNormalizationTechnique(
             parametersMissingMode,
-            new ScoreNormalizationUtil()
+            new ScoreNormalizationUtil(),
+            false
         );
         assertEquals("min_max, lower bounds [(apply, 0.2), (clip, 0.1)]", techniqueMissingMode.describe());
 
@@ -507,7 +510,8 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parametersMissingScore.put("lower_bounds", lowerBoundsMissingScore);
         MinMaxScoreNormalizationTechnique techniqueMissingScore = new MinMaxScoreNormalizationTechnique(
             parametersMissingScore,
-            new ScoreNormalizationUtil()
+            new ScoreNormalizationUtil(),
+            false
         );
         assertEquals("min_max, lower bounds [(apply, 0.0), (clip, 0.1)]", techniqueMissingScore.describe());
     }
@@ -522,7 +526,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parametersInvalidMode.put("lower_bounds", lowerBoundsInvalidMode);
         IllegalArgumentException invalidModeException = expectThrows(
             IllegalArgumentException.class,
-            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidMode, new ScoreNormalizationUtil())
+            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidMode, new ScoreNormalizationUtil(), false)
         );
         assertEquals("invalid mode: invalid_mode, valid values are: apply, clip, ignore", invalidModeException.getMessage());
 
@@ -535,7 +539,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parametersInvalidScore.put("lower_bounds", lowerBoundsInvalidScore);
         IllegalArgumentException invalidScoreException = expectThrows(
             IllegalArgumentException.class,
-            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidScore, new ScoreNormalizationUtil())
+            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidScore, new ScoreNormalizationUtil(), false)
         );
         assertEquals("invalid format for min_score: must be a valid float value", invalidScoreException.getMessage());
     }
@@ -559,7 +563,11 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
                 SEARCH_SHARD
             )
         );
-        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(
+            parameters,
+            new ScoreNormalizationUtil(),
+            false
+        );
         NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
             .queryTopDocs(compoundTopDocs)
             .normalizationTechnique(minMaxTechnique)
@@ -599,7 +607,11 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
                 SEARCH_SHARD
             )
         );
-        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(
+            parameters,
+            new ScoreNormalizationUtil(),
+            false
+        );
         NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
             .queryTopDocs(compoundTopDocs)
             .normalizationTechnique(minMaxTechnique)
@@ -643,7 +655,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parameters.put("lower_bounds", lowerBoundsList);
 
         try {
-            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false);
             fail("Expected IllegalArgumentException was not thrown");
         } catch (IllegalArgumentException e) {
             assertEquals("unrecognized parameters in normalization technique", e.getMessage());
@@ -655,7 +667,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parameters.put("invalid_top_level_param", "value"); // Adding an invalid top-level parameter
 
         try {
-            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
+            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false);
             fail("Expected IllegalArgumentException was not thrown");
         } catch (IllegalArgumentException e) {
             assertEquals("unrecognized parameters in normalization technique", e.getMessage());

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -654,7 +654,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
             .normalizationTechnique(normalizationTechnique)
             .subQueryScores(true)
             .build();
-        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+        Map<String, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
 
         CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
             new TotalHits(2, TotalHits.Relation.EQUAL_TO),
@@ -668,17 +668,17 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
             SEARCH_SHARD
         );
 
-        Map<Integer, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
-            Map.entry(2, new float[] { 0.5f }),
-            Map.entry(4, new float[] { 0.2f })
+        Map<String, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
+            Map.entry(SEARCH_SHARD.getShardId() + "_" + "2", new float[] { 0.5f }),
+            Map.entry(SEARCH_SHARD.getShardId() + "_" + "4", new float[] { 0.2f })
         );
         assertEquals(expectedDocIdToSubqueryScores.size(), docIdToSubqueryScores.size());
-        for (Map.Entry<Integer, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
-            int docId = entry.getKey();
+        for (Map.Entry<String, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
+            String key = entry.getKey();
             float[] expectedScores = entry.getValue();
-            float[] actualScores = docIdToSubqueryScores.get(docId);
+            float[] actualScores = docIdToSubqueryScores.get(key);
 
-            assertArrayEquals("Scores don't match for docId: " + docId, expectedScores, actualScores, 0.0001f);
+            assertArrayEquals(expectedScores, actualScores, 0.0001f);
         }
         assertNotNull(compoundTopDocs);
         assertEquals(1, compoundTopDocs.size());
@@ -709,7 +709,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
             .normalizationTechnique(normalizationTechnique)
             .subQueryScores(false)
             .build();
-        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+        Map<String, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
 
         assertTrue(docIdToSubqueryScores.isEmpty());
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/MinMaxScoreNormalizationTechniqueTests.java
@@ -451,7 +451,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
 
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false)
+            () -> new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil())
         );
 
         assertEquals(
@@ -475,8 +475,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parameters.put("lower_bounds", lowerBounds);
         MinMaxScoreNormalizationTechnique techniqueWithBounds = new MinMaxScoreNormalizationTechnique(
             parameters,
-            new ScoreNormalizationUtil(),
-            false
+            new ScoreNormalizationUtil()
         );
         assertEquals("min_max, lower bounds [(apply, 0.2), (clip, 0.1)]", techniqueWithBounds.describe());
 
@@ -484,8 +483,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         Map<String, Object> emptyParameters = new HashMap<>();
         MinMaxScoreNormalizationTechnique techniqueWithoutBounds = new MinMaxScoreNormalizationTechnique(
             emptyParameters,
-            new ScoreNormalizationUtil(),
-            false
+            new ScoreNormalizationUtil()
         );
         assertEquals("min_max", techniqueWithoutBounds.describe());
 
@@ -497,8 +495,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parametersMissingMode.put("lower_bounds", lowerBoundsMissingMode);
         MinMaxScoreNormalizationTechnique techniqueMissingMode = new MinMaxScoreNormalizationTechnique(
             parametersMissingMode,
-            new ScoreNormalizationUtil(),
-            false
+            new ScoreNormalizationUtil()
         );
         assertEquals("min_max, lower bounds [(apply, 0.2), (clip, 0.1)]", techniqueMissingMode.describe());
 
@@ -510,8 +507,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parametersMissingScore.put("lower_bounds", lowerBoundsMissingScore);
         MinMaxScoreNormalizationTechnique techniqueMissingScore = new MinMaxScoreNormalizationTechnique(
             parametersMissingScore,
-            new ScoreNormalizationUtil(),
-            false
+            new ScoreNormalizationUtil()
         );
         assertEquals("min_max, lower bounds [(apply, 0.0), (clip, 0.1)]", techniqueMissingScore.describe());
     }
@@ -526,7 +522,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parametersInvalidMode.put("lower_bounds", lowerBoundsInvalidMode);
         IllegalArgumentException invalidModeException = expectThrows(
             IllegalArgumentException.class,
-            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidMode, new ScoreNormalizationUtil(), false)
+            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidMode, new ScoreNormalizationUtil())
         );
         assertEquals("invalid mode: invalid_mode, valid values are: apply, clip, ignore", invalidModeException.getMessage());
 
@@ -539,7 +535,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parametersInvalidScore.put("lower_bounds", lowerBoundsInvalidScore);
         IllegalArgumentException invalidScoreException = expectThrows(
             IllegalArgumentException.class,
-            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidScore, new ScoreNormalizationUtil(), false)
+            () -> new MinMaxScoreNormalizationTechnique(parametersInvalidScore, new ScoreNormalizationUtil())
         );
         assertEquals("invalid format for min_score: must be a valid float value", invalidScoreException.getMessage());
     }
@@ -563,11 +559,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
                 SEARCH_SHARD
             )
         );
-        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(
-            parameters,
-            new ScoreNormalizationUtil(),
-            false
-        );
+        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
         NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
             .queryTopDocs(compoundTopDocs)
             .normalizationTechnique(minMaxTechnique)
@@ -607,11 +599,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
                 SEARCH_SHARD
             )
         );
-        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(
-            parameters,
-            new ScoreNormalizationUtil(),
-            false
-        );
+        ScoreNormalizationTechnique minMaxTechnique = new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
         NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
             .queryTopDocs(compoundTopDocs)
             .normalizationTechnique(minMaxTechnique)
@@ -655,7 +643,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parameters.put("lower_bounds", lowerBoundsList);
 
         try {
-            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false);
+            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
             fail("Expected IllegalArgumentException was not thrown");
         } catch (IllegalArgumentException e) {
             assertEquals("unrecognized parameters in normalization technique", e.getMessage());
@@ -667,7 +655,7 @@ public class MinMaxScoreNormalizationTechniqueTests extends OpenSearchQueryTestC
         parameters.put("invalid_top_level_param", "value"); // Adding an invalid top-level parameter
 
         try {
-            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil(), false);
+            new MinMaxScoreNormalizationTechnique(parameters, new ScoreNormalizationUtil());
             fail("Expected IllegalArgumentException was not thrown");
         } catch (IllegalArgumentException e) {
             assertEquals("unrecognized parameters in normalization technique", e.getMessage());

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -35,16 +35,16 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
 
     public void testDescribe() {
         // verify with default values for parameters
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
         assertEquals("rrf, rank_constant [60]", normalizationTechnique.describe());
 
         // verify when parameter values are set
-        normalizationTechnique = new RRFNormalizationTechnique(Map.of("rank_constant", 25), scoreNormalizationUtil, false);
+        normalizationTechnique = new RRFNormalizationTechnique(Map.of("rank_constant", 25), scoreNormalizationUtil);
         assertEquals("rrf, rank_constant [25]", normalizationTechnique.describe());
     }
 
     public void testNormalization_whenResultFromOneShardOneSubQuery_thenSuccessful() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
         float[] scores = { 0.5f, 0.2f };
         List<CompoundTopDocs> compoundTopDocs = List.of(
             new CompoundTopDocs(
@@ -86,7 +86,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     public void testNormalization_whenResultFromOneShardMultipleSubQueries_thenSuccessful() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
         float[] scoresQuery1 = { 0.5f, 0.2f };
         float[] scoresQuery2 = { 0.9f, 0.7f, 0.1f };
         List<CompoundTopDocs> compoundTopDocs = List.of(
@@ -141,7 +141,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     public void testNormalization_whenResultFromMultipleShardsMultipleSubQueries_thenSuccessful() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
         float[] scoresShard1Query1 = { 0.5f, 0.2f };
         float[] scoresShard1and2Query3 = { 0.9f, 0.7f, 0.1f, 0.8f, 0.7f, 0.6f, 0.5f };
         float[] scoresShard2Query2 = { 2.9f, 0.7f };
@@ -278,7 +278,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             searchShard
         );
 
-        RRFNormalizationTechnique normalizer = new RRFNormalizationTechnique(Map.of(), new ScoreNormalizationUtil(), false);
+        RRFNormalizationTechnique normalizer = new RRFNormalizationTechnique(Map.of(), new ScoreNormalizationUtil());
         Map<DocIdAtSearchShard, ExplanationDetails> result = normalizer.explain(Collections.singletonList(compoundTopDocs));
 
         // Verify results
@@ -326,7 +326,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     public void testExplainWithEmptyAndNullList() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
         normalizationTechnique.explain(List.of());
 
         List<CompoundTopDocs> compoundTopDocs = new ArrayList<>();
@@ -335,7 +335,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     public void testExplainWithSingleTopDocs() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
         CompoundTopDocs topDocs = createCompoundTopDocs(new float[] { 0.8f }, 1);
         List<CompoundTopDocs> queryTopDocs = Collections.singletonList(topDocs);
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -346,6 +346,88 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
         assertTrue(explanation.containsKey(new DocIdAtSearchShard(0, new SearchShard("test_index", 0, "uuid"))));
     }
 
+    public void testSubQueryScores_whenSubQueryScoreIsEnabled_thenSuccessful() {
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        float[] scores = { 0.5f, 0.2f };
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, scores[0]), new ScoreDoc(4, scores[1]) }
+                    )
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(normalizationTechnique)
+            .subQueryScores(true)
+            .build();
+        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+
+        CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] { new ScoreDoc(2, rrfNorm(0)), new ScoreDoc(4, rrfNorm(1)) }
+                )
+            ),
+            false,
+            SEARCH_SHARD
+        );
+
+        Map<Integer, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
+            Map.entry(2, new float[] { 0.5f }),
+            Map.entry(4, new float[] { 0.2f })
+        );
+        assertEquals(expectedDocIdToSubqueryScores.size(), docIdToSubqueryScores.size());
+        for (Map.Entry<Integer, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
+            int docId = entry.getKey();
+            float[] expectedScores = entry.getValue();
+            float[] actualScores = docIdToSubqueryScores.get(docId);
+
+            assertArrayEquals("Scores don't match for docId: " + docId, expectedScores, actualScores, 0.0001f);
+        }
+
+        assertNotNull(compoundTopDocs);
+        assertEquals(1, compoundTopDocs.size());
+        assertNotNull(compoundTopDocs.get(0).getTopDocs());
+        assertCompoundTopDocs(
+            new TopDocs(expectedCompoundDocs.getTotalHits(), expectedCompoundDocs.getScoreDocs().toArray(new ScoreDoc[0])),
+            compoundTopDocs.get(0).getTopDocs().get(0)
+        );
+    }
+
+    public void testSubQueryScores_whenSubQueryScoreIsDisabled_thenSuccessful() {
+        L2ScoreNormalizationTechnique normalizationTechnique = new L2ScoreNormalizationTechnique();
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    )
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(normalizationTechnique)
+            .subQueryScores(false)
+            .build();
+        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+
+        assertTrue(docIdToSubqueryScores.isEmpty());
+    }
+
     private float rrfNorm(int rank) {
         // 1.0f / (float) (rank + RANK_CONSTANT + 1);
         return BigDecimal.ONE.divide(BigDecimal.valueOf(rank + RANK_CONSTANT + 1), 10, RoundingMode.HALF_UP).floatValue();

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -367,7 +367,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             .normalizationTechnique(normalizationTechnique)
             .subQueryScores(true)
             .build();
-        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+        Map<String, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
 
         CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
             new TotalHits(2, TotalHits.Relation.EQUAL_TO),
@@ -381,17 +381,17 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             SEARCH_SHARD
         );
 
-        Map<Integer, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
-            Map.entry(2, new float[] { 0.5f }),
-            Map.entry(4, new float[] { 0.2f })
+        Map<String, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
+            Map.entry(SEARCH_SHARD.getShardId() + "_" + "2", new float[] { 0.5f }),
+            Map.entry(SEARCH_SHARD.getShardId() + "_" + "4", new float[] { 0.2f })
         );
         assertEquals(expectedDocIdToSubqueryScores.size(), docIdToSubqueryScores.size());
-        for (Map.Entry<Integer, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
-            int docId = entry.getKey();
+        for (Map.Entry<String, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
+            String key = entry.getKey();
             float[] expectedScores = entry.getValue();
-            float[] actualScores = docIdToSubqueryScores.get(docId);
+            float[] actualScores = docIdToSubqueryScores.get(key);
 
-            assertArrayEquals("Scores don't match for docId: " + docId, expectedScores, actualScores, 0.0001f);
+            assertArrayEquals(expectedScores, actualScores, 0.0001f);
         }
 
         assertNotNull(compoundTopDocs);
@@ -423,7 +423,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             .normalizationTechnique(normalizationTechnique)
             .subQueryScores(false)
             .build();
-        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+        Map<String, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
 
         assertTrue(docIdToSubqueryScores.isEmpty());
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -35,16 +35,16 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
 
     public void testDescribe() {
         // verify with default values for parameters
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
         assertEquals("rrf, rank_constant [60]", normalizationTechnique.describe());
 
         // verify when parameter values are set
-        normalizationTechnique = new RRFNormalizationTechnique(Map.of("rank_constant", 25), scoreNormalizationUtil);
+        normalizationTechnique = new RRFNormalizationTechnique(Map.of("rank_constant", 25), scoreNormalizationUtil, false);
         assertEquals("rrf, rank_constant [25]", normalizationTechnique.describe());
     }
 
     public void testNormalization_whenResultFromOneShardOneSubQuery_thenSuccessful() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
         float[] scores = { 0.5f, 0.2f };
         List<CompoundTopDocs> compoundTopDocs = List.of(
             new CompoundTopDocs(
@@ -86,7 +86,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     public void testNormalization_whenResultFromOneShardMultipleSubQueries_thenSuccessful() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
         float[] scoresQuery1 = { 0.5f, 0.2f };
         float[] scoresQuery2 = { 0.9f, 0.7f, 0.1f };
         List<CompoundTopDocs> compoundTopDocs = List.of(
@@ -141,7 +141,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     public void testNormalization_whenResultFromMultipleShardsMultipleSubQueries_thenSuccessful() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
         float[] scoresShard1Query1 = { 0.5f, 0.2f };
         float[] scoresShard1and2Query3 = { 0.9f, 0.7f, 0.1f, 0.8f, 0.7f, 0.6f, 0.5f };
         float[] scoresShard2Query2 = { 2.9f, 0.7f };
@@ -278,7 +278,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             searchShard
         );
 
-        RRFNormalizationTechnique normalizer = new RRFNormalizationTechnique(Map.of(), new ScoreNormalizationUtil());
+        RRFNormalizationTechnique normalizer = new RRFNormalizationTechnique(Map.of(), new ScoreNormalizationUtil(), false);
         Map<DocIdAtSearchShard, ExplanationDetails> result = normalizer.explain(Collections.singletonList(compoundTopDocs));
 
         // Verify results
@@ -326,7 +326,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     public void testExplainWithEmptyAndNullList() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
         normalizationTechnique.explain(List.of());
 
         List<CompoundTopDocs> compoundTopDocs = new ArrayList<>();
@@ -335,7 +335,7 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     public void testExplainWithSingleTopDocs() {
-        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil, false);
         CompoundTopDocs topDocs = createCompoundTopDocs(new float[] { 0.8f }, 1);
         List<CompoundTopDocs> queryTopDocs = Collections.singletonList(topDocs);
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactoryTests.java
@@ -64,7 +64,7 @@ public class ScoreNormalizationFactoryTests extends OpenSearchQueryTestCase {
         parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
 
         ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
-        ScoreNormalizationTechnique normalizationTechnique = scoreNormalizationFactory.createNormalization("min_max", parameters, false);
+        ScoreNormalizationTechnique normalizationTechnique = scoreNormalizationFactory.createNormalization("min_max", parameters);
 
         assertNotNull(normalizationTechnique);
         assertTrue(normalizationTechnique instanceof MinMaxScoreNormalizationTechnique);
@@ -79,7 +79,7 @@ public class ScoreNormalizationFactoryTests extends OpenSearchQueryTestCase {
         ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> scoreNormalizationFactory.createNormalization(L2ScoreNormalizationTechnique.TECHNIQUE_NAME, parameters, false)
+            () -> scoreNormalizationFactory.createNormalization(L2ScoreNormalizationTechnique.TECHNIQUE_NAME, parameters)
         );
         assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationFactoryTests.java
@@ -64,7 +64,7 @@ public class ScoreNormalizationFactoryTests extends OpenSearchQueryTestCase {
         parameters.put(PARAM_NAME_LOWER_BOUNDS, lowerBounds);
 
         ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
-        ScoreNormalizationTechnique normalizationTechnique = scoreNormalizationFactory.createNormalization("min_max", parameters);
+        ScoreNormalizationTechnique normalizationTechnique = scoreNormalizationFactory.createNormalization("min_max", parameters, false);
 
         assertNotNull(normalizationTechnique);
         assertTrue(normalizationTechnique instanceof MinMaxScoreNormalizationTechnique);
@@ -79,7 +79,7 @@ public class ScoreNormalizationFactoryTests extends OpenSearchQueryTestCase {
         ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> scoreNormalizationFactory.createNormalization(L2ScoreNormalizationTechnique.TECHNIQUE_NAME, parameters)
+            () -> scoreNormalizationFactory.createNormalization(L2ScoreNormalizationTechnique.TECHNIQUE_NAME, parameters, false)
         );
         assertEquals("unrecognized parameters in normalization technique", exception.getMessage());
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechniqueTests.java
@@ -368,7 +368,7 @@ public class ZScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             .normalizationTechnique(normalizationTechnique)
             .subQueryScores(true)
             .build();
-        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+        Map<String, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
 
         CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
             new TotalHits(2, TotalHits.Relation.EQUAL_TO),
@@ -384,17 +384,17 @@ public class ZScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             SEARCH_SHARD
         );
 
-        Map<Integer, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
-            Map.entry(2, new float[] { 0.5f }),
-            Map.entry(4, new float[] { 0.2f })
+        Map<String, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
+            Map.entry(SEARCH_SHARD.getShardId() + "_" + "2", new float[] { 0.5f }),
+            Map.entry(SEARCH_SHARD.getShardId() + "_" + "4", new float[] { 0.2f })
         );
         assertEquals(expectedDocIdToSubqueryScores.size(), docIdToSubqueryScores.size());
-        for (Map.Entry<Integer, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
-            int docId = entry.getKey();
+        for (Map.Entry<String, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
+            String key = entry.getKey();
             float[] expectedScores = entry.getValue();
-            float[] actualScores = docIdToSubqueryScores.get(docId);
+            float[] actualScores = docIdToSubqueryScores.get(key);
 
-            assertArrayEquals("Scores don't match for docId: " + docId, expectedScores, actualScores, 0.0001f);
+            assertArrayEquals(expectedScores, actualScores, 0.0001f);
         }
 
         assertNotNull(compoundTopDocs);
@@ -426,7 +426,7 @@ public class ZScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase {
             .normalizationTechnique(normalizationTechnique)
             .subQueryScores(false)
             .build();
-        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+        Map<String, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
 
         assertTrue(docIdToSubqueryScores.isEmpty());
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechniqueTests.java
@@ -347,6 +347,90 @@ public class ZScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase {
         assertTrue(doc1Scores.get(2).getValue().contains("z_score normalization"));
     }
 
+    public void testSubQueryScores_whenSubQueryScoreIsEnabled_thenSuccessful() {
+        ZScoreNormalizationTechnique normalizationTechnique = new ZScoreNormalizationTechnique();
+        Float[] scores = { 0.5f, 0.2f };
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, scores[0]), new ScoreDoc(4, scores[1]) }
+                    )
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(normalizationTechnique)
+            .subQueryScores(true)
+            .build();
+        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+
+        CompoundTopDocs expectedCompoundDocs = new CompoundTopDocs(
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            List.of(
+                new TopDocs(
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    new ScoreDoc[] {
+                        new ScoreDoc(2, zscoreNorm(scores[0], Arrays.asList(scores))),
+                        new ScoreDoc(4, zscoreNorm(scores[1], Arrays.asList(scores))) }
+                )
+            ),
+            false,
+            SEARCH_SHARD
+        );
+
+        Map<Integer, float[]> expectedDocIdToSubqueryScores = Map.ofEntries(
+            Map.entry(2, new float[] { 0.5f }),
+            Map.entry(4, new float[] { 0.2f })
+        );
+        assertEquals(expectedDocIdToSubqueryScores.size(), docIdToSubqueryScores.size());
+        for (Map.Entry<Integer, float[]> entry : expectedDocIdToSubqueryScores.entrySet()) {
+            int docId = entry.getKey();
+            float[] expectedScores = entry.getValue();
+            float[] actualScores = docIdToSubqueryScores.get(docId);
+
+            assertArrayEquals("Scores don't match for docId: " + docId, expectedScores, actualScores, 0.0001f);
+        }
+
+        assertNotNull(compoundTopDocs);
+        assertEquals(1, compoundTopDocs.size());
+        assertNotNull(compoundTopDocs.get(0).getTopDocs());
+        assertCompoundTopDocs(
+            new TopDocs(expectedCompoundDocs.getTotalHits(), expectedCompoundDocs.getScoreDocs().toArray(new ScoreDoc[0])),
+            compoundTopDocs.get(0).getTopDocs().get(0)
+        );
+    }
+
+    public void testSubQueryScores_whenSubQueryScoreIsDisabled_thenSuccessful() {
+        ZScoreNormalizationTechnique normalizationTechnique = new ZScoreNormalizationTechnique();
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                List.of(
+                    new TopDocs(
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        new ScoreDoc[] { new ScoreDoc(2, 0.5f), new ScoreDoc(4, 0.2f) }
+                    )
+                ),
+                false,
+                SEARCH_SHARD
+            )
+        );
+        NormalizeScoresDTO normalizeScoresDTO = NormalizeScoresDTO.builder()
+            .queryTopDocs(compoundTopDocs)
+            .normalizationTechnique(normalizationTechnique)
+            .subQueryScores(false)
+            .build();
+        Map<Integer, float[]> docIdToSubqueryScores = normalizationTechnique.normalize(normalizeScoresDTO);
+
+        assertTrue(docIdToSubqueryScores.isEmpty());
+    }
+
     private float zscoreNorm(float score, List<Float> scores) {
         DescriptiveStatistics stats = new DescriptiveStatistics();
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -85,7 +85,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true
+            true,
+            false
         );
 
         TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
@@ -141,7 +142,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
-            true
+            true,
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -274,6 +276,7 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
+            false,
             false
         );
 
@@ -429,7 +432,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true
+            true,
+            false
         );
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
@@ -490,7 +494,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true
+            true,
+            false
         );
 
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -684,7 +689,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true
+            true,
+            false
         );
 
         TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryExplainIT.java
@@ -85,8 +85,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true,
-            false
+            false,
+            true
         );
 
         TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
@@ -142,8 +142,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(PARAM_NAME_WEIGHTS, Arrays.toString(new float[] { 0.3f, 0.7f })),
-            true,
-            false
+            false,
+            true
         );
 
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -432,8 +432,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true,
-            false
+            false,
+            true
         );
 
         TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);
@@ -494,8 +494,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true,
-            false
+            false,
+            true
         );
 
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -689,8 +689,8 @@ public class HybridQueryExplainIT extends BaseNeuralSearchIT {
             ),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true,
-            false
+            false,
+            true
         );
 
         TermQueryBuilder termQueryBuilder1 = QueryBuilders.termQuery(TEST_TEXT_FIELD_NAME_1, TEST_QUERY_TEXT3);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryInnerHitsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryInnerHitsIT.java
@@ -75,7 +75,7 @@ public class HybridQueryInnerHitsIT extends BaseNeuralSearchIT {
 
     private void testInnerHits_whenMultipleSubqueriesOnNestedFields_thenSuccessful(String indexName) {
         initializeIndexIfNotExist(indexName);
-        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of());
+        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), false);
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
         NestedQueryBuilder nestedQueryBuilder1 = new NestedQueryBuilder("user", new MatchQueryBuilder("user.name", "John"), ScoreMode.Avg);
         nestedQueryBuilder1.innerHit(new InnerHitBuilder());
@@ -110,7 +110,7 @@ public class HybridQueryInnerHitsIT extends BaseNeuralSearchIT {
 
     public void testInnerHits_whenMultipleSubqueriesOnParentChildFields_thenSuccessful() {
         initializeIndexIfNotExist(TEST_MULTI_DOC_WITH_PARENT_CHILD_INDEX_NAME);
-        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of());
+        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), false);
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
         HasChildQueryBuilder hasChildQueryBuilder = new HasChildQueryBuilder(
             "child",
@@ -139,7 +139,7 @@ public class HybridQueryInnerHitsIT extends BaseNeuralSearchIT {
     @SneakyThrows
     public void testInnerHits_whenMultipleSubqueriesOnNestedAndParentChildFields_thenSuccessful() {
         initializeIndexIfNotExist(TEST_MULTI_DOC_WITH_NESTED_PARENT_CHILD_INDEX_NAME);
-        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of());
+        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), false);
         NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder("user", new MatchQueryBuilder("user.name", "John"), ScoreMode.Avg);
         nestedQueryBuilder.innerHit(new InnerHitBuilder());
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
@@ -174,7 +174,7 @@ public class HybridQueryInnerHitsIT extends BaseNeuralSearchIT {
     @SneakyThrows
     public void testInnerHits_withSortingAndPagination_thenSuccessful() {
         initializeIndexIfNotExist(TEST_MULTI_DOC_WITH_NESTED_FIELDS_MULTIPLE_SHARD_INDEX_NAME);
-        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of());
+        createSearchPipeline(NORMALIZATION_SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), false);
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
         NestedQueryBuilder nestedQueryBuilder1 = new NestedQueryBuilder("user", new MatchQueryBuilder("user.name", "John"), ScoreMode.Avg);
 
@@ -233,7 +233,8 @@ public class HybridQueryInnerHitsIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true
+            true,
+            false
         );
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
         NestedQueryBuilder nestedQueryBuilder1 = new NestedQueryBuilder("user", new MatchQueryBuilder("user.name", "John"), ScoreMode.Max);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryInnerHitsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryInnerHitsIT.java
@@ -233,8 +233,8 @@ public class HybridQueryInnerHitsIT extends BaseNeuralSearchIT {
             Map.of(),
             DEFAULT_COMBINATION_METHOD,
             Map.of(),
-            true,
-            false
+            false,
+            true
         );
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
         NestedQueryBuilder nestedQueryBuilder1 = new NestedQueryBuilder("user", new MatchQueryBuilder("user.name", "John"), ScoreMode.Max);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
@@ -516,7 +516,7 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
         updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
 
         initializeIndexIfNotExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SHARDS_COUNT_IN_MULTI_NODE_CLUSTER);
-        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true, false);
+        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), false, true);
         // Assert
         // scores for search hits
         HybridQueryBuilder hybridQueryBuilder = createHybridQueryBuilderWithMatchTermAndRangeQuery(

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQuerySortIT.java
@@ -516,7 +516,7 @@ public class HybridQuerySortIT extends BaseNeuralSearchIT {
         updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
 
         initializeIndexIfNotExists(TEST_MULTI_DOC_INDEX_WITH_TEXT_AND_INT_MULTIPLE_SHARDS, SHARDS_COUNT_IN_MULTI_NODE_CLUSTER);
-        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true);
+        createSearchPipeline(SEARCH_PIPELINE, DEFAULT_NORMALIZATION_METHOD, Map.of(), DEFAULT_COMBINATION_METHOD, Map.of(), true, false);
         // Assert
         // scores for search hits
         HybridQueryBuilder hybridQueryBuilder = createHybridQueryBuilderWithMatchTermAndRangeQuery(

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1823,7 +1823,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
     @SneakyThrows
     protected void createSearchPipelineWithResultsPostProcessor(final String pipelineId) {
-        createSearchPipeline(pipelineId, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of());
+        createSearchPipeline(pipelineId, DEFAULT_NORMALIZATION_METHOD, DEFAULT_COMBINATION_METHOD, Map.of(), false);
     }
 
     @SneakyThrows
@@ -1831,9 +1831,10 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final String pipelineId,
         final String normalizationMethod,
         String combinationMethod,
-        final Map<String, String> combinationParams
+        final Map<String, String> combinationParams,
+        boolean subQueryScores
     ) {
-        createSearchPipeline(pipelineId, normalizationMethod, Map.of(), combinationMethod, combinationParams, false);
+        createSearchPipeline(pipelineId, normalizationMethod, Map.of(), combinationMethod, combinationParams, subQueryScores, false);
     }
 
     @SneakyThrows
@@ -1843,6 +1844,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final Map<String, Object> normalizationParams,
         final String combinationMethod,
         final Map<String, String> combinationParams,
+        boolean subQueryScores,
         boolean addExplainResponseProcessor
     ) {
         StringBuilder stringBuilderForContentBody = new StringBuilder();
@@ -1900,7 +1902,11 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             }
             stringBuilderForContentBody.append(" }");
         }
-        stringBuilderForContentBody.append("},").append("\"combination\": {").append("\"technique\": \"%s\"");
+        stringBuilderForContentBody.append("}");
+        if (subQueryScores) {
+            stringBuilderForContentBody.append(", \"sub-query-scores\": true");
+        }
+        stringBuilderForContentBody.append(", ").append("\"combination\": {").append("\"technique\": \"%s\"");
         if (Objects.nonNull(combinationParams) && !combinationParams.isEmpty()) {
             stringBuilderForContentBody.append(", \"parameters\": {");
             if (combinationParams.containsKey(PARAM_NAME_WEIGHTS)) {


### PR DESCRIPTION
### Description

Support sub query raw scores in Hybrid Search Response through `getFetchSubPhases` extension point.
Also, added a small improvement for RRF processors while working on this.

Flag to enable sub query scores while creating the pipeline
```
{
  "description": "Post processor for hybrid search",
  "phase_results_processors": [
    {
      "normalization-processor": {
        "normalization": {
          "technique": "z_score"
        },
        "sub-query-scores": true,
        "combination": {
          "technique": "arithmetic_mean",
          "parameters": {
            "weights": [
              0.3,
              0.4,
              0.3
            ]
          }
        }
      }
    }
  ]
}
```
Response
```
"hits": {
        "total": {
            "value": 2,
            "relation": "eq"
        },
        "max_score": 0.016393442,
        "hits": [
            {
                "_index": "my-nlp-index1",
                "_id": "3",
                "_score": 0.016393442,
                "_source": {
                    "passage_text": "zoo keeper here",
                    "id": "s3"
                },
                "fields": {
                    "hybridization_sub_query_scores": [
                        0.0,
                        0.0,
                        0.26156494
                    ]
                }
            },
            {
                "_index": "my-nlp-index1",
                "_id": "1",
                "_score": 0.016393442,
                "_source": {
                    "passage_text": "hello hi what",
                    "id": "s1"
                },
                "fields": {
                    "hybridization_sub_query_scores": [
                        0.13076457,
                        0.0,
                        0.0
                    ]
                }
            }
        ]
    }
}
```

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/1294, https://github.com/opensearch-project/neural-search/issues/1180 & https://github.com/opensearch-project/neural-search/issues/1419

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
