### PR TITLE
Eliminate non-deterministic behavior in scoring for unit test

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -924,10 +924,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         when(searchContext.shouldUseConcurrentSearch()).thenReturn(true);
         // index segment 1
         Directory directory = newDirectory();
-        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig());
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
-        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
-        ft.setOmitNorms(random().nextBoolean());
         ft.freeze();
 
         int docId1 = RandomizedTest.randomInt();
@@ -953,10 +951,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         when(searchContext2.shouldUseConcurrentSearch()).thenReturn(true);
 
         Directory directory2 = newDirectory();
-        final IndexWriter w2 = new IndexWriter(directory2, newIndexWriterConfig(new MockAnalyzer(random())));
+        final IndexWriter w2 = new IndexWriter(directory2, newIndexWriterConfig());
         FieldType ft2 = new FieldType(TextField.TYPE_NOT_STORED);
-        ft2.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
-        ft2.setOmitNorms(random().nextBoolean());
         ft2.freeze();
 
         w2.addDocument(getDocument(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
@@ -964,9 +960,9 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         w2.commit();
 
         IndexReader reader1 = DirectoryReader.open(w);
-        IndexSearcher searcher1 = newSearcher(reader1);
+        IndexSearcher searcher1 = new IndexSearcher(reader1);
         IndexReader reader2 = DirectoryReader.open(w2);
-        IndexSearcher searcher2 = newSearcher(reader2);
+        IndexSearcher searcher2 = new IndexSearcher(reader2);
 
         RescorerBuilder<QueryRescorerBuilder> rescorerBuilder = new QueryRescorerBuilder(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY2));
         RescoreContext rescoreContext = rescorerBuilder.buildContext(mockQueryShardContext);
@@ -1068,10 +1064,8 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         when(searchContext.shouldUseConcurrentSearch()).thenReturn(false);
 
         Directory directory = newDirectory();
-        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig());
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
-        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
-        ft.setOmitNorms(random().nextBoolean());
         ft.freeze();
 
         int docId1 = RandomizedTest.randomInt();
@@ -1080,7 +1074,7 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         w.commit();
 
         IndexReader reader = DirectoryReader.open(w);
-        IndexSearcher searcher = newSearcher(reader);
+        IndexSearcher searcher = new IndexSearcher(reader);
 
         RescoreContext rescoreContext = mock(RescoreContext.class);
         Rescorer rescorer = mock(Rescorer.class);


### PR DESCRIPTION
### Description
Two flaky test failures were identified. These tests are highly sensitive to document scoring for a given query. The issue stems from the IndexSearcher introducing randomness, resulting in inconsistent scores — sometimes returning zero unexpectedly, which causes the tests to fail.

To fix this, we removed the source of randomness to ensure deterministic scoring for a given query, regardless of seed value. The key change is the use of `new IndexSearcher(reader)`, which provides stable behavior.

Additionally, index options and omit norms were removed, as they are unrelated to the test’s purpose and do not contribute meaningful coverage.

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1376
https://github.com/opensearch-project/neural-search/issues/1199

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
