### PR TITLE
Add transport-grpc as compileOnly dependency for neural-search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,7 @@ opensearchplugin {
     classname "${projectPath}.${pathToPlugin}.${pluginClassName}"
     licenseFile rootProject.file('LICENSE')
     noticeFile rootProject.file('NOTICE')
-    extendedPlugins = ['opensearch-knn']
+    extendedPlugins = ['opensearch-knn', 'transport-grpc']
 }
 
 dependencyLicenses.enabled = false
@@ -255,6 +255,7 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-job-scheduler', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
+    zipArchive group: 'org.opensearch.module', name:'transport-grpc', version: "${opensearch_build}"
     secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
     compileOnly fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
     compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'


### PR DESCRIPTION
### Description

Adding transport-grpc as a compileOnly dep of neural-search, in order to:
* Fix failing neural-search build after merging https://github.com/opensearch-project/k-NN/pull/2817#issuecomment-3169538365
*  It will eventually be needed in order to implement neural search GRPC APIs as well. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
