### PR TITLE
[backport 3.1]Fix some bugs for neural query with semantic field using sparse model

### DIFF
--- a/release-notes/opensearch-neural-search.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-neural-search.release-notes-3.1.0.0.md
@@ -32,6 +32,7 @@ Compatible with OpenSearch 3.1.0
 - Add validation for invalid nested hybrid query ([#1305](https://github.com/opensearch-project/neural-search/pull/1305))
 - Use stack to collect semantic fields to avoid stack overflow ([#1357](https://github.com/opensearch-project/neural-search/pull/1357))
 - Filter requested stats based on minimum cluster version to fix BWC tests for stats API ([#1373](https://github.com/opensearch-project/neural-search/pull/1373))
+- Fix some bugs for neural query with semantic field using sparse model. ([#1396](https://github.com/opensearch-project/neural-search/pull/1396))
 - Fix neural radial search serialization in multi-node clusters ([#1393](https://github.com/opensearch-project/neural-search/pull/1393)))
 
 ### Infrastructure

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderBuilderTests.java
@@ -55,7 +55,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
             () -> NeuralQueryBuilder.builder().fieldName(FIELD_NAME).k(K).maxDistance(MAX_DISTANCE).build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: Either query_text or query_image must"
+        final String expectedMessage = "Invalid neural query: Either query_text or query_image must"
             + " be provided.; Only one of k, max_distance, or min_score can be provided";
         assertEquals(expectedMessage, exception.getMessage());
     }
@@ -68,7 +68,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
             () -> NeuralQueryBuilder.builder().fieldName(FIELD_NAME).k(K).maxDistance(MAX_DISTANCE).build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: Either query_text or query_image must"
+        final String expectedMessage = "Invalid neural query: Either query_text or query_image must"
             + " be provided.; Only one of k, max_distance, or min_score can be provided; model_id must be provided.";
         assertEquals(expectedMessage, exception.getMessage());
     }
@@ -81,7 +81,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
             () -> NeuralQueryBuilder.builder().fieldName(FIELD_NAME).queryTokensMapSupplier(TEST_QUERY_TOKENS_MAP_SUPPLIER).build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: Either query_text or query_image must "
+        final String expectedMessage = "Invalid neural query: Either query_text or query_image must "
             + "be provided.; model_id must be provided.; Target field is a KNN field using a dense model. "
             + "query_tokens is not supported since it is for the sparse model.";
         assertEquals(expectedMessage, exception.getMessage());
@@ -204,7 +204,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
                 .build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: query_tokens, model_id and "
+        final String expectedMessage = "Invalid neural query: query_tokens, model_id and "
             + "semantic_field_search_analyzer can not coexist; Target field is a semantic field using a sparse model. "
             + "[filter, query_image, k, expand_nested_docs] are not supported since they are for the dense model.";
         assertEquals(expectedMessage, exception.getMessage());
@@ -233,7 +233,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
                 .build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: Target field is a semantic field"
+        final String expectedMessage = "Invalid neural query: Target field is a semantic field"
             + " using a dense model. query_tokens is not supported since it is for the sparse model.";
         assertEquals(expectedMessage, exception.getMessage());
     }
@@ -261,7 +261,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
                 .build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: Target field is a semantic field"
+        final String expectedMessage = "Invalid neural query: Target field is a semantic field"
             + " using a dense model. semantic_field_search_analyzer is not supported since it is for the sparse model.";
         assertEquals(expectedMessage, exception.getMessage());
     }
@@ -284,7 +284,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
                 .build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: query_tokens, model_id and "
+        final String expectedMessage = "Invalid neural query: query_tokens, model_id and "
             + "semantic_field_search_analyzer can not coexist";
         assertEquals(expectedMessage, exception.getMessage());
     }
@@ -306,7 +306,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
                 .build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: " + "semantic_field_search_analyzer field can not be empty";
+        final String expectedMessage = "Invalid neural query: " + "semantic_field_search_analyzer field can not be empty";
         assertEquals(expectedMessage, exception.getMessage());
     }
 
@@ -327,7 +327,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
                 .build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: " + "model_id field can not be empty";
+        final String expectedMessage = "Invalid neural query: " + "model_id field can not be empty";
         assertEquals(expectedMessage, exception.getMessage());
     }
 
@@ -349,8 +349,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
                 .build()
         );
 
-        final String expectedMessage =
-            "Failed to build the NeuralQueryBuilder: query_tokens, model_id and semantic_field_search_analyzer can not coexist";
+        final String expectedMessage = "Invalid neural query: query_tokens, model_id and semantic_field_search_analyzer can not coexist";
         assertEquals(expectedMessage, exception.getMessage());
     }
 
@@ -370,7 +369,7 @@ public class NeuralQueryBuilderBuilderTests extends OpenSearchTestCase {
                 .build()
         );
 
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: Target field is a semantic field"
+        final String expectedMessage = "Invalid neural query: Target field is a semantic field"
             + " using a dense model. semantic_field_search_analyzer is not supported since it is for the sparse model.";
         assertEquals(expectedMessage, exception.getMessage());
     }

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -160,9 +160,8 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> NeuralQueryBuilder.fromXContent(contentParser)
         );
-        final String expectedMessage = "Failed to build the NeuralQueryBuilder: Target field is a KNN "
-            + "field using a dense model. semantic_field_search_analyzer "
-            + "is not supported since it is for the sparse model.";
+        final String expectedMessage = "Invalid neural query: Target field is a KNN field using a dense model."
+            + " semantic_field_search_analyzer is not supported since it is for the sparse model.";
         assertEquals(expectedMessage, exception.getMessage());
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryIT.java
@@ -37,6 +37,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
     private static final String TEST_MULTI_DOC_INDEX_NAME = "test-neural-multi-doc-index";
     private static final String TEST_SEMANTIC_INDEX_SPARSE_NAME = "test-neural-sparse-semantic-index";
     private static final String TEST_QUERY_TEXT = "Hello world";
+    private static final String TEST_QUERY_TEXT_SPARSE = "Hello world a b";
     private static final String TEST_IMAGE_TEXT = "/9j/4AAQSkZJRgABAQAASABIAAD";
     private static final String TEST_KNN_VECTOR_FIELD_NAME_1 = "test-knn-vector-1";
     private static final String TEST_KNN_VECTOR_FIELD_NAME_2 = "test-knn-vector-2";
@@ -531,7 +532,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         initializeIndexIfNotExist(TEST_SEMANTIC_INDEX_SPARSE_NAME, modelId, null);
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
             .fieldName(TEST_SEMANTIC_TEXT_FIELD)
-            .queryText(TEST_QUERY_TEXT)
+            .queryText(TEST_QUERY_TEXT_SPARSE)
             .boost(2.0f)
             .searchAnalyzer("standard")
             .build();
@@ -540,7 +541,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         assertEquals(1, getHitCount(searchResponseAsMap));
         Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
         assertEquals("4", firstInnerHit.get("_id"));
-        float expectedScore = 2 * computeExpectedScore(modelId, testRankFeaturesDoc, TEST_QUERY_TEXT);
+        float expectedScore = 2 * computeExpectedScore(testRankFeaturesDoc, Map.of("hello", 1f, "world", 1f, "a", 1f, "b", 1f));
         assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
     }
 
@@ -563,7 +564,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         initializeIndexIfNotExist(TEST_SEMANTIC_INDEX_SPARSE_NAME, modelId, "standard");
         NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
             .fieldName(TEST_SEMANTIC_TEXT_FIELD)
-            .queryText(TEST_QUERY_TEXT)
+            .queryText(TEST_QUERY_TEXT_SPARSE)
             .boost(2.0f)
             .build();
 
@@ -571,7 +572,7 @@ public class NeuralQueryIT extends BaseNeuralSearchIT {
         assertEquals(1, getHitCount(searchResponseAsMap));
         Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
         assertEquals("4", firstInnerHit.get("_id"));
-        float expectedScore = 2 * computeExpectedScore(modelId, testRankFeaturesDoc, TEST_QUERY_TEXT);
+        float expectedScore = 2 * computeExpectedScore(testRankFeaturesDoc, Map.of("hello", 1f, "world", 1f, "a", 1f, "b", 1f));
         assertEquals(expectedScore, objectToFloat(firstInnerHit.get("_score")), DELTA);
     }
 


### PR DESCRIPTION
### Description
[backport 3.1]Fix some bugs for neural query with semantic field using sparse model

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
