### PR TITLE
refactor bwc tests to find model ID in index for semantic field

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/restart/SemanticFieldIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/restart/SemanticFieldIT.java
@@ -12,10 +12,11 @@ import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
 import org.opensearch.neuralsearch.util.TestUtils;
 
 import static org.opensearch.neuralsearch.util.TestUtils.NODES_BWC_CLUSTER;
+import static org.opensearch.neuralsearch.util.TestUtils.getModelId;
 
 public class SemanticFieldIT extends AbstractRestartUpgradeRestTestCase {
-    private static final String PIPELINE_NAME = "nlp-pipeline-semantic-field";
     private static final String TEST_SEMANTIC_TEXT_FIELD = "test_field";
+    private static final String TEST_SEMANTIC_TEXT_FIELD_PATH = "mappings.properties.test_field";
     private static final String SEMANTIC_INFO_FIELD = "semantic_info";
     private static final String SEMANTIC_EMBEDDING_FIELD = "embedding";
     private static final String TEST_QUERY_TEXT = "Hello world";
@@ -43,11 +44,11 @@ public class SemanticFieldIT extends AbstractRestartUpgradeRestTestCase {
                 List.of(SEMANTIC_EMBEDDING_FIELD),
                 List.of(testRankFeaturesDoc)
             );
-            // This is just to block the deletion of the model by other tests
-            createPipelineForSparseEncodingProcessor(modelId, PIPELINE_NAME);
         } else {
             try {
-                loadAndWaitForModelToBeReady(modelId);
+                loadAndWaitForModelToBeReady(
+                    getModelId(getIndexMapping(getIndexNameForTest()), getIndexNameForTest(), TEST_SEMANTIC_TEXT_FIELD_PATH)
+                );
                 addSemanticDoc(
                     getIndexNameForTest(),
                     "1",
@@ -57,7 +58,7 @@ public class SemanticFieldIT extends AbstractRestartUpgradeRestTestCase {
                 );
                 validateTestIndex();
             } finally {
-                wipeOfTestResources(getIndexNameForTest(), PIPELINE_NAME, modelId, null);
+                wipeOfTestResources(getIndexNameForTest(), null, modelId, null);
             }
         }
 
@@ -71,7 +72,7 @@ public class SemanticFieldIT extends AbstractRestartUpgradeRestTestCase {
             .build();
 
         Map<String, Object> searchResponseAsMap = search(getIndexNameForTest(), neuralQueryBuilder, 1);
-        assertEquals(2, getHitCount(searchResponseAsMap));
+        assertEquals(1, getHitCount(searchResponseAsMap));
         Map<String, Object> firstInnerHit = getFirstInnerHit(searchResponseAsMap);
         assertEquals("0", firstInnerHit.get("_id"));
     }

--- a/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/util/TestUtils.java
@@ -388,6 +388,23 @@ public class TestUtils {
         return modelId;
     }
 
+    /**
+     * Fetches model ID in given index with given path
+     * @param indexMapping mappings associated with index
+     * @param indexName name of the index
+     * @param path path to model ID
+     */
+    public static String getModelId(Map<String, Object> indexMapping, String indexName, String path) {
+        String[] paths = path.split("\\.");
+        Map<String, Object> curr = (Map<String, Object>) indexMapping.get(indexName);
+        for (String key : paths) {
+            curr = (Map<String, Object>) curr.get(key);
+        }
+        String modelId = (String) curr.get("model_id");
+        assertNotNull(modelId);
+        return modelId;
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> T getValueByKey(Map<String, Object> map, String key) {
         assertNotNull(map);


### PR DESCRIPTION
### Description
This PR addresses model ID missing in semanticFieldIT by fetching model ID in semantic index. For Semantic Field, model ID is stored in index, and not in pipeline. We had previously created a manual pipeline in SemanticField IT for model ID to be shared across different tests, but it should be fetched from index

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
