### PR TITLE
Fix the HybridQueryDocIdStream to properly handle upTo value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+- Fix the HybridQueryDocIdStream to properly handle upTo value ([#1414](https://github.com/opensearch-project/neural-search/pull/1414))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.query;
 
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.lucene.search.CheckedIntConsumer;
 import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.util.FixedBitSet;
@@ -19,19 +20,32 @@ import java.util.Objects;
 public class HybridQueryDocIdStream extends DocIdStream {
     private static final int BLOCK_SHIFT = 6;
     private final HybridBulkScorer hybridBulkScorer;
+    private FixedBitSet localMatchingBitSet;
+    @Setter
     private int base;
-    private int upTo;
 
-    /**
-     * Iterate over all doc ids and collect each doc id with leaf collector
-     * @param consumer consumer that is called for each accepted doc id
-     * @throws IOException in case of IO exception
-     */
+    @Override
+    public boolean mayHaveRemaining() {
+        return getLocalMatchingBitSet().cardinality() > 0;
+    }
+
+    @Override
+    public int count(int upTo) {
+        // Use a counter to track how many documents are processed
+        final int[] count = { 0 };
+        try {
+            forEach(upTo, docId -> count[0]++);
+        } catch (IOException e) {
+            // This should not happen as we're just counting, not doing any I/O
+            throw new RuntimeException(e);
+        }
+        return count[0];
+    }
+
     @Override
     public void forEach(int upTo, CheckedIntConsumer<IOException> consumer) throws IOException {
-        upTo = Math.min(upTo, hybridBulkScorer.getMaxDoc());
         // bitset that represents matching documents, bit is set (1) if doc id is a match
-        FixedBitSet matchingBitSet = hybridBulkScorer.getMatching();
+        FixedBitSet matchingBitSet = getLocalMatchingBitSet();
         long[] bitArray = matchingBitSet.getBits();
         // iterate through each block of 64 documents (since each long contains 64 bits)
         for (int idx = 0; idx < bitArray.length; idx++) {
@@ -43,6 +57,13 @@ public class HybridQueryDocIdStream extends DocIdStream {
                 // idx << 6 is equivalent to idx * 64 (block offset)
                 // numberOfTrailingZeros gives position within the block
                 final int docIndexInWindow = (idx << BLOCK_SHIFT) | numberOfTrailingZeros;
+                final int docId = base | docIndexInWindow;
+
+                // Only process documents up to the specified limit
+                if (docId >= upTo) {
+                    return;
+                }
+
                 float[][] windowScores = hybridBulkScorer.getWindowScores();
                 for (int subQueryIndex = 0; subQueryIndex < windowScores.length; subQueryIndex++) {
                     if (Objects.isNull(windowScores[subQueryIndex])) {
@@ -52,33 +73,22 @@ public class HybridQueryDocIdStream extends DocIdStream {
                     hybridBulkScorer.getHybridSubQueryScorer().getSubQueryScores()[subQueryIndex] = scoreOfDocIdForSubQuery;
                 }
                 // process the document with its base offset
-                int doc = base | docIndexInWindow;
-                if (doc < upTo + base) {
-                    consumer.accept(doc);
-                    this.upTo++;
-                }
+                consumer.accept(docId);
                 // reset scores after processing of one doc, this is required because scorer object is re-used
                 hybridBulkScorer.getHybridSubQueryScorer().resetScores();
+                // clear bit from the local bitset copy to indicate that it has been consumed
+                matchingBitSet.clear(docIndexInWindow);
                 // reset bit for this doc id to indicate that it has been consumed
                 bits ^= 1L << numberOfTrailingZeros;
             }
         }
     }
 
-    @Override
-    public int count(int upTo) throws IOException {
-        int[] count = new int[1];
-        forEach(upTo, (doc -> count[0]++));
-        return count[0];
-    }
-
-    @Override
-    public boolean mayHaveRemaining() {
-        return this.upTo + 1 < hybridBulkScorer.getMaxDoc();
-    }
-
-    public void setBase(int base) {
-        this.base = base;
-        this.upTo = base;
+    // This lazy loading is necessary because the matching bit isn't available at the time this class is constructed.
+    private FixedBitSet getLocalMatchingBitSet() {
+        if (localMatchingBitSet == null) {
+            localMatchingBitSet = hybridBulkScorer.getMatching().clone();
+        }
+        return localMatchingBitSet;
     }
 }


### PR DESCRIPTION
### Description
The HybridQueryDocIdStream class contained a bug in how it handled the upTo parameter. This issue led to a flaky test failure in HybridQueryTests.testWithRandomDocuments_whenMultipleTermSubQueriesWithMatch_thenReturnSuccessfully.

The failure occurred because the mayHaveRemaining method returned true even after all documents had been consumed from the hybridBulkScorer. As a result, OpenSearch Core attempted to call the forEach method again, which reconsumed documents from the beginning—triggering an assertion failure.

This PR addresses the issue by properly clearing document ID which was already consumed, ensuring that documents aren't reprocessed. It also fixes the mayHaveRemaining method to return false if there is no more document to process.

### Related Issues
Resolves #1344 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
