### PR TITLE
 Fix flakey unit tests.

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextImageEmbeddingProcessorTests.java
@@ -54,6 +54,7 @@ import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.factory.TextImageEmbeddingProcessorFactory;
+import org.opensearch.neuralsearch.util.TestUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
 import com.google.common.collect.ImmutableList;
@@ -89,6 +90,7 @@ public class TextImageEmbeddingProcessorTests extends OpenSearchTestCase {
 
     @Before
     public void setup() {
+        TestUtils.initializeEventStatsManager();
         MockitoAnnotations.openMocks(this);
         Settings settings = Settings.builder().put("index.mapping.depth.limit", 20).build();
         when(env.settings()).thenReturn(settings);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -1092,6 +1092,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     }
 
     public void testFilter() {
+        setUpClusterService();
         HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(
             NeuralQueryBuilder.builder().fieldName("test").queryText("test").build()
         ).add(new NeuralSparseQueryBuilder());

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridCollectorManagerTests.java
@@ -63,6 +63,7 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.query.QuerySearchResult;
 import org.opensearch.search.query.ReduceableSearchResult;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -71,6 +72,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.MAGIC_NUMBER_DELIMITER;
@@ -764,6 +766,11 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+        // mock to query to generate the parsed query
+        doAnswer(invocationOnMock -> {
+            final QueryBuilder queryBuilder = invocationOnMock.getArgument(0);
+            return new ParsedQuery(queryBuilder.toQuery(mockQueryShardContext), Collections.emptyMap());
+        }).when(mockQueryShardContext).toQuery(any());
         HybridQueryContext hybridQueryContext = HybridQueryContext.builder().paginationDepth(10).build();
 
         HybridQuery hybridQueryWithTerm = new HybridQuery(
@@ -804,6 +811,7 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
 
         RescorerBuilder<QueryRescorerBuilder> rescorerBuilder = new QueryRescorerBuilder(QueryBuilders.termQuery(TEXT_FIELD_NAME, QUERY2));
         RescoreContext rescoreContext = rescorerBuilder.buildContext(mockQueryShardContext);
+
         List<RescoreContext> rescoreContexts = List.of(rescoreContext);
         when(searchContext.rescore()).thenReturn(rescoreContexts);
         Weight rescoreWeight = mock(Weight.class);
@@ -890,6 +898,11 @@ public class HybridCollectorManagerTests extends OpenSearchQueryTestCase {
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         TextFieldMapper.TextFieldType fieldType = (TextFieldMapper.TextFieldType) createMapperService().fieldType(TEXT_FIELD_NAME);
         when(mockQueryShardContext.fieldMapper(eq(TEXT_FIELD_NAME))).thenReturn(fieldType);
+        // mock to query to generate the parsed query
+        doAnswer(invocationOnMock -> {
+            final QueryBuilder queryBuilder = invocationOnMock.getArgument(0);
+            return new ParsedQuery(queryBuilder.toQuery(mockQueryShardContext), Collections.emptyMap());
+        }).when(mockQueryShardContext).toQuery(any());
         HybridQueryContext hybridQueryContext = HybridQueryContext.builder().paginationDepth(10).build();
 
         HybridQuery hybridQueryWithTerm = new HybridQuery(


### PR DESCRIPTION
### Description

Fix flakey unit tests. Mainly because we don't ensure we set up the resources and rely on other tests to set it up so it will fail if we happens to run them first.

1. If we don't `initializeEventStatsManager` for `TextImageEmbeddingProcessorTests` and we run it before we run other tests with `initializeEventStatsManager` then we will run into null pointer exception.
2. If we run `testFilter ` in `HybridQueryBuilderTests` before other tests with `setUpClusterService()` then it will run into null pointer exception.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
