### PR TITLE
Use index mapping to to verify if the model is in use before deletion…

### DIFF
--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseUpgradeTestCase.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseUpgradeTestCase.java
@@ -114,7 +114,8 @@ public abstract class BaseUpgradeTestCase extends BaseNeuralSearchIT {
         if (indexMap == null || indexMap.isEmpty()) {
             return false;
         }
-        return indexMap.toString().contains(modelId);
+        final String indexName = (String) indexMap.get("index");
+        return getIndexMapping(indexName).toString().contains(modelId);
     }
 
     @SneakyThrows
@@ -132,6 +133,9 @@ public abstract class BaseUpgradeTestCase extends BaseNeuralSearchIT {
             if (searchPipeline != null) {
                 deleteSearchPipeline(searchPipeline);
             }
+            if (indexName != null) {
+                deleteIndex(indexName);
+            }
             if (modelId != null) {
                 if (!isModelUsedByAnyPipeline(modelId) && !isModelUsedByAnyIndex(modelId)) {
                     deleteModel(modelId);
@@ -146,9 +150,6 @@ public abstract class BaseUpgradeTestCase extends BaseNeuralSearchIT {
                         sharedSparseEmbeddingModelId = null;
                     }
                 }
-            }
-            if (indexName != null) {
-                deleteIndex(indexName);
             }
         }
     }


### PR DESCRIPTION
… in bwc test

### Description
The semantic text field defines the model ID in its index mapping. Therefore, we should inspect the index mapping to determine if a model is in use before deleting it. Additionally, during cleanup, the index should be deleted first to ensure the model can be removed properly.

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
