### PR TITLE
Add info stats fort agentic query

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
@@ -93,7 +93,14 @@ public enum InfoStatName implements StatName {
     /** Counts rerank by field processors */
     RERANK_BY_FIELD_PROCESSORS("rerank_by_field_processors", "processors.search", InfoStatType.INFO_COUNTER, Version.V_3_1_0),
     /** Counts ML reranking processors */
-    RERANK_ML_PROCESSORS("rerank_ml_processors", "processors.search", InfoStatType.INFO_COUNTER, Version.V_3_1_0),;
+    RERANK_ML_PROCESSORS("rerank_ml_processors", "processors.search", InfoStatType.INFO_COUNTER, Version.V_3_1_0),
+    /** Counts agentic query translator processors */
+    AGENTIC_QUERY_TRANSLATOR_PROCESSORS(
+        "agentic_query_translator_processors",
+        "processors.search",
+        InfoStatType.INFO_COUNTER,
+        Version.V_3_2_0
+    ),;
 
     private final String nameString;
     private final String path;

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
@@ -7,6 +7,7 @@ package org.opensearch.neuralsearch.stats.info;
 import org.opensearch.neuralsearch.processor.NeuralQueryEnricherProcessor;
 import org.opensearch.neuralsearch.processor.NeuralSparseTwoPhaseProcessor;
 import org.opensearch.neuralsearch.processor.SparseEncodingProcessor;
+import org.opensearch.neuralsearch.processor.AgenticQueryTranslatorProcessor;
 import com.google.common.annotations.VisibleForTesting;
 import org.opensearch.neuralsearch.processor.NormalizationProcessor;
 import org.opensearch.neuralsearch.processor.RRFProcessor;
@@ -189,6 +190,7 @@ public class InfoStatsManager {
                         switch (processorType) {
                             case NeuralQueryEnricherProcessor.TYPE -> increment(stats, InfoStatName.NEURAL_QUERY_ENRICHER_PROCESSORS);
                             case NeuralSparseTwoPhaseProcessor.TYPE -> increment(stats, InfoStatName.NEURAL_SPARSE_TWO_PHASE_PROCESSORS);
+                            case AgenticQueryTranslatorProcessor.TYPE -> increment(stats, InfoStatName.AGENTIC_QUERY_TRANSLATOR_PROCESSORS);
                         }
                     }
                 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorTests.java
@@ -27,6 +27,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettingsAccessor;
+import org.opensearch.neuralsearch.util.TestUtils;
 
 import static org.mockito.Mockito.when;
 
@@ -60,6 +61,7 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        TestUtils.initializeEventStatsManager();
         mockMLClient = mock(MLCommonsClientAccessor.class);
         mockXContentRegistry = mock(NamedXContentRegistry.class);
         mockContext = mock(PipelineProcessingContext.class);

--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessorTests.java
@@ -31,6 +31,7 @@ import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.IntStream;
 
@@ -827,7 +828,7 @@ public class ByFieldRerankProcessorTests extends OpenSearchTestCase {
             int docId = sampleIndexMLScorePairs.get(i).getKey();
             String mlScore = sampleIndexMLScorePairs.get(i).getValue() + "";
 
-            String sourceMap = templateString.formatted(i, mlScore);
+            String sourceMap = String.format(Locale.ROOT, templateString, i, mlScore);
 
             hits[i] = new SearchHit(docId, docId + "", Collections.emptyMap(), Collections.emptyMap());
             hits[i].sourceRef(new BytesArray(sourceMap));
@@ -868,7 +869,7 @@ public class ByFieldRerankProcessorTests extends OpenSearchTestCase {
             int docId = sampleIndexMLScorePairs.get(i).getKey();
             String mlScore = sampleIndexMLScorePairs.get(i).getValue() + "";
 
-            String sourceMap = templateString.formatted(i, mlScore);
+            String sourceMap = String.format(Locale.ROOT, templateString, i, mlScore);
 
             hits[i] = new SearchHit(docId, docId + "", Collections.emptyMap(), Collections.emptyMap());
             hits[i].sourceRef(new BytesArray(sourceMap));
@@ -907,7 +908,7 @@ public class ByFieldRerankProcessorTests extends OpenSearchTestCase {
             int docId = sampleIndexMLScorePairs.get(i).getKey();
             String mlScore = sampleIndexMLScorePairs.get(i).getValue() + "";
 
-            String sourceMap = templateString.formatted(i, mlScore);
+            String sourceMap = String.format(Locale.ROOT, templateString, i, mlScore);
 
             hits[i] = new SearchHit(docId, docId + "", Collections.emptyMap(), Collections.emptyMap());
             hits[i].sourceRef(new BytesArray(sourceMap));


### PR DESCRIPTION
### Description
Continuing https://github.com/opensearch-project/neural-search/pull/1529 and adding info stats for the processor
```
 "agentic_query_translator_processors": 2
```

### Related Issues
Part of https://github.com/opensearch-project/neural-search/issues/1525

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
