### PR TITLE
Publish plugin jar to maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ plugins{
     id "de.undercouch.download" version "5.3.0"
 }
 apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'java-test-fixtures'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'


### PR DESCRIPTION
### Description
Gradle plugin `java-library` does all heavy lifting, we need just enable it, similar to other plugin like  k-NN https://github.com/opensearch-project/k-NN/blob/main/build.gradle.

Tested by running: `./gradlew jar` and `./gradlew publishToMavenLocal`, they are building and publishing jar

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1371

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
