### PR TITLE
Fix flaky testSparseEncodingProcessor_E2EFlow and yellow cluster issue

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
@@ -22,7 +22,7 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
     private static final String EMBEDDING_FIELD_NAME = "passage_embedding";
 
     public void testBatchIngestion_SparseEncodingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 120);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         String indexName = getIndexNameForTest();
         String sparseModelId = null;
         switch (getClusterType()) {

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/BatchIngestionIT.java
@@ -22,7 +22,7 @@ public class BatchIngestionIT extends AbstractRollingUpgradeTestCase {
     private static final String EMBEDDING_FIELD_NAME = "passage_embedding";
 
     public void testBatchIngestion_SparseEncodingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 120);
         String indexName = getIndexNameForTest();
         String sparseModelId = null;
         switch (getClusterType()) {

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchIT.java
@@ -42,7 +42,7 @@ public class HybridSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Text Embedding Processor, Ingestion Pipeline, add document and search pipeline with noramlization processor
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testNormalizationProcessor_whenIndexWithMultipleShards_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextEmbeddingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchRelevancyIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchRelevancyIT.java
@@ -88,7 +88,7 @@ public class HybridSearchRelevancyIT extends AbstractRollingUpgradeTestCase {
         "seamlessly" };
 
     public void testSearchHitsAfterNormalization_whenIndexWithMultipleShards_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         String indexName = getIndexNameForTest();
         String[] testDocuments = generateTestDocuments(NUM_DOCS);
         switch (getClusterType()) {

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchWithRescoreIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchWithRescoreIT.java
@@ -43,7 +43,7 @@ public class HybridSearchWithRescoreIT extends AbstractRollingUpgradeTestCase {
      * Test normalization with hybrid query and rescore. This test is required as rescore will not be compatible with version lower than 2.15
      */
     public void testHybridQueryWithRescore_whenIndexWithMultipleShards_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextEmbeddingModel();
@@ -106,7 +106,7 @@ public class HybridSearchWithRescoreIT extends AbstractRollingUpgradeTestCase {
         int docCount = getDocCount(getIndexNameForTest());
         assertEquals(numberOfDocs, docCount);
         // Try to ensure all nodes are green before we do the search.
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         Map<String, Object> searchResponseAsMap = search(
             getIndexNameForTest(),
             hybridQueryBuilder,

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/KnnRadialSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/KnnRadialSearchIT.java
@@ -32,7 +32,7 @@ public class KnnRadialSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Text Image Embedding Processor, Ingestion Pipeline and add document
     // Validate radial query, pipeline and document count in rolling-upgrade scenario
     public void testKnnRadialSearch_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextImageEmbeddingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/MultiModalSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/MultiModalSearchIT.java
@@ -30,7 +30,7 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Text Image Embedding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testTextImageEmbeddingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 120);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextImageEmbeddingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/MultiModalSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/MultiModalSearchIT.java
@@ -30,7 +30,7 @@ public class MultiModalSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Text Image Embedding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testTextImageEmbeddingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 120);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextImageEmbeddingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralQueryEnricherProcessorIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralQueryEnricherProcessorIT.java
@@ -32,7 +32,7 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
     // test of NeuralQueryEnricherProcessor supports neural_sparse query default model_id
     // the feature is introduced from 2.13
     public void testNeuralQueryEnricherProcessor_NeuralSparseSearch_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         NeuralSparseQueryBuilder sparseEncodingQueryBuilderWithoutModelId = new NeuralSparseQueryBuilder().fieldName(TEST_ENCODING_FIELD)
             .queryText(TEXT_1);
         // will set the model_id after we obtain the id
@@ -66,7 +66,7 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
                 loadAndWaitForModelToBeReady(sparseModelId);
                 sparseEncodingQueryBuilderWithModelId.modelId(sparseModelId);
 
-                waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+                waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
                 assertEquals(
                     search(getIndexNameForTest(), sparseEncodingQueryBuilderWithoutModelId, 1).get("hits"),
                     search(getIndexNameForTest(), sparseEncodingQueryBuilderWithModelId, 1).get("hits")
@@ -93,7 +93,7 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
     // test of NeuralQueryEnricherProcessor supports neural query default model_id
     // the feature is introduced from 2.11
     public void testNeuralQueryEnricherProcessor_NeuralSearch_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         NeuralQueryBuilder neuralQueryBuilderWithoutModelId = NeuralQueryBuilder.builder()
             .fieldName(TEST_ENCODING_FIELD)
             .queryText(TEXT_1)
@@ -131,7 +131,7 @@ public class NeuralQueryEnricherProcessorIT extends AbstractRollingUpgradeTestCa
                 loadAndWaitForModelToBeReady(denseModelId);
                 neuralQueryBuilderWithModelId.modelId(denseModelId);
 
-                waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+                waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
                 assertEquals(
                     search(getIndexNameForTest(), neuralQueryBuilderWithoutModelId, 1).get("hits"),
                     search(getIndexNameForTest(), neuralQueryBuilderWithModelId, 1).get("hits")

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralSparseSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralSparseSearchIT.java
@@ -39,7 +39,7 @@ public class NeuralSparseSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Sparse Encoding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testSparseEncodingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 120);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadSparseEncodingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralSparseSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralSparseSearchIT.java
@@ -39,7 +39,7 @@ public class NeuralSparseSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Sparse Encoding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testSparseEncodingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 120);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadSparseEncodingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralSparseSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralSparseSearchIT.java
@@ -130,7 +130,7 @@ public class NeuralSparseSearchIT extends AbstractRollingUpgradeTestCase {
             .queryText(TEXT)
             .modelId(modelId);
         MatchQueryBuilder matchQueryBuilder = new MatchQueryBuilder(TEST_TEXT_FIELD, TEXT);
-        boolQueryBuilder.should(sparseEncodingQueryBuilder).should(matchQueryBuilder).filter(new TermQueryBuilder("_id", "0"));
+        boolQueryBuilder.should(sparseEncodingQueryBuilder).should(matchQueryBuilder);
         Map<String, Object> response = search(getIndexNameForTest(), boolQueryBuilder, 1);
         Map<String, Object> firstInnerHit = getFirstInnerHit(response);
 

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralSparseTwoPhaseProcessorIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/NeuralSparseTwoPhaseProcessorIT.java
@@ -27,7 +27,7 @@ public class NeuralSparseTwoPhaseProcessorIT extends AbstractRollingUpgradeTestC
     // test of NeuralSparseTwoPhaseProcessor supports neural_sparse query's two phase speed up
     // the feature is introduced from 2.15
     public void testNeuralSparseTwoPhaseProcessorIT_NeuralSparseSearch_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         // will set the model_id after we obtain the id
         NeuralSparseQueryBuilder neuralSparseQueryBuilder = new NeuralSparseQueryBuilder().fieldName(TEST_ENCODING_FIELD).queryText(TEXT_1);
 

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/RestNeuralStatsActionIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/RestNeuralStatsActionIT.java
@@ -33,7 +33,7 @@ public class RestNeuralStatsActionIT extends AbstractRollingUpgradeTestCase {
     // https://github.com/opensearch-project/neural-search/issues/1368
     public void testStats_E2EFlow() throws Exception {
 
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         enableStats();
 
         // Get initial stats

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticFieldIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticFieldIT.java
@@ -28,7 +28,7 @@ public class SemanticFieldIT extends AbstractRollingUpgradeTestCase {
     // Create Index with Semantic Field and add document
     // Validate document with generated embeddings in rolling-upgrade scenario
     public void testSemanticFieldProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadSparseEncodingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticSearchIT.java
@@ -25,7 +25,7 @@ public class SemanticSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Text Embedding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testSemanticSearch_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 120);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextEmbeddingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticSearchIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/SemanticSearchIT.java
@@ -25,7 +25,7 @@ public class SemanticSearchIT extends AbstractRollingUpgradeTestCase {
     // Create Text Embedding Processor, Ingestion Pipeline and add document
     // Validate process , pipeline and document count in rolling-upgrade scenario
     public void testSemanticSearch_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 90);
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER, 120);
         switch (getClusterType()) {
             case OLD:
                 modelId = uploadTextEmbeddingModel();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/TextChunkingProcessorIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/TextChunkingProcessorIT.java
@@ -34,7 +34,7 @@ public class TextChunkingProcessorIT extends AbstractRollingUpgradeTestCase {
     // Create Text Chunking Processor, Ingestion Pipeline and add document
     // Validate process, pipeline and document count in rolling-upgrade scenario
     public void testTextChunkingProcessor_E2EFlow() throws Exception {
-        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        waitForClusterHealthGreenOrYellow(NODES_BWC_CLUSTER);
         String indexName = getIndexNameForTest();
         switch (getClusterType()) {
             case OLD:

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1954,6 +1954,16 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         waitForClusterHealthGreen(numOfNodes, 60);
     }
 
+    // Method that waits till the health of nodes in the cluster goes green or yellow
+    protected void waitForClusterHealthGreenOrYellow(final String numOfNodes) throws IOException {
+        Request waitForGreen = new Request("GET", "/_cluster/health");
+        waitForGreen.addParameter("wait_for_nodes", numOfNodes);
+        waitForGreen.addParameter("wait_for_status", "yellow");
+        waitForGreen.addParameter("cluster_manager_timeout", "60s");
+        waitForGreen.addParameter("timeout", "60s");
+        client().performRequest(waitForGreen);
+    }
+
     /**
      * Add a single Doc to an index
      *


### PR DESCRIPTION
### Description
Trying fix for `testSparseEncodingProcessor_E2EFlow` flkay test.
The test unconditionally expects document ID "0" to be the top hit. During the MIXED phase, after adding document "1", this document appears to rank higher than document "0"


### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/1416 and https://github.com/opensearch-project/neural-search/issues/1468
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
