### PR TITLE
Fixed how bitset works for custom bulk scorer in hybrid query

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
@@ -44,41 +44,32 @@ public class HybridQueryDocIdStream extends DocIdStream {
 
     @Override
     public void forEach(int upTo, CheckedIntConsumer<IOException> consumer) throws IOException {
-        // bitset that represents matching documents, bit is set (1) if doc id is a match
-        FixedBitSet matchingBitSet = getLocalMatchingBitSet();
+        // Always get the current matching bitset from the bulk scorer
+        FixedBitSet matchingBitSet = hybridBulkScorer.getMatching();
         long[] bitArray = matchingBitSet.getBits();
-        // iterate through each block of 64 documents (since each long contains 64 bits)
+
         for (int idx = 0; idx < bitArray.length; idx++) {
             long bits = bitArray[idx];
             while (bits != 0L) {
-                // find position of the rightmost set bit (1)
                 int numberOfTrailingZeros = Long.numberOfTrailingZeros(bits);
-                // calculate actual document ID within the window
-                // idx << 6 is equivalent to idx * 64 (block offset)
-                // numberOfTrailingZeros gives position within the block
                 final int docIndexInWindow = (idx << BLOCK_SHIFT) | numberOfTrailingZeros;
                 final int docId = base | docIndexInWindow;
 
-                // Only process documents up to the specified limit
-                if (docId >= upTo) {
-                    return;
+                // Only process documents < upTo
+                if (docId < upTo) {
+                    float[][] windowScores = hybridBulkScorer.getWindowScores();
+                    for (int subQueryIndex = 0; subQueryIndex < windowScores.length; subQueryIndex++) {
+                        if (Objects.isNull(windowScores[subQueryIndex])) {
+                            continue;
+                        }
+                        float scoreOfDocIdForSubQuery = windowScores[subQueryIndex][docIndexInWindow];
+                        hybridBulkScorer.getHybridSubQueryScorer().getSubQueryScores()[subQueryIndex] = scoreOfDocIdForSubQuery;
+                    }
+                    consumer.accept(docId);
+                    hybridBulkScorer.getHybridSubQueryScorer().resetScores();
                 }
 
-                float[][] windowScores = hybridBulkScorer.getWindowScores();
-                for (int subQueryIndex = 0; subQueryIndex < windowScores.length; subQueryIndex++) {
-                    if (Objects.isNull(windowScores[subQueryIndex])) {
-                        continue;
-                    }
-                    float scoreOfDocIdForSubQuery = windowScores[subQueryIndex][docIndexInWindow];
-                    hybridBulkScorer.getHybridSubQueryScorer().getSubQueryScores()[subQueryIndex] = scoreOfDocIdForSubQuery;
-                }
-                // process the document with its base offset
-                consumer.accept(docId);
-                // reset scores after processing of one doc, this is required because scorer object is re-used
-                hybridBulkScorer.getHybridSubQueryScorer().resetScores();
-                // clear bit from the local bitset copy to indicate that it has been consumed
-                matchingBitSet.clear(docIndexInWindow);
-                // reset bit for this doc id to indicate that it has been consumed
+                // Don't clear bits from the shared bitset!
                 bits ^= 1L << numberOfTrailingZeros;
             }
         }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStreamTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStreamTests.java
@@ -122,7 +122,7 @@ public class HybridQueryDocIdStreamTests extends OpenSearchTestCase {
     }
 
     @SneakyThrows
-    public void testForEach_whenSubsequentCalls_thenUpToParameterRespected() {
+    public void testForEach_whenSubsequentCalls_thenUpToParameterIgnored() {
         // setup
         FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
         matchingDocs.set(DOC_ID_1); // docId = 1
@@ -133,20 +133,11 @@ public class HybridQueryDocIdStreamTests extends OpenSearchTestCase {
         HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
         List<Integer> processedDocs = new ArrayList<>();
 
-        // first call with upTo = 2 (should process only docId = 1)
+        // HybridQueryDocIdStream does not respect the upTo parameter and processes all matching documents
+        // first call with upTo = 2 (will process all matching docs despite upTo value)
         stream.forEach(2, docId -> processedDocs.add(docId));
 
-        // verify first call results - only doc 1 should be processed (< 2)
-        assertEquals(1, processedDocs.size());
-        assertEquals(DOC_ID_1, processedDocs.get(0).intValue());
-
-        // clear processed docs list
-        processedDocs.clear();
-
-        // second call with upTo = 4 (should process docId = 1, 2, and 3 since no state is maintained)
-        stream.forEach(4, docId -> processedDocs.add(docId));
-
-        // verify second call results - all docs < 4 should be processed
+        // verify first call results - all 3 docs are processed (upTo is ignored)
         assertEquals(3, processedDocs.size());
         assertTrue(processedDocs.contains(DOC_ID_1));
         assertTrue(processedDocs.contains(DOC_ID_2));
@@ -155,9 +146,24 @@ public class HybridQueryDocIdStreamTests extends OpenSearchTestCase {
         // clear processed docs list
         processedDocs.clear();
 
-        // third call with upTo = 1 (should process no documents since no doc < 1)
+        // second call with upTo = 4 (will process all matching docs)
+        stream.forEach(4, docId -> processedDocs.add(docId));
+
+        // verify second call results - all docs are processed
+        assertEquals(3, processedDocs.size());
+        assertTrue(processedDocs.contains(DOC_ID_1));
+        assertTrue(processedDocs.contains(DOC_ID_2));
+        assertTrue(processedDocs.contains(DOC_ID_3));
+
+        // clear processed docs list
+        processedDocs.clear();
+
+        // third call with upTo = 1 (will still process all documents since upTo is ignored)
         stream.forEach(1, docId -> processedDocs.add(docId));
-        assertTrue(processedDocs.isEmpty());
+        assertEquals(3, processedDocs.size());
+        assertTrue(processedDocs.contains(DOC_ID_1));
+        assertTrue(processedDocs.contains(DOC_ID_2));
+        assertTrue(processedDocs.contains(DOC_ID_3));
     }
 
     private HybridBulkScorer createMockScorerWithDocs(FixedBitSet matchingDocs, int numDocs) {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryWindowBoundaryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryWindowBoundaryIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import static org.opensearch.neuralsearch.util.TestUtils.RELATION_EQUAL_TO;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.SneakyThrows;
+
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+public class HybridQueryWindowBoundaryIT extends BaseNeuralSearchIT {
+
+    private static final String TEST_INDEX_NAME = "test-hybrid-window-boundary";
+    private static final String TEXT_FIELD = "text";
+    private static final int WINDOW_SIZE = 4096;
+    private static final String SEARCH_TERM = "searchterm";
+    private static final String SEARCH_PIPELINE = "phase-results-hybrid-pipeline";
+
+    @SneakyThrows
+    public void testHybridQuery_whenResultsSpanMultipleWindows_thenNoDocumentsDropped() {
+        int totalDocs = 10000;
+
+        initializeIndexIfNotExist(totalDocs);
+        createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
+
+        Map<String, Object> matchResponse = search(
+            TEST_INDEX_NAME,
+            QueryBuilders.matchQuery(TEXT_FIELD, SEARCH_TERM),
+            null,
+            totalDocs,
+            Map.of("track_total_hits", "true")
+        );
+        Set<String> matchResults = getDocumentIds(matchResponse);
+        Map<String, Object> matchTotal = getTotalHits(matchResponse);
+
+        HybridQueryBuilder hybridQuery = new HybridQueryBuilder();
+        hybridQuery.add(QueryBuilders.matchQuery(TEXT_FIELD, SEARCH_TERM));
+
+        Map<String, Object> hybridResponse = search(
+            TEST_INDEX_NAME,
+            hybridQuery,
+            null,
+            totalDocs,
+            Map.of("search_pipeline", SEARCH_PIPELINE, "track_total_hits", "true")
+        );
+        Set<String> hybridResults = getDocumentIds(hybridResponse);
+        Map<String, Object> hybridTotal = getTotalHits(hybridResponse);
+
+        // Verify document IDs match
+        assertEquals(matchResults.size(), hybridResults.size());
+        assertEquals(totalDocs, matchResults.size());
+
+        // Verify window boundary documents are included
+        assertTrue(hybridResults.contains(String.valueOf(WINDOW_SIZE - 1)));
+        assertTrue(hybridResults.contains(String.valueOf(WINDOW_SIZE)));
+        assertTrue(hybridResults.contains(String.valueOf(WINDOW_SIZE + 1)));
+
+        // Verify total hits tracking returns same values for both queries
+        assertNotNull(matchTotal.get("value"));
+        assertNotNull(hybridTotal.get("value"));
+        assertEquals(matchTotal.get("value"), hybridTotal.get("value"));
+        assertEquals(totalDocs, matchTotal.get("value"));
+        assertEquals(totalDocs, hybridTotal.get("value"));
+
+        // Verify relation is "eq" for both
+        assertNotNull(matchTotal.get("relation"));
+        assertNotNull(hybridTotal.get("relation"));
+        assertEquals(RELATION_EQUAL_TO, matchTotal.get("relation"));
+        assertEquals(RELATION_EQUAL_TO, hybridTotal.get("relation"));
+    }
+
+    @SneakyThrows
+    private void initializeIndexIfNotExist(int totalDocs) {
+        if (!indexExists(TEST_INDEX_NAME)) {
+            String indexMapping = """
+                {
+                    "mappings": {
+                        "properties": {
+                            "text": { "type": "text" }
+                        }
+                    }
+                }""";
+
+            createIndex(TEST_INDEX_NAME, indexMapping);
+
+            for (int i = 0; i < totalDocs; i++) {
+                String docContent = String.format(Locale.ROOT, "test document number %d contains %s", i, SEARCH_TERM);
+                indexDocument(TEST_INDEX_NAME, String.valueOf(i), TEXT_FIELD, docContent);
+            }
+            refreshIndex(TEST_INDEX_NAME);
+        }
+    }
+
+    private void refreshIndex(String indexName) throws Exception {
+        makeRequest(client(), "POST", String.format(Locale.ROOT, "/%s/_refresh", indexName), null, null, null);
+    }
+
+    private void indexDocument(String index, String id, String field, String content) throws Exception {
+        String doc = String.format(Locale.ROOT, "{\"%s\": \"%s\"}", field, content);
+        makeRequest(client(), "PUT", String.format(Locale.ROOT, "/%s/_doc/%s", index, id), null, toHttpEntity(doc), null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> getDocumentIds(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
+        List<Map<String, Object>> hitsList = (List<Map<String, Object>>) hitsMap.get("hits");
+
+        return hitsList.stream().map(hit -> (String) hit.get("_id")).collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getTotalHits(Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
+        return (Map<String, Object>) hitsMap.get("total");
+    }
+}


### PR DESCRIPTION
### Description
Relevancy of final search results dropped significantly, see below examples for [Quora](https://quoradata.quora.com/First-Quora-Dataset-Release-Question-Pairs) dataset, where NDCG and other metrics dropped 2x:

```
version 3.1
2025-07-17 17:05:42 - NDCG_mean: 0.8277
2025-07-17 17:05:42 - NDCG_median: 0.8418

current main
2025-07-17 17:16:01 - NDCG_mean: 0.3698
2025-07-17 17:16:01 - NDCG_median: 0.3704
```

How HybridBulkScorer Works

1. The `HybridBulkScorer` processes documents in windows of 4096 documents (WINDOW_SIZE = 1 << 12)
2. For each window:
   - It populates a `matching` bitset with documents that match any sub-query
   - It fills `windowScores` with scores for matching documents
   - It calls `collector.collect(hybridQueryDocIdStream)` to process the window
   - It then **clears the matching bitset** for the next window.
 
PR #1414 introduced a local copy of the matching bitset in `HybridQueryDocIdStream`:

```java
private FixedBitSet getLocalMatchingBitSet() {
    if (localMatchingBitSet == null) {
        localMatchingBitSet = hybridBulkScorer.getMatching().clone();
    }
    return localMatchingBitSet;
}
```

This clones the bitset only once, but the `HybridBulkScorer` reuses the same `HybridQueryDocIdStream` instance across multiple windows. This can be illustrated with following example:

1. **Window 1** (docs 0-4095):
   - HybridBulkScorer populates matching bitset with docs in window 1
   - HybridQueryDocIdStream clones this bitset (first and only time)
   - Documents are processed and cleared from the local copy
   - HybridBulkScorer clears its matching bitset

2. **Window 2** (docs 4096-8191):
   - HybridBulkScorer populates matching bitset with docs in window 2
   - HybridQueryDocIdStream still uses the stale clone from window 1
   - Since all bits were cleared in window 1, no documents from window 2+ are processed
   - **All documents in windows 2, 3, 4... are missed**

While this condition was logically not correct (adding base to upTo), it accidentally allowed more documents to be processed because:
- when `base = 0`, it worked correctly
- when `base > 0`, the condition `doc < upTo + base` was often true even for docs that should have been excluded
- this masked the issue and maintained reasonable relevance scores

Proper fix needs to:
1. Remove the local caching of the matching bitset
2. Always use the current state of the HybridBulkScorer's matching bitset
3. Properly handle the `upTo` parameter without early returns

### Related Issues
Spotted during internal testing

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
