### PR TITLE
Fix flaky test in HybridQueryAggregationsIT

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
@@ -497,7 +497,7 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                 .replace("\"{indexname}\"", "\"" + index + "\"");
 
             // wait until cluster is healthy before running ingest to reduce flakiness
-            waitForClusterHealthGreen(numOfNode, 100);
+            waitForClusterHealthGreen(numOfNodes);
             bulkIngest(ingestBulkPayload, null);
         }
         createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
@@ -497,7 +497,7 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                 .replace("\"{indexname}\"", "\"" + index + "\"");
 
             // wait until cluster is healthy before running ingest to reduce flakiness
-            waitForClusterHealthGreen(numOfNode, 60);
+            waitForClusterHealthGreen(numOfNode, 100);
             bulkIngest(ingestBulkPayload, null);
         }
         createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
@@ -497,7 +497,7 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
                 .replace("\"{indexname}\"", "\"" + index + "\"");
 
             // wait until cluster is healthy before running ingest to reduce flakiness
-            waitForClusterHealthGreen(numOfNode, 60, "all");
+            waitForClusterHealthGreen(numOfNode, 60);
             bulkIngest(ingestBulkPayload, null);
         }
         createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryAggregationsIT.java
@@ -496,6 +496,8 @@ public class HybridQueryAggregationsIT extends BaseNeuralSearchIT {
             String ingestBulkPayload = Files.readString(Path.of(classLoader.getResource("processor/ingest_bulk.json").toURI()))
                 .replace("\"{indexname}\"", "\"" + index + "\"");
 
+            // wait until cluster is healthy before running ingest to reduce flakiness
+            waitForClusterHealthGreen(numOfNode, 60, "all");
             bulkIngest(ingestBulkPayload, null);
         }
         createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -2039,7 +2039,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     // Method that waits till the health of nodes in the cluster goes green with default timeout value of 60
     protected void waitForClusterHealthGreen(final String numOfNodes) throws Exception {
         try {
-            waitForClusterHealthGreen(numOfNodes, 60);
+            waitForClusterHealthGreen(numOfNodes, 100);
         } catch (ResponseException e) {
             // Perform additional API calls to log the cause of the yellow cluster state
             Request explain = new Request("GET", "/_cluster/allocation/explain");

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -2027,17 +2027,10 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     }
 
     protected void waitForClusterHealthGreen(final String numOfNodes, final int timeoutInSeconds) throws IOException {
-        // default value for `wait_for_active_shards` is 0
-        waitForClusterHealthGreen(numOfNodes, timeoutInSeconds, "0");
-    }
-
-    // Method that waits till the health of nodes in the cluster goes green
-    protected void waitForClusterHealthGreen(final String numOfNodes, final int timeoutInSeconds, final String activeShards)
-        throws IOException {
         Request waitForGreen = new Request("GET", "/_cluster/health");
         waitForGreen.addParameter("wait_for_nodes", numOfNodes);
         waitForGreen.addParameter("wait_for_status", "green");
-        waitForGreen.addParameter("wait_for_active_shards", activeShards);
+        waitForGreen.addParameter("wait_for_active_shards", "all");
         waitForGreen.addParameter("cluster_manager_timeout", String.format(LOCALE, "%ds", timeoutInSeconds));
         waitForGreen.addParameter("timeout", String.format(LOCALE, "%ds", timeoutInSeconds));
         client().performRequest(waitForGreen);

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -153,14 +153,14 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     private static final int MAX_ATTEMPTS = 30;
     private static final int WAIT_TIME_IN_SECONDS = 2;
     private static final long TIMEOUT = 10000;
-    protected String numOfNode;
+    protected String numOfNodes;
 
     @Before
     public void setupSettings() {
         threadPool = setUpThreadPool();
         clusterService = createClusterService(threadPool);
         final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
-        numOfNode = System.getProperty("cluster.number_of_nodes", "1");
+        numOfNodes = System.getProperty("cluster.number_of_nodes", "1");
         if (isUpdateClusterSettings()) {
             updateClusterSettings();
         }
@@ -1661,10 +1661,12 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final List<String> dateFields,
         final int numberOfShards
     ) {
+        int numberOfReplica = numOfNodes.equals("1") ? 0 : 1;
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("settings")
             .field("number_of_shards", numberOfShards)
+            .field("number_of_replicas", numberOfReplica)
             .field("index.knn", true)
             .endObject()
             .startObject("mappings")
@@ -1733,10 +1735,12 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         final int numberOfShards,
         final String semanticFieldSearchAnalyzer
     ) {
+        int numberOfReplica = numOfNodes.equals("1") ? 0 : 1;
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("settings")
             .field("number_of_shards", numberOfShards)
+            .field("number_of_replicas", numberOfReplica)
             .field("index.knn", true)
             .endObject()
             .startObject("mappings")
@@ -2064,7 +2068,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     // Method that waits till the health of nodes in the cluster goes green with default timeout value of 60
     protected void waitForClusterHealthGreen(final String numOfNodes) throws Exception {
         try {
-            waitForClusterHealthGreen(numOfNodes, 100);
+            waitForClusterHealthGreen(numOfNodes, 60);
         } catch (ResponseException e) {
             // Perform additional API calls to log the cause of the yellow cluster state
             Request explain = new Request("GET", "/_cluster/allocation/explain");

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -151,13 +151,14 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     private static final int MAX_ATTEMPTS = 30;
     private static final int WAIT_TIME_IN_SECONDS = 2;
     private static final long TIMEOUT = 10000;
+    protected String numOfNode;
 
     @Before
     public void setupSettings() {
         threadPool = setUpThreadPool();
         clusterService = createClusterService(threadPool);
         final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
-
+        numOfNode = System.getProperty("cluster.number_of_nodes", "1");
         if (isUpdateClusterSettings()) {
             updateClusterSettings();
         }
@@ -2025,11 +2026,18 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
         return modelGroupId;
     }
 
-    // Method that waits till the health of nodes in the cluster goes green
     protected void waitForClusterHealthGreen(final String numOfNodes, final int timeoutInSeconds) throws IOException {
+        // default value for `wait_for_active_shards` is 0
+        waitForClusterHealthGreen(numOfNodes, timeoutInSeconds, "0");
+    }
+
+    // Method that waits till the health of nodes in the cluster goes green
+    protected void waitForClusterHealthGreen(final String numOfNodes, final int timeoutInSeconds, final String activeShards)
+        throws IOException {
         Request waitForGreen = new Request("GET", "/_cluster/health");
         waitForGreen.addParameter("wait_for_nodes", numOfNodes);
         waitForGreen.addParameter("wait_for_status", "green");
+        waitForGreen.addParameter("wait_for_active_shards", activeShards);
         waitForGreen.addParameter("cluster_manager_timeout", String.format(LOCALE, "%ds", timeoutInSeconds));
         waitForGreen.addParameter("timeout", String.format(LOCALE, "%ds", timeoutInSeconds));
         client().performRequest(waitForGreen);


### PR DESCRIPTION
### Description
The test fails because when preparing documents using `bulkIngest` function, we may get `primary shard is not active` issue. The fix adds a `waitForClusterHealthGreen` check before running `bulkIngest`. Also update `waitForClusterHealthGreen` to wait for active shard as well.

Verified through:
```
./gradlew integTest -PnumNodes=3  -Dtests.iters=10 --tests "org.opensearch.neuralsearch.query.HybridQueryAggregationsIT.testNestedAggs_whenMultipleShardsAndConcurrentSearchDisabled_thenSuccessful"
```

### Related Issues
Resolves #1488 #1489 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
