### PR TITLE
Support configuring reusing existing embedding for the semantic field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Semantic Field] Allow configuring prune strategies for sparse encoding in semantic fields. ([#1434](https://github.com/opensearch-project/neural-search/pull/1434))
 - Enable inner hits within collapse parameter for hybrid query ([#1447](https://github.com/opensearch-project/neural-search/pull/1447))
 - [Semantic Field] Support configuring the chunking strategies through the semantic field. ([#1446](https://github.com/opensearch-project/neural-search/pull/1446))
+- [Semantic Field] Support configuring reusing existing embedding for the semantic field. ([#1480](https://github.com/opensearch-project/neural-search/pull/1480/files))
 
 ### Bug Fixes
 - Fix for collapse bug with knn query not deduplicating results ([#1413](https://github.com/opensearch-project/neural-search/pull/1413))

--- a/src/main/java/org/opensearch/neuralsearch/constants/DocFieldNames.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/DocFieldNames.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.constants;
+
+/**
+ * Constants related to SourceAndMetadata of a doc
+ */
+public class DocFieldNames {
+    /**
+     * field name of the doc index
+     */
+    public static final String INDEX_FIELD = "_index";
+    /**
+     * field name of the doc id
+     */
+    public static final String ID_FIELD = "_id";
+}

--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
@@ -59,4 +59,11 @@ public class SemanticFieldConstants {
      * {@link org.opensearch.neuralsearch.mapper.dto.SparseEncodingConfig}
      */
     public static final String SPARSE_ENCODING_CONFIG = "sparse_encoding_config";
+
+    /**
+     * Name of the field to configure if we should skip the embedding generation for the semantic field with existing
+     * reusable embedding. We think the embedding is reusable if it exists and the semantic field value and the
+     * model is not changed.
+     */
+    public static final String SKIP_EXISTING_EMBEDDING = "skip_existing_embedding";
 }

--- a/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
@@ -39,6 +39,7 @@ import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DEFAU
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DENSE_EMBEDDING_CONFIG;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SKIP_EXISTING_EMBEDDING;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_FIELD_SEARCH_ANALYZER;
@@ -196,6 +197,14 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
             }
         }, (value) -> value == null ? null : value.toString());
 
+        @Getter
+        protected final Parameter<Boolean> skipExistingEmbedding = Parameter.boolParam(
+            SKIP_EXISTING_EMBEDDING,
+            true,
+            m -> ((SemanticFieldMapper) m).semanticParameters.getSkipExistingEmbedding(),
+            false
+        );
+
         @Setter
         protected ParametrizedFieldMapper.Builder delegateBuilder;
 
@@ -213,7 +222,8 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
                 chunkingConfig,
                 semanticFieldSearchAnalyzer,
                 denseEmbeddingConfig,
-                sparseEncodingConfig
+                sparseEncodingConfig,
+                skipExistingEmbedding
             );
         }
 
@@ -244,6 +254,7 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
                 .semanticFieldSearchAnalyzer(semanticFieldSearchAnalyzer.getValue())
                 .denseEmbeddingConfig(denseEmbeddingConfig.getValue())
                 .sparseEncodingConfig(sparseEncodingConfig.getValue())
+                .skipExistingEmbedding(skipExistingEmbedding.getValue())
                 .build();
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/mapper/dto/SemanticParameters.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/dto/SemanticParameters.java
@@ -30,4 +30,6 @@ public class SemanticParameters {
         }
         return chunkingConfig.isEnabled();
     }
+
+    private final Boolean skipExistingEmbedding;
 }

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -311,7 +311,8 @@ public class NeuralSearch extends Plugin
                 clientAccessor,
                 parameters.env,
                 parameters.ingestService.getClusterService(),
-                parameters.analysisRegistry
+                parameters.analysisRegistry,
+                parameters.client
             )
         );
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -52,6 +52,9 @@ import org.opensearch.neuralsearch.util.TokenWeightUtil;
 import org.opensearch.neuralsearch.util.prune.PruneType;
 import org.opensearch.neuralsearch.util.prune.PruneUtils;
 
+import static org.opensearch.neuralsearch.constants.DocFieldNames.ID_FIELD;
+import static org.opensearch.neuralsearch.constants.DocFieldNames.INDEX_FIELD;
+
 /**
  * The abstract class for text processing use cases. Users provide a field name map and a model id.
  * During ingestion, the processor will use the corresponding model to inference the input texts,
@@ -62,8 +65,6 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
 
     public static final String MODEL_ID_FIELD = "model_id";
     public static final String FIELD_MAP_FIELD = "field_map";
-    public static final String INDEX_FIELD = "_index";
-    public static final String ID_FIELD = "_id";
     public static final String SKIP_EXISTING = "skip_existing";
     public static final boolean DEFAULT_SKIP_EXISTING = false;
     private static final BiFunction<Object, Object, Object> REMAPPING_FUNCTION = (v1, v2) -> {

--- a/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
@@ -32,6 +32,9 @@ import lombok.extern.log4j.Log4j2;
 import org.opensearch.neuralsearch.util.prune.PruneUtils;
 import org.opensearch.transport.client.OpenSearchClient;
 
+import static org.opensearch.neuralsearch.constants.DocFieldNames.ID_FIELD;
+import static org.opensearch.neuralsearch.constants.DocFieldNames.INDEX_FIELD;
+
 /**
  * This processor is used for user input data text sparse encoding processing, model_id can be used to indicate which model user use,
  * and field_map can be used to indicate which fields needs text embedding and the corresponding keys for the sparse encoding results.

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -27,6 +27,9 @@ import org.opensearch.transport.client.OpenSearchClient;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
 import org.opensearch.neuralsearch.stats.events.EventStatName;
 
+import static org.opensearch.neuralsearch.constants.DocFieldNames.ID_FIELD;
+import static org.opensearch.neuralsearch.constants.DocFieldNames.INDEX_FIELD;
+
 /**
  * This processor is used for user input data text embedding processing, model_id can be used to indicate which model user use,
  * and field_map can be used to indicate which fields needs text embedding and the corresponding keys for the text embedding results.

--- a/src/main/java/org/opensearch/neuralsearch/processor/dto/SemanticFieldInfo.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/dto/SemanticFieldInfo.java
@@ -46,6 +46,10 @@ public class SemanticFieldInfo {
      */
     private String semanticFieldFullPathInMapping;
     /**
+     * The full path to the semantic field in the doc
+     */
+    private String semanticFieldFullPathInDoc;
+    /**
      * The full path to the semantic info fields in the doc. The path in the doc will contain the index of the inter
      * nested object.
      */
@@ -66,6 +70,17 @@ public class SemanticFieldInfo {
     private List<String> chunks;
 
     private SparseEncodingConfig sparseEncodingConfig;
+
+    /**
+     * If we should skip the embedding generation for the semantic field with exist reusable embedding. We think the
+     * embedding is reusable if it exists and semantic field value and model are not changed.
+     */
+    private Boolean skipExistingEmbedding;
+
+    /**
+     * The id of the doc of the semantic field
+     */
+    private String docId;
 
     /**
      * @return full path to the chunks field of the semantic field in a doc

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/SemanticFieldProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/SemanticFieldProcessorFactory.java
@@ -15,6 +15,7 @@ import org.opensearch.neuralsearch.processor.chunker.FixedTokenLengthChunker;
 import org.opensearch.neuralsearch.util.SemanticMappingUtils;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.semantic.SemanticFieldProcessor;
+import org.opensearch.transport.client.OpenSearchClient;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,18 +49,21 @@ public final class SemanticFieldProcessorFactory extends AbstractBatchingSystemP
 
     private final ClusterService clusterService;
     private final AnalysisRegistry analysisRegistry;
+    private final OpenSearchClient openSearchClient;
 
     public SemanticFieldProcessorFactory(
         final MLCommonsClientAccessor mlClientAccessor,
         final Environment environment,
         final ClusterService clusterService,
-        final AnalysisRegistry analysisRegistry
+        final AnalysisRegistry analysisRegistry,
+        final OpenSearchClient openSearchClient
     ) {
         super(PROCESSOR_FACTORY_TYPE);
         this.mlClientAccessor = mlClientAccessor;
         this.environment = environment;
         this.clusterService = clusterService;
         this.analysisRegistry = analysisRegistry;
+        this.openSearchClient = openSearchClient;
     }
 
     @SuppressWarnings("unchecked")
@@ -127,7 +131,8 @@ public final class SemanticFieldProcessorFactory extends AbstractBatchingSystemP
             environment,
             clusterService,
             createDefaultTextChunker(),
-            analysisRegistry
+            analysisRegistry,
+            openSearchClient
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessor.java
@@ -8,6 +8,9 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.action.get.MultiGetAction;
+import org.opensearch.action.get.MultiGetItemResponse;
+import org.opensearch.action.get.MultiGetRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.core.action.ActionListener;
@@ -29,6 +32,7 @@ import org.opensearch.neuralsearch.stats.events.EventStatsManager;
 import org.opensearch.neuralsearch.util.TokenWeightUtil;
 import org.opensearch.neuralsearch.util.prune.PruneType;
 import org.opensearch.neuralsearch.util.prune.PruneUtils;
+import org.opensearch.transport.client.OpenSearchClient;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -45,6 +50,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.opensearch.neuralsearch.constants.DocFieldNames.ID_FIELD;
+import static org.opensearch.neuralsearch.constants.DocFieldNames.INDEX_FIELD;
 import static org.opensearch.neuralsearch.constants.MappingConstants.PATH_SEPARATOR;
 import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.CHUNKS_TEXT_FIELD_NAME;
 import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.MODEL_ID_FIELD_NAME;
@@ -55,12 +62,14 @@ import static org.opensearch.neuralsearch.processor.chunker.Chunker.MAX_CHUNK_LI
 import static org.opensearch.neuralsearch.processor.util.ChunkUtils.chunkList;
 import static org.opensearch.neuralsearch.processor.util.ChunkUtils.chunkString;
 import static org.opensearch.neuralsearch.processor.util.ProcessorUtils.getMaxTokenCount;
+import static org.opensearch.neuralsearch.processor.util.ProcessorUtils.getValueFromSourceByFullPath;
 import static org.opensearch.neuralsearch.util.ProcessorDocumentUtils.unflattenIngestDoc;
 import static org.opensearch.neuralsearch.util.SemanticMLModelUtils.getModelType;
 import static org.opensearch.neuralsearch.util.SemanticMLModelUtils.isDenseModel;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.getModelId;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.getSemanticInfoFieldFullPath;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.isChunkingEnabled;
+import static org.opensearch.neuralsearch.util.SemanticMappingUtils.isSkipExistingEmbeddingEnabled;
 
 /**
  * Processor to ingest the semantic fields. It will do text chunking and embedding generation for the semantic field.
@@ -86,6 +95,8 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
 
     private final static float DEFAULT_PRUNE_RATIO = 0.1f;
 
+    private final OpenSearchClient openSearchClient;
+
     public SemanticFieldProcessor(
         @Nullable final String tag,
         @Nullable final String description,
@@ -95,7 +106,8 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
         @NonNull final Environment environment,
         @NonNull final ClusterService clusterService,
         @NonNull final Chunker defaultTextChunker,
-        @NonNull final AnalysisRegistry analysisRegistry
+        @NonNull final AnalysisRegistry analysisRegistry,
+        @NonNull final OpenSearchClient openSearchClient
     ) {
         super(tag, description, batchSize);
         this.pathToFieldConfig = pathToFieldConfig;
@@ -103,6 +115,7 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
         this.environment = environment;
         this.clusterService = clusterService;
         this.defaultTextChunker = defaultTextChunker;
+        this.openSearchClient = openSearchClient;
         this.analysisRegistry = analysisRegistry;
     }
 
@@ -180,14 +193,119 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
         @NonNull final List<SemanticFieldInfo> semanticFieldInfoList,
         @NonNull final BiConsumer<IngestDocument, Exception> handler
     ) {
-        setModelInfo(ingestDocument, semanticFieldInfoList);
-
         boolean isChunked = chunk(ingestDocument, semanticFieldInfoList);
         if (isChunked) {
             EventStatsManager.increment(EventStatName.SEMANTIC_FIELD_PROCESSOR_CHUNKING_EXECUTIONS);
         }
 
+        final Set<String> docIdsToCheckReuse = getDocIdsToCheckReuse(List.of(semanticFieldInfoList));
+        final Object index = ingestDocument.getSourceAndMetadata().get(INDEX_FIELD);
+        if (shouldCheckExistDoc(docIdsToCheckReuse, index)) {
+            getExistingDocs(docIdsToCheckReuse, (String) index, (existingDocs, exception) -> {
+                if (exception != null) {
+                    handler.accept(null, wrapGetExistDocException(exception));
+                    return;
+                }
+                final List<SemanticFieldInfo> semanticFieldInfoToGenerateEmbedding = applyReusableEmbeddingsAndFilterUnprocessedFields(
+                    ingestDocument,
+                    semanticFieldInfoList,
+                    existingDocs
+                );
+                if (semanticFieldInfoToGenerateEmbedding.isEmpty()) {
+                    handler.accept(ingestDocument, null);
+                } else {
+                    setModelInfo(ingestDocument, semanticFieldInfoToGenerateEmbedding);
+                    generateAndSetEmbedding(ingestDocument, semanticFieldInfoToGenerateEmbedding, handler);
+                }
+            });
+            return;
+        }
+
+        setModelInfo(ingestDocument, semanticFieldInfoList);
         generateAndSetEmbedding(ingestDocument, semanticFieldInfoList, handler);
+    }
+
+    private Exception wrapGetExistDocException(@NonNull final Exception exception) {
+        return new RuntimeException(
+            String.format(
+                Locale.ROOT,
+                "Failed to get existing docs to check embedding reusability for the semantic field. Error: %s",
+                exception.getMessage()
+            ),
+            exception
+        );
+    }
+
+    private List<SemanticFieldInfo> applyReusableEmbeddingsAndFilterUnprocessedFields(
+        @NonNull IngestDocument ingestDocument,
+        @NonNull List<SemanticFieldInfo> semanticFieldInfoList,
+        @NonNull final Map<String, Map<String, Object>> existingDocs
+    ) {
+        return semanticFieldInfoList.stream().filter(info -> {
+            // If skip_exist_embedding is not enabled or no doc ID, we need to generate embedding
+            if (info.getSkipExistingEmbedding() == false || info.getDocId() == null) {
+                return true;
+            }
+
+            // If no existing doc then no reuse
+            final Map<String, Object> existingDoc = existingDocs.get(info.getDocId());
+            if (existingDoc == null) {
+                return true;
+            }
+
+            // If original value is changed then no reuse
+            final Object existingValue = getValueFromSourceByFullPath(existingDoc, info.getSemanticFieldFullPathInDoc());
+            if (Objects.equals(info.getValue(), existingValue) == false) {
+                return true;
+            }
+
+            // If the model id is changed then no reuse
+            final Object modelInfo = getValueFromSourceByFullPath(existingDoc, info.getFullPathForModelInfoInDoc());
+            if (!(modelInfo instanceof Map<?, ?> modelMap)
+                || Objects.equals(modelMap.get(MODEL_ID_FIELD_NAME), info.getModelId()) == false) {
+                return true;
+            }
+
+            // If the chunked texts are changed then no reuse
+            if (info.getChunkingEnabled()) {
+                final Object chunksObj = getValueFromSourceByFullPath(existingDoc, info.getFullPathForChunksInDoc());
+                if (!(chunksObj instanceof List<?> chunks)) {
+                    return true;
+                }
+
+                final List<Object> existingChunkedTexts = new ArrayList<>();
+                for (final Object chunk : chunks) {
+                    if (chunk instanceof Map<?, ?> chunkMap) {
+                        existingChunkedTexts.add(chunkMap.get(CHUNKS_TEXT_FIELD_NAME));
+                    }
+                }
+
+                if (Objects.equals(existingChunkedTexts, info.getChunks()) == false) {
+                    return true;
+                }
+            }
+
+            // All checks passed — reuse existing embedding and skip generation
+            final Object semanticInfo = getValueFromSourceByFullPath(existingDoc, info.getSemanticInfoFullPathInDoc());
+            ingestDocument.setFieldValue(info.getSemanticInfoFullPathInDoc(), semanticInfo);
+            return false;
+        }).toList();
+    }
+
+    private boolean shouldCheckExistDoc(@NonNull final Set<String> docIdsToCheckReuse, final Object index) {
+        return docIdsToCheckReuse.isEmpty() == false && index instanceof String;
+    }
+
+    private Set<String> getDocIdsToCheckReuse(@NonNull final Collection<List<SemanticFieldInfo>> semanticFieldInfoList) {
+        final Set<String> docIdsToCheckReuse = new HashSet<>();
+        for (List<SemanticFieldInfo> semanticFieldInfos : semanticFieldInfoList) {
+            for (SemanticFieldInfo semanticFieldInfo : semanticFieldInfos) {
+                if (semanticFieldInfo.getSkipExistingEmbedding() && Objects.nonNull(semanticFieldInfo.getDocId())) {
+                    docIdsToCheckReuse.add(semanticFieldInfo.getDocId());
+                }
+            }
+        }
+        return docIdsToCheckReuse;
     }
 
     private void setModelInfo(@NonNull final IngestDocument ingestDocument, @NonNull final List<SemanticFieldInfo> semanticFieldInfoList) {
@@ -291,7 +409,15 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
     private List<SemanticFieldInfo> getSemanticFieldInfo(IngestDocument ingestDocument) {
         final List<SemanticFieldInfo> semanticFieldInfos = new ArrayList<>();
         final Object doc = ingestDocument.getSourceAndMetadata();
-        pathToFieldConfig.forEach((path, config) -> collectSemanticFieldInfo(doc, path.split("\\."), config, 0, "", semanticFieldInfos));
+        String docId = null;
+        if (doc instanceof Map<?, ?> docMap) {
+            docId = (String) docMap.get(ID_FIELD);
+        }
+        for (Map.Entry<String, Map<String, Object>> entry : pathToFieldConfig.entrySet()) {
+            final String path = entry.getKey();
+            final Map<String, Object> config = entry.getValue();
+            collectSemanticFieldInfo(doc, path.split("\\."), config, 0, "", semanticFieldInfos, docId);
+        }
         return semanticFieldInfos;
     }
 
@@ -355,7 +481,8 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
         @NonNull final Map<String, Object> fieldConfig,
         final int depth,
         @NonNull final String currentPath,
-        @NonNull final List<SemanticFieldInfo> semanticFieldInfoList
+        @NonNull final List<SemanticFieldInfo> semanticFieldInfoList,
+        @Nullable final String docId
     ) {
         if (depth > pathParts.length || node == null) {
             return;
@@ -368,12 +495,12 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
         if (depth < pathParts.length && node instanceof Map<?, ?> mapNode) {
             final Object nextNode = mapNode.get(key);
             final String newPath = currentPath.isEmpty() ? key : currentPath + PATH_SEPARATOR + key;
-            collectSemanticFieldInfo(nextNode, pathParts, fieldConfig, depth + 1, newPath, semanticFieldInfoList);
+            collectSemanticFieldInfo(nextNode, pathParts, fieldConfig, depth + 1, newPath, semanticFieldInfoList, docId);
         } else if (depth < pathParts.length && node instanceof List<?> listNode) {
             for (int i = 0; i < listNode.size(); i++) {
                 final Object listItem = listNode.get(i);
                 final String indexedPath = currentPath + PATH_SEPARATOR + i;
-                collectSemanticFieldInfo(listItem, pathParts, fieldConfig, depth, indexedPath, semanticFieldInfoList);
+                collectSemanticFieldInfo(listItem, pathParts, fieldConfig, depth, indexedPath, semanticFieldInfoList, docId);
             }
         } else if (depth == pathParts.length) {
             // the current node is the value of the semantic field, and it should be a string value
@@ -392,12 +519,15 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
             final SemanticFieldInfo semanticFieldInfo = SemanticFieldInfo.builder()
                 .value(node.toString())
                 .modelId(getModelId(fieldConfig, pathToSemanticField))
-                .semanticFieldFullPathInMapping(currentPath)
+                .semanticFieldFullPathInMapping(String.join(PATH_SEPARATOR, pathParts))
+                .semanticFieldFullPathInDoc(currentPath)
                 // Here we should use the currentPath because it has the inter index if there is any inter nested object
                 // By using this path we can handle the nested object properly when we use it to set the data for the semantic field
                 .semanticInfoFullPathInDoc(getSemanticInfoFieldFullPath(fieldConfig, currentPath, pathToSemanticField))
                 .chunkingEnabled(isChunkingEnabled(fieldConfig, pathToSemanticField))
                 .sparseEncodingConfig(new SparseEncodingConfig(fieldConfig))
+                .skipExistingEmbedding(isSkipExistingEmbeddingEnabled(fieldConfig, pathToSemanticField))
+                .docId(docId)
                 .build();
             semanticFieldInfo.setChunkingConfig(new ChunkingConfig(fieldConfig), analysisRegistry);
 
@@ -474,29 +604,17 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
         @NonNull final Consumer<List<IngestDocumentWrapper>> handler
     ) {
         boolean isChunked = false;
-        for (Map.Entry<IngestDocumentWrapper, List<SemanticFieldInfo>> entry : docToSemanticFieldInfoMap.entrySet()) {
-            final IngestDocumentWrapper ingestDocumentWrapper = entry.getKey();
-            final IngestDocument ingestDocument = entry.getKey().getIngestDocument();
-            final List<SemanticFieldInfo> semanticFieldInfoList = entry.getValue();
-            try {
-                setModelInfo(ingestDocument, semanticFieldInfoList);
 
-                if (chunk(ingestDocument, semanticFieldInfoList)) {
+        for (Map.Entry<IngestDocumentWrapper, List<SemanticFieldInfo>> entry : docToSemanticFieldInfoMap.entrySet()) {
+            try {
+                final IngestDocument ingestDoc = entry.getKey().getIngestDocument();
+                final List<SemanticFieldInfo> fields = entry.getValue();
+
+                if (chunk(ingestDoc, fields)) {
                     isChunked = true;
                 }
             } catch (Exception e) {
-                log.error(
-                    String.format(
-                        Locale.ROOT,
-                        "Failed to set model info and chunk the semantic fields for the ingest document %s. Root cause: %s",
-                        ingestDocument.toString(),
-                        e.getMessage()
-                    ),
-                    e
-                );
-                if (ingestDocumentWrapper.getException() == null) {
-                    ingestDocumentWrapper.update(ingestDocument, e);
-                }
+                logAndUpdate(entry.getKey(), "chunk", e);
             }
         }
 
@@ -504,7 +622,87 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
             EventStatsManager.increment(EventStatName.SEMANTIC_FIELD_PROCESSOR_CHUNKING_EXECUTIONS);
         }
 
+        final Set<String> docIdsToCheckReuse = getDocIdsToCheckReuse(docToSemanticFieldInfoMap.values());
+        // All docs should be in the same index so simply get the index from the first doc.
+        final Object index = ingestDocumentWrappers.getFirst().getIngestDocument().getSourceAndMetadata().get(INDEX_FIELD);
+
+        if (shouldCheckExistDoc(docIdsToCheckReuse, index)) {
+            getExistingDocs(docIdsToCheckReuse, (String) index, (existingDocs, exception) -> {
+                if (exception != null) {
+                    addExceptionToImpactedDocs(docToSemanticFieldInfoMap.keySet(), wrapGetExistDocException(exception));
+                    handler.accept(ingestDocumentWrappers);
+                    return;
+                }
+
+                Map<IngestDocumentWrapper, List<SemanticFieldInfo>> docToFieldsNeedingEmbedding = new HashMap<>();
+                docToSemanticFieldInfoMap.forEach((docWrapper, infos) -> {
+                    List<SemanticFieldInfo> fieldsNeedingEmbedding = applyReusableEmbeddingsAndFilterUnprocessedFields(
+                        docWrapper.getIngestDocument(),
+                        infos,
+                        existingDocs
+                    );
+                    if (fieldsNeedingEmbedding.isEmpty() == false) {
+                        docToFieldsNeedingEmbedding.put(docWrapper, fieldsNeedingEmbedding);
+                    }
+                });
+
+                if (docToFieldsNeedingEmbedding.isEmpty()) {
+                    handler.accept(ingestDocumentWrappers);
+                } else {
+                    batchSetModelInfo(docToFieldsNeedingEmbedding);
+                    batchGenerateAndSetEmbedding(ingestDocumentWrappers, docToFieldsNeedingEmbedding, handler);
+                }
+            });
+            return;
+        }
+        batchSetModelInfo(docToSemanticFieldInfoMap);
         batchGenerateAndSetEmbedding(ingestDocumentWrappers, docToSemanticFieldInfoMap, handler);
+    }
+
+    private void batchSetModelInfo(Map<IngestDocumentWrapper, List<SemanticFieldInfo>> docToFieldsNeedingEmbedding) {
+        docToFieldsNeedingEmbedding.forEach((docWrapper, infos) -> {
+            try {
+                setModelInfo(docWrapper.getIngestDocument(), infos);
+            } catch (Exception e) {
+                logAndUpdate(docWrapper, "set model info", e);
+            }
+        });
+    }
+
+    private void logAndUpdate(@NonNull final IngestDocumentWrapper wrapper, @NonNull final String operation, @NonNull final Exception e) {
+        final IngestDocument doc = wrapper.getIngestDocument();
+        log.error(
+            String.format(Locale.ROOT, "Failed to %s ingest document %s. Root cause: %s", operation, doc.toString(), e.getMessage()),
+            e
+        );
+        if (wrapper.getException() == null) {
+            wrapper.update(doc, e);
+        }
+    }
+
+    private void getExistingDocs(
+        @NonNull final Set<String> docIds,
+        @NonNull final String index,
+        @NonNull final BiConsumer<Map<String, Map<String, Object>>, Exception> handler
+    ) {
+        MultiGetRequest multiGetRequest = new MultiGetRequest();
+        for (String docId : docIds) {
+            multiGetRequest.add(index, docId);
+        }
+        openSearchClient.execute(MultiGetAction.INSTANCE, multiGetRequest, ActionListener.wrap(response -> {
+            MultiGetItemResponse[] items = response.getResponses();
+            if (items == null || items.length == 0) {
+                handler.accept(Collections.emptyMap(), null);
+                return;
+            }
+            Map<String, Map<String, Object>> existingDocs = new HashMap<>();
+            for (MultiGetItemResponse item : items) {
+                if (item.getResponse() != null && item.getResponse().isExists()) {
+                    existingDocs.put(item.getId(), item.getResponse().getSourceAsMap());
+                }
+            }
+            handler.accept(existingDocs, null);
+        }, e -> handler.accept(null, e)));
     }
 
     @SuppressWarnings("unchecked")
@@ -585,7 +783,7 @@ public class SemanticFieldProcessor extends AbstractBatchingSystemProcessor {
         }
     }
 
-    private void addExceptionToImpactedDocs(@NonNull final Set<IngestDocumentWrapper> impactedDocs, @NonNull final Exception e) {
+    private void addExceptionToImpactedDocs(@NonNull final Collection<IngestDocumentWrapper> impactedDocs, @NonNull final Exception e) {
 
         for (final IngestDocumentWrapper ingestDocumentWrapper : impactedDocs) {
             // Do not override the previous exception. We do not filter out the doc with exception at the

--- a/src/main/java/org/opensearch/neuralsearch/processor/util/ProcessorUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/util/ProcessorUtils.java
@@ -209,6 +209,71 @@ public class ProcessorUtils {
         return Optional.ofNullable(current);
     }
 
+    /**
+     * Returns the data found in the doc source based on the full path.
+     * e.g.
+     * {
+     *     level1: [
+     *       {
+     *           level2: [
+     *             {
+     *                 level3: value1
+     *             }
+     *           ]
+     *       },
+     *       {
+     *           level2: [
+     *             {
+     *                 level3: value2
+     *             }
+     *           ]
+     *       }
+     *     ]
+     * }
+     *
+     * fullPath: level1.0.level2.0.level3
+     * return: value1
+     *
+     * fullPath: level1.1.level2.0.level3
+     * return: value2
+     *
+     * @param sourceAsMap The source of a doc.
+     * @param fullPath The full path in the doc to the value.
+     * @return The data at the full path in the doc.
+     */
+    public static Object getValueFromSourceByFullPath(final Map<String, Object> sourceAsMap, final String fullPath) {
+        if (sourceAsMap == null || fullPath == null || fullPath.isEmpty()) {
+            return null;
+        }
+
+        String[] parts = fullPath.split("\\.");
+        Object current = sourceAsMap;
+
+        for (String part : parts) {
+            if (current instanceof Map<?, ?> map) {
+                current = map.get(part);
+            } else if (current instanceof List<?> list) {
+                try {
+                    int index = Integer.parseInt(part);
+                    if (index < 0 || index >= list.size()) {
+                        return null;
+                    }
+                    current = list.get(index);
+                } catch (NumberFormatException e) {
+                    return null; // Cannot parse list index
+                }
+            } else {
+                return null; // Neither Map nor List at this path step
+            }
+
+            if (current == null) {
+                return null; // Path resolution failed
+            }
+        }
+
+        return current;
+    }
+
     // iterate each Map Object in given list and return a list of map values with given key
     private static List<Object> parseList(List<Object> list, String key) {
         List<Object> result = new ArrayList<>();

--- a/src/main/java/org/opensearch/neuralsearch/util/SemanticMappingUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/SemanticMappingUtils.java
@@ -27,6 +27,7 @@ import static org.opensearch.neuralsearch.constants.MappingConstants.PROPERTIES;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.CHUNKING;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DENSE_EMBEDDING_CONFIG;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SKIP_EXISTING_EMBEDDING;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_FIELD_SEARCH_ANALYZER;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
 import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
@@ -502,5 +503,33 @@ public class SemanticMappingUtils {
         }
 
         return (Map<String, Object>) config;
+    }
+
+    /**
+     * Check if skip_existing_embedding is enabled for the semantic field.
+     * @param fieldConfigMap The config for a semantic field.
+     * @return If skip_existing_embedding is enabled in the semantic filed config.
+     */
+    public static Boolean isSkipExistingEmbeddingEnabled(
+        @NonNull final Map<String, Object> fieldConfigMap,
+        @NonNull final String semanticFieldPath
+    ) {
+        if (fieldConfigMap.containsKey(SKIP_EXISTING_EMBEDDING)) {
+            final Object skipExistingEmbeddingObject = fieldConfigMap.get(SKIP_EXISTING_EMBEDDING);
+            if (skipExistingEmbeddingObject instanceof Boolean) {
+                return (Boolean) skipExistingEmbeddingObject;
+            } else {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "%s should be a boolean for the semantic field at %s",
+                        SKIP_EXISTING_EMBEDDING,
+                        semanticFieldPath
+                    )
+                );
+            }
+        }
+
+        return false;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTests.java
@@ -39,6 +39,7 @@ import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.CHUNK
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DENSE_EMBEDDING_CONFIG;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SKIP_EXISTING_EMBEDDING;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_FIELD_SEARCH_ANALYZER;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
@@ -175,7 +176,7 @@ public class SemanticFieldMapperTests extends OpenSearchTestCase {
 
     public void testBuilder_getParameters() {
         final SemanticFieldMapper.Builder builder = new SemanticFieldMapper.Builder(SemanticFieldMapperTestUtil.fieldName);
-        assertEquals(8, builder.getParameters().size());
+        assertEquals(9, builder.getParameters().size());
         List<String> actualParams = builder.getParameters().stream().map(a -> a.name).collect(Collectors.toList());
         List<String> expectedParams = Arrays.asList(
             MODEL_ID,
@@ -185,7 +186,8 @@ public class SemanticFieldMapperTests extends OpenSearchTestCase {
             CHUNKING,
             SEMANTIC_FIELD_SEARCH_ANALYZER,
             DENSE_EMBEDDING_CONFIG,
-            SPARSE_ENCODING_CONFIG
+            SPARSE_ENCODING_CONFIG,
+            SKIP_EXISTING_EMBEDDING
         );
         assertEquals(expectedParams, actualParams);
     }

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/SemanticFieldProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/SemanticFieldProcessorFactoryTests.java
@@ -15,6 +15,7 @@ import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.semantic.SemanticFieldProcessor;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.OpenSearchClient;
 
 import java.util.Collections;
 import java.util.List;
@@ -37,6 +38,8 @@ public class SemanticFieldProcessorFactoryTests extends OpenSearchTestCase {
     private Environment environment;
     @Mock
     private ClusterService clusterService;
+    @Mock
+    private OpenSearchClient openSearchClient;
 
     private SemanticFieldProcessorFactory factory;
 
@@ -45,7 +48,7 @@ public class SemanticFieldProcessorFactoryTests extends OpenSearchTestCase {
         MockitoAnnotations.openMocks(this);
         // analysisRegistry is a final class so use a real one
         AnalysisRegistry analysisRegistry = getAnalysisRegistry();
-        factory = new SemanticFieldProcessorFactory(mlClientAccessor, environment, clusterService, analysisRegistry);
+        factory = new SemanticFieldProcessorFactory(mlClientAccessor, environment, clusterService, analysisRegistry, openSearchClient);
     }
 
     public void testNewProcessor_noMappings_thenReturnNull() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessorIT.java
@@ -269,6 +269,22 @@ public class SemanticFieldProcessorIT extends BaseNeuralSearchIT {
         assertModelUpdate(originalDoc, updatedDoc, modelId, newModelId);
     }
 
+    public void testReuseExitEmbedding_withSparseModel() throws Exception {
+        String modelId = prepareSparseEncodingModel();
+        loadModel(modelId);
+        createIndexWithModelId(INDEX_WITH_SPARSE_MODEL, "semantic/SemanticIndexMappingsSkipExistingEmbedding.json", modelId);
+
+        // Initial ingestion
+        ingestDocument(INDEX_WITH_SPARSE_MODEL, INGEST_DOC1, "1");
+        Map<String, Object> originalDoc = (Map<String, Object>) getDocById(INDEX_WITH_SPARSE_MODEL, "1").get("_source");
+        assertEmbeddings(originalDoc);
+
+        // Re-ingest and verify changes
+        ingestDocument(INDEX_WITH_SPARSE_MODEL, INGEST_DOC1, "1", true);
+        Map<String, Object> updatedDoc = (Map<String, Object>) getDocById(INDEX_WITH_SPARSE_MODEL, "1").get("_source");
+        assertEmbeddings(updatedDoc);
+    }
+
     private List<Object> assertEmbeddings(Map<String, Object> source) {
         List<Object> embeddings = new ArrayList<>();
         List<Map<String, Object>> level1 = (List<Map<String, Object>>) source.get(LEVEL_1_FIELD);

--- a/src/test/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/semantic/SemanticFieldProcessorTests.java
@@ -8,7 +8,11 @@ import lombok.NonNull;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.get.MultiGetItemResponse;
+import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
@@ -55,9 +59,11 @@ import static org.opensearch.neuralsearch.constants.MappingConstants.PATH_SEPARA
 import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.CHUNKING;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SKIP_EXISTING_EMBEDDING;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SPARSE_ENCODING_CONFIG;
 import static org.opensearch.neuralsearch.processor.TextChunkingProcessorTests.getAnalysisRegistry;
 import org.opensearch.neuralsearch.util.TestUtils;
+import org.opensearch.transport.client.OpenSearchClient;
 
 public class SemanticFieldProcessorTests extends OpenSearchTestCase {
     @Mock
@@ -68,6 +74,9 @@ public class SemanticFieldProcessorTests extends OpenSearchTestCase {
     private Environment environment;
     @Mock
     private ClusterService clusterService;
+    @Mock
+    private OpenSearchClient openSearchClient;
+    private Chunker chunker;
     private final ClassLoader classLoader = this.getClass().getClassLoader();
 
     private Map<String, Map<String, Object>> pathToFieldConfigMap;
@@ -98,7 +107,7 @@ public class SemanticFieldProcessorTests extends OpenSearchTestCase {
         // mock cluster
         final Metadata metadata = mock(Metadata.class);
         final ClusterState clusterState = mock(ClusterState.class);
-        final ClusterService clusterService = mock(ClusterService.class);
+        clusterService = mock(ClusterService.class);
         when(metadata.index(anyString())).thenReturn(null);
         when(clusterState.metadata()).thenReturn(metadata);
         when(clusterService.state()).thenReturn(clusterState);
@@ -142,7 +151,7 @@ public class SemanticFieldProcessorTests extends OpenSearchTestCase {
         chunkerParameters.put(FixedTokenLengthChunker.TOKEN_LIMIT_FIELD, 50);
         chunkerParameters.put(FixedTokenLengthChunker.OVERLAP_RATE_FIELD, 0.2);
         chunkerParameters.put(FixedTokenLengthChunker.ANALYSIS_REGISTRY_FIELD, analysisRegistry);
-        Chunker chunker = ChunkerFactory.create(FixedTokenLengthChunker.ALGORITHM_NAME, chunkerParameters);
+        chunker = ChunkerFactory.create(FixedTokenLengthChunker.ALGORITHM_NAME, chunkerParameters);
 
         semanticFieldProcessor = new SemanticFieldProcessor(
             "tag",
@@ -153,7 +162,8 @@ public class SemanticFieldProcessorTests extends OpenSearchTestCase {
             environment,
             clusterService,
             chunker,
-            analysisRegistry
+            analysisRegistry,
+            openSearchClient
         );
     }
 
@@ -203,6 +213,102 @@ public class SemanticFieldProcessorTests extends OpenSearchTestCase {
             // No more invocation of getModel API but still invoke inference function.
             verify(mlCommonsClientAccessor, times(1)).getModels(any(), any(), any());
             verify(mlCommonsClientAccessor, times(2)).inferenceSentences(any(), any());
+            verify(mlCommonsClientAccessor, times(2)).inferenceSentencesWithMapResult(any(), any());
+        });
+    }
+
+    public void testExecute_whenValidDocReuseEmbedding_thenIngestDocSuccessfully() throws URISyntaxException, IOException {
+        // enable reuse exist embedding
+        final Map<String, Map<String, Object>> pathToFieldConfigMap = Map.of(
+            FIELD_NAME_PRODUCTS + PATH_SEPARATOR + FIELD_NAME_PRODUCT_DESCRIPTION,
+            Map.of(TYPE, SemanticFieldMapper.CONTENT_TYPE, MODEL_ID, DUMMY_MODEL_ID_1, CHUNKING, true, SKIP_EXISTING_EMBEDDING, true),
+            FIELD_NAME_GEO_DATA,
+            Map.of(
+                TYPE,
+                SemanticFieldMapper.CONTENT_TYPE,
+                MODEL_ID,
+                DUMMY_MODEL_ID_2,
+                SPARSE_ENCODING_CONFIG,
+                Map.of(PruneUtils.PRUNE_TYPE_FIELD, PruneType.MAX_RATIO.getValue(), PruneUtils.PRUNE_RATIO_FIELD, 0.5)
+            )
+        );
+        semanticFieldProcessor = new SemanticFieldProcessor(
+            "tag",
+            "description",
+            1,
+            pathToFieldConfigMap,
+            mlCommonsClientAccessor,
+            environment,
+            clusterService,
+            chunker,
+            analysisRegistry,
+            openSearchClient
+        );
+        // prepare ingest doc
+        final Map<String, Object> ingestDocSource = readDocSourceFromFile("processor/semantic/ingest_doc1.json");
+        final IngestDocument ingestDocument = new IngestDocument("index", "1", "routing", 1L, VersionType.INTERNAL, ingestDocSource);
+
+        mockGetModelAndInferenceAPI();
+
+        // first time doc not exist
+        final MultiGetResponse multiGetResponse = Mockito.mock(MultiGetResponse.class);
+        final MultiGetItemResponse multiGetItemResponse = Mockito.mock(MultiGetItemResponse.class);
+        final GetResponse getResponse = Mockito.mock(GetResponse.class);
+        when(multiGetResponse.getResponses()).thenReturn(new MultiGetItemResponse[] { multiGetItemResponse });
+        when(multiGetItemResponse.getId()).thenReturn("1");
+        when(multiGetItemResponse.getResponse()).thenReturn(getResponse);
+        when(getResponse.isExists()).thenReturn(false);
+        doAnswer(invocationOnMock -> {
+            final ActionListener<MultiGetResponse> listener = (ActionListener<MultiGetResponse>) invocationOnMock.getArguments()[2];
+            listener.onResponse(multiGetResponse);
+            return null;
+        }).when(openSearchClient).execute(any(), any(), any());
+
+        // prepare data for verify
+        final Map<String, Object> expectedIngestedDoc;
+        try {
+            expectedIngestedDoc = readExpectedDocFromFile("processor/semantic/ingested_doc1.json");
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+        // Call the method
+        semanticFieldProcessor.execute(ingestDocument, (doc, e) -> {
+            assertNull("No error should occur", e);
+
+            org.assertj.core.api.Assertions.assertThat(ingestDocument.getSourceAndMetadata()).isEqualTo(expectedIngestedDoc);
+
+            verify(mlCommonsClientAccessor, times(1)).getModels(any(), any(), any());
+            verify(mlCommonsClientAccessor, times(1)).inferenceSentences(any(), any());
+            verify(mlCommonsClientAccessor, times(1)).inferenceSentencesWithMapResult(any(), any());
+        });
+
+        // ingest the doc again to verify it should reuse the existing embedding
+        final Map<String, Object> ingestDocSourceSame = readDocSourceFromFile("processor/semantic/ingest_doc1.json");
+        final IngestDocument ingestDocumentSame = new IngestDocument(
+            "index",
+            "1",
+            "routing",
+            1L,
+            VersionType.INTERNAL,
+            ingestDocSourceSame
+        );
+
+        // second time doc exist
+        when(getResponse.isExists()).thenReturn(true);
+        when(getResponse.getSourceAsMap()).thenReturn(ingestDocument.getSourceAndMetadata());
+
+        // call method
+        semanticFieldProcessor.execute(ingestDocumentSame, (doc, e) -> {
+            assertNull("No error should occur", e);
+
+            // verify
+            org.assertj.core.api.Assertions.assertThat(ingestDocumentSame.getSourceAndMetadata()).isEqualTo(expectedIngestedDoc);
+
+            // No more invocation of getModel API
+            verify(mlCommonsClientAccessor, times(1)).getModels(any(), any(), any());
+            // No more inference for the dense model since we reuse the existing embedding for it
+            verify(mlCommonsClientAccessor, times(1)).inferenceSentences(any(), any());
+            // Still inference for the sparse model since we don't reuse the existing embedding for it
             verify(mlCommonsClientAccessor, times(2)).inferenceSentencesWithMapResult(any(), any());
         });
     }
@@ -294,6 +400,113 @@ public class SemanticFieldProcessorTests extends OpenSearchTestCase {
         org.assertj.core.api.Assertions.assertThat(ingestedDocs.get(1).getIngestDocument().getSourceAndMetadata())
             .isEqualTo(expectedIngestedDoc2);
 
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSubBatchExecute_whenValidDocsSkipExistingEmbedding_thenIngestDocsSuccessfully() throws URISyntaxException, IOException {
+        // enable reuse exist embedding
+        final Map<String, Map<String, Object>> pathToFieldConfigMap = Map.of(
+            FIELD_NAME_PRODUCTS + PATH_SEPARATOR + FIELD_NAME_PRODUCT_DESCRIPTION,
+            Map.of(TYPE, SemanticFieldMapper.CONTENT_TYPE, MODEL_ID, DUMMY_MODEL_ID_1, CHUNKING, true, SKIP_EXISTING_EMBEDDING, true),
+            FIELD_NAME_GEO_DATA,
+            Map.of(
+                TYPE,
+                SemanticFieldMapper.CONTENT_TYPE,
+                MODEL_ID,
+                DUMMY_MODEL_ID_2,
+                SPARSE_ENCODING_CONFIG,
+                Map.of(PruneUtils.PRUNE_TYPE_FIELD, PruneType.MAX_RATIO.getValue(), PruneUtils.PRUNE_RATIO_FIELD, 0.5),
+                SKIP_EXISTING_EMBEDDING,
+                true
+            )
+        );
+        semanticFieldProcessor = new SemanticFieldProcessor(
+            "tag",
+            "description",
+            1,
+            pathToFieldConfigMap,
+            mlCommonsClientAccessor,
+            environment,
+            clusterService,
+            chunker,
+            analysisRegistry,
+            openSearchClient
+        );
+        // prepare ingest doc 1
+        final Map<String, Object> ingestDocSource1 = readDocSourceFromFile("processor/semantic/ingest_doc1.json");
+        final IngestDocumentWrapper ingestDocumentWrapper1 = createIngestDocWrapper("1", ingestDocSource1);
+        // prepare ingest doc 2
+        final Map<String, Object> ingestDocSource2 = readDocSourceFromFile("processor/semantic/ingest_doc2.json");
+        final IngestDocumentWrapper ingestDocumentWrapper2 = createIngestDocWrapper("2", ingestDocSource2);
+
+        // mock handler
+        final Consumer<List<IngestDocumentWrapper>> handler = mock(Consumer.class);
+
+        mockGetModelAndInferenceAPI();
+        // first time docs not exist
+        final MultiGetResponse multiGetResponse = Mockito.mock(MultiGetResponse.class);
+        final MultiGetItemResponse multiGetItemResponse1 = Mockito.mock(MultiGetItemResponse.class);
+        final GetResponse getResponse1 = Mockito.mock(GetResponse.class);
+        final MultiGetItemResponse multiGetItemResponse2 = Mockito.mock(MultiGetItemResponse.class);
+        final GetResponse getResponse2 = Mockito.mock(GetResponse.class);
+        when(multiGetResponse.getResponses()).thenReturn(new MultiGetItemResponse[] { multiGetItemResponse1, multiGetItemResponse2 });
+        when(multiGetItemResponse1.getId()).thenReturn("1");
+        when(multiGetItemResponse1.getResponse()).thenReturn(getResponse1);
+        when(getResponse1.isExists()).thenReturn(false);
+        when(multiGetItemResponse2.getId()).thenReturn("2");
+        when(multiGetItemResponse2.getResponse()).thenReturn(getResponse2);
+        when(getResponse2.isExists()).thenReturn(false);
+        doAnswer(invocationOnMock -> {
+            final ActionListener<MultiGetResponse> listener = (ActionListener<MultiGetResponse>) invocationOnMock.getArguments()[2];
+            listener.onResponse(multiGetResponse);
+            return null;
+        }).when(openSearchClient).execute(any(), any(), any());
+
+        // Call the method
+        semanticFieldProcessor.subBatchExecute(List.of(ingestDocumentWrapper1, ingestDocumentWrapper2), handler);
+
+        // Capture the final invocation of handler.accept
+        final ArgumentCaptor<List<IngestDocumentWrapper>> handlerCaptor = ArgumentCaptor.forClass(List.class);
+        verify(handler).accept(handlerCaptor.capture());
+
+        verify(mlCommonsClientAccessor, times(1)).getModels(any(), any(), any());
+        verify(mlCommonsClientAccessor, times(1)).inferenceSentences(any(), any());
+        verify(mlCommonsClientAccessor, times(1)).inferenceSentencesWithMapResult(any(), any());
+
+        final List<IngestDocumentWrapper> ingestedDocs = handlerCaptor.getValue();
+
+        // verify
+        final Map<String, Object> expectedIngestedDoc1 = readExpectedDocFromFile("processor/semantic/ingested_doc1.json");
+        org.assertj.core.api.Assertions.assertThat(ingestedDocs.get(0).getIngestDocument().getSourceAndMetadata())
+            .isEqualTo(expectedIngestedDoc1);
+
+        final Map<String, Object> expectedIngestedDoc2 = readExpectedDocFromFile("processor/semantic/ingested_doc2.json");
+        org.assertj.core.api.Assertions.assertThat(ingestedDocs.get(1).getIngestDocument().getSourceAndMetadata())
+            .isEqualTo(expectedIngestedDoc2);
+
+        // prepare ingest doc 1 same
+        final Map<String, Object> ingestDocSource1Same = readDocSourceFromFile("processor/semantic/ingest_doc1.json");
+        final IngestDocumentWrapper ingestDocumentWrapper1Same = createIngestDocWrapper("1", ingestDocSource1Same);
+        // prepare ingest doc 2 modified
+        final Map<String, Object> ingestDocSource2Modified = readDocSourceFromFile("processor/semantic/ingest_doc2.json");
+        ingestDocSource2Modified.put("geo_data", "updated dummy_geo_data");
+        final IngestDocumentWrapper ingestDocumentWrapper2Modified = createIngestDocWrapper("2", ingestDocSource2Modified);
+
+        // second time doc exist
+        when(getResponse1.isExists()).thenReturn(true);
+        when(getResponse1.getSourceAsMap()).thenReturn(ingestedDocs.get(0).getIngestDocument().getSourceAndMetadata());
+        when(getResponse2.isExists()).thenReturn(true);
+        when(getResponse2.getSourceAsMap()).thenReturn(ingestedDocs.get(1).getIngestDocument().getSourceAndMetadata());
+
+        // Call the method
+        semanticFieldProcessor.subBatchExecute(List.of(ingestDocumentWrapper1Same, ingestDocumentWrapper2Modified), handler);
+
+        // reuse model info
+        verify(mlCommonsClientAccessor, times(1)).getModels(any(), any(), any());
+        // reuse dense embedding since the original value is not changed
+        verify(mlCommonsClientAccessor, times(1)).inferenceSentences(any(), any());
+        // generate sparse embedding again since the original value is updated
+        verify(mlCommonsClientAccessor, times(2)).inferenceSentencesWithMapResult(any(), any());
     }
 
     public void testSubBatchExecute_whenModelNotFound_thenAddExceptionToDocProperly() throws URISyntaxException, IOException {

--- a/src/test/resources/processor/semantic/SemanticIndexMappingsSkipExistingEmbedding.json
+++ b/src/test/resources/processor/semantic/SemanticIndexMappingsSkipExistingEmbedding.json
@@ -1,0 +1,22 @@
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "products":{
+        "type":"nested",
+        "properties":{
+          "id": {
+            "type": "text"
+          },
+          "product_description":{
+            "type": "semantic",
+            "model_id": "%s",
+            "skip_existing_embedding": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Support configuring reusing existing embedding for the semantic field.

Configurable reusing existing embedding

* Support a configurable parameter that controls should we reuse the exist embedding if the value of the semantic field is not changed and the exist doc has the embedding for reuse.
* Default should be false and CX should explicitly turn it on if they want to use it.

### Related Issues
Resolves #1350 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
