### PR TITLE
Handle a hybrid query extended with DLS rules by the security plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix for collapse bug with knn query not deduplicating results ([#1413](https://github.com/opensearch-project/neural-search/pull/1413))
 - Fix the HybridQueryDocIdStream to properly handle upTo value ([#1414](https://github.com/opensearch-project/neural-search/pull/1414))
 - Handle remote dense model properly during mapping transform for the semantic field ([#1427](https://github.com/opensearch-project/neural-search/pull/1427))
+- Handle a hybrid query extended with DLS rules by the security plugin ([#1432](https://github.com/opensearch-project/neural-search/pull/1432))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
@@ -94,8 +94,7 @@ public final class HybridQuery extends Query implements Iterable<Query> {
      * Create new instance of hybrid query object based on query extended with DLS rules by the security plugin, and
      * boolean clauses that are used as filters for each sub-query
      */
-    public static HybridQuery fromQueryExtendedWithDlsRules(Query query, List<BooleanClause> filterClauses) {
-        BooleanQuery booleanQuery = (BooleanQuery) query;
+    public static HybridQuery fromQueryExtendedWithDlsRules(BooleanQuery booleanQuery, List<BooleanClause> filterClauses) {
         List<BooleanClause> booleanClauses = booleanQuery.clauses();
         HybridQuery hybridQuery = booleanClauses.stream()
             .map(BooleanClause::query)

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
@@ -94,18 +94,16 @@ public final class HybridQuery extends Query implements Iterable<Query> {
      * Create new instance of hybrid query object based on query extended with DLS rules by the security plugin, and
      * boolean clauses that are used as filters for each sub-query
      */
-    public static HybridQuery fromQueryExtendedWithDlsRules(BooleanQuery booleanQuery, List<BooleanClause> filterClauses) {
-        List<BooleanClause> booleanClauses = booleanQuery.clauses();
-        HybridQuery hybridQuery = booleanClauses.stream()
-            .map(BooleanClause::query)
-            .filter(clauseQuery -> clauseQuery instanceof HybridQuery)
-            .map(HybridQuery.class::cast)
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Given boolean query does not contain a HybridQuery clause"));
+    public static HybridQuery fromQueryExtendedWithDlsRules(
+        BooleanQuery queryExtendedWithDls,
+        HybridQuery hybridQuery,
+        List<BooleanClause> filterClauses
+    ) {
+        List<BooleanClause> booleanClauses = queryExtendedWithDls.clauses();
         List<BooleanClause> nonHybridClauses = booleanClauses.stream().filter(clause -> !(clause.query() instanceof HybridQuery)).toList();
         List<Query> subqueriesWithFilters = hybridQuery.getSubQueries().stream().map(subquery -> {
             BooleanQuery.Builder booleanBuilder = new BooleanQuery.Builder();
-            booleanBuilder.setMinimumNumberShouldMatch(booleanQuery.getMinimumNumberShouldMatch());
+            booleanBuilder.setMinimumNumberShouldMatch(queryExtendedWithDls.getMinimumNumberShouldMatch());
             booleanBuilder.add(subquery, BooleanClause.Occur.MUST);
             nonHybridClauses.forEach(booleanBuilder::add);
             filterClauses.forEach(booleanBuilder::add);

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQuery.java
@@ -91,6 +91,31 @@ public final class HybridQuery extends Query implements Iterable<Query> {
     }
 
     /**
+     * Create new instance of hybrid query object based on query extended with DLS rules by the security plugin, and
+     * boolean clauses that are used as filters for each sub-query
+     */
+    public static HybridQuery fromQueryExtendedWithDlsRules(Query query, List<BooleanClause> filterClauses) {
+        BooleanQuery booleanQuery = (BooleanQuery) query;
+        List<BooleanClause> booleanClauses = booleanQuery.clauses();
+        HybridQuery hybridQuery = booleanClauses.stream()
+            .map(BooleanClause::query)
+            .filter(clauseQuery -> clauseQuery instanceof HybridQuery)
+            .map(HybridQuery.class::cast)
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Given boolean query does not contain a HybridQuery clause"));
+        List<BooleanClause> nonHybridClauses = booleanClauses.stream().filter(clause -> !(clause.query() instanceof HybridQuery)).toList();
+        List<Query> subqueriesWithFilters = hybridQuery.getSubQueries().stream().map(subquery -> {
+            BooleanQuery.Builder booleanBuilder = new BooleanQuery.Builder();
+            booleanBuilder.setMinimumNumberShouldMatch(booleanQuery.getMinimumNumberShouldMatch());
+            booleanBuilder.add(subquery, BooleanClause.Occur.MUST);
+            nonHybridClauses.forEach(booleanBuilder::add);
+            filterClauses.forEach(booleanBuilder::add);
+            return booleanBuilder.build();
+        }).collect(Collectors.toUnmodifiableList());
+        return new HybridQuery(subqueriesWithFilters, hybridQuery.getQueryContext());
+    }
+
+    /**
      * Returns an iterator over sub-queries that are parts of this hybrid query
      * @return iterator
      */

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridCollectorManager.java
@@ -8,18 +8,19 @@ import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
-import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.TotalHits;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
-import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.grouping.CollapseTopFieldDocs;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.Nullable;
@@ -60,7 +61,9 @@ import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUt
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createFieldDocStartStopElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createFieldDocDelimiterElementForHybridSearchResults;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.createSortFieldsForDelimiterResults;
+import static org.opensearch.neuralsearch.util.HybridQueryUtil.isHybridQueryExtendedWithDlsRulesAndWrappedInBoolQuery;
 import static org.opensearch.neuralsearch.util.HybridQueryUtil.isHybridQueryWrappedInBooleanQuery;
+import static org.opensearch.neuralsearch.util.HybridQueryUtil.isHybridQueryExtendedWithDlsRules;
 
 /**
  * Collector manager based on HybridTopScoreDocCollector that allows users to parallelize counting the number of hits.
@@ -607,19 +610,43 @@ public abstract class HybridCollectorManager implements CollectorManager<Collect
     }
 
     /**
-     * Unwraps a HybridQuery from either a direct query or a nested BooleanQuery
+     * Unwraps a HybridQuery from a direct query, a nested BooleanQuery, or a query extended with DLS rules by the security plugin.
      */
     private static HybridQuery unwrapHybridQuery(final SearchContext searchContext) {
         HybridQuery hybridQuery;
         Query query = searchContext.query();
-        // In case of nested fields and alias filter, hybrid query is wrapped under bool query and lies in the first clause.
-        if (isHybridQueryWrappedInBooleanQuery(searchContext, searchContext.query())) {
+        if (isHybridQueryExtendedWithDlsRules(query, searchContext)) {
+            BooleanQuery booleanQuery = (BooleanQuery) query;
+            hybridQuery = unwrapHybridQueryWrappedInSecurityDlsRules(booleanQuery);
+        } else if (isHybridQueryExtendedWithDlsRulesAndWrappedInBoolQuery(searchContext, query)) {
+            BooleanQuery booleanQuery = (BooleanQuery) query;
+            hybridQuery = booleanQuery.clauses()
+                .stream()
+                .filter(clause -> isHybridQueryExtendedWithDlsRules(clause.query(), searchContext))
+                .findFirst()
+                .map(BooleanClause::query)
+                .map(BooleanQuery.class::cast)
+                .map(HybridCollectorManager::unwrapHybridQueryWrappedInSecurityDlsRules)
+                .orElseThrow(() -> new IllegalArgumentException("Given query does not contain a HybridQuery clause with DLS rules"));
+
+        } else if (isHybridQueryWrappedInBooleanQuery(searchContext, searchContext.query())) {
+            // In case of nested fields and alias filter, hybrid query is wrapped under bool query and lies in the first clause.
             BooleanQuery booleanQuery = (BooleanQuery) query;
             hybridQuery = (HybridQuery) booleanQuery.clauses().get(0).query();
         } else {
             hybridQuery = (HybridQuery) query;
         }
         return hybridQuery;
+    }
+
+    private static HybridQuery unwrapHybridQueryWrappedInSecurityDlsRules(BooleanQuery booleanQuery) {
+        return booleanQuery.clauses()
+            .stream()
+            .map(BooleanClause::query)
+            .filter(clauseQuery -> clauseQuery instanceof HybridQuery)
+            .map(HybridQuery.class::cast)
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Given boolean query does not contain a HybridQuery clause"));
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -80,14 +80,15 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
     @VisibleForTesting
     protected Query extractHybridQuery(final SearchContext searchContext, final Query query) {
         if (isHybridQueryExtendedWithDlsRules(query, searchContext)) {
-            return HybridQuery.fromQueryExtendedWithDlsRules(query, List.of());
+            return HybridQuery.fromQueryExtendedWithDlsRules((BooleanQuery) query, List.of());
         }
         if (isHybridQueryExtendedWithDlsRulesAndWrappedInBoolQuery(searchContext, query)) {
             List<BooleanClause> booleanClauses = ((BooleanQuery) query).clauses();
-            Query queryWithDls = booleanClauses.stream()
+            BooleanQuery queryWithDls = booleanClauses.stream()
                 .filter(clause -> isHybridQueryExtendedWithDlsRules(clause.query(), searchContext))
                 .findFirst()
                 .map(BooleanClause::query)
+                .map(BooleanQuery.class::cast)
                 .orElseThrow(
                     () -> new IllegalArgumentException("Given boolean query does not contain a HybridQuery clause with DLS rules")
                 );

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -6,13 +6,18 @@ package org.opensearch.neuralsearch.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 import org.opensearch.index.search.NestedHelper;
 import org.opensearch.neuralsearch.query.HybridQuery;
 import org.opensearch.search.internal.SearchContext;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 /**
  * Utility class for anything related to hybrid query
@@ -28,7 +33,9 @@ public class HybridQueryUtil {
             || (Objects.nonNull(searchContext.parsedQuery()) && searchContext.parsedQuery().query() instanceof HybridQuery)) {
             return true;
         }
-        return false;
+        return isHybridQueryExtendedWithDlsRules(query, searchContext)
+            || (Objects.nonNull(searchContext.parsedQuery())
+                && isHybridQueryExtendedWithDlsRules(searchContext.parsedQuery().query(), searchContext));
     }
 
     private static boolean hasNestedFieldOrNestedDocs(final Query query, final SearchContext searchContext) {
@@ -51,5 +58,51 @@ public class HybridQueryUtil {
         return ((hasAliasFilter(query, searchContext) || hasNestedFieldOrNestedDocs(query, searchContext))
             && isWrappedHybridQuery(query)
             && !((BooleanQuery) query).clauses().isEmpty());
+    }
+
+    /**
+     * This method checks whether the query object is an instance of a HybridQuery extended with DLS rules by the
+     * security plugin. The security plugin returns a boolean query where the user-submitted query is preceded by
+     * ConstantScoreQuery clauses.
+     */
+    public static boolean isHybridQueryExtendedWithDlsRules(final Query query, final SearchContext searchContext) {
+        if (query instanceof BooleanQuery booleanQuery) {
+            List<BooleanClause> booleanClauses = booleanQuery.clauses();
+            int hybridQueryIndex = IntStream.range(0, booleanClauses.size())
+                .filter(i -> booleanClauses.get(i).query() instanceof HybridQuery)
+                .findFirst()
+                .orElse(-1);
+
+            if (hybridQueryIndex == -1 || booleanClauses.get(hybridQueryIndex).occur() != BooleanClause.Occur.MUST) {
+                return false;
+            }
+
+            List<BooleanClause> dlsClauses = booleanClauses.subList(0, hybridQueryIndex);
+
+            return !dlsClauses.isEmpty() && dlsClauses.stream().allMatch(clause -> {
+                if (clause.query() instanceof ConstantScoreQuery && clause.occur() == BooleanClause.Occur.SHOULD) {
+                    return true;
+                } else if (searchContext.mapperService().hasNested()
+                    && clause.query() instanceof ToChildBlockJoinQuery toChildBlockJoinQuery
+                    && clause.occur() == BooleanClause.Occur.SHOULD) {
+                        // security plugin may also append ToChildBlockJoinQuery
+                        // https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/privileges/dlsfls/DlsRestriction.java#L88
+                        return toChildBlockJoinQuery.getParentQuery() instanceof ConstantScoreQuery;
+                    } else {
+                        return false;
+                    }
+            });
+        }
+        return false;
+    }
+
+    /**
+     * This method checks whether the query object is an instance of a hybrid query extended with DLS rules
+     * by the security plugin, and wrapped in another boolean query object
+     */
+    public static boolean isHybridQueryExtendedWithDlsRulesAndWrappedInBoolQuery(final SearchContext searchContext, final Query query) {
+        return ((hasAliasFilter(query, searchContext) || hasNestedFieldOrNestedDocs(query, searchContext))
+            && query instanceof BooleanQuery booleanQuery
+            && booleanQuery.clauses().stream().anyMatch(clause -> isHybridQueryExtendedWithDlsRules(clause.query(), searchContext)));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryTests.java
@@ -361,7 +361,11 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
             .setMinimumNumberShouldMatch(1)
             .build();
 
-        HybridQuery hybridFromExtendedWithDlsRules = HybridQuery.fromQueryExtendedWithDlsRules(hybridWrappedInDlsRules, List.of());
+        HybridQuery hybridFromExtendedWithDlsRules = HybridQuery.fromQueryExtendedWithDlsRules(
+            hybridWrappedInDlsRules,
+            originHybridQuery,
+            List.of()
+        );
 
         List<Query> subqueriesWithDlsRules = hybridFromExtendedWithDlsRules.getSubQueries().stream().toList();
         assertEquals(originHybridSubQueries.size(), subqueriesWithDlsRules.size());
@@ -413,6 +417,7 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
 
         HybridQuery hybridFromExtendedWithDlsRules = HybridQuery.fromQueryExtendedWithDlsRules(
             hybridWrappedInDlsRules,
+            originHybridQuery,
             List.of(filterNotSomething)
         );
 
@@ -436,17 +441,5 @@ public class HybridQueryTests extends OpenSearchQueryTestCase {
             assertEquals(BooleanClause.Occur.FILTER, booleanWithDls.clauses().get(2).occur());
             QueryUtils.checkEqual(booleanWithDls.clauses().get(2).query(), filterNotSomething.query());
         }
-    }
-
-    @SneakyThrows
-    public void testFromQueryExtendedWithDlsRulesBySecurityPlugin_whenBooleanQueryWithNoHybridClause_thenFail() {
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> HybridQuery.fromQueryExtendedWithDlsRules(
-                new BooleanQuery.Builder().add(new TermQuery(new Term(TEXT_FIELD_NAME, QUERY_TEXT)), BooleanClause.Occur.SHOULD).build(),
-                List.of()
-            )
-        );
-        assertThat(exception.getMessage(), containsString("Given boolean query does not contain a HybridQuery clause"));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -1220,10 +1220,8 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
 
         Directory directory = newDirectory();
-        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig());
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
-        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
-        ft.setOmitNorms(random().nextBoolean());
         ft.freeze();
         int docId1 = RandomizedTest.randomInt();
         int docId2 = RandomizedTest.randomInt();
@@ -1338,10 +1336,8 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
 
         Directory directory = newDirectory();
-        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig());
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
-        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
-        ft.setOmitNorms(random().nextBoolean());
         ft.freeze();
         int docId1 = RandomizedTest.randomInt();
         int docId2 = RandomizedTest.randomInt();
@@ -1462,10 +1458,8 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
         when(mockQueryShardContext.simpleMatchToIndexNames(anyString())).thenReturn(Set.of(TEXT_FIELD_NAME));
 
         Directory directory = newDirectory();
-        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig());
         FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
-        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
-        ft.setOmitNorms(random().nextBoolean());
         ft.freeze();
         int docId1 = RandomizedTest.randomInt();
         int docId2 = RandomizedTest.randomInt();

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -41,6 +41,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 import org.apache.lucene.store.Directory;
 import org.opensearch.Version;
 import org.opensearch.action.OriginalIndices;
@@ -55,9 +57,10 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
+import org.opensearch.index.query.DisMaxQueryBuilder;
 import org.opensearch.index.query.ParsedQuery;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.query.DisMaxQueryBuilder;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.remote.RemoteStoreEnums;
@@ -1183,6 +1186,358 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
 
         when(searchContext.query()).thenReturn(query);
         when(searchContext.aliasFilter()).thenReturn(termFilter);
+
+        Query hybridQuery = queryBuilder.toQuery(mockQueryShardContext);
+        when(searchContext.parsedQuery()).thenReturn(new ParsedQuery(hybridQuery));
+
+        CollectorManager<? extends Collector, ReduceableSearchResult> collectorManager = HybridCollectorManager
+            .createHybridCollectorManager(searchContext);
+        Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> queryCollectorManagers = new HashMap<>();
+        queryCollectorManagers.put(HybridCollectorManager.class, collectorManager);
+        when(searchContext.queryCollectorManagers()).thenReturn(queryCollectorManagers);
+
+        hybridQueryPhaseSearcher.searchWith(searchContext, contextIndexSearcher, query, collectors, hasFilterCollector, hasTimeout);
+        hybridQueryPhaseSearcher.aggregationProcessor(searchContext).postProcess(searchContext);
+
+        assertNotNull(querySearchResult.topDocs());
+        TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
+        TopDocs topDocs = topDocsAndMaxScore.topDocs;
+        assertEquals(0, topDocs.totalHits.value());
+        ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+        assertNotNull(scoreDocs);
+        assertEquals(0, scoreDocs.length);
+
+        releaseResources(directory, w, reader);
+    }
+
+    @SneakyThrows
+    public void testWrappedHybridQuery_whenHybridWrappedIntoBoolBecauseOfSecurityDlsRules_thenSuccess() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = spy(new HybridQueryPhaseSearcher());
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        MapperService mapperService = createMapperService();
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) mapperService.fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+
+        Directory directory = newDirectory();
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+        int docId1 = RandomizedTest.randomInt();
+        int docId2 = RandomizedTest.randomInt();
+        int docId3 = RandomizedTest.randomInt();
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId1, TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId2, TEST_DOC_TEXT2, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
+        w.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+        SearchContext searchContext = mock(SearchContext.class);
+
+        ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null,
+            searchContext
+        );
+
+        ShardId shardId = new ShardId(dummyIndex, 1);
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            randomAlphaOfLength(10),
+            shardId,
+            randomAlphaOfLength(10),
+            OriginalIndices.NONE
+        );
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        when(searchContext.size()).thenReturn(3);
+        when(searchContext.numberOfShards()).thenReturn(1);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        IndexShard indexShard = mock(IndexShard.class);
+        when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
+        when(searchContext.indexShard()).thenReturn(indexShard);
+        QuerySearchResult querySearchResult = new QuerySearchResult();
+        when(searchContext.queryResult()).thenReturn(querySearchResult);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+        when(searchContext.mapperService()).thenReturn(mapperService);
+        IndexMetadata indexMetadata = getIndexMetadata();
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, Integer.toString(1)).build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
+        when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
+
+        LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
+        boolean hasFilterCollector = randomBoolean();
+        boolean hasTimeout = randomBoolean();
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+
+        TermQueryBuilder termSubQuery = QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1);
+        hybridQueryBuilder.add(termSubQuery);
+        hybridQueryBuilder.paginationDepth(10);
+
+        ConstantScoreQueryBuilder dlsQuery = QueryBuilders.constantScoreQuery(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT2));
+
+        Query query = new BooleanQuery.Builder().add(dlsQuery.toQuery(mockQueryShardContext), BooleanClause.Occur.SHOULD)
+            .add(hybridQueryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.MUST)
+            .build();
+        when(searchContext.query()).thenReturn(query);
+
+        CollectorManager<? extends Collector, ReduceableSearchResult> collectorManager = HybridCollectorManager
+            .createHybridCollectorManager(searchContext);
+        Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> queryCollectorManagers = new HashMap<>();
+        queryCollectorManagers.put(HybridCollectorManager.class, collectorManager);
+        when(searchContext.queryCollectorManagers()).thenReturn(queryCollectorManagers);
+
+        hybridQueryPhaseSearcher.searchWith(searchContext, contextIndexSearcher, query, collectors, hasFilterCollector, hasTimeout);
+        hybridQueryPhaseSearcher.aggregationProcessor(searchContext).postProcess(searchContext);
+
+        assertNotNull(querySearchResult.topDocs());
+        TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
+        TopDocs topDocs = topDocsAndMaxScore.topDocs;
+        assertEquals(0, topDocs.totalHits.value());
+        ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+        assertNotNull(scoreDocs);
+        assertEquals(0, scoreDocs.length);
+
+        releaseResources(directory, w, reader);
+    }
+
+    @SneakyThrows
+    public void testWrappedHybridQuery_whenHybridWrappedIntoBoolBecauseOfNestedAndSecurityDlsRules_thenSuccess() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = new HybridQueryPhaseSearcher();
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("field");
+            b.field("type", "text")
+                .field("fielddata", true)
+                .startObject("fielddata_frequency_filter")
+                .field("min", 2d)
+                .field("min_segment_size", 1000)
+                .endObject();
+            b.endObject();
+            b.startObject("user");
+            b.field("type", "nested");
+            b.endObject();
+        }));
+
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) mapperService.fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+        when(mockQueryShardContext.getMapperService()).thenReturn(mapperService);
+        when(mockQueryShardContext.simpleMatchToIndexNames(anyString())).thenReturn(Set.of(TEXT_FIELD_NAME));
+        IndexMetadata indexMetadata = getIndexMetadata();
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, Integer.toString(1)).build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
+        when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
+
+        Directory directory = newDirectory();
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+        int docId1 = RandomizedTest.randomInt();
+        int docId2 = RandomizedTest.randomInt();
+        int docId3 = RandomizedTest.randomInt();
+        int docId4 = RandomizedTest.randomInt();
+        w.addDocument(document(TEXT_FIELD_NAME, docId1, TEST_DOC_TEXT1, ft));
+        w.addDocument(document(TEXT_FIELD_NAME, docId2, TEST_DOC_TEXT2, ft));
+        w.addDocument(document(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
+        w.addDocument(document(TEXT_FIELD_NAME, docId4, TEST_DOC_TEXT4, ft));
+        w.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+        SearchContext searchContext = mock(SearchContext.class);
+
+        ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null,
+            searchContext
+        );
+
+        ShardId shardId = new ShardId(dummyIndex, 1);
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            randomAlphaOfLength(10),
+            shardId,
+            randomAlphaOfLength(10),
+            OriginalIndices.NONE
+        );
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        when(searchContext.size()).thenReturn(4);
+        QuerySearchResult querySearchResult = new QuerySearchResult();
+        when(searchContext.queryResult()).thenReturn(querySearchResult);
+        when(searchContext.numberOfShards()).thenReturn(1);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        IndexShard indexShard = mock(IndexShard.class);
+        when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
+        when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+        when(searchContext.mapperService()).thenReturn(mapperService);
+        when(searchContext.getQueryShardContext()).thenReturn(mockQueryShardContext);
+
+        LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
+        boolean hasFilterCollector = randomBoolean();
+        boolean hasTimeout = randomBoolean();
+
+        HybridQueryBuilder queryBuilder = new HybridQueryBuilder();
+
+        queryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1));
+        queryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT2));
+        queryBuilder.paginationDepth(10);
+
+        BooleanQuery.Builder dlsBuilder = new BooleanQuery.Builder();
+        dlsBuilder.add(
+            QueryBuilders.constantScoreQuery(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT2)).toQuery(mockQueryShardContext),
+            BooleanClause.Occur.SHOULD
+        )
+            .add(
+                new ToChildBlockJoinQuery(
+                    QueryBuilders.constantScoreQuery(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT2)).toQuery(mockQueryShardContext),
+                    mock(BitSetProducer.class)
+                ),
+                BooleanClause.Occur.SHOULD
+            )
+            .add(queryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.MUST);
+        BooleanQuery.Builder nestedBuilder = new BooleanQuery.Builder();
+        nestedBuilder.add(dlsBuilder.build(), BooleanClause.Occur.MUST).add(Queries.newNonNestedFilter(), BooleanClause.Occur.FILTER);
+        Query query = nestedBuilder.build();
+
+        when(searchContext.query()).thenReturn(query);
+        Query dlsQuery = dlsBuilder.build();
+        when(searchContext.parsedQuery()).thenReturn(new ParsedQuery(dlsQuery));
+
+        CollectorManager<? extends Collector, ReduceableSearchResult> collectorManager = HybridCollectorManager
+            .createHybridCollectorManager(searchContext);
+        Map<Class<?>, CollectorManager<? extends Collector, ReduceableSearchResult>> queryCollectorManagers = new HashMap<>();
+        queryCollectorManagers.put(HybridCollectorManager.class, collectorManager);
+        when(searchContext.queryCollectorManagers()).thenReturn(queryCollectorManagers);
+
+        hybridQueryPhaseSearcher.searchWith(searchContext, contextIndexSearcher, query, collectors, hasFilterCollector, hasTimeout);
+        hybridQueryPhaseSearcher.aggregationProcessor(searchContext).postProcess(searchContext);
+
+        assertNotNull(querySearchResult.topDocs());
+        TopDocsAndMaxScore topDocsAndMaxScore = querySearchResult.topDocs();
+        TopDocs topDocs = topDocsAndMaxScore.topDocs;
+        assertEquals(0, topDocs.totalHits.value());
+        ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+        assertNotNull(scoreDocs);
+        assertEquals(0, scoreDocs.length);
+
+        releaseResources(directory, w, reader);
+    }
+
+    @SneakyThrows
+    public void testWrappedHybridQuery_whenHybridWrappedIntoBoolBecauseOfAliasFilterAndSecurityDlsRules_thenSuccess() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = new HybridQueryPhaseSearcher();
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("field");
+            b.field("type", "text")
+                .field("fielddata", true)
+                .startObject("fielddata_frequency_filter")
+                .field("min", 2d)
+                .field("min_segment_size", 1000)
+                .endObject();
+            b.endObject();
+        }));
+
+        TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) mapperService.fieldType(TEXT_FIELD_NAME);
+        when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+        when(mockQueryShardContext.getMapperService()).thenReturn(mapperService);
+        when(mockQueryShardContext.simpleMatchToIndexNames(anyString())).thenReturn(Set.of(TEXT_FIELD_NAME));
+
+        Directory directory = newDirectory();
+        IndexWriter w = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.setIndexOptions(random().nextBoolean() ? IndexOptions.DOCS : IndexOptions.DOCS_AND_FREQS);
+        ft.setOmitNorms(random().nextBoolean());
+        ft.freeze();
+        int docId1 = RandomizedTest.randomInt();
+        int docId2 = RandomizedTest.randomInt();
+        int docId3 = RandomizedTest.randomInt();
+        int docId4 = RandomizedTest.randomInt();
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId1, TEST_DOC_TEXT1, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId2, TEST_DOC_TEXT2, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId3, TEST_DOC_TEXT3, ft));
+        w.addDocument(getDocument(TEXT_FIELD_NAME, docId4, TEST_DOC_TEXT4, ft));
+        w.commit();
+
+        IndexReader reader = DirectoryReader.open(w);
+        SearchContext searchContext = mock(SearchContext.class);
+
+        ContextIndexSearcher contextIndexSearcher = new ContextIndexSearcher(
+            reader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            true,
+            null,
+            searchContext
+        );
+
+        ShardId shardId = new ShardId(dummyIndex, 1);
+        SearchShardTarget shardTarget = new SearchShardTarget(
+            randomAlphaOfLength(10),
+            shardId,
+            randomAlphaOfLength(10),
+            OriginalIndices.NONE
+        );
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        when(searchContext.size()).thenReturn(4);
+        QuerySearchResult querySearchResult = new QuerySearchResult();
+        when(searchContext.queryResult()).thenReturn(querySearchResult);
+        when(searchContext.numberOfShards()).thenReturn(1);
+        when(searchContext.searcher()).thenReturn(contextIndexSearcher);
+        IndexShard indexShard = mock(IndexShard.class);
+        when(indexShard.shardId()).thenReturn(new ShardId("test", "test", 0));
+        when(indexShard.getSearchOperationListener()).thenReturn(mock(SearchOperationListener.class));
+        when(searchContext.indexShard()).thenReturn(indexShard);
+        when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+        when(searchContext.mapperService()).thenReturn(mapperService);
+        IndexMetadata indexMetadata = getIndexMetadata();
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, Integer.toString(1)).build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
+        when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
+
+        LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
+        boolean hasFilterCollector = randomBoolean();
+        boolean hasTimeout = randomBoolean();
+
+        HybridQueryBuilder queryBuilder = new HybridQueryBuilder();
+
+        queryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1));
+        queryBuilder.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT2));
+        queryBuilder.paginationDepth(10);
+
+        BooleanQuery.Builder dlsQueryBuilder = new BooleanQuery.Builder();
+        dlsQueryBuilder.add(
+            QueryBuilders.constantScoreQuery(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT2)).toQuery(mockQueryShardContext),
+            BooleanClause.Occur.SHOULD
+        ).add(queryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.MUST);
+
+        Query aliasTermFilter = QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY_TEXT1).toQuery(mockQueryShardContext);
+        BooleanQuery.Builder aliasQueryBuilder = new BooleanQuery.Builder();
+        aliasQueryBuilder.add(dlsQueryBuilder.build(), BooleanClause.Occur.MUST).add(aliasTermFilter, BooleanClause.Occur.FILTER);
+        Query query = aliasQueryBuilder.build();
+
+        when(searchContext.query()).thenReturn(query);
+        when(searchContext.aliasFilter()).thenReturn(aliasTermFilter);
 
         Query hybridQuery = queryBuilder.toQuery(mockQueryShardContext);
         when(searchContext.parsedQuery()).thenReturn(new ParsedQuery(hybridQuery));


### PR DESCRIPTION
### Description
Handle a hybrid query extended with DLS rules by the security plugin

### Related Issues
Resolves #1303


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
