### PR TITLE
Enable inner hits within collapse parameter for hybrid query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 - [Semantic Field] Support configuring the auto-generated knn_vector field through the semantic field. ([#1420](https://github.com/opensearch-project/neural-search/pull/1420))
+- Enable inner hits within collapse parameter for hybrid query ([#1447](https://github.com/opensearch-project/neural-search/pull/1447))
 
 ### Bug Fixes
 - Fix for collapse bug with knn query not deduplicating results ([#1413](https://github.com/opensearch-project/neural-search/pull/1413))

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -128,8 +128,7 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
      */
     private void validateQuery(final SearchContext searchContext, final Query query) {
         if (query instanceof BooleanQuery) {
-            BooleanQuery boolQuery = (BooleanQuery) query;
-            List<BooleanClause> booleanClauses = boolQuery.clauses();
+            List<BooleanClause> booleanClauses = ((BooleanQuery) query).clauses();
 
             // Allow hybrid query in MUST clause with additional FILTER clauses
             // This format is used when inner hits are passed within the collapse parameter

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -61,20 +61,29 @@ public class HybridQueryUtil {
 
         BooleanQuery boolQuery = (BooleanQuery) query;
 
-        // Check if there's a hybrid query in MUST clause
-        boolean hasHybridQuery = boolQuery.clauses()
-            .stream()
-            .anyMatch(clause -> clause.occur() == BooleanClause.Occur.MUST && clause.query() instanceof HybridQuery);
+        return isHybridQueryWrappedInBooleanMustQueryWithFilters(boolQuery.clauses())
+            || ((hasAliasFilter(query, searchContext) || hasNestedFieldOrNestedDocs(query, searchContext))
+                && isWrappedHybridQuery(query)
+                && !((BooleanQuery) query).clauses().isEmpty());
+    }
 
-        // Check if all other clauses are FILTER
-        boolean onlyFilters = boolQuery.clauses()
-            .stream()
-            .filter(clause -> !(clause.query() instanceof HybridQuery))
-            .allMatch(clause -> clause.occur() == BooleanClause.Occur.FILTER);
+    /**
+     * This method checks if the hybrid query is in a MUST clause with additional FILTER clauses
+     * This format is used when inner hits are passed within the collapse parameter
+     * @param booleanClauses a list of boolean clauses from a boolean query
+     * @return true if the clauses represent a hybrid query wrapped in a boolean must clause with the rest of the clauses being filters
+     */
+    public static boolean isHybridQueryWrappedInBooleanMustQueryWithFilters(List<BooleanClause> booleanClauses) {
+        boolean isFirstClauseMustHybrid = !booleanClauses.isEmpty()
+            && booleanClauses.get(0).occur() == BooleanClause.Occur.MUST
+            && booleanClauses.get(0).query() instanceof HybridQuery;
 
-        return hasHybridQuery
-            && onlyFilters
-            && (hasAliasFilter(query, searchContext) || hasNestedFieldOrNestedDocs(query, searchContext) || !boolQuery.clauses().isEmpty());
+        boolean areRemainingClausesFilters = booleanClauses.size() <= 1
+            || booleanClauses.stream()
+                .skip(1)  // Skip the first clause
+                .allMatch(clause -> clause.occur() == BooleanClause.Occur.FILTER);
+
+        return isFirstClauseMustHybrid && areRemainingClausesFilters;
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -64,7 +64,7 @@ public class HybridQueryUtil {
         return isHybridQueryWrappedInBooleanMustQueryWithFilters(boolQuery.clauses())
             || ((hasAliasFilter(query, searchContext) || hasNestedFieldOrNestedDocs(query, searchContext))
                 && isWrappedHybridQuery(query)
-                && !((BooleanQuery) query).clauses().isEmpty());
+                && !boolQuery.clauses().isEmpty());
     }
 
     /**
@@ -80,7 +80,7 @@ public class HybridQueryUtil {
 
         boolean areRemainingClausesFilters = booleanClauses.size() <= 1
             || booleanClauses.stream()
-                .skip(1)  // Skip the first clause
+                .skip(1)  // Skip the first clause since we checked it above for a hybrid within a must clause
                 .allMatch(clause -> clause.occur() == BooleanClause.Occur.FILTER);
 
         return isFirstClauseMustHybrid && areRemainingClausesFilters;

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -55,7 +55,7 @@ public class HybridQueryUtil {
      * This method checks whether hybrid query is wrapped under boolean query object
      */
     public static boolean isHybridQueryWrappedInBooleanQuery(final SearchContext searchContext, final Query query) {
-        if (!(query instanceof BooleanQuery)) {
+        if (query instanceof BooleanQuery == false) {
             return false;
         }
 
@@ -64,7 +64,7 @@ public class HybridQueryUtil {
         return isHybridQueryWrappedInBooleanMustQueryWithFilters(boolQuery.clauses())
             || ((hasAliasFilter(query, searchContext) || hasNestedFieldOrNestedDocs(query, searchContext))
                 && isWrappedHybridQuery(query)
-                && !boolQuery.clauses().isEmpty());
+                && boolQuery.clauses().isEmpty() == false);
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/util/HybridQueryUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/HybridQueryUtilTests.java
@@ -5,9 +5,11 @@
 package org.opensearch.neuralsearch.util;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
@@ -17,6 +19,7 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.TextFieldMapper;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.neuralsearch.query.HybridQuery;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
@@ -24,6 +27,8 @@ import org.opensearch.neuralsearch.query.HybridQueryContext;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 import org.opensearch.search.internal.SearchContext;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +36,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathType.HASHED_PREFIX;
+import static org.opensearch.neuralsearch.util.HybridQueryUtil.isHybridQueryWrappedInBooleanMustQueryWithFilters;
+import static org.opensearch.neuralsearch.util.HybridQueryUtil.isHybridQueryWrappedInBooleanQuery;
 
 public class HybridQueryUtilTests extends OpenSearchQueryTestCase {
 
@@ -141,6 +148,86 @@ public class HybridQueryUtilTests extends OpenSearchQueryTestCase {
         when(searchContext.mapperService()).thenReturn(mapperService);
 
         assertTrue(HybridQueryUtil.isHybridQuery(booleanQuery, searchContext));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryWrappedInBooleanMustQueryWithFilters_whenEmptyClauses_thenSuccessful() {
+        List<BooleanClause> clauses = new ArrayList<>();
+        assertFalse(isHybridQueryWrappedInBooleanMustQueryWithFilters(clauses));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryWrappedInBooleanMustQueryWithFilters_whenSingleHybridMustClause_thenSuccessful() {
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new TermQueryBuilder("field", "text"));
+        BooleanClause hybridMustClause = new BooleanClause(hybridQueryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.MUST);
+        List<BooleanClause> clauses = Arrays.asList(hybridMustClause);
+
+        assertTrue(isHybridQueryWrappedInBooleanMustQueryWithFilters(clauses));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryWrappedInBooleanMustQueryWithFilters_whenHybridMustWithValidFilters_thenSuccessful() {
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new TermQueryBuilder("field", "text"));
+
+        BooleanClause hybridMustClause = new BooleanClause(hybridQueryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.MUST);
+        BooleanClause filterClause1 = new BooleanClause(new TermQuery(new Term("field", "value")), BooleanClause.Occur.FILTER);
+        BooleanClause filterClause2 = new BooleanClause(new TermQuery(new Term("field2", "value2")), BooleanClause.Occur.FILTER);
+
+        List<BooleanClause> clauses = Arrays.asList(hybridMustClause, filterClause1, filterClause2);
+
+        assertTrue(isHybridQueryWrappedInBooleanMustQueryWithFilters(clauses));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryWrappedInBooleanMustQueryWithFilters_whenFirstClauseNotMust_thenSuccessful() {
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new TermQueryBuilder("field", "text"));
+
+        BooleanClause hybridShouldClause = new BooleanClause(hybridQueryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.SHOULD);
+        BooleanClause filterClause = new BooleanClause(new TermQuery(new Term("field", "value")), BooleanClause.Occur.FILTER);
+
+        List<BooleanClause> clauses = Arrays.asList(hybridShouldClause, filterClause);
+
+        assertFalse(isHybridQueryWrappedInBooleanMustQueryWithFilters(clauses));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryWrappedInBooleanMustQueryWithFilters_whenFirstClauseNotHybrid_thenSuccessful() {
+        BooleanClause termMustClause = new BooleanClause(new TermQuery(new Term("field", "value")), BooleanClause.Occur.MUST);
+        BooleanClause filterClause = new BooleanClause(new TermQuery(new Term("field2", "value2")), BooleanClause.Occur.FILTER);
+
+        List<BooleanClause> clauses = Arrays.asList(termMustClause, filterClause);
+
+        assertFalse(isHybridQueryWrappedInBooleanMustQueryWithFilters(clauses));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryWrappedInBooleanMustQueryWithFilters_NonFilterSecondClause_thenSuccessful() {
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new TermQueryBuilder("field", "text"));
+
+        BooleanClause hybridMustClause = new BooleanClause(hybridQueryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.MUST);
+        BooleanClause mustClause = new BooleanClause(new TermQuery(new Term("field", "value")), BooleanClause.Occur.MUST);
+
+        List<BooleanClause> clauses = Arrays.asList(hybridMustClause, mustClause);
+
+        assertFalse(isHybridQueryWrappedInBooleanMustQueryWithFilters(clauses));
+    }
+
+    @SneakyThrows
+    public void testIsHybridQueryWrappedInBooleanQuery_whenHybridMustClauseAndFilterClauses_thenSuccessful() {
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(new TermQueryBuilder("field", "text"));
+
+        BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
+        booleanQueryBuilder.add(hybridQueryBuilder.toQuery(mockQueryShardContext), BooleanClause.Occur.MUST);
+        booleanQueryBuilder.add(new TermQuery(new Term("filter_field", "filter_value")), BooleanClause.Occur.FILTER);
+        BooleanQuery booleanQuery = booleanQueryBuilder.build();
+        SearchContext mockSearchContext = mock(SearchContext.class);
+
+        assertTrue(isHybridQueryWrappedInBooleanQuery(mockSearchContext, booleanQuery));
     }
 
     private static IndexMetadata getIndexMetadata() {

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -45,6 +45,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.ml.common.model.MLModelState;
@@ -58,6 +59,7 @@ import org.opensearch.neuralsearch.transport.NeuralStatsResponse;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.neuralsearch.util.TokenWeightUtil;
 import org.opensearch.search.SearchHit;
+import org.opensearch.search.collapse.CollapseContext;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.ScoreSortBuilder;
 import org.opensearch.search.sort.SortBuilder;
@@ -758,7 +760,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
      * @param highlightOptions global highlight options
      * @param preTags pre tag for highlight
      * @param postTags post tag for highlight
-     * @param collapseField field to collapse results on
+     * @param collapseContext context containing collapse details
      * @return Search results represented as a map
      */
     @SneakyThrows
@@ -778,7 +780,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         Map<String, Object> highlightOptions,
         List<String> preTags,
         List<String> postTags,
-        String collapseField
+        CollapseContext collapseContext
     ) {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         builder.field("from", from);
@@ -794,8 +796,18 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         }
 
         // Add collapse if specified
-        if (collapseField != null) {
-            builder.startObject("collapse").field("field", collapseField).endObject();
+        if (collapseContext != null) {
+            builder.startObject("collapse").field("field", collapseContext.getFieldName());
+            List<InnerHitBuilder> innerHitBuilders = collapseContext.getInnerHit();
+            if (innerHitBuilders != null) {
+                builder.startArray("inner_hits");
+                for (int innerHitIndex = 0; innerHitIndex < innerHitBuilders.size(); innerHitIndex++) {
+                    InnerHitBuilder innerHitBuilder = innerHitBuilders.get(innerHitIndex);
+                    innerHitBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                }
+                builder.endArray();
+            }
+            builder.endObject();
         }
 
         if (Objects.nonNull(aggs)) {


### PR DESCRIPTION
### Description
Enables inner hits within collapse parameter for hybrid query

### Related Issues
#1379

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
