### PR TITLE
Support configuring the auto-generated knn_vector field through the semantic field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 
 ### Enhancements
+- [Semantic Field] Support configuring the auto-generated knn_vector field through the semantic field. ([#1420](https://github.com/opensearch-project/neural-search/pull/1420))
 
 ### Bug Fixes
 - Fix for collapse bug with knn query not deduplicating results ([#1413](https://github.com/opensearch-project/neural-search/pull/1413))

--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
@@ -47,4 +47,10 @@ public class SemanticFieldConstants {
      * it during query time.
      */
     public static final String SEMANTIC_FIELD_SEARCH_ANALYZER = "semantic_field_search_analyzer";
+
+    /**
+     * Name of the field for dense embedding config. The config will be used to override config of the underlying
+     * knn_vector field.
+     */
+    public static final String DENSE_EMBEDDING_CONFIG = "dense_embedding_config";
 }

--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticInfoFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticInfoFieldConstants.java
@@ -16,6 +16,7 @@ import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
  */
 public class SemanticInfoFieldConstants {
     public static final String KNN_VECTOR_DIMENSION_FIELD_NAME = "dimension";
+    public static final String KNN_VECTOR_DATA_TYPE_FIELD_NAME = "data_type";
     public static final String KNN_VECTOR_METHOD_FIELD_NAME = "method";
     public static final String KNN_VECTOR_METHOD_NAME_FIELD_NAME = "name";
     public static final String KNN_VECTOR_METHOD_DEFAULT_NAME = "hnsw";

--- a/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import static org.opensearch.neuralsearch.constants.MappingConstants.PATH_SEPARATOR;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.CHUNKING;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DEFAULT_SEMANTIC_INFO_FIELD_NAME_SUFFIX;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DENSE_EMBEDDING_CONFIG;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
@@ -146,6 +147,30 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
             null
         );
 
+        protected final Parameter<Map<String, Object>> denseEmbeddingConfig = new Parameter<>(
+            DENSE_EMBEDDING_CONFIG,
+            false,
+            () -> null,
+            (name, ctx, o) -> {
+                if (o == null) {
+                    return null;
+                } else if (o instanceof Map<?, ?>) {
+                    return (Map<String, Object>) o;
+                } else {
+                    throw new MapperParsingException("[" + DENSE_EMBEDDING_CONFIG + "] must be an object");
+                }
+            },
+            m -> ((SemanticFieldMapper) m).semanticParameters.getDenseEmbeddingConfig()
+        ).setSerializer((builder, name, value) -> {
+            if (value == null) {
+                builder.nullField(name);
+            } else {
+                builder.startObject(name);
+                builder.mapContents(value);
+                builder.endObject();
+            }
+        }, (v) -> v == null ? null : v.toString());
+
         @Setter
         protected ParametrizedFieldMapper.Builder delegateBuilder;
 
@@ -155,7 +180,15 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         protected List<Parameter<?>> getParameters() {
-            return List.of(modelId, searchModelId, rawFieldType, semanticInfoFieldName, chunkingEnabled, semanticFieldSearchAnalyzer);
+            return List.of(
+                modelId,
+                searchModelId,
+                rawFieldType,
+                semanticInfoFieldName,
+                chunkingEnabled,
+                semanticFieldSearchAnalyzer,
+                denseEmbeddingConfig
+            );
         }
 
         @Override
@@ -183,6 +216,7 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
                 .semanticInfoFieldName(semanticInfoFieldName.getValue())
                 .chunkingEnabled(chunkingEnabled.getValue())
                 .semanticFieldSearchAnalyzer(semanticFieldSearchAnalyzer.getValue())
+                .denseEmbeddingConfig(denseEmbeddingConfig.getValue())
                 .build();
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/mapper/dto/SemanticParameters.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/dto/SemanticParameters.java
@@ -7,6 +7,8 @@ package org.opensearch.neuralsearch.mapper.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Map;
+
 /**
  * A DTO to hold all the semantic parameters.
  */
@@ -19,4 +21,5 @@ public class SemanticParameters {
     private final String semanticInfoFieldName;
     private final Boolean chunkingEnabled;
     private final String semanticFieldSearchAnalyzer;
+    private final Map<String, Object> denseEmbeddingConfig;
 }

--- a/src/main/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformer.java
+++ b/src/main/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformer.java
@@ -27,6 +27,7 @@ import static org.opensearch.neuralsearch.constants.MappingConstants.PROPERTIES;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.collectSemanticField;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.extractModelIdToFieldPathMap;
+import static org.opensearch.neuralsearch.util.SemanticMappingUtils.getDenseEmbeddingConfig;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.isChunkingEnabled;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.getSemanticFieldSearchAnalyzer;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.getProperties;
@@ -219,6 +220,7 @@ public class SemanticMappingTransformer implements MappingTransformer {
         builder.mlModel(modelConfig, modelId);
         builder.chunkingEnabled(isChunkingEnabled(fieldConfig, fieldPath));
         builder.semanticFieldSearchAnalyzer(getSemanticFieldSearchAnalyzer(fieldConfig, fieldPath));
+        builder.denseEmbeddingConfig(getDenseEmbeddingConfig(fieldConfig, fieldPath));
         return builder.build();
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/util/SemanticMappingUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/SemanticMappingUtils.java
@@ -25,6 +25,7 @@ import static org.opensearch.neuralsearch.constants.MappingConstants.DOC;
 import static org.opensearch.neuralsearch.constants.MappingConstants.PATH_SEPARATOR;
 import static org.opensearch.neuralsearch.constants.MappingConstants.PROPERTIES;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.CHUNKING;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DENSE_EMBEDDING_CONFIG;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_FIELD_SEARCH_ANALYZER;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
@@ -464,5 +465,35 @@ public class SemanticMappingUtils {
         }
 
         return null;
+    }
+
+    /**
+     * Check if the semantic field search analyzer is provided in the semantic field config.
+     * If the field is not defined then return null as the default value.
+     * @param fieldConfigMap The config for a semantic field.
+     * @return if the semantic field search analyzer is provided in the semantic field config.
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> getDenseEmbeddingConfig(
+        @NonNull final Map<String, Object> fieldConfigMap,
+        @NonNull final String semanticFieldPath
+    ) {
+        final Object config = fieldConfigMap.get(DENSE_EMBEDDING_CONFIG);
+        if (config == null) {
+            return null;
+        }
+
+        if (!(config instanceof Map)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "%s should be a Map<String, Object> for the semantic field at %s",
+                    DENSE_EMBEDDING_CONFIG,
+                    semanticFieldPath
+                )
+            );
+        }
+
+        return (Map<String, Object>) config;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/mappingtransformer/SemanticInfoConfigBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mappingtransformer/SemanticInfoConfigBuilderTests.java
@@ -8,6 +8,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.model.RemoteModelConfig;
+import org.opensearch.ml.common.model.BaseModelConfig;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collections;
@@ -15,6 +16,13 @@ import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.constants.MappingConstants.PROPERTIES;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.EMBEDDING_FIELD_NAME;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_DIMENSION_FIELD_NAME;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_METHOD_DEFAULT_NAME;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_METHOD_FIELD_NAME;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_METHOD_NAME_FIELD_NAME;
+import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME;
 
 public class SemanticInfoConfigBuilderTests extends OpenSearchTestCase {
     private final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(Collections.emptyList());
@@ -107,5 +115,125 @@ public class SemanticInfoConfigBuilderTests extends OpenSearchTestCase {
             .build();
 
         builder.mlModel(remoteTextEmbeddingModel, "dummyModelId");
+    }
+
+    public void testBuild_whenDenseEmbeddingConfigWithSparseEmbedding_thenException() {
+        final SemanticInfoConfigBuilder builder = new SemanticInfoConfigBuilder(namedXContentRegistry);
+
+        // prepare mock model config
+        final String modelId = "dummyModelId";
+        final BaseModelConfig remoteSparseEmbeddingModelConfig = mock(BaseModelConfig.class);
+        final MLModel dummyModel = MLModel.builder()
+            .modelId(modelId)
+            .algorithm(FunctionName.REMOTE)
+            .modelConfig(remoteSparseEmbeddingModelConfig)
+            .build();
+        when(remoteSparseEmbeddingModelConfig.getModelType()).thenReturn(FunctionName.SPARSE_ENCODING.name());
+
+        builder.mlModel(dummyModel, modelId);
+        builder.denseEmbeddingConfig(Collections.emptyMap());
+
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+
+        final String expectedErrorMessage =
+            "Cannot build the semantic info config because dense_embedding_config is not supported by rank_features.";
+        assertEquals(expectedErrorMessage, exception.getMessage());
+    }
+
+    public void testBuild_whenDenseEmbeddingConfigWithEmbeddingDimension_thenException() {
+        final SemanticInfoConfigBuilder builder = new SemanticInfoConfigBuilder(namedXContentRegistry);
+
+        // prepare mock model config
+        final String modelId = "dummyModelId";
+        final Integer embeddingDimension = 768;
+        final String allConfig = "{}";
+        final RemoteModelConfig remoteTextEmbeddingModelConfig = RemoteModelConfig.builder()
+            .embeddingDimension(embeddingDimension)
+            .allConfig(allConfig)
+            .modelType(FunctionName.TEXT_EMBEDDING.name())
+            .frameworkType(RemoteModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .additionalConfig(Map.of(KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME, "l2"))
+            .build();
+        final MLModel remoteTextEmbeddingModel = MLModel.builder()
+            .modelId(modelId)
+            .algorithm(FunctionName.REMOTE)
+            .modelConfig(remoteTextEmbeddingModelConfig)
+            .build();
+        builder.mlModel(remoteTextEmbeddingModel, modelId);
+        builder.denseEmbeddingConfig(Map.of(KNN_VECTOR_DIMENSION_FIELD_NAME, 128));
+
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+
+        final String expectedErrorMessage = "Cannot configure dimension in dense_embedding_config in the semantic field.";
+        assertEquals(expectedErrorMessage, exception.getMessage());
+    }
+
+    public void testBuild_whenDenseEmbeddingConfigWithMethodNotMap_thenException() {
+        final SemanticInfoConfigBuilder builder = new SemanticInfoConfigBuilder(namedXContentRegistry);
+
+        // prepare mock model config
+        final String modelId = "dummyModelId";
+        final Integer embeddingDimension = 768;
+        final String allConfig = "{}";
+        final RemoteModelConfig remoteTextEmbeddingModelConfig = RemoteModelConfig.builder()
+            .embeddingDimension(embeddingDimension)
+            .allConfig(allConfig)
+            .modelType(FunctionName.TEXT_EMBEDDING.name())
+            .frameworkType(RemoteModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .additionalConfig(Map.of(KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME, "l2"))
+            .build();
+        final MLModel remoteTextEmbeddingModel = MLModel.builder()
+            .modelId(modelId)
+            .algorithm(FunctionName.REMOTE)
+            .modelConfig(remoteTextEmbeddingModelConfig)
+            .build();
+        builder.mlModel(remoteTextEmbeddingModel, modelId);
+        builder.denseEmbeddingConfig(Map.of(KNN_VECTOR_METHOD_FIELD_NAME, "invalid"));
+
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+
+        final String expectedErrorMessage = "Cannot build the semantic info config because method must be a Map when provided.";
+        assertEquals(expectedErrorMessage, exception.getMessage());
+    }
+
+    public void testBuild_whenValidDenseEmbeddingConfig_thenOverride() {
+        final SemanticInfoConfigBuilder builder = new SemanticInfoConfigBuilder(namedXContentRegistry);
+
+        // prepare mock model config
+        final String modelId = "dummyModelId";
+        final Integer embeddingDimension = 768;
+        final String allConfig = "{}";
+        final RemoteModelConfig remoteTextEmbeddingModelConfig = RemoteModelConfig.builder()
+            .embeddingDimension(embeddingDimension)
+            .allConfig(allConfig)
+            .modelType(FunctionName.TEXT_EMBEDDING.name())
+            .frameworkType(RemoteModelConfig.FrameworkType.HUGGINGFACE_TRANSFORMERS)
+            .additionalConfig(Map.of(KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME, "l2"))
+            .build();
+        final MLModel remoteTextEmbeddingModel = MLModel.builder()
+            .modelId(modelId)
+            .algorithm(FunctionName.REMOTE)
+            .modelConfig(remoteTextEmbeddingModelConfig)
+            .build();
+        builder.mlModel(remoteTextEmbeddingModel, modelId);
+
+        builder.denseEmbeddingConfig(Map.of(KNN_VECTOR_METHOD_FIELD_NAME, Map.of("engine", "lucene")));
+
+        final Map<String, Object> semanticInfoConfig = builder.build();
+
+        // verify
+        final Map<String, Object> expectedMethod = Map.of(
+            "engine",
+            "lucene",
+            KNN_VECTOR_METHOD_NAME_FIELD_NAME,
+            KNN_VECTOR_METHOD_DEFAULT_NAME,
+            KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME,
+            "l2"
+        );
+
+        final Map<String, Object> properties = (Map<String, Object>) semanticInfoConfig.get(PROPERTIES);
+        final Map<String, Object> embeddingConfig = (Map<String, Object>) properties.get(EMBEDDING_FIELD_NAME);
+        final Map<String, Object> actualMethod = (Map<String, Object>) embeddingConfig.get(KNN_VECTOR_METHOD_FIELD_NAME);
+        assertEquals(expectedMethod, actualMethod);
     }
 }

--- a/src/test/resources/processor/semantic/SemanticIndexMappingsForDense.json
+++ b/src/test/resources/processor/semantic/SemanticIndexMappingsForDense.json
@@ -1,0 +1,26 @@
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "products":{
+        "type":"nested",
+        "properties":{
+          "id": {
+            "type": "text"
+          },
+          "product_description":{
+            "type": "semantic",
+            "model_id": "%s",
+            "dense_embedding_config": {
+              "method": {
+                "engine": "lucene"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/processor/semantic/SemanticIndexMappingsForDenseWithChunking.json
+++ b/src/test/resources/processor/semantic/SemanticIndexMappingsForDenseWithChunking.json
@@ -1,0 +1,27 @@
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "products":{
+        "type":"nested",
+        "properties":{
+          "id": {
+            "type": "text"
+          },
+          "product_description":{
+            "type": "semantic",
+            "chunking": true,
+            "model_id": "%s",
+            "dense_embedding_config": {
+              "method": {
+                "engine": "lucene"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Support configuring the auto-generated knn_vector field through the semantic field.

### Related Issues
Resolves #1356 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
