### PR TITLE
Fix for collapse bug with knn query not deduplicating results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
-* Change where collapse context is read from in collector factory ([#1413](https://github.com/opensearch-project/neural-search/pull/1413))
+* Fix for collapse bug with knn query not deduplicating results ([#1413](https://github.com/opensearch-project/neural-search/pull/1413))
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+* Change where collapse context is read from in collector factory ([#1413](https://github.com/opensearch-project/neural-search/pull/1413))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridCollectorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridCollectorFactory.java
@@ -46,7 +46,7 @@ public class HybridCollectorFactory {
                     collapseContext.getFieldName(),
                     fieldType,
                     sortAndFormats == null ? new Sort(new SortField(null, SortField.Type.SCORE)) : sortAndFormats.sort,
-                    searchContext.size(),
+                    searchContext.size() + searchContext.from(),
                     hitsThresholdChecker
                 );
             } else if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
@@ -54,7 +54,7 @@ public class HybridCollectorFactory {
                     collapseContext.getFieldName(),
                     fieldType,
                     sortAndFormats == null ? new Sort(new SortField(null, SortField.Type.SCORE)) : sortAndFormats.sort,
-                    searchContext.size(),
+                    searchContext.size() + searchContext.from(),
                     hitsThresholdChecker
                 );
             } else {

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridCollectorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridCollectorFactory.java
@@ -46,7 +46,7 @@ public class HybridCollectorFactory {
                     collapseContext.getFieldName(),
                     fieldType,
                     sortAndFormats == null ? new Sort(new SortField(null, SortField.Type.SCORE)) : sortAndFormats.sort,
-                    searchContext.size() + searchContext.from(),
+                    numHits,
                     hitsThresholdChecker
                 );
             } else if (fieldType instanceof NumberFieldMapper.NumberFieldType) {
@@ -54,7 +54,7 @@ public class HybridCollectorFactory {
                     collapseContext.getFieldName(),
                     fieldType,
                     sortAndFormats == null ? new Sort(new SortField(null, SortField.Type.SCORE)) : sortAndFormats.sort,
-                    searchContext.size() + searchContext.from(),
+                    numHits,
                     hitsThresholdChecker
                 );
             } else {

--- a/src/test/java/org/opensearch/neuralsearch/collector/HybridCollectorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/collector/HybridCollectorFactoryTests.java
@@ -31,6 +31,7 @@ public class HybridCollectorFactoryTests extends OpenSearchTestCase {
         HybridCollectorFactoryDTO mockDTO = mock(HybridCollectorFactoryDTO.class);
         when(mockDTO.getCollapseContext()).thenReturn(collapseContext);
         when(mockDTO.getSearchContext()).thenReturn(searchContext);
+        when(mockDTO.getNumHits()).thenReturn(5);
 
         Collector collector = HybridCollectorFactory.createCollector(mockDTO);
         assertTrue(collector instanceof HybridCollapsingTopDocsCollector);
@@ -47,6 +48,7 @@ public class HybridCollectorFactoryTests extends OpenSearchTestCase {
         HybridCollectorFactoryDTO mockDTO = mock(HybridCollectorFactoryDTO.class);
         when(mockDTO.getCollapseContext()).thenReturn(collapseContext);
         when(mockDTO.getSearchContext()).thenReturn(searchContext);
+        when(mockDTO.getNumHits()).thenReturn(5);
 
         Collector collector = HybridCollectorFactory.createCollector(mockDTO);
         assertTrue(collector instanceof HybridCollapsingTopDocsCollector);

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTestCase.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTestCase.java
@@ -33,7 +33,7 @@ public class InferenceProcessorTestCase extends OpenSearchTestCase {
             sourceAndMetadata.put("key1", value);
             sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
             sourceAndMetadata.put("_id", String.valueOf(i));
-            wrapperList.add(new IngestDocumentWrapper(i, new IngestDocument(sourceAndMetadata, new HashMap<>()), null));
+            wrapperList.add(new IngestDocumentWrapper(i, 0, new IngestDocument(sourceAndMetadata, new HashMap<>()), null));
         }
         return wrapperList;
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
@@ -780,7 +780,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
 
     public void test_subBatchExecute_emptyInferenceList_successful() {
         List<IngestDocumentWrapper> ingestDocumentWrappers = new ArrayList<>();
-        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, null, null));
+        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, 0, null, null));
         SparseEncodingProcessor processor = createInstance(false);
         Consumer resultHandler = mock(Consumer.class);
         processor.subBatchExecute(ingestDocumentWrappers, resultHandler);
@@ -790,7 +790,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
 
     public void test_execute_emptyInferenceList_successful() {
         List<IngestDocumentWrapper> ingestDocumentWrappers = new ArrayList<>();
-        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, null, null));
+        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, 0, null, null));
         SparseEncodingProcessor processor = createInstance(false);
         Consumer resultHandler = mock(Consumer.class);
         processor.subBatchExecute(ingestDocumentWrappers, resultHandler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -1183,7 +1183,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
 
     public void test_subBatchExecute_emptyInferenceList_successful() {
         List<IngestDocumentWrapper> ingestDocumentWrappers = new ArrayList<>();
-        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, null, null));
+        ingestDocumentWrappers.add(new IngestDocumentWrapper(0, 0, null, null));
         TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(1, false);
         Consumer resultHandler = mock(Consumer.class);
         processor.subBatchExecute(ingestDocumentWrappers, resultHandler);

--- a/src/test/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessorTests.java
@@ -463,7 +463,7 @@ public class SemanticFieldProcessorTests extends OpenSearchTestCase {
 
     private IngestDocumentWrapper createIngestDocWrapper(@NonNull final String id, @NonNull final Map<String, Object> source, Exception e) {
         final IngestDocument ingestDocument = new IngestDocument("index", id, "routing", 1L, VersionType.INTERNAL, source);
-        return new IngestDocumentWrapper(1, ingestDocument, e);
+        return new IngestDocumentWrapper(1, 0, ingestDocument, e);
     }
 
 }


### PR DESCRIPTION
### Description
Changes how the collapse context is retrieved in the hybrid collector factory.  This fixes a bug where sometimes the collapse context would incorrectly be read as null, which would 

### Related Issues
Resolves #1411

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
