### PR TITLE
Fix ingest document wrapper constructor compilation errors in unit tests

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTestCase.java
@@ -33,7 +33,7 @@ public class InferenceProcessorTestCase extends OpenSearchTestCase {
             sourceAndMetadata.put("key1", value);
             sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
             sourceAndMetadata.put("_id", String.valueOf(i));
-            wrapperList.add(new IngestDocumentWrapper(i, new IngestDocument(sourceAndMetadata, new HashMap<>()), null));
+            wrapperList.add(new IngestDocumentWrapper(i, 0, new IngestDocument(sourceAndMetadata, new HashMap<>()), null));
         }
         return wrapperList;
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
@@ -780,7 +780,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
 
     public void test_subBatchExecute_emptyInferenceList_successful() {
         List<IngestDocumentWrapper> ingestDocumentWrappers = new ArrayList<>();
-        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, null, null));
+        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, 0, null, null));
         SparseEncodingProcessor processor = createInstance(false);
         Consumer resultHandler = mock(Consumer.class);
         processor.subBatchExecute(ingestDocumentWrappers, resultHandler);
@@ -790,7 +790,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
 
     public void test_execute_emptyInferenceList_successful() {
         List<IngestDocumentWrapper> ingestDocumentWrappers = new ArrayList<>();
-        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, null, null));
+        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, 0, null, null));
         SparseEncodingProcessor processor = createInstance(false);
         Consumer resultHandler = mock(Consumer.class);
         processor.subBatchExecute(ingestDocumentWrappers, resultHandler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -1183,7 +1183,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
     public void test_subBatchExecute_emptyInferenceList_successful() {
         List<IngestDocumentWrapper> ingestDocumentWrappers = new ArrayList<>();
-        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, null, null));
+        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, 0, null, null));
         TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(1, false);
         Consumer resultHandler = mock(Consumer.class);
         processor.subBatchExecute(ingestDocumentWrappers, resultHandler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessorTests.java
@@ -463,7 +463,7 @@ public class SemanticFieldProcessorTests extends OpenSearchTestCase {
 
     private IngestDocumentWrapper createIngestDocWrapper(@NonNull final String id, @NonNull final Map<String, Object> source, Exception e) {
         final IngestDocument ingestDocument = new IngestDocument("index", id, "routing", 1L, VersionType.INTERNAL, source);
-        return new IngestDocumentWrapper(1, ingestDocument, e);
+        return new IngestDocumentWrapper(1, 0, ingestDocument, e);
     }
 
 }


### PR DESCRIPTION
### Description
Fixes compilation error from core 3.1

With https://github.com/opensearch-project/OpenSearch/pull/18277 in core, we introduce a new parameter to the constructor of IngestDocumentWrapper. AbstractBatchingProcessor interacts with IngestDocumentWrappers directly so we need to update the constructor usages to fix compilation error in #1382 1382

### Related Issues
n/a

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
