### PR TITLE
combine skip existing flag execution into single info and execution stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Stats] Add stats for score based and rank based normalization processors ([#1326](https://github.com/opensearch-project/neural-search/pull/1326))
 - [Stats] Add stats tracking for semantic field ([#1362](https://github.com/opensearch-project/neural-search/pull/1362))
 - [Stats] Add stats for neural query enricher, neural sparse encoding, two phase, and reranker processors ([#1343](https://github.com/opensearch-project/neural-search/pull/1343))
-
 - [Stats] Add `include_individual_nodes`, `include_all_nodes`, `include_info` parameters to stats API ([#1360](https://github.com/opensearch-project/neural-search/pull/1360))
+- [Stats] Add stats for custom flags set in ingest processors ([#1378](https://github.com/opensearch-project/neural-search/pull/1378))
 ### Bug Fixes
 - Fix score value as null for single shard when sorting is not done on score field ([#1277](https://github.com/opensearch-project/neural-search/pull/1277))
 - Return bad request for stats API calls with invalid stat names instead of ignoring them ([#1291](https://github.com/opensearch-project/neural-search/pull/1291))

--- a/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
@@ -85,6 +85,7 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
             generateAndSetMapInference(ingestDocument, processMap, inferenceList, pruneType, pruneRatio, handler);
             return;
         }
+        EventStatsManager.increment(EventStatName.SKIP_EXISTING_EXECUTIONS);
         // if skipExisting flag is turned on, eligible inference texts will be compared and filtered after embeddings are copied
         Object index = ingestDocument.getSourceAndMetadata().get(INDEX_FIELD);
         Object id = ingestDocument.getSourceAndMetadata().get(ID_FIELD);

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -72,7 +72,7 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
             generateAndSetInference(ingestDocument, processMap, inferenceList, handler);
             return;
         }
-        EventStatsManager.increment(EventStatName.TEXT_EMBEDDING_PROCESSOR_SKIP_EXISTING_EXECUTIONS);
+        EventStatsManager.increment(EventStatName.SKIP_EXISTING_EXECUTIONS);
         // if skipExisting flag is turned on, eligible inference texts will be compared and filtered after embeddings are copied
         Object index = ingestDocument.getSourceAndMetadata().get(INDEX_FIELD);
         Object id = ingestDocument.getSourceAndMetadata().get(ID_FIELD);
@@ -128,7 +128,7 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
             }
             // skipExisting flag is turned on, eligible inference texts in dataForInferences will be compared and filtered after embeddings
             // are copied
-            EventStatsManager.increment(EventStatName.TEXT_EMBEDDING_PROCESSOR_SKIP_EXISTING_EXECUTIONS);
+            EventStatsManager.increment(EventStatName.SKIP_EXISTING_EXECUTIONS);
             openSearchClient.execute(
                 MultiGetAction.INSTANCE,
                 buildMultiGetRequest(dataForInferences),

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessor.java
@@ -134,6 +134,7 @@ public class TextImageEmbeddingProcessor extends AbstractProcessor {
                 generateAndSetInference(ingestDocument, inferenceMap, handler);
                 return;
             }
+            EventStatsManager.increment(EventStatName.SKIP_EXISTING_EXECUTIONS);
             // if skipExisting flag is turned on, eligible inference text and images will be compared and filtered after embeddings are
             // copied
             Object index = ingestDocument.getSourceAndMetadata().get(INDEX_FIELD);

--- a/src/main/java/org/opensearch/neuralsearch/stats/events/EventStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/events/EventStatName.java
@@ -28,14 +28,8 @@ public enum EventStatName implements StatName {
         EventStatType.TIMESTAMPED_EVENT_COUNTER,
         Version.V_3_0_0
     ),
-    /** Tracks skipped executions of the text embedding processor for existing embeddings */
-    TEXT_EMBEDDING_PROCESSOR_SKIP_EXISTING_EXECUTIONS(
-        "text_embedding_skip_existing_executions",
-        "processors.ingest",
-        EventStatType.TIMESTAMPED_EVENT_COUNTER,
-        Version.V_3_1_0
-    ),
-    /** Tracks executions of the text chunking processor */
+    /** Tracks skipped executions of ingest processor for existing embeddings */
+    SKIP_EXISTING_EXECUTIONS("skip_existing_executions", "processors.ingest", EventStatType.TIMESTAMPED_EVENT_COUNTER, Version.V_3_1_0),
     TEXT_CHUNKING_PROCESSOR_EXECUTIONS(
         "text_chunking_executions",
         "processors.ingest",

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
@@ -25,14 +25,8 @@ public enum InfoStatName implements StatName {
     CLUSTER_VERSION("cluster_version", "", InfoStatType.INFO_STRING, Version.V_3_0_0),
     /** Counts text embedding processors in pipelines */
     TEXT_EMBEDDING_PROCESSORS("text_embedding_processors_in_pipelines", "processors.ingest", InfoStatType.INFO_COUNTER, Version.V_3_0_0),
-    /** Counts text embedding processors with skip existing embeddings enabled */
-    TEXT_EMBEDDING_SKIP_EXISTING_PROCESSORS(
-        "text_embedding_skip_existing_processors",
-        "processors.ingest",
-        InfoStatType.INFO_COUNTER,
-        Version.V_3_1_0
-    ),
-    /** Counts text chunking processors */
+    /** Counts ingest processors with skip existing embeddings enabled */
+    SKIP_EXISTING_PROCESSORS("skip_existing_processors", "processors.ingest", InfoStatType.INFO_COUNTER, Version.V_3_1_0),
     TEXT_CHUNKING_PROCESSORS("text_chunking_processors", "processors.ingest", InfoStatType.INFO_COUNTER, Version.V_3_1_0),
     /** Counts delimiter-based text chunking processors */
     TEXT_CHUNKING_DELIMITER_PROCESSORS(

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
@@ -242,9 +242,9 @@ public class InfoStatsManager {
                         Map<String, Object> processorConfig = asMap(entry.getValue());
                         switch (processorType) {
                             case TextEmbeddingProcessor.TYPE -> countTextEmbeddingProcessorStats(stats, processorConfig);
-                            case TextImageEmbeddingProcessor.TYPE -> increment(stats, InfoStatName.TEXT_IMAGE_EMBEDDING_PROCESSORS);
+                            case TextImageEmbeddingProcessor.TYPE -> countTextImageEmbeddingProcessorStats(stats, processorConfig);
                             case TextChunkingProcessor.TYPE -> countTextChunkingProcessorStats(stats, processorConfig);
-                            case SparseEncodingProcessor.TYPE -> increment(stats, InfoStatName.SPARSE_ENCODING_PROCESSORS);
+                            case SparseEncodingProcessor.TYPE -> countSparseEncodingProcessorStats(stats, processorConfig);
                         }
                     }
                 }
@@ -261,7 +261,39 @@ public class InfoStatsManager {
         increment(stats, InfoStatName.TEXT_EMBEDDING_PROCESSORS);
         Object skipExisting = processorConfig.get(TextEmbeddingProcessor.SKIP_EXISTING);
         if (Objects.nonNull(skipExisting) && skipExisting.equals(Boolean.TRUE)) {
-            increment(stats, InfoStatName.TEXT_EMBEDDING_SKIP_EXISTING_PROCESSORS);
+            increment(stats, InfoStatName.SKIP_EXISTING_PROCESSORS);
+        }
+    }
+
+    /**
+     * Counts text/image embedding processor stats based on processor config
+     * @param stats map containing the stat to increment
+     * @param processorConfig map of the processor config, parsed to add stats
+     */
+    private void countTextImageEmbeddingProcessorStats(
+        Map<InfoStatName, CountableInfoStatSnapshot> stats,
+        Map<String, Object> processorConfig
+    ) {
+        increment(stats, InfoStatName.TEXT_IMAGE_EMBEDDING_PROCESSORS);
+        Object skipExisting = processorConfig.get(TextImageEmbeddingProcessor.SKIP_EXISTING);
+        if (Objects.nonNull(skipExisting) && skipExisting.equals(Boolean.TRUE)) {
+            increment(stats, InfoStatName.SKIP_EXISTING_PROCESSORS);
+        }
+    }
+
+    /**
+     * Counts sparse encoding processor stats based on processor config
+     * @param stats map containing the stat to increment
+     * @param processorConfig map of the processor config, parsed to add stats
+     */
+    private void countSparseEncodingProcessorStats(
+        Map<InfoStatName, CountableInfoStatSnapshot> stats,
+        Map<String, Object> processorConfig
+    ) {
+        increment(stats, InfoStatName.SPARSE_ENCODING_PROCESSORS);
+        Object skipExisting = processorConfig.get(SparseEncodingProcessor.SKIP_EXISTING);
+        if (Objects.nonNull(skipExisting) && skipExisting.equals(Boolean.TRUE)) {
+            increment(stats, InfoStatName.SKIP_EXISTING_PROCESSORS);
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessIT.java
@@ -125,12 +125,12 @@ public class SparseEncodingProcessIT extends BaseNeuralSearchIT {
         assertEquals(4.4433594, maxScore, 1e-3);
     }
 
-    public void testSparseEncodingProcessor_statsEnabled() throws Exception {
+    public void testSparseEncodingProcessor_withSkipExisting_statsEnabled() throws Exception {
         enableStats();
 
         String modelId = null;
         modelId = prepareSparseEncodingModel();
-        createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.SPARSE_ENCODING);
+        createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.SPARSE_ENCODING_WITH_SKIP_EXISTING);
         createIndexWithPipeline(INDEX_NAME, "SparseEncodingIndexMappings.json", PIPELINE_NAME);
         ingestDocument(INDEX_NAME, INGEST_DOCUMENT);
         assertEquals(1, getDocCount(INDEX_NAME));
@@ -149,7 +149,9 @@ public class SparseEncodingProcessIT extends BaseNeuralSearchIT {
         Map<String, Object> allNodesStats = parseAggregatedNodeStatsResponse(responseBody);
 
         assertEquals(1, getNestedValue(allNodesStats, EventStatName.SPARSE_ENCODING_PROCESSOR_EXECUTIONS));
+        assertEquals(1, getNestedValue(allNodesStats, EventStatName.SKIP_EXISTING_EXECUTIONS));
         assertEquals(1, getNestedValue(stats, InfoStatName.SPARSE_ENCODING_PROCESSORS));
+        assertEquals(1, getNestedValue(stats, InfoStatName.SKIP_EXISTING_PROCESSORS));
 
         disableStats();
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -496,15 +496,15 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
 
         // Parse json to get stats
         assertEquals(2, getNestedValue(allNodesStats, EventStatName.TEXT_EMBEDDING_PROCESSOR_EXECUTIONS));
-        assertEquals(2, getNestedValue(allNodesStats, EventStatName.TEXT_EMBEDDING_PROCESSOR_SKIP_EXISTING_EXECUTIONS));
+        assertEquals(2, getNestedValue(allNodesStats, EventStatName.SKIP_EXISTING_EXECUTIONS));
 
         assertEquals(1, getNestedValue(stats, InfoStatName.TEXT_EMBEDDING_PROCESSORS));
-        assertEquals(1, getNestedValue(stats, InfoStatName.TEXT_EMBEDDING_SKIP_EXISTING_PROCESSORS));
+        assertEquals(1, getNestedValue(stats, InfoStatName.SKIP_EXISTING_PROCESSORS));
         // Reset stats
         updateClusterSettings("plugins.neural_search.stats_enabled", false);
     }
 
-    public void testTextEmbeddingProcessor_batch__processorStats_successful() throws Exception {
+    public void testTextEmbeddingProcessor_batch_processorStats_successful() throws Exception {
         updateClusterSettings("plugins.neural_search.stats_enabled", true);
         String modelId = uploadTextEmbeddingModel();
         loadModel(modelId);
@@ -528,10 +528,10 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
 
         // Parse json to get stats
         assertEquals(2, getNestedValue(allNodesStats, EventStatName.TEXT_EMBEDDING_PROCESSOR_EXECUTIONS));
-        assertEquals(2, getNestedValue(allNodesStats, EventStatName.TEXT_EMBEDDING_PROCESSOR_SKIP_EXISTING_EXECUTIONS));
+        assertEquals(2, getNestedValue(allNodesStats, EventStatName.SKIP_EXISTING_EXECUTIONS));
 
         assertEquals(1, getNestedValue(stats, InfoStatName.TEXT_EMBEDDING_PROCESSORS));
-        assertEquals(1, getNestedValue(stats, InfoStatName.TEXT_EMBEDDING_SKIP_EXISTING_PROCESSORS));
+        assertEquals(1, getNestedValue(stats, InfoStatName.SKIP_EXISTING_PROCESSORS));
         updateClusterSettings("plugins.neural_search.stats_enabled", false);
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorIT.java
@@ -106,12 +106,12 @@ public class TextImageEmbeddingProcessorIT extends BaseNeuralSearchIT {
     }
 
     @SneakyThrows
-    public void testEmbeddingProcessor_whenIngestingDocumentWithOrWithoutSourceMatchingMapping_thenSuccessful_statsEnabled() {
+    public void testEmbeddingProcessor_withDocumentWithOrWithoutSourceMatchingMapping_withSkipExisting_thenSuccessful_statsEnabled() {
         enableStats();
 
         String modelId = uploadModel();
         loadModel(modelId);
-        createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_IMAGE_EMBEDDING);
+        createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_IMAGE_EMBEDDING_WITH_SKIP_EXISTING);
         createIndexWithPipeline(INDEX_NAME, "IndexMappings.json", PIPELINE_NAME);
         // verify doc with mapping
         ingestDocument(INDEX_NAME, INGEST_DOCUMENT);
@@ -129,7 +129,9 @@ public class TextImageEmbeddingProcessorIT extends BaseNeuralSearchIT {
 
         // Parse json to get stats
         assertEquals(2, getNestedValue(allNodesStats, EventStatName.TEXT_IMAGE_EMBEDDING_PROCESSOR_EXECUTIONS.getFullPath()));
+        assertEquals(1, getNestedValue(allNodesStats, EventStatName.SKIP_EXISTING_EXECUTIONS.getFullPath()));
         assertEquals(1, getNestedValue(stats, InfoStatName.TEXT_IMAGE_EMBEDDING_PROCESSORS.getFullPath()));
+        assertEquals(1, getNestedValue(stats, InfoStatName.SKIP_EXISTING_PROCESSORS.getFullPath()));
 
         // Reset stats
         updateClusterSettings("plugins.neural_search.stats_enabled", false);


### PR DESCRIPTION
### Description
This change combines `skip_existing` flag in info and events stats into a single stat. 

Previously, `skip_existing` flag enabled processors had separate stats associated with them.
For example:

**InfoStats**
`text_embedding_skip_existing_processors`

**EventStats**
`text_embedding_skip_existing_executions`

This PR combines `skip_existing` stats in different processor into single stat

**InfoStats**
`skip_existing_processors`

**EventStats**
`skip_existing_executions`

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
