### PR TITLE
Support configuring the ingest batch size for the semantic field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 - [Semantic Field] Support configuring the auto-generated knn_vector field through the semantic field. ([#1420](https://github.com/opensearch-project/neural-search/pull/1420))
+- [Semantic Field] Support configuring the ingest batch size for the semantic field.
 
 ### Bug Fixes
 - Fix for collapse bug with knn query not deduplicating results ([#1413](https://github.com/opensearch-project/neural-search/pull/1413))

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.plugin;
 
 import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.RERANKER_MAX_DOC_FIELDS;
 import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.NEURAL_STATS_ENABLED;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.SEMANTIC_INGEST_BATCH_SIZE;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -246,7 +247,7 @@ public class NeuralSearch extends Plugin
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(RERANKER_MAX_DOC_FIELDS, NEURAL_STATS_ENABLED);
+        return List.of(RERANKER_MAX_DOC_FIELDS, NEURAL_STATS_ENABLED, SEMANTIC_INGEST_BATCH_SIZE);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessor.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.neuralsearch.processor.semantic;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
@@ -592,5 +593,10 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
     @Override
     public String getType() {
         return PROCESSOR_TYPE;
+    }
+
+    @VisibleForTesting
+    public int getBatchSize() {
+        return batchSize;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
+++ b/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
@@ -35,4 +35,16 @@ public final class NeuralSearchSettings {
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
+
+    /**
+     * Configure the maximum number of docs we can batch ingest for the semantic field.
+     */
+    public static final Setting<Integer> SEMANTIC_INGEST_BATCH_SIZE = Setting.intSetting(
+        "index.neural_search.semantic_ingest_batch_size",
+        10,
+        1,
+        100,
+        Setting.Property.IndexScope,
+        Setting.Property.Dynamic
+    );
 }

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -167,7 +167,7 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
 
     public void testGetSettings() {
         List<Setting<?>> settings = plugin.getSettings();
-        assertEquals(2, settings.size());
+        assertEquals(3, settings.size());
     }
 
     public void testRequestProcessors() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/SemanticFieldProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/SemanticFieldProcessorFactoryTests.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
@@ -23,8 +24,11 @@ import static org.opensearch.neuralsearch.constants.MappingConstants.DOC;
 import static org.opensearch.neuralsearch.constants.MappingConstants.PROPERTIES;
 import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
 import static org.opensearch.neuralsearch.processor.TextChunkingProcessorTests.getAnalysisRegistry;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.SEMANTIC_INGEST_BATCH_SIZE;
 import static org.opensearch.plugins.IngestPlugin.SystemIngestPipelineConfigKeys.INDEX_MAPPINGS;
+import static org.opensearch.plugins.IngestPlugin.SystemIngestPipelineConfigKeys.INDEX_SETTINGS;
 import static org.opensearch.plugins.IngestPlugin.SystemIngestPipelineConfigKeys.INDEX_TEMPLATE_MAPPINGS;
+import static org.opensearch.plugins.IngestPlugin.SystemIngestPipelineConfigKeys.INDEX_TEMPLATE_SETTINGS;
 
 public class SemanticFieldProcessorFactoryTests extends OpenSearchTestCase {
     @Mock
@@ -50,32 +54,48 @@ public class SemanticFieldProcessorFactoryTests extends OpenSearchTestCase {
     }
 
     public void testNewProcessor_indexMappingsWithoutProperties_thenReturnNull() {
-        Map<String, Object> mappings = Map.of(INDEX_MAPPINGS, Map.of(DOC, Map.of()));
-        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, mappings);
+        Map<String, Object> processorConfig = Map.of(INDEX_MAPPINGS, Map.of(DOC, Map.of()));
+        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, processorConfig);
         assertNull(processor);
     }
 
     public void testNewProcessor_templateMappingsWithoutProperties_thenReturnNull() {
-        Map<String, Object> mappings = Map.of(INDEX_TEMPLATE_MAPPINGS, List.of(Map.of(DOC, Map.of())));
-        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, mappings);
+        Map<String, Object> processorConfig = Map.of(INDEX_TEMPLATE_MAPPINGS, List.of(Map.of(DOC, Map.of())));
+        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, processorConfig);
         assertNull(processor);
     }
 
     public void testNewProcessor_indexMappingsWithSemanticField_thenCreateProcessor() {
-        Map<String, Object> mappings = Map.of(
+        Map<String, Object> processorConfig = Map.of(
             INDEX_MAPPINGS,
             Map.of(DOC, Map.of(PROPERTIES, Map.of("semantic_field", Map.of(TYPE, SemanticFieldMapper.CONTENT_TYPE))))
         );
-        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, mappings);
+        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, processorConfig);
         assertNotNull(processor);
+        assertEquals(10, processor.getBatchSize());
     }
 
-    public void testNewProcessor_templateIndexMappingsWithSemanticField_thenCreateProcessor() {
-        Map<String, Object> mappings = Map.of(
-            INDEX_TEMPLATE_MAPPINGS,
-            List.of(Map.of(DOC, Map.of(PROPERTIES, Map.of("semantic_field", Map.of(TYPE, SemanticFieldMapper.CONTENT_TYPE)))))
+    public void testNewProcessor_indexMappingsWithSemanticFieldAndCustomBatchSize_thenCreateProcessor() {
+        Map<String, Object> processorConfig = Map.of(
+            INDEX_MAPPINGS,
+            Map.of(DOC, Map.of(PROPERTIES, Map.of("semantic_field", Map.of(TYPE, SemanticFieldMapper.CONTENT_TYPE)))),
+            INDEX_SETTINGS,
+            Settings.builder().put(SEMANTIC_INGEST_BATCH_SIZE.getKey(), 1).build()
         );
-        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, mappings);
+        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, processorConfig);
         assertNotNull(processor);
+        assertEquals(1, processor.getBatchSize());
+    }
+
+    public void testNewProcessor_templateIndexMappingsWithSemanticFieldAndCustomBatchSize_thenCreateProcessor() {
+        Map<String, Object> processorConfig = Map.of(
+            INDEX_TEMPLATE_MAPPINGS,
+            List.of(Map.of(DOC, Map.of(PROPERTIES, Map.of("semantic_field", Map.of(TYPE, SemanticFieldMapper.CONTENT_TYPE))))),
+            INDEX_TEMPLATE_SETTINGS,
+            List.of(Settings.builder().build(), Settings.builder().put(SEMANTIC_INGEST_BATCH_SIZE.getKey(), 100).build())
+        );
+        final SemanticFieldProcessor processor = (SemanticFieldProcessor) factory.newProcessor(null, null, processorConfig);
+        assertNotNull(processor);
+        assertEquals(100, processor.getBatchSize());
     }
 }


### PR DESCRIPTION
### Description
Support configuring the ingest batch size for the semantic field.

### Related Issues
Resolves #1349 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
