### PR TITLE
Fix the case where all subScorers are null

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryWeight.java
@@ -89,7 +89,7 @@ public final class HybridQueryWeight extends Weight {
         }
         HybridQueryExecutor.getExecutor().invokeAll(scoreSupplierTasks);
         final List<ScorerSupplier> scorerSuppliers = manager.mergeScoreSuppliers(collectors);
-        if (scorerSuppliers.isEmpty()) {
+        if (scorerSuppliers.isEmpty() || scorerSuppliers.stream().allMatch(Objects::isNull)) {
             return null;
         }
         return new HybridScorerSupplier(scorerSuppliers, this, scoreMode, context);


### PR DESCRIPTION
### Description
Handle the case gracefully where all subScorers are null.

### Related Issues
Resolves #1377
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
