### PR TITLE
[Experimental] Added new query clause agentic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Features
 - [Hybrid Query] Add upper bound parameter for min-max normalization technique ([#1431](https://github.com/opensearch-project/neural-search/pull/1431))
+- [Experimental] Add agentic search query clause for agentic search
 
 ### Enhancements
 - [Semantic Field] Support configuring the auto-generated knn_vector field through the semantic field. ([#1420](https://github.com/opensearch-project/neural-search/pull/1420))

--- a/build.gradle
+++ b/build.gradle
@@ -264,6 +264,7 @@ dependencies {
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     // ml-common excluded reflection for runtime so we need to add it by ourselves.
     // https://github.com/opensearch-project/ml-commons/commit/464bfe34c66d7a729a00dd457f03587ea4e504d9
     // TODO: Remove following three lines of dependencies if ml-common include them in their jar
@@ -271,7 +272,6 @@ dependencies {
     runtimeOnly group: 'org.javassist', name: 'javassist', version: '3.29.2-GA'
     runtimeOnly group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
     runtimeOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
-    runtimeOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     runtimeOnly group: 'org.json', name: 'json', version: '20231013'
     // json-path 2.9.0 depends on slf4j 2.0.11, which conflicts with the version used by OpenSearch core.
     // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.

--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -247,8 +247,7 @@ public class MLCommonsClientAccessor {
             );
         }
         List<ModelTensor> tensorList = tensorOutputList.get(0).getMlModelTensors();
-        String result = tensorList.get(0).getResult();
-        return result;
+        return tensorList.get(0).getResult();
     }
 
     private <T extends Number> List<T> buildSingleVectorFromResponse(final MLOutput mlOutput) {
@@ -341,7 +340,7 @@ public class MLCommonsClientAccessor {
      * It will fail if any one of the get model request fail. Only return the success result if all model info is
      * successfully retrieved.
      *
-     * @param modelIds  a set of model ids
+     * @param modelIds a set of model ids
      * @param onSuccess onSuccess consumer
      * @param onFailure onFailure consumer
      */
@@ -451,7 +450,7 @@ public class MLCommonsClientAccessor {
      * This method will highlight relevant sentences in the context based on the question.
      *
      * @param inferenceRequest the request containing the question and context for highlighting
-     * @param listener         the listener to be called with the highlighting results
+     * @param listener the listener to be called with the highlighting results
      */
     public void inferenceSentenceHighlighting(
         @NonNull final SentenceHighlightingRequest inferenceRequest,
@@ -488,7 +487,6 @@ public class MLCommonsClientAccessor {
                 // Extract DSL query from inference results following the structure:
                 MLOutput mlOutput = (MLOutput) response.getOutput();
                 final String inferenceResults = buildQueryResultFromResponseOfOutput(mlOutput);
-                ;
 
                 listener.onResponse(inferenceResults);
             } catch (Exception e) {

--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -57,9 +57,9 @@ public class MLCommonsClientAccessor {
      * Wrapper around {@link #inferenceSentences} that expected a single input text and produces a single floating
      * point vector as a response.
      *
-     * @param modelId {@link String}
+     * @param modelId   {@link String}
      * @param inputText {@link String}
-     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out
+     * @param listener  {@link ActionListener} which will be called when prediction is completed or errored out
      */
     public void inferenceSentence(
         @NonNull final String modelId,
@@ -92,7 +92,7 @@ public class MLCommonsClientAccessor {
      * need to run only TextEmbedding tasks only.
      *
      * @param inferenceRequest {@link InferenceRequest}
-     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out.
+     * @param listener         {@link ActionListener} which will be called when prediction is completed or errored out.
      */
     public void inferenceSentences(
         @NonNull final TextInferenceRequest inferenceRequest,
@@ -114,7 +114,7 @@ public class MLCommonsClientAccessor {
      * using the actionListener which will have a list of floats in the order of inputText.
      *
      * @param inferenceRequest {@link InferenceRequest}
-     * @param listener {@link ActionListener} which will be called when prediction is completed or errored out.
+     * @param listener         {@link ActionListener} which will be called when prediction is completed or errored out.
      */
     public void inferenceSentencesMap(@NonNull MapInferenceRequest inferenceRequest, @NonNull final ActionListener<List<Number>> listener) {
         retryableInferenceSentencesWithSingleVectorResult(inferenceRequest, 0, listener);
@@ -126,7 +126,7 @@ public class MLCommonsClientAccessor {
      * the similarity scores of the texts w.r.t. the query text, in the order of the input texts.
      *
      * @param inferenceRequest {@link InferenceRequest}
-     * @param listener {@link ActionListener} receives the result of the inference
+     * @param listener         {@link ActionListener} receives the result of the inference
      */
     public void inferenceSimilarity(
         @NonNull SimilarityInferenceRequest inferenceRequest,
@@ -325,7 +325,8 @@ public class MLCommonsClientAccessor {
      * Get model info for multiple model ids. It will send multiple getModel requests to get the model info in parallel.
      * It will fail if any one of the get model request fail. Only return the success result if all model info is
      * successfully retrieved.
-     * @param modelIds a set of model ids
+     *
+     * @param modelIds  a set of model ids
      * @param onSuccess onSuccess consumer
      * @param onFailure onFailure consumer
      */
@@ -435,7 +436,7 @@ public class MLCommonsClientAccessor {
      * This method will highlight relevant sentences in the context based on the question.
      *
      * @param inferenceRequest the request containing the question and context for highlighting
-     * @param listener the listener to be called with the highlighting results
+     * @param listener         the listener to be called with the highlighting results
      */
     public void inferenceSentenceHighlighting(
         @NonNull final SentenceHighlightingRequest inferenceRequest,
@@ -443,4 +444,40 @@ public class MLCommonsClientAccessor {
     ) {
         retryableInferenceSentenceHighlighting(inferenceRequest, 0, listener);
     }
+
+    /**
+     * Execute agent with provided parameters and return DSL query string.
+     *
+     * @param agentId    the agent ID to execute
+     * @param parameters the parameters to pass to the agent
+     * @param listener   the listener to be called with the DSL query result
+     */
+    //TODO add execute Agent
+    /*public void executeAgent(
+        @NonNull final String agentId,
+        @NonNull final Map<String, String> parameters,
+        @NonNull final ActionListener<String> listener
+    ) {
+        retryableExecuteAgent(agentId, parameters, 0, listener);
+    }
+
+    private void retryableExecuteAgent(
+        final String agentId,
+        final Map<String, String> parameters,
+        final int retryTime,
+        final ActionListener<String> listener
+    ) {
+        mlClient.executeAgent(agentId, "POST", parameters, ActionListener.wrap(response -> {
+            // Extract DSL query from inference results
+            String dslQuery = response.getInferenceResults().get(0).get("output").get(0).get("result");
+            listener.onResponse(dslQuery);
+        },
+            e -> RetryUtil.handleRetryOrFailure(
+                e,
+                retryTime,
+                () -> retryableExecuteAgent(agentId, parameters, retryTime + 1, listener),
+                listener
+            )
+        ));
+    }*/
 }

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -22,6 +22,11 @@ import org.opensearch.neuralsearch.highlight.SemanticHighlighterEngine;
 import org.opensearch.neuralsearch.highlight.extractor.QueryTextExtractorRegistry;
 import com.google.common.collect.ImmutableList;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralKNNQueryBuilder;
+import org.opensearch.neuralsearch.query.AgenticSearchQueryBuilder;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettingsAccessor;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
 import org.opensearch.neuralsearch.stats.info.InfoStatsManager;
@@ -71,10 +76,6 @@ import org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFacto
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
 import org.opensearch.neuralsearch.processor.rerank.RerankProcessor;
-import org.opensearch.neuralsearch.query.HybridQueryBuilder;
-import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
-import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
-import org.opensearch.neuralsearch.query.NeuralKNNQueryBuilder;
 import org.opensearch.neuralsearch.query.ext.RerankSearchExtBuilder;
 import org.opensearch.neuralsearch.rest.RestNeuralStatsAction;
 import org.opensearch.neuralsearch.search.query.HybridQueryPhaseSearcher;
@@ -148,6 +149,7 @@ public class NeuralSearch extends Plugin
         NeuralSearchClusterUtil.instance().initialize(clusterService, indexNameExpressionResolver);
         NeuralQueryBuilder.initialize(clientAccessor);
         NeuralSparseQueryBuilder.initialize(clientAccessor);
+        AgenticSearchQueryBuilder.initialize(clientAccessor);
         QueryTextExtractorRegistry queryTextExtractorRegistry = new QueryTextExtractorRegistry();
         SemanticHighlighterEngine semanticHighlighterEngine = SemanticHighlighterEngine.builder()
             .mlCommonsClient(clientAccessor)
@@ -170,7 +172,8 @@ public class NeuralSearch extends Plugin
             new QuerySpec<>(NeuralQueryBuilder.NAME, NeuralQueryBuilder::new, NeuralQueryBuilder::fromXContent),
             new QuerySpec<>(HybridQueryBuilder.NAME, HybridQueryBuilder::new, HybridQueryBuilder::fromXContent),
             new QuerySpec<>(NeuralSparseQueryBuilder.NAME, NeuralSparseQueryBuilder::new, NeuralSparseQueryBuilder::fromXContent),
-            new QuerySpec<>(NeuralKNNQueryBuilder.NAME, NeuralKNNQueryBuilder::new, NeuralKNNQueryBuilder::fromXContent)
+            new QuerySpec<>(NeuralKNNQueryBuilder.NAME, NeuralKNNQueryBuilder::new, NeuralKNNQueryBuilder::fromXContent),
+            new QuerySpec<>(AgenticSearchQueryBuilder.NAME, AgenticSearchQueryBuilder::new, AgenticSearchQueryBuilder::fromXContent)
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.lucene.search.Query;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.WithFieldName;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryRewriteContext;
+import org.opensearch.index.query.QueryCoordinatorContext;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import java.util.concurrent.CompletableFuture;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * AgenticSearchQueryBuilder is responsible for agentic_search query type. It executes a root agent to extract the DSL query and parse it to innerQueryBuilder for parsing.
+ */
+@Accessors(chain = true, fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter(AccessLevel.PACKAGE)
+@Setter(AccessLevel.PACKAGE)
+public final class AgenticSearchQueryBuilder extends AbstractQueryBuilder<AgenticSearchQueryBuilder> implements WithFieldName {
+
+    public static final String NAME = "agentic_search";
+    static final ParseField QUERY_TEXT_FIELD = new ParseField("query_text");
+    static final ParseField AGENT_ID = new ParseField("agent_id");
+    static final ParseField QUERY_FIELDS = new ParseField("query_fields");
+
+    private String queryText;
+    private String agentId;
+    private List<String> queryFields;
+
+    // client to invoke ml-common APIs
+    private static MLCommonsClientAccessor ML_CLIENT;
+
+    public static void initialize(MLCommonsClientAccessor mlClient) {
+        AgenticSearchQueryBuilder.ML_CLIENT = mlClient;
+    }
+
+    // For testing purposes
+    static void resetMLClient() {
+        AgenticSearchQueryBuilder.ML_CLIENT = null;
+    }
+
+    public AgenticSearchQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.queryText = in.readString();
+        this.agentId = in.readString();
+        this.queryFields = in.readOptionalStringList();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(this.queryText);
+        out.writeString(this.agentId);
+        out.writeOptionalStringCollection(this.queryFields);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+        xContentBuilder.startObject(NAME);
+        xContentBuilder.field(QUERY_TEXT_FIELD.getPreferredName(), queryText);
+        xContentBuilder.field(AGENT_ID.getPreferredName(), agentId);
+        if (queryFields != null && !queryFields.isEmpty()) {
+            xContentBuilder.field(QUERY_FIELDS.getPreferredName(), queryFields);
+        }
+        xContentBuilder.endObject();
+    }
+
+    /**
+     * Creates AgenticSearchQueryBuilder from XContent.
+     * The expected parsing form looks like:
+     * {
+     *  "agentic_search": {
+     *    "query_text": "string",
+     *    "agent_id": "string",
+     *    "query_fields": ["string", "string"..]
+     *    }
+     * }
+     *
+     */
+
+    public static AgenticSearchQueryBuilder fromXContent(XContentParser parser) throws IOException {
+        AgenticSearchQueryBuilder agenticSearchQueryBuilder = new AgenticSearchQueryBuilder();
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (QUERY_TEXT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    agenticSearchQueryBuilder.queryText = parser.text();
+                } else if (AGENT_ID.match(currentFieldName, parser.getDeprecationHandler())) {
+                    agenticSearchQueryBuilder.agentId = parser.text();
+                } else {
+                    throw new ParsingException(parser.getTokenLocation(), "Unknown field [" + currentFieldName + "]");
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (QUERY_FIELDS.match(currentFieldName, parser.getDeprecationHandler())) {
+                    List<String> fieldsList = new ArrayList<>();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        fieldsList.add(parser.text());
+                    }
+                    agenticSearchQueryBuilder.queryFields = fieldsList;
+                } else {
+                    throw new ParsingException(parser.getTokenLocation(), "Unknown field [" + currentFieldName + "]");
+                }
+            }
+        }
+        return agenticSearchQueryBuilder;
+    }
+
+    @Override
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        if (ML_CLIENT == null) {
+            throw new IllegalStateException("ML client not initialized");
+        }
+
+        if (!(queryRewriteContext instanceof QueryCoordinatorContext)) {
+            throw new IllegalStateException(
+                "Agentic query must be rewritten at the coordinator node. Rewriting at shard level is not supported."
+            );
+        }
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        // TODO Integrate execute agent API
+        /*ML_CLIENT.inferenceSentences(agentId, List.of(queryText), ActionListener.wrap(
+            response -> {
+                String dslQuery = response.getInferenceResults().get(0).getOutput().get(0).getResult();
+                future.complete(dslQuery);
+            },
+            future::completeExceptionally
+        ));*/
+
+        try {
+            // String dslQueryString = future.get();
+            String dslQueryString = "{\n"
+                + "                    \"match\": {\n"
+                + "                        \"passage_text\": {\n"
+                + "                            \"query\": \"science\"\n"
+                + "                        }\n"
+                + "                    }\n"
+                + "                }";
+            XContentParser parser = XContentType.JSON.xContent()
+                .createParser(queryRewriteContext.getXContentRegistry(), LoggingDeprecationHandler.INSTANCE, dslQueryString);
+            return parseInnerQueryBuilder(parser);
+        } catch (Exception e) {
+            throw new IOException("Failed to execute agentic search", e);
+        }
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        throw new IllegalStateException("Agentic search query must be rewritten first");
+    }
+
+    @Override
+    protected boolean doEquals(AgenticSearchQueryBuilder obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        EqualsBuilder equalsBuilder = new EqualsBuilder();
+        equalsBuilder.append(queryText, obj.queryText);
+        equalsBuilder.append(agentId, obj.agentId);
+        equalsBuilder.append(queryFields, obj.queryFields);
+        return equalsBuilder.isEquals();
+    }
+
+    @Override
+    protected int doHashCode() {
+        return new HashCodeBuilder().append(queryText).append(agentId).append(queryFields).toHashCode();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public String fieldName() {
+        return NAME;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java
@@ -162,11 +162,26 @@ public final class AgenticSearchQueryBuilder extends AbstractQueryBuilder<Agenti
             );
         }
 
+        QueryCoordinatorContext coordinatorContext = (QueryCoordinatorContext) queryRewriteContext;
+        // TODO Get index mapping from shard context
+        /*String indexMapping = null;
+        try {
+            QueryShardContext shardContext = coordinatorContext.convertToShardContext();
+            XContentBuilder mappingBuilder = XContentBuilder.builder(XContentType.JSON.xContent());
+            shardContext.getMapperService().documentMapper().mapping().toXContent(mappingBuilder, null);
+            indexMapping = mappingBuilder.toString();
+        } catch (Exception e) {
+            throw new IOException("Failed to extract index mapping", e);
+        }*/
+
         CompletableFuture<String> future = new CompletableFuture<>();
-        // TODO Integrate execute agent API
-        /*ML_CLIENT.inferenceSentences(agentId, List.of(queryText), ActionListener.wrap(
+        // TODO Integrate execute agent API with index mapping
+        /*ML_CLIENT.executeAgent(agentId, Map.of(
+            "query_text", queryText,
+            "index_mapping", indexMapping
+        ), ActionListener.wrap(
             response -> {
-                String dslQuery = response.getInferenceResults().get(0).getOutput().get(0).getResult();
+                String dslQuery = response.getResult();
                 future.complete(dslQuery);
             },
             future::completeExceptionally

--- a/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java
@@ -29,6 +29,8 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import java.io.IOException;
@@ -83,9 +85,13 @@ public final class AgenticSearchQueryBuilder extends AbstractQueryBuilder<Agenti
     @Override
     protected void doXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
         xContentBuilder.startObject(NAME);
-        xContentBuilder.field(QUERY_TEXT_FIELD.getPreferredName(), queryText);
-        xContentBuilder.field(AGENT_ID.getPreferredName(), agentId);
-        if (queryFields != null && !queryFields.isEmpty()) {
+        if (Objects.nonNull(QUERY_TEXT_FIELD)) {
+            xContentBuilder.field(QUERY_TEXT_FIELD.getPreferredName(), queryText);
+        }
+        if (Objects.nonNull(AGENT_ID)) {
+            xContentBuilder.field(AGENT_ID.getPreferredName(), agentId);
+        }
+        if (Objects.nonNull(queryFields) && !queryFields.isEmpty()) {
             xContentBuilder.field(QUERY_FIELDS.getPreferredName(), queryFields);
         }
         xContentBuilder.endObject();
@@ -132,6 +138,15 @@ public final class AgenticSearchQueryBuilder extends AbstractQueryBuilder<Agenti
                 }
             }
         }
+
+        // Validate mandatory fields
+        if (agenticSearchQueryBuilder.queryText == null || agenticSearchQueryBuilder.queryText.trim().isEmpty()) {
+            throw new ParsingException(parser.getTokenLocation(), "[" + QUERY_TEXT_FIELD.getPreferredName() + "] is required");
+        }
+        if (agenticSearchQueryBuilder.agentId == null || agenticSearchQueryBuilder.agentId.trim().isEmpty()) {
+            throw new ParsingException(parser.getTokenLocation(), "[" + AGENT_ID.getPreferredName() + "] is required");
+        }
+
         return agenticSearchQueryBuilder;
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
@@ -80,7 +80,8 @@ public class NeuralSearchClusterUtil {
             }
         } catch (Exception e) {
             log.warn("Failed to extract index mapping", e);
+            throw new IllegalStateException("Failed to extract index mapping", e);
         }
-        return "{}";
+        throw new IllegalStateException("No valid index found to extract mapping");
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
@@ -15,9 +15,11 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.core.index.Index;
+import org.opensearch.index.query.QueryCoordinatorContext;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -64,5 +66,21 @@ public class NeuralSearchClusterUtil {
         return Arrays.stream(concreteIndices)
             .map(concreteIndex -> clusterService.state().metadata().index(concreteIndex))
             .collect(Collectors.toList());
+    }
+
+    public String getIndexMapping(QueryCoordinatorContext coordinatorContext) {
+        try {
+            String[] indices = coordinatorContext.getSearchRequest().indices();
+
+            if (indices != null && indices.length > 0) {
+                IndexMetadata indexMetadata = clusterService.state().metadata().index(indices[0]);
+                if (indexMetadata != null) {
+                    return Objects.requireNonNull(indexMetadata.mapping()).source().toString();
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to extract index mapping", e);
+        }
+        return "{}";
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
@@ -161,4 +161,44 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
         AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder();
         assertEquals("Field name should match", "agentic_search", queryBuilder.fieldName());
     }
+
+    public void testFromXContent_missingQueryText() throws IOException {
+        String json = "{\n" + "  \"agent_id\": \"" + AGENT_ID + "\"\n" + "}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry(), null, json);
+        parser.nextToken();
+
+        Exception exception = expectThrows(Exception.class, () -> AgenticSearchQueryBuilder.fromXContent(parser));
+        assertTrue(exception.getMessage().contains("query_text") && exception.getMessage().contains("required"));
+    }
+
+    public void testFromXContent_missingAgentId() throws IOException {
+        String json = "{\n" + "  \"query_text\": \"" + QUERY_TEXT + "\"\n" + "}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry(), null, json);
+        parser.nextToken();
+
+        Exception exception = expectThrows(Exception.class, () -> AgenticSearchQueryBuilder.fromXContent(parser));
+        assertTrue(exception.getMessage().contains("agent_id") && exception.getMessage().contains("required"));
+    }
+
+    public void testFromXContent_emptyQueryText() throws IOException {
+        String json = "{\n" + "  \"query_text\": \"\",\n" + "  \"agent_id\": \"" + AGENT_ID + "\"\n" + "}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry(), null, json);
+        parser.nextToken();
+
+        Exception exception = expectThrows(Exception.class, () -> AgenticSearchQueryBuilder.fromXContent(parser));
+        assertTrue(exception.getMessage().contains("query_text") && exception.getMessage().contains("required"));
+    }
+
+    public void testFromXContent_emptyAgentId() throws IOException {
+        String json = "{\n" + "  \"query_text\": \"" + QUERY_TEXT + "\",\n" + "  \"agent_id\": \"\"\n" + "}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry(), null, json);
+        parser.nextToken();
+
+        Exception exception = expectThrows(Exception.class, () -> AgenticSearchQueryBuilder.fromXContent(parser));
+        assertTrue(exception.getMessage().contains("agent_id") && exception.getMessage().contains("required"));
+    }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
@@ -54,7 +54,7 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
         assertNotNull("Query builder should not be null", queryBuilder);
         assertEquals("Query text should match", QUERY_TEXT, queryBuilder.queryText());
         assertEquals("Agent ID should match", AGENT_ID, queryBuilder.agentId());
-        assertEquals("Writable name should match", "agentic_search", queryBuilder.getWriteableName());
+        assertEquals("Writable name should match", "agentic", queryBuilder.getWriteableName());
     }
 
     public void testBuilder_withAllFields() {
@@ -182,7 +182,7 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
 
     public void testFieldName() {
         AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder();
-        assertEquals("agentic_search", queryBuilder.fieldName());
+        assertEquals("agentic", queryBuilder.fieldName());
     }
 
     public void testFromXContent_missingQueryText() throws IOException {
@@ -280,7 +280,32 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
         MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
         AgenticSearchQueryBuilder.initialize(mockMLClient);
 
+        // Mock cluster service and related components
+        ClusterService mockClusterService = mock(ClusterService.class);
+        ClusterState mockClusterState = mock(ClusterState.class);
+        Metadata mockMetadata = mock(Metadata.class);
+        IndexMetadata mockIndexMetadata = mock(IndexMetadata.class);
+        MappingMetadata mockMappingMetadata = mock(MappingMetadata.class);
+
+        when(mockClusterService.state()).thenReturn(mockClusterState);
+        when(mockClusterState.metadata()).thenReturn(mockMetadata);
+        when(mockMetadata.index("test-index")).thenReturn(mockIndexMetadata);
+        when(mockIndexMetadata.mapping()).thenReturn(mockMappingMetadata);
+        when(mockMappingMetadata.source()).thenReturn(new org.opensearch.common.compress.CompressedXContent("{\"properties\":{}}"));
+
+        // Initialize NeuralSearchClusterUtil with mocked cluster service
+        NeuralSearchClusterUtil.instance().initialize(mockClusterService, null);
+
         QueryCoordinatorContext mockContext = mock(QueryCoordinatorContext.class);
+        SearchRequest mockSearchRequest = mock(SearchRequest.class);
+
+        // Mock the coordinator context to return a search request with indices
+        when(mockContext.getSearchRequest()).thenReturn(mockSearchRequest);
+        when(mockSearchRequest.indices()).thenReturn(new String[] { "test-index" });
+        // Create proper XContentRegistry with QueryBuilder parsers
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, java.util.Collections.emptyList());
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+        when(mockContext.getXContentRegistry()).thenReturn(namedXContentRegistry);
 
         AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
 
@@ -299,7 +324,32 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
         MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
         AgenticSearchQueryBuilder.initialize(mockMLClient);
 
+        // Mock cluster service and related components
+        ClusterService mockClusterService = mock(ClusterService.class);
+        ClusterState mockClusterState = mock(ClusterState.class);
+        Metadata mockMetadata = mock(Metadata.class);
+        IndexMetadata mockIndexMetadata = mock(IndexMetadata.class);
+        MappingMetadata mockMappingMetadata = mock(MappingMetadata.class);
+
+        when(mockClusterService.state()).thenReturn(mockClusterState);
+        when(mockClusterState.metadata()).thenReturn(mockMetadata);
+        when(mockMetadata.index("test-index")).thenReturn(mockIndexMetadata);
+        when(mockIndexMetadata.mapping()).thenReturn(mockMappingMetadata);
+        when(mockMappingMetadata.source()).thenReturn(new org.opensearch.common.compress.CompressedXContent("{\"properties\":{}}"));
+
+        // Initialize NeuralSearchClusterUtil with mocked cluster service
+        NeuralSearchClusterUtil.instance().initialize(mockClusterService, null);
+
         QueryCoordinatorContext mockContext = mock(QueryCoordinatorContext.class);
+        SearchRequest mockSearchRequest = mock(SearchRequest.class);
+
+        // Mock the coordinator context to return a search request with indices
+        when(mockContext.getSearchRequest()).thenReturn(mockSearchRequest);
+        when(mockSearchRequest.indices()).thenReturn(new String[] { "test-index" });
+        // Create proper XContentRegistry with QueryBuilder parsers
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, java.util.Collections.emptyList());
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+        when(mockContext.getXContentRegistry()).thenReturn(namedXContentRegistry);
 
         AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
 
@@ -318,7 +368,32 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
         MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
         AgenticSearchQueryBuilder.initialize(mockMLClient);
 
+        // Mock cluster service and related components
+        ClusterService mockClusterService = mock(ClusterService.class);
+        ClusterState mockClusterState = mock(ClusterState.class);
+        Metadata mockMetadata = mock(Metadata.class);
+        IndexMetadata mockIndexMetadata = mock(IndexMetadata.class);
+        MappingMetadata mockMappingMetadata = mock(MappingMetadata.class);
+
+        when(mockClusterService.state()).thenReturn(mockClusterState);
+        when(mockClusterState.metadata()).thenReturn(mockMetadata);
+        when(mockMetadata.index("test-index")).thenReturn(mockIndexMetadata);
+        when(mockIndexMetadata.mapping()).thenReturn(mockMappingMetadata);
+        when(mockMappingMetadata.source()).thenReturn(new org.opensearch.common.compress.CompressedXContent("{\"properties\":{}}"));
+
+        // Initialize NeuralSearchClusterUtil with mocked cluster service
+        NeuralSearchClusterUtil.instance().initialize(mockClusterService, null);
+
         QueryCoordinatorContext mockContext = mock(QueryCoordinatorContext.class);
+        SearchRequest mockSearchRequest = mock(SearchRequest.class);
+
+        // Mock the coordinator context to return a search request with indices
+        when(mockContext.getSearchRequest()).thenReturn(mockSearchRequest);
+        when(mockSearchRequest.indices()).thenReturn(new String[] { "test-index" });
+        // Create proper XContentRegistry with QueryBuilder parsers
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, java.util.Collections.emptyList());
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+        when(mockContext.getXContentRegistry()).thenReturn(namedXContentRegistry);
 
         AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
 

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
@@ -4,26 +4,49 @@
  */
 package org.opensearch.neuralsearch.query;
 
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryCoordinatorContext;
+import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.search.SearchModule;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.common.settings.Settings;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Arrays;
 
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 
 public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
 
     private static final String QUERY_TEXT = "Find me red car";
     private static final String AGENT_ID = "test-agent";
     private static final List<String> QUERY_FIELDS = Arrays.asList("title", "description");
+    MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
 
     public void testBuilder_withRequiredFields() {
         AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
@@ -200,5 +223,131 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
 
         Exception exception = expectThrows(Exception.class, () -> AgenticSearchQueryBuilder.fromXContent(parser));
         assertTrue(exception.getMessage().contains("agent_id") && exception.getMessage().contains("required"));
+    }
+
+    public void testDoRewrite_success() throws IOException {
+        MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
+        AgenticSearchQueryBuilder.initialize(mockMLClient);
+
+        // Mock cluster service and related components
+        ClusterService mockClusterService = mock(ClusterService.class);
+        ClusterState mockClusterState = mock(ClusterState.class);
+        Metadata mockMetadata = mock(Metadata.class);
+        IndexMetadata mockIndexMetadata = mock(IndexMetadata.class);
+        MappingMetadata mockMappingMetadata = mock(MappingMetadata.class);
+
+        when(mockClusterService.state()).thenReturn(mockClusterState);
+        when(mockClusterState.metadata()).thenReturn(mockMetadata);
+        when(mockMetadata.index("test-index")).thenReturn(mockIndexMetadata);
+        when(mockIndexMetadata.mapping()).thenReturn(mockMappingMetadata);
+        when(mockMappingMetadata.source()).thenReturn(new org.opensearch.common.compress.CompressedXContent("{\"properties\":{}}"));
+
+        // Initialize NeuralSearchClusterUtil with mocked cluster service
+        NeuralSearchClusterUtil.instance().initialize(mockClusterService, null);
+
+        QueryCoordinatorContext mockContext = mock(QueryCoordinatorContext.class);
+        SearchRequest mockSearchRequest = mock(SearchRequest.class);
+
+        // Mock the coordinator context to return a search request with indices
+        when(mockContext.getSearchRequest()).thenReturn(mockSearchRequest);
+        when(mockSearchRequest.indices()).thenReturn(new String[] { "test-index" });
+        // Create proper XContentRegistry with QueryBuilder parsers
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, java.util.Collections.emptyList());
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
+        when(mockContext.getXContentRegistry()).thenReturn(namedXContentRegistry);
+
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT)
+            .agentId(AGENT_ID)
+            .queryFields(QUERY_FIELDS);
+
+        // Mock the agent to return a valid query response
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(2);
+            listener.onResponse("{\"query\": {\"match\": {\"title\": \"red car\"}}}");
+            return null;
+        }).when(mockMLClient).executeAgent(anyString(), anyMap(), any(ActionListener.class));
+
+        QueryBuilder result = queryBuilder.doRewrite(mockContext);
+
+        assertNotNull("Rewritten query should not be null", result);
+        assertTrue("Should return a MatchQueryBuilder", result instanceof MatchQueryBuilder);
+
+        // Verify that the agent was called with correct parameters
+        verify(mockMLClient).executeAgent(anyString(), anyMap(), any(ActionListener.class));
+    }
+
+    public void testDoRewrite_withMalformedAgentResponse() throws IOException {
+        MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
+        AgenticSearchQueryBuilder.initialize(mockMLClient);
+
+        QueryCoordinatorContext mockContext = mock(QueryCoordinatorContext.class);
+
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        // Mock the agent to return malformed JSON
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(2);
+            listener.onResponse("{ malformed json }");
+            return null;
+        }).when(mockMLClient).executeAgent(anyString(), anyMap(), any(ActionListener.class));
+
+        IOException exception = expectThrows(IOException.class, () -> queryBuilder.doRewrite(mockContext));
+        assertTrue(exception.getMessage().contains("Failed to execute agentic search"));
+    }
+
+    public void testDoRewrite_withAgentFailure() throws IOException {
+        MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
+        AgenticSearchQueryBuilder.initialize(mockMLClient);
+
+        QueryCoordinatorContext mockContext = mock(QueryCoordinatorContext.class);
+
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        // Mock the agent to return failure
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(2);
+            listener.onFailure(new RuntimeException("Agent execution failed"));
+            return null;
+        }).when(mockMLClient).executeAgent(anyString(), anyMap(), any(ActionListener.class));
+
+        IOException exception = expectThrows(IOException.class, () -> queryBuilder.doRewrite(mockContext));
+        assertTrue(exception.getMessage().contains("Failed to execute agentic search"));
+    }
+
+    public void testDoRewrite_withMissingQueryField() throws IOException {
+        MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
+        AgenticSearchQueryBuilder.initialize(mockMLClient);
+
+        QueryCoordinatorContext mockContext = mock(QueryCoordinatorContext.class);
+
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        // Mock the agent to return response without "query" field
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(2);
+            listener.onResponse("{\"result\": {\"match\": {\"field\": \"value\"}}}");
+            return null;
+        }).when(mockMLClient).executeAgent(anyString(), anyMap(), any(ActionListener.class));
+
+        IOException exception = expectThrows(IOException.class, () -> queryBuilder.doRewrite(mockContext));
+        assertTrue(exception.getMessage().contains("Failed to execute agentic search"));
+    }
+
+    public void testDoRewrite_idempotentCheck() throws IOException {
+        MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
+        AgenticSearchQueryBuilder.initialize(mockMLClient);
+
+        QueryCoordinatorContext mockContext = mock(QueryCoordinatorContext.class);
+
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        // Set a rewritten query to test idempotent behavior
+        queryBuilder.rewrittenQuery(mock(MatchQueryBuilder.class));
+
+        // Should return the cached rewritten query without calling ML client
+        QueryBuilder result = queryBuilder.doRewrite(mockContext);
+
+        assertNotNull(result);
+        verify(mockMLClient, never()).executeAgent(anyString(), anyMap(), any(ActionListener.class));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
@@ -127,8 +127,8 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
             .agentId(AGENT_ID)
             .queryFields(QUERY_FIELDS);
 
-        assertEquals("Identical builders should be equal", builder1, builder2);
-        assertEquals("Identical builders should have same hash code", builder1.hashCode(), builder2.hashCode());
+        assertEquals(builder1, builder2);
+        assertEquals(builder1.hashCode(), builder2.hashCode());
     }
 
     public void testNotEquals() {
@@ -136,8 +136,8 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
 
         AgenticSearchQueryBuilder builder2 = new AgenticSearchQueryBuilder().queryText("different query").agentId(AGENT_ID);
 
-        assertNotEquals("Different builders should not be equal", builder1, builder2);
-        assertNotEquals("Different builders should have different hash codes", builder1.hashCode(), builder2.hashCode());
+        assertNotEquals(builder1, builder2);
+        assertNotEquals(builder1.hashCode(), builder2.hashCode());
     }
 
     public void testSerialization() throws IOException {
@@ -151,15 +151,15 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
         StreamInput input = output.bytes().streamInput();
         AgenticSearchQueryBuilder deserialized = new AgenticSearchQueryBuilder(input);
 
-        assertEquals("Deserialized query should equal original", original, deserialized);
-        assertEquals("Query text should match", QUERY_TEXT, deserialized.queryText());
-        assertEquals("Agent ID should match", AGENT_ID, deserialized.agentId());
-        assertEquals("Fields should match", QUERY_FIELDS, deserialized.queryFields());
+        assertEquals(original, deserialized);
+        assertEquals(QUERY_TEXT, deserialized.queryText());
+        assertEquals(AGENT_ID, deserialized.agentId());
+        assertEquals(QUERY_FIELDS, deserialized.queryFields());
     }
 
     public void testFieldName() {
         AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder();
-        assertEquals("Field name should match", "agentic_search", queryBuilder.fieldName());
+        assertEquals("agentic_search", queryBuilder.fieldName());
     }
 
     public void testFromXContent_missingQueryText() throws IOException {

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.QueryRewriteContext;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.mock;
+
+public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
+
+    private static final String QUERY_TEXT = "Find me red car";
+    private static final String AGENT_ID = "test-agent";
+    private static final List<String> QUERY_FIELDS = Arrays.asList("title", "description");
+
+    public void testBuilder_withRequiredFields() {
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        assertNotNull("Query builder should not be null", queryBuilder);
+        assertEquals("Query text should match", QUERY_TEXT, queryBuilder.queryText());
+        assertEquals("Agent ID should match", AGENT_ID, queryBuilder.agentId());
+        assertEquals("Writable name should match", "agentic_search", queryBuilder.getWriteableName());
+    }
+
+    public void testBuilder_withAllFields() {
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT)
+            .agentId(AGENT_ID)
+            .queryFields(QUERY_FIELDS);
+
+        assertNotNull("Query builder should not be null", queryBuilder);
+        assertEquals("Query text should match", QUERY_TEXT, queryBuilder.queryText());
+        assertEquals("Agent ID should match", AGENT_ID, queryBuilder.agentId());
+        assertEquals("Fields should match", QUERY_FIELDS, queryBuilder.queryFields());
+    }
+
+    public void testFromXContent_withRequiredFields() throws IOException {
+        String json = "{\n" + "  \"query_text\": \"" + QUERY_TEXT + "\",\n" + "  \"agent_id\": \"" + AGENT_ID + "\"\n" + "}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry(), null, json);
+        parser.nextToken();
+
+        AgenticSearchQueryBuilder queryBuilder = AgenticSearchQueryBuilder.fromXContent(parser);
+
+        assertNotNull("Query builder should not be null", queryBuilder);
+        assertEquals("Query text should match", QUERY_TEXT, queryBuilder.queryText());
+        assertEquals("Agent ID should match", AGENT_ID, queryBuilder.agentId());
+    }
+
+    public void testFromXContent_withAllFields() throws IOException {
+        String json = "{\n"
+            + "  \"query_text\": \""
+            + QUERY_TEXT
+            + "\",\n"
+            + "  \"agent_id\": \""
+            + AGENT_ID
+            + "\",\n"
+            + "  \"query_fields\": [\"title\", \"description\"]\n"
+            + "}";
+
+        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry(), null, json);
+        parser.nextToken();
+
+        AgenticSearchQueryBuilder queryBuilder = AgenticSearchQueryBuilder.fromXContent(parser);
+
+        assertNotNull("Query builder should not be null", queryBuilder);
+        assertEquals("Query text should match", QUERY_TEXT, queryBuilder.queryText());
+        assertEquals("Agent ID should match", AGENT_ID, queryBuilder.agentId());
+        assertEquals("Fields should match", QUERY_FIELDS, queryBuilder.queryFields());
+    }
+
+    public void testDoToQuery_throwsException() {
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        QueryShardContext mockContext = mock(QueryShardContext.class);
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> queryBuilder.doToQuery(mockContext));
+
+        assertEquals("Exception message should match", "Agentic search query must be rewritten first", exception.getMessage());
+    }
+
+    public void testDoRewrite_withoutMLClient() {
+        AgenticSearchQueryBuilder.resetMLClient();
+
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        QueryRewriteContext mockContext = mock(QueryRewriteContext.class);
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> queryBuilder.doRewrite(mockContext));
+
+        assertEquals("Exception message should match", "ML client not initialized", exception.getMessage());
+    }
+
+    public void testDoRewrite_withNonCoordinatorContext() {
+        AgenticSearchQueryBuilder.initialize(mock(MLCommonsClientAccessor.class));
+
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        QueryRewriteContext mockContext = mock(QueryRewriteContext.class);
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> queryBuilder.doRewrite(mockContext));
+
+        assertEquals(
+            "Exception message should match",
+            "Agentic query must be rewritten at the coordinator node. Rewriting at shard level is not supported.",
+            exception.getMessage()
+        );
+    }
+
+    public void testEquals() {
+        AgenticSearchQueryBuilder builder1 = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT)
+            .agentId(AGENT_ID)
+            .queryFields(QUERY_FIELDS);
+
+        AgenticSearchQueryBuilder builder2 = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT)
+            .agentId(AGENT_ID)
+            .queryFields(QUERY_FIELDS);
+
+        assertEquals("Identical builders should be equal", builder1, builder2);
+        assertEquals("Identical builders should have same hash code", builder1.hashCode(), builder2.hashCode());
+    }
+
+    public void testNotEquals() {
+        AgenticSearchQueryBuilder builder1 = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT).agentId(AGENT_ID);
+
+        AgenticSearchQueryBuilder builder2 = new AgenticSearchQueryBuilder().queryText("different query").agentId(AGENT_ID);
+
+        assertNotEquals("Different builders should not be equal", builder1, builder2);
+        assertNotEquals("Different builders should have different hash codes", builder1.hashCode(), builder2.hashCode());
+    }
+
+    public void testSerialization() throws IOException {
+        AgenticSearchQueryBuilder original = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT)
+            .agentId(AGENT_ID)
+            .queryFields(QUERY_FIELDS);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        original.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        AgenticSearchQueryBuilder deserialized = new AgenticSearchQueryBuilder(input);
+
+        assertEquals("Deserialized query should equal original", original, deserialized);
+        assertEquals("Query text should match", QUERY_TEXT, deserialized.queryText());
+        assertEquals("Agent ID should match", AGENT_ID, deserialized.agentId());
+        assertEquals("Fields should match", QUERY_FIELDS, deserialized.queryFields());
+    }
+
+    public void testFieldName() {
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder();
+        assertEquals("Field name should match", "agentic_search", queryBuilder.fieldName());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryIT.java
@@ -6,7 +6,7 @@ package org.opensearch.neuralsearch.query;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
 
 import java.nio.file.Files;
@@ -15,7 +15,7 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 
-@Ignore("Ignoring until we find a way to fetch access, secret key for remote model")
+@AwaitsFix(bugUrl = "Ignoring until we find a way to fetch access, secret key for remote model")
 public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
 
     private static final String TEST_INDEX = "test-agentic-index";

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryIT.java
@@ -4,57 +4,74 @@
  */
 package org.opensearch.neuralsearch.query;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
-import org.opensearch.client.Request;
-import org.opensearch.client.Response;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 
+@Ignore("Ignoring until we find a way to fetch access, secret key for remote model")
 public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
 
     private static final String TEST_INDEX = "test-agentic-index";
-    private static final String TEST_AGENT_ID = "test-agent-123";
+    private static String TEST_AGENT_ID;
+    private static String TEST_MODEL_ID;
     private static final String TEST_QUERY_TEXT = "Find documents about machine learning";
+    private static final String AWS_ACCESS_KEY_ID = System.getenv("AWS_ACCESS_KEY_ID");
 
-    public void testAgenticSearchQuery_withValidParameters_thenSuccess() throws Exception {
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        updateClusterSettings();
+        if (TEST_AGENT_ID == null) {
+            try {
+                String connectorId = createTestConnector();
+                TEST_MODEL_ID = registerAndDeployTestModel(connectorId);
+                TEST_AGENT_ID = registerTestAgent(TEST_MODEL_ID);
+            } catch (Exception e) {
+                TEST_AGENT_ID = "dummy-agent-id";
+                TEST_MODEL_ID = "dummy-model-id";
+            }
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // if (TEST_MODEL_ID != null && !TEST_MODEL_ID.equals("dummy-model-id")) {
+        // undeployModel(TEST_MODEL_ID);
+        // }
+        if (TEST_AGENT_ID != null && !TEST_AGENT_ID.equals("dummy-agent-id")) {
+            deleteAgent(TEST_AGENT_ID);
+        }
+        super.tearDown();
+    }
+
+    public void testAgenticSearchQuery_withValidParameters_thenExpectError() throws Exception {
         initializeIndexIfNotExist(TEST_INDEX);
 
-        String queryJson = String.format(
-            Locale.ROOT,
-            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"query_text\": \"%s\"," + "\"agent_id\": \"%s\"" + "}" + "}" + "}",
-            TEST_QUERY_TEXT,
-            TEST_AGENT_ID
-        );
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(TEST_QUERY_TEXT).agentId(TEST_AGENT_ID);
 
-        Request searchRequest = new Request("POST", "/" + TEST_INDEX + "/_search");
-        searchRequest.setJsonEntity(queryJson);
-
-        // TODO Should succeed because the hardcoded DSL query is executed
-        Response response = client().performRequest(searchRequest);
-        assertEquals(200, response.getStatusLine().getStatusCode());
+        Map<String, Object> searchResponse = search(TEST_INDEX, agenticQuery, null, 10, Map.of());
+        assertEquals(1, getHitCount(searchResponse));
     }
 
     public void testAgenticSearchQuery_withMissingQueryText_thenFail() throws Exception {
         initializeIndexIfNotExist(TEST_INDEX);
 
-        String queryJson = String.format(
-            Locale.ROOT,
-            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"agent_id\": \"%s\"" + "}" + "}" + "}",
-            TEST_AGENT_ID
-        );
-
-        Request searchRequest = new Request("POST", "/" + TEST_INDEX + "/_search");
-        searchRequest.setJsonEntity(queryJson);
-
         try {
-            client().performRequest(searchRequest);
+            // This should fail during query builder construction
+            AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().agentId(TEST_AGENT_ID);
+            search(TEST_INDEX, agenticQuery, null, 10, Map.of());
             fail("Expected parsing exception for missing query_text");
         } catch (Exception e) {
             assertTrue(
                 "Should contain query_text required error",
-                e.getMessage().contains("query_text") && e.getMessage().contains("required")
+                e.getMessage().contains("query_text") || e.getMessage().contains("required")
             );
         }
     }
@@ -62,86 +79,57 @@ public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
     public void testAgenticSearchQuery_withMissingAgentId_thenFail() throws Exception {
         initializeIndexIfNotExist(TEST_INDEX);
 
-        String queryJson = String.format(
-            Locale.ROOT,
-            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"query_text\": \"%s\"" + "}" + "}" + "}",
-            TEST_QUERY_TEXT
-        );
-
-        Request searchRequest = new Request("POST", "/" + TEST_INDEX + "/_search");
-        searchRequest.setJsonEntity(queryJson);
-
         try {
-            client().performRequest(searchRequest);
+            // This should fail during query builder construction
+            AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(TEST_QUERY_TEXT);
+            search(TEST_INDEX, agenticQuery, null, 10, Map.of());
             fail("Expected parsing exception for missing agent_id");
         } catch (Exception e) {
             assertTrue(
                 "Should contain agent_id required error",
-                e.getMessage().contains("agent_id") && e.getMessage().contains("required")
+                e.getMessage().contains("agent_id") || e.getMessage().contains("required")
             );
         }
     }
 
-    public void testAgenticSearchQuery_withQueryFields_thenSuccess() throws Exception {
+    public void testAgenticSearchQuery_withQueryFields_thenExpectError() throws Exception {
         initializeIndexIfNotExist(TEST_INDEX);
 
-        String queryJson = String.format(
-            Locale.ROOT,
-            "{"
-                + "\"query\": {"
-                + "\"agentic_search\": {"
-                + "\"query_text\": \"%s\","
-                + "\"agent_id\": \"%s\","
-                + "\"query_fields\": [\"title\", \"content\"]"
-                + "}"
-                + "}"
-                + "}",
-            TEST_QUERY_TEXT,
-            TEST_AGENT_ID
-        );
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(TEST_QUERY_TEXT)
+            .agentId(TEST_AGENT_ID)
+            .queryFields(java.util.Arrays.asList("title", "content"));
 
-        Request searchRequest = new Request("POST", "/" + TEST_INDEX + "/_search");
-        searchRequest.setJsonEntity(queryJson);
-
-        // TODO Should succeed because the hardcoded DSL query is executed
-        Response response = client().performRequest(searchRequest);
-        assertEquals(200, response.getStatusLine().getStatusCode());
+        try {
+            Map<String, Object> searchResponse = search(TEST_INDEX, agenticQuery, null, 10, Map.of());
+            fail("Expected error due to setup limitations");
+        } catch (Exception e) {
+            assertTrue(
+                "Should be a setup-related error",
+                e.getMessage().contains("Agent index not found")
+                    || e.getMessage().contains("model not found")
+                    || e.getMessage().contains("Failed to execute agentic search")
+            );
+        }
     }
 
     public void testAgenticSearchQuery_withSingleShard_thenSuccess() throws Exception {
         String singleShardIndex = TEST_INDEX + "-single-shard";
         initializeIndexIfNotExist(singleShardIndex, 1);
 
-        String queryJson = String.format(
-            Locale.ROOT,
-            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"query_text\": \"%s\"," + "\"agent_id\": \"%s\"" + "}" + "}" + "}",
-            TEST_QUERY_TEXT,
-            TEST_AGENT_ID
-        );
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(TEST_QUERY_TEXT).agentId(TEST_AGENT_ID);
 
-        Request searchRequest = new Request("POST", "/" + singleShardIndex + "/_search");
-        searchRequest.setJsonEntity(queryJson);
-
-        Response response = client().performRequest(searchRequest);
-        assertEquals(200, response.getStatusLine().getStatusCode());
+        Map<String, Object> searchResponse = search(singleShardIndex, agenticQuery, null, 10, Map.of());
+        assertEquals(1, getHitCount(searchResponse));
     }
 
     public void testAgenticSearchQuery_withMultipleShards_thenSuccess() throws Exception {
         String multiShardIndex = TEST_INDEX + "-multi-shard";
         initializeIndexIfNotExist(multiShardIndex, 3);
 
-        String queryJson = String.format(
-            Locale.ROOT,
-            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"query_text\": \"%s\"," + "\"agent_id\": \"%s\"" + "}" + "}" + "}",
-            TEST_QUERY_TEXT,
-            TEST_AGENT_ID
-        );
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(TEST_QUERY_TEXT).agentId(TEST_AGENT_ID);
 
-        Request searchRequest = new Request("POST", "/" + multiShardIndex + "/_search");
-        searchRequest.setJsonEntity(queryJson);
-
-        Response response = client().performRequest(searchRequest);
-        assertEquals(200, response.getStatusLine().getStatusCode());
+        Map<String, Object> searchResponse = search(multiShardIndex, agenticQuery, null, 10, Map.of());
+        assertEquals(1, getHitCount(searchResponse));
     }
 
     private void initializeIndexIfNotExist(String indexName) throws Exception {
@@ -167,4 +155,30 @@ public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
             assertEquals(2, getDocCount(indexName));
         }
     }
+
+    private String createTestConnector() throws Exception {
+        final String createConnectorRequestBody = Files.readString(
+            Path.of(classLoader.getResource("agenticsearch/CreateConnectorRequestBody.json").toURI())
+        );
+        return createConnector(createConnectorRequestBody);
+    }
+
+    private String registerAndDeployTestModel(String connectorId) throws Exception {
+        final String registerModelRequestBody = String.format(
+            Locale.ROOT,
+            Files.readString(Path.of(classLoader.getResource("agenticsearch/RegisterModelRequestBody.json").toURI())),
+            connectorId
+        );
+        return registerModelGroupAndUploadModel(registerModelRequestBody);
+    }
+
+    private String registerTestAgent(String modelId) throws Exception {
+        final String registerAgentRequestBody = String.format(
+            Locale.ROOT,
+            Files.readString(Path.of(classLoader.getResource("agenticsearch/RegisterAgentRequestBody.json").toURI())),
+            modelId
+        );
+        return registerAgent(registerAgentRequestBody);
+    }
+
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.util.Locale;
+
+public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
+
+    private static final String TEST_INDEX = "test-agentic-index";
+    private static final String TEST_AGENT_ID = "test-agent-123";
+    private static final String TEST_QUERY_TEXT = "Find documents about machine learning";
+
+    public void testAgenticSearchQuery_withValidParameters_thenSuccess() throws Exception {
+        createIndex(TEST_INDEX, "{\"mappings\":{\"properties\":{\"passage_text\":{\"type\":\"text\"}}}}");
+        addDocument(TEST_INDEX, "1", "passage_text", "This is about science and technology", null, null);
+
+        String queryJson = String.format(
+            Locale.ROOT,
+            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"query_text\": \"%s\"," + "\"agent_id\": \"%s\"" + "}" + "}" + "}",
+            TEST_QUERY_TEXT,
+            TEST_AGENT_ID
+        );
+
+        Request searchRequest = new Request("POST", "/" + TEST_INDEX + "/_search");
+        searchRequest.setJsonEntity(queryJson);
+
+        // TODO Should succeed because the hardcoded DSL query is executed
+        Response response = client().performRequest(searchRequest);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    public void testAgenticSearchQuery_withMissingQueryText_thenFail() throws Exception {
+        createIndex(TEST_INDEX, "{\"mappings\":{\"properties\":{\"text\":{\"type\":\"text\"}}}}");
+
+        String queryJson = String.format(
+            Locale.ROOT,
+            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"agent_id\": \"%s\"" + "}" + "}" + "}",
+            TEST_AGENT_ID
+        );
+
+        Request searchRequest = new Request("POST", "/" + TEST_INDEX + "/_search");
+        searchRequest.setJsonEntity(queryJson);
+
+        try {
+            client().performRequest(searchRequest);
+            fail("Expected parsing exception for missing query_text");
+        } catch (Exception e) {
+            assertTrue(
+                "Should contain query_text required error",
+                e.getMessage().contains("query_text") && e.getMessage().contains("required")
+            );
+        }
+    }
+
+    public void testAgenticSearchQuery_withMissingAgentId_thenFail() throws Exception {
+        createIndex(TEST_INDEX, "{\"mappings\":{\"properties\":{\"text\":{\"type\":\"text\"}}}}");
+
+        String queryJson = String.format(
+            Locale.ROOT,
+            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"query_text\": \"%s\"" + "}" + "}" + "}",
+            TEST_QUERY_TEXT
+        );
+
+        Request searchRequest = new Request("POST", "/" + TEST_INDEX + "/_search");
+        searchRequest.setJsonEntity(queryJson);
+
+        try {
+            client().performRequest(searchRequest);
+            fail("Expected parsing exception for missing agent_id");
+        } catch (Exception e) {
+            assertTrue(
+                "Should contain agent_id required error",
+                e.getMessage().contains("agent_id") && e.getMessage().contains("required")
+            );
+        }
+    }
+
+    public void testAgenticSearchQuery_withQueryFields_thenSuccess() throws Exception {
+        createIndex(TEST_INDEX, "{\"mappings\":{\"properties\":{\"passage_text\":{\"type\":\"text\"}}}}");
+        addDocument(TEST_INDEX, "1", "passage_text", "This is about science and technology", null, null);
+
+        String queryJson = String.format(
+            Locale.ROOT,
+            "{"
+                + "\"query\": {"
+                + "\"agentic_search\": {"
+                + "\"query_text\": \"%s\","
+                + "\"agent_id\": \"%s\","
+                + "\"query_fields\": [\"title\", \"content\"]"
+                + "}"
+                + "}"
+                + "}",
+            TEST_QUERY_TEXT,
+            TEST_AGENT_ID
+        );
+
+        Request searchRequest = new Request("POST", "/" + TEST_INDEX + "/_search");
+        searchRequest.setJsonEntity(queryJson);
+
+        // TODO Should succeed because the hardcoded DSL query is executed
+        Response response = client().performRequest(searchRequest);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryIT.java
@@ -8,7 +8,9 @@ import org.opensearch.neuralsearch.BaseNeuralSearchIT;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 
+import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 
 public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
 
@@ -17,8 +19,7 @@ public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
     private static final String TEST_QUERY_TEXT = "Find documents about machine learning";
 
     public void testAgenticSearchQuery_withValidParameters_thenSuccess() throws Exception {
-        createIndex(TEST_INDEX, "{\"mappings\":{\"properties\":{\"passage_text\":{\"type\":\"text\"}}}}");
-        addDocument(TEST_INDEX, "1", "passage_text", "This is about science and technology", null, null);
+        initializeIndexIfNotExist(TEST_INDEX);
 
         String queryJson = String.format(
             Locale.ROOT,
@@ -36,7 +37,7 @@ public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
     }
 
     public void testAgenticSearchQuery_withMissingQueryText_thenFail() throws Exception {
-        createIndex(TEST_INDEX, "{\"mappings\":{\"properties\":{\"text\":{\"type\":\"text\"}}}}");
+        initializeIndexIfNotExist(TEST_INDEX);
 
         String queryJson = String.format(
             Locale.ROOT,
@@ -59,7 +60,7 @@ public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
     }
 
     public void testAgenticSearchQuery_withMissingAgentId_thenFail() throws Exception {
-        createIndex(TEST_INDEX, "{\"mappings\":{\"properties\":{\"text\":{\"type\":\"text\"}}}}");
+        initializeIndexIfNotExist(TEST_INDEX);
 
         String queryJson = String.format(
             Locale.ROOT,
@@ -82,8 +83,7 @@ public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
     }
 
     public void testAgenticSearchQuery_withQueryFields_thenSuccess() throws Exception {
-        createIndex(TEST_INDEX, "{\"mappings\":{\"properties\":{\"passage_text\":{\"type\":\"text\"}}}}");
-        addDocument(TEST_INDEX, "1", "passage_text", "This is about science and technology", null, null);
+        initializeIndexIfNotExist(TEST_INDEX);
 
         String queryJson = String.format(
             Locale.ROOT,
@@ -106,5 +106,65 @@ public class AgenticSearchQueryIT extends BaseNeuralSearchIT {
         // TODO Should succeed because the hardcoded DSL query is executed
         Response response = client().performRequest(searchRequest);
         assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    public void testAgenticSearchQuery_withSingleShard_thenSuccess() throws Exception {
+        String singleShardIndex = TEST_INDEX + "-single-shard";
+        initializeIndexIfNotExist(singleShardIndex, 1);
+
+        String queryJson = String.format(
+            Locale.ROOT,
+            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"query_text\": \"%s\"," + "\"agent_id\": \"%s\"" + "}" + "}" + "}",
+            TEST_QUERY_TEXT,
+            TEST_AGENT_ID
+        );
+
+        Request searchRequest = new Request("POST", "/" + singleShardIndex + "/_search");
+        searchRequest.setJsonEntity(queryJson);
+
+        Response response = client().performRequest(searchRequest);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    public void testAgenticSearchQuery_withMultipleShards_thenSuccess() throws Exception {
+        String multiShardIndex = TEST_INDEX + "-multi-shard";
+        initializeIndexIfNotExist(multiShardIndex, 3);
+
+        String queryJson = String.format(
+            Locale.ROOT,
+            "{" + "\"query\": {" + "\"agentic_search\": {" + "\"query_text\": \"%s\"," + "\"agent_id\": \"%s\"" + "}" + "}" + "}",
+            TEST_QUERY_TEXT,
+            TEST_AGENT_ID
+        );
+
+        Request searchRequest = new Request("POST", "/" + multiShardIndex + "/_search");
+        searchRequest.setJsonEntity(queryJson);
+
+        Response response = client().performRequest(searchRequest);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    private void initializeIndexIfNotExist(String indexName) throws Exception {
+        initializeIndexIfNotExist(indexName, 1);
+    }
+
+    private void initializeIndexIfNotExist(String indexName, int numberOfShards) throws Exception {
+        if (!indexExists(indexName)) {
+            createIndexWithConfiguration(
+                indexName,
+                buildIndexConfiguration(
+                    Collections.emptyList(),
+                    Map.of(),
+                    Collections.emptyList(),
+                    Collections.singletonList("passage_text"),
+                    Collections.emptyList(),
+                    numberOfShards
+                ),
+                ""
+            );
+            addDocument(indexName, "1", "passage_text", "This is about science and technology", null, null);
+            addDocument(indexName, "2", "passage_text", "Machine learning and artificial intelligence", null, null);
+            assertEquals(2, getDocCount(indexName));
+        }
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtilTests.java
@@ -109,7 +109,7 @@ public class NeuralSearchClusterUtilTests extends OpenSearchTestCase {
         assertEquals("{\"properties\":{\"field1\":{\"type\":\"text\"}}}", result);
     }
 
-    public void testGetIndexMapping_whenNoIndices_thenReturnEmptyMapping() {
+    public void testGetIndexMapping_whenNoIndices_thenThrowException() {
         final ClusterService clusterService = mock(ClusterService.class);
         final QueryCoordinatorContext coordinatorContext = mock(QueryCoordinatorContext.class);
         final SearchRequest searchRequest = mock(SearchRequest.class);
@@ -121,8 +121,10 @@ public class NeuralSearchClusterUtilTests extends OpenSearchTestCase {
         final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
         neuralSearchClusterUtil.initialize(clusterService, indexNameExpressionResolver);
 
-        String result = neuralSearchClusterUtil.getIndexMapping(coordinatorContext);
-
-        assertEquals("{}", result);
+        IllegalStateException exception = expectThrows(
+            IllegalStateException.class,
+            () -> neuralSearchClusterUtil.getIndexMapping(coordinatorContext)
+        );
+        assertEquals("No valid index found to extract mapping", exception.getMessage());
     }
 }

--- a/src/test/resources/agenticsearch/CreateConnectorRequestBody.json
+++ b/src/test/resources/agenticsearch/CreateConnectorRequestBody.json
@@ -1,0 +1,28 @@
+{
+  "name": "Amazon Bedrock Claude connector",
+  "description": "connector for agentic search",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-west-2",
+    "service_name": "bedrock",
+    "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "system_prompt": "please help answer the user question."
+  },
+  "credential": {
+    "access_key": "${AWS_ACCESS_KEY_ID:-dummy_key}",
+    "secret_key": "${AWS_SECRET_ACCESS_KEY:-dummy_secret}",
+    "session_token": "${AWS_SESSION_TOKEN:-dummy_token}"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+      "headers": {
+        "content-type": "application/json"
+      },
+      "request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": [{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.prompt}\"}]}]}"
+    }
+  ]
+}

--- a/src/test/resources/agenticsearch/RegisterAgentRequestBody.json
+++ b/src/test/resources/agenticsearch/RegisterAgentRequestBody.json
@@ -1,0 +1,18 @@
+{
+  "name": "Agentic Search Test Agent",
+  "type": "flow",
+  "description": "Test agent for agentic search",
+  "tools": [
+    {
+      "type": "QueryPlanningTool",
+      "name": "MyQueryPlanningTool",
+      "description": "A tool for planning queries",
+      "parameters": {
+        "model_id": "%s",
+        "response_filter": "$.output.message.content[0].text",
+        "prompt": "You are an OpenSearch Query DSL generation assistant; try using the optional provided index mapping ${parameters.index_mapping:-}, specified fields ${parameters.query_fields:-}, and the given sample queries as examples, generate an OpenSearch Query DSL to retrieve the most relevant documents for the user provided natural language question: ${parameters.query_text}, please return the query dsl only in a string format, no other texts. Do not include any special characters."
+      },
+      "include_output_in_agent_response": true
+    }
+  ]
+}

--- a/src/test/resources/agenticsearch/RegisterModelRequestBody.json
+++ b/src/test/resources/agenticsearch/RegisterModelRequestBody.json
@@ -1,0 +1,6 @@
+{
+  "name": "bedrock claude model",
+  "function_name": "remote",
+  "connector_id": "%s",
+  "description": "test model for agentic search"
+}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1978,6 +1978,36 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         return modelGroupId;
     }
 
+    protected String registerAgent(final String agentRequestBody) throws Exception {
+        Response response = makeRequest(
+            client(),
+            "POST",
+            "/_plugins/_ml/agents/_register",
+            null,
+            toHttpEntity(agentRequestBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> responseJson = XContentHelper.convertToMap(
+            XContentType.JSON.xContent(),
+            EntityUtils.toString(response.getEntity()),
+            false
+        );
+        String agentId = responseJson.get("agent_id").toString();
+        assertNotNull(agentId);
+        return agentId;
+    }
+
+    protected void deleteAgent(final String agentId) throws Exception {
+        makeRequest(
+            client(),
+            "DELETE",
+            "/_plugins/_ml/agents/" + agentId,
+            null,
+            toHttpEntity(""),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+    }
+
     // Method that waits till the health of nodes in the cluster goes green
     protected void waitForClusterHealthGreen(final String numOfNodes, final int timeoutInSeconds) throws IOException {
         Request waitForGreen = new Request("GET", "/_cluster/health");


### PR DESCRIPTION
### Description
Added new query clause agentic search and tests
```
GET /<index_name>/_search
{
  "query": {
    "agentic_search": {
      "query_text": "Find me a red car",
      "agent_id": "asn123456789".
      "query_fields": ["title", "description", "location"] //optional
    }
  }
}
```

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1479

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
