### PR TITLE
SEISMIC: Add codec

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/accessor/SparseVectorReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/accessor/SparseVectorReader.java
@@ -18,6 +18,10 @@ import java.io.IOException;
  */
 @FunctionalInterface
 public interface SparseVectorReader {
+    /**
+     * A no-op implementation of SparseVectorReader that always returns null.
+     */
+    SparseVectorReader NOOP_READER = docId -> null;
 
     /**
      * Reads and returns the sparse vector associated with the specified document ID.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/accessor/SparseVectorWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/accessor/SparseVectorWriter.java
@@ -17,6 +17,7 @@ import java.io.IOException;
  * Implementations of this interface are responsible for efficiently persisting
  * sparse vector data, which may involve writing to disk, memory, or other storage media.
  */
+@FunctionalInterface
 public interface SparseVectorWriter {
     /**
      * A no-op implementation of SparseVectorWriter that ignores all write operations.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/accessor/SparseVectorWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/accessor/SparseVectorWriter.java
@@ -17,8 +17,11 @@ import java.io.IOException;
  * Implementations of this interface are responsible for efficiently persisting
  * sparse vector data, which may involve writing to disk, memory, or other storage media.
  */
-@FunctionalInterface
 public interface SparseVectorWriter {
+    /**
+     * A no-op implementation of SparseVectorWriter that ignores all write operations.
+     */
+    SparseVectorWriter NOOP_WRITER = (docId, vector) -> {};
 
     /**
      * Inserts a sparse vector for the specified document ID.

--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/BatchClusteringTask.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/BatchClusteringTask.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm.seismic;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.accessor.ClusteredPostingWriter;
+import org.opensearch.neuralsearch.sparse.accessor.SparseVectorReader;
+import org.opensearch.neuralsearch.sparse.cache.CacheGatedForwardIndexReader;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ClusteredPostingCache;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCache;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCacheItem;
+import org.opensearch.neuralsearch.sparse.codec.MergeHelper;
+import org.opensearch.neuralsearch.sparse.codec.SparseBinaryDocValuesPassThrough;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+import org.opensearch.neuralsearch.sparse.data.DocWeight;
+import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Task for clustering postings in batches during index merging.
+ * Processes multiple terms and generates clustered postings for sparse vector optimization.
+ */
+@Log4j2
+public class BatchClusteringTask implements Supplier<List<Pair<BytesRef, PostingClusters>>> {
+    @Getter
+    private final List<BytesRef> terms;
+    private final CacheKey key;
+    private final float summaryPruneRatio;
+    private final float clusterRatio;
+    private final int nPostings;
+    private final MergeStateFacade mergeStateFacade;
+    private final FieldInfo fieldInfo;
+    private final MergeHelper mergeHelper;
+
+    /**
+     * Creates a batch clustering task.
+     *
+     * @param terms list of terms to cluster
+     * @param key cache key for storing results
+     * @param summaryPruneRatio ratio for pruning summary vectors
+     * @param clusterRatio ratio for clustering algorithm
+     * @param nPostings number of postings to process
+     * @param mergeStateFacade merge state containing segment information
+     * @param fieldInfo field information for the sparse vector field
+     */
+    public BatchClusteringTask(
+        List<BytesRef> terms,
+        CacheKey key,
+        float summaryPruneRatio,
+        float clusterRatio,
+        int nPostings,
+        @NonNull MergeStateFacade mergeStateFacade,
+        FieldInfo fieldInfo,
+        MergeHelper mergeHelper
+    ) {
+        this.terms = terms.stream().map(BytesRef::deepCopyOf).toList();
+        this.key = key;
+        this.summaryPruneRatio = summaryPruneRatio;
+        this.clusterRatio = clusterRatio;
+        this.nPostings = nPostings;
+        this.mergeStateFacade = mergeStateFacade;
+        this.fieldInfo = fieldInfo;
+        this.mergeHelper = mergeHelper;
+    }
+
+    /**
+     * Executes the clustering task and returns clustered postings for all terms.
+     *
+     * @return list of term-cluster pairs
+     */
+    @Override
+    public List<Pair<BytesRef, PostingClusters>> get() {
+        List<Pair<BytesRef, PostingClusters>> postingClusters = new ArrayList<>();
+        int maxDocs = getTotalDocs();
+        if (maxDocs == 0) {
+            return postingClusters;
+        }
+        try {
+            for (BytesRef term : this.terms) {
+                int[] newIdToFieldProducerIndex = new int[maxDocs];
+                int[] newIdToOldId = new int[maxDocs];
+                List<DocWeight> docWeights = mergeHelper.getMergedPostingForATerm(
+                    this.mergeStateFacade,
+                    term,
+                    this.fieldInfo,
+                    newIdToFieldProducerIndex,
+                    newIdToOldId
+                );
+                SeismicPostingClusterer seismicPostingClusterer = new SeismicPostingClusterer(
+                    nPostings,
+                    new RandomClusteringAlgorithm(summaryPruneRatio, clusterRatio, (newDocId) -> {
+                        int oldId = newIdToOldId[newDocId];
+                        int segmentIndex = newIdToFieldProducerIndex[newDocId];
+                        BinaryDocValues binaryDocValues = mergeStateFacade.getDocValuesProducers()[segmentIndex].getBinary(fieldInfo);
+                        SparseVectorReader reader = getCacheGatedForwardIndexReader(binaryDocValues);
+                        return reader.read(oldId);
+                    })
+                );
+                List<DocumentCluster> clusters = seismicPostingClusterer.cluster(docWeights);
+                postingClusters.add(Pair.of(term, new PostingClusters(clusters)));
+                ClusteredPostingWriter writer = ClusteredPostingCache.getInstance().getOrCreate(key).getWriter();
+                writer.insert(term, clusters);
+            }
+        } catch (IOException e) {
+            log.error("cluster failed", e);
+            throw new RuntimeException(e);
+        }
+        return postingClusters;
+    }
+
+    private int getTotalDocs() {
+        int maxDocs = 0;
+        for (int i = 0; i < this.mergeStateFacade.getMaxDocs().length; ++i) {
+            maxDocs += this.mergeStateFacade.getMaxDocs()[i];
+        }
+        return maxDocs;
+    }
+
+    /**
+     * Creates a createSparseVectorReader for vector access.
+     *
+     * @param binaryDocValues binaryDocValues The binary doc values containing sparse vector data
+     * @return A SparseVectorReader instance
+     */
+    private SparseVectorReader getCacheGatedForwardIndexReader(BinaryDocValues binaryDocValues) {
+        if (binaryDocValues instanceof SparseBinaryDocValuesPassThrough sparseBinaryDocValues) {
+            SegmentInfo segmentInfo = sparseBinaryDocValues.getSegmentInfo();
+            CacheKey cacheKey = new CacheKey(segmentInfo, fieldInfo);
+            ForwardIndexCacheItem index = ForwardIndexCache.getInstance().get(cacheKey);
+            if (index == null) {
+                return new CacheGatedForwardIndexReader(null, null, sparseBinaryDocValues);
+            }
+            return new CacheGatedForwardIndexReader(index.getReader(), index.getWriter(), sparseBinaryDocValues);
+        } else {
+            return SparseVectorReader.NOOP_READER;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/ClusteringTask.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/ClusteringTask.java
@@ -7,8 +7,6 @@ package org.opensearch.neuralsearch.sparse.algorithm.seismic;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.neuralsearch.sparse.accessor.ClusteredPostingWriter;
-import org.opensearch.neuralsearch.sparse.cache.CacheKey;
-import org.opensearch.neuralsearch.sparse.cache.ClusteredPostingCache;
 import org.opensearch.neuralsearch.sparse.data.DocWeight;
 import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
 import org.opensearch.neuralsearch.sparse.data.PostingClusters;
@@ -23,12 +21,17 @@ public class ClusteringTask implements Supplier<PostingClusters> {
     private final BytesRef term;
     private final List<DocWeight> docs;
     private final SeismicPostingClusterer seismicPostingClusterer;
-    private final CacheKey key;
+    private final ClusteredPostingWriter writer;
 
-    public ClusteringTask(BytesRef term, Collection<DocWeight> docs, CacheKey key, SeismicPostingClusterer seismicPostingClusterer) {
+    public ClusteringTask(
+        BytesRef term,
+        Collection<DocWeight> docs,
+        ClusteredPostingWriter writer,
+        SeismicPostingClusterer seismicPostingClusterer
+    ) {
         this.docs = docs.stream().toList();
         this.term = BytesRef.deepCopyOf(term);
-        this.key = key;
+        this.writer = writer;
         this.seismicPostingClusterer = seismicPostingClusterer;
     }
 
@@ -41,7 +44,6 @@ public class ClusteringTask implements Supplier<PostingClusters> {
             log.error("cluster failed", e);
             throw new RuntimeException(e);
         }
-        ClusteredPostingWriter writer = ClusteredPostingCache.getInstance().getOrCreate(key).getWriter();
         writer.insert(term, clusters);
         return new PostingClusters(clusters);
     }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/ClusteringTask.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/ClusteringTask.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm.seismic;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.accessor.ClusteredPostingWriter;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ClusteredPostingCache;
+import org.opensearch.neuralsearch.sparse.data.DocWeight;
+import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+@Log4j2
+public class ClusteringTask implements Supplier<PostingClusters> {
+    private final BytesRef term;
+    private final List<DocWeight> docs;
+    private final SeismicPostingClusterer seismicPostingClusterer;
+    private final CacheKey key;
+
+    public ClusteringTask(BytesRef term, Collection<DocWeight> docs, CacheKey key, SeismicPostingClusterer seismicPostingClusterer) {
+        this.docs = docs.stream().toList();
+        this.term = BytesRef.deepCopyOf(term);
+        this.key = key;
+        this.seismicPostingClusterer = seismicPostingClusterer;
+    }
+
+    @Override
+    public PostingClusters get() {
+        List<DocumentCluster> clusters;
+        try {
+            clusters = seismicPostingClusterer.cluster(this.docs);
+        } catch (IOException e) {
+            log.error("cluster failed", e);
+            throw new RuntimeException(e);
+        }
+        ClusteredPostingWriter writer = ClusteredPostingCache.getInstance().getOrCreate(key).getWriter();
+        writer.insert(term, clusters);
+        return new PostingClusters(clusters);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/cache/CacheGatedForwardIndexReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/cache/CacheGatedForwardIndexReader.java
@@ -16,16 +16,6 @@ import java.io.IOException;
  */
 public class CacheGatedForwardIndexReader implements SparseVectorReader {
 
-    /**
-     * A no-op implementation of SparseVectorReader that always returns null.
-     */
-    private static final SparseVectorReader NOOP_READER = docId -> null;
-
-    /**
-     * A no-op implementation of SparseVectorWriter that ignores all write operations.
-     */
-    private static final SparseVectorWriter NOOP_WRITER = (docId, vector) -> {};
-
     private final SparseVectorReader cacheReader;
     private final SparseVectorWriter cacheWriter;
     private final SparseVectorReader luceneReader;
@@ -38,9 +28,9 @@ public class CacheGatedForwardIndexReader implements SparseVectorReader {
      * @param luceneReader the reader for accessing sparse vectors from Lucene storage
      */
     public CacheGatedForwardIndexReader(SparseVectorReader cacheReader, SparseVectorWriter cacheWriter, SparseVectorReader luceneReader) {
-        this.cacheReader = cacheReader == null ? NOOP_READER : cacheReader;
-        this.cacheWriter = cacheWriter == null ? NOOP_WRITER : cacheWriter;
-        this.luceneReader = luceneReader == null ? NOOP_READER : luceneReader;
+        this.cacheReader = cacheReader == null ? SparseVectorReader.NOOP_READER : cacheReader;
+        this.cacheWriter = cacheWriter == null ? SparseVectorWriter.NOOP_WRITER : cacheWriter;
+        this.luceneReader = luceneReader == null ? SparseVectorReader.NOOP_READER : luceneReader;
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/BinaryDocValuesSub.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/BinaryDocValuesSub.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.Getter;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocIDMerger;
+import org.apache.lucene.index.MergeState;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+
+import java.io.IOException;
+
+/**
+ * It holds binary doc values sub for each segment. It is used to merge doc values from multiple segments.
+ */
+@Getter
+public class BinaryDocValuesSub extends DocIDMerger.Sub {
+
+    private final BinaryDocValues values;
+    private final CacheKey key;
+    private int docId = 0;
+
+    public BinaryDocValuesSub(MergeState.DocMap docMap, BinaryDocValues values, CacheKey key) {
+        super(docMap);
+        if (values == null || (values.docID() != -1)) {
+            throw new IllegalStateException("Doc values is either null or docID is not -1 ");
+        }
+        this.values = values;
+        this.key = key;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        docId = values.nextDoc();
+        return docId;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.PushPostingsWriterBase;
+import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.neuralsearch.sparse.accessor.SparseVectorForwardIndex;
+import org.opensearch.neuralsearch.sparse.algorithm.seismic.ClusteringTask;
+import org.opensearch.neuralsearch.sparse.algorithm.seismic.RandomClusteringAlgorithm;
+import org.opensearch.neuralsearch.sparse.algorithm.seismic.SeismicPostingClusterer;
+import org.opensearch.neuralsearch.sparse.cache.CacheGatedForwardIndexReader;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCache;
+import org.opensearch.neuralsearch.sparse.common.IteratorWrapper;
+import org.opensearch.neuralsearch.sparse.common.ValueEncoder;
+import org.opensearch.neuralsearch.sparse.data.DocWeight;
+import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+import org.opensearch.neuralsearch.sparse.data.SparseVector;
+import org.opensearch.neuralsearch.sparse.quantization.ByteQuantizer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_N_POSTINGS;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_POSTING_MINIMUM_LENGTH;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_POSTING_PRUNE_RATIO;
+
+/**
+ * ClusteredPostingTermsWriter is used to write postings for each segment.
+ * It handles the logic to write data to both cache and lucene index.
+ */
+@Log4j2
+public class ClusteredPostingTermsWriter extends PushPostingsWriterBase {
+    private FixedBitSet docsSeen;
+    private IndexOutput postingOut;
+    private final List<DocWeight> docWeights = new ArrayList<>();
+    private BytesRef currentTerm;
+    private SeismicPostingClusterer seismicPostingClusterer;
+    private CacheKey key;
+    private final int version;
+    private final String codec_name;
+    private SegmentWriteState state;
+    private DocValuesProducer docValuesProducer;
+
+    public ClusteredPostingTermsWriter(String codec_name, int version) {
+        super();
+        this.version = version;
+        this.codec_name = codec_name;
+    }
+
+    public BlockTermState write(BytesRef text, TermsEnum termsEnum, NormsProducer norms) throws IOException {
+        this.currentTerm = text;
+        return super.writeTerm(text, termsEnum, docsSeen, norms);
+    }
+
+    public BlockTermState write(BytesRef text, PostingClusters postingClusters) throws IOException {
+        this.currentTerm = text;
+        BlockTermState state = newTermState();
+        writePostingClusters(postingClusters, state);
+        return state;
+    }
+
+    public void setFieldAndMaxDoc(FieldInfo fieldInfo, int maxDoc, boolean isMerge) {
+        super.setField(fieldInfo);
+        key = new CacheKey(this.state.segmentInfo, fieldInfo);
+
+        if (!isMerge) {
+            setSeismicPostingClusterer(maxDoc);
+        }
+    }
+
+    @Override
+    public BlockTermState newTermState() throws IOException {
+        return new Lucene101PostingsFormat.IntBlockTermState();
+    }
+
+    @Override
+    public void startTerm(NumericDocValues norms) throws IOException {
+        docWeights.clear();
+    }
+
+    private void setSeismicPostingClusterer(int maxDoc) {
+        SparseVectorForwardIndex index = ForwardIndexCache.getInstance().getOrCreate(key, maxDoc);
+
+        SparseBinaryDocValuesPassThrough luceneReader = null;
+        DocValuesFormat fmt = this.state.segmentInfo.getCodec().docValuesFormat();
+        SegmentReadState readState = new SegmentReadState(
+            this.state.directory,
+            this.state.segmentInfo,
+            this.state.fieldInfos,
+            IOContext.DEFAULT
+        );
+        try {
+            this.docValuesProducer = fmt.fieldsProducer(readState);
+            BinaryDocValues binaryDocValues = this.docValuesProducer.getBinary(fieldInfo);
+            if (binaryDocValues != null) {
+                luceneReader = new SparseBinaryDocValuesPassThrough(binaryDocValues, this.state.segmentInfo);
+            }
+        } catch (Exception e) {
+            log.error(String.format(Locale.ROOT, "Failed to retrieve lucene reader due to exception: [%s]", e.getMessage()));
+        }
+
+        float clusterRatio = Float.parseFloat(fieldInfo.attributes().get(CLUSTER_RATIO_FIELD));
+        int nPostings;
+        if (Integer.parseInt(fieldInfo.attributes().get(N_POSTINGS_FIELD)) == DEFAULT_N_POSTINGS) {
+            nPostings = Math.max((int) (DEFAULT_POSTING_PRUNE_RATIO * maxDoc), DEFAULT_POSTING_MINIMUM_LENGTH);
+        } else {
+            nPostings = Integer.parseInt(fieldInfo.attributes().get(N_POSTINGS_FIELD));
+        }
+        float summaryPruneRatio = Float.parseFloat(fieldInfo.attributes().get(SUMMARY_PRUNE_RATIO_FIELD));
+
+        this.seismicPostingClusterer = new SeismicPostingClusterer(
+            nPostings,
+            new RandomClusteringAlgorithm(
+                summaryPruneRatio,
+                clusterRatio,
+                new CacheGatedForwardIndexReader(index.getReader(), index.getWriter(), luceneReader)
+            )
+        );
+    }
+
+    private void writePostingClusters(PostingClusters postingClusters, BlockTermState state) throws IOException {
+        List<DocumentCluster> clusters = postingClusters.getClusters();
+        // write file
+        state.blockFilePointer = postingOut.getFilePointer();
+        postingOut.writeVLong(clusters.size());
+        for (DocumentCluster cluster : clusters) {
+            postingOut.writeVLong(cluster.size());
+            Iterator<DocWeight> iterator = cluster.iterator();
+            while (iterator.hasNext()) {
+                DocWeight docWeight = iterator.next();
+                postingOut.writeVInt(docWeight.getDocID());
+                postingOut.writeByte(docWeight.getWeight());
+            }
+            postingOut.writeByte((byte) (cluster.isShouldNotSkip() ? 1 : 0));
+            if (cluster.getSummary() == null) {
+                postingOut.writeVLong(0);
+            } else {
+                IteratorWrapper<SparseVector.Item> iter = cluster.getSummary().iterator();
+                postingOut.writeVLong(cluster.getSummary().getSize());
+                while (iter.hasNext()) {
+                    SparseVector.Item item = iter.next();
+                    postingOut.writeVInt(item.getToken());
+                    postingOut.writeByte(item.getWeight());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void finishTerm(BlockTermState state) throws IOException {
+        PostingClusters postingClusters = new ClusteringTask(this.currentTerm, docWeights, key, this.seismicPostingClusterer).get();
+        writePostingClusters(postingClusters, state);
+        this.docWeights.clear();
+        this.currentTerm = null;
+    }
+
+    @Override
+    public void startDoc(int docID, int freq) throws IOException {
+        if (docID == -1) {
+            throw new IllegalStateException("docId must be set before startDoc");
+        }
+        docWeights.add(new DocWeight(docID, ByteQuantizer.quantizeFloatToByte(ValueEncoder.decodeFeatureValue(freq))));
+    }
+
+    @Override
+    public void addPosition(int position, BytesRef payload, int startOffset, int endOffset) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void finishDoc() throws IOException {
+        // we don't have logic around finishing docs
+    }
+
+    @Override
+    public void init(IndexOutput termsOut, SegmentWriteState state) throws IOException {
+        this.postingOut = termsOut;
+        this.state = state;
+        this.docsSeen = new FixedBitSet(state.segmentInfo.maxDoc());
+        CodecUtil.writeIndexHeader(postingOut, this.codec_name, version, state.segmentInfo.getId(), state.segmentSuffix);
+    }
+
+    @Override
+    public void encodeTerm(DataOutput out, FieldInfo fieldInfo, BlockTermState state, boolean absolute) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() throws IOException {
+        CodecUtil.writeFooter(this.postingOut);
+        if (this.docValuesProducer != null) {
+            this.docValuesProducer.close();
+            this.docValuesProducer = null;
+        }
+    }
+
+    public void closeWithException() {
+        IOUtils.closeWhileHandlingException(this.postingOut);
+        if (this.docValuesProducer != null) {
+            IOUtils.closeWhileHandlingException(this.docValuesProducer);
+            this.docValuesProducer = null;
+        }
+    }
+
+    public void close(long startFp) throws IOException {
+        this.postingOut.writeLong(startFp);
+        close();
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/CodecUtilWrapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/CodecUtilWrapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+
+import java.io.IOException;
+
+/**
+ * A wrapper on CodecUtil class to enable better testability.
+ */
+public class CodecUtilWrapper {
+    public long retrieveChecksum(IndexInput in) throws IOException {
+        return CodecUtil.retrieveChecksum(in);
+    }
+
+    public int footerLength() {
+        return CodecUtil.footerLength();
+    }
+
+    public long checksumEntireFile(IndexInput input) throws IOException {
+        return CodecUtil.checksumEntireFile(input);
+    }
+
+    public int checkIndexHeader(DataInput in, String codec, int minVersion, int maxVersion, byte[] expectedID, String expectedSuffix)
+        throws IOException {
+        return CodecUtil.checkIndexHeader(in, codec, minVersion, maxVersion, expectedID, expectedSuffix);
+    }
+
+    public void writeIndexHeader(DataOutput out, String codec, int version, byte[] id, String suffix) throws IOException {
+        CodecUtil.writeIndexHeader(out, codec, version, id, suffix);
+    }
+
+    public void writeFooter(IndexOutput out) throws IOException {
+        CodecUtil.writeFooter(out);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/MergeHelper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/MergeHelper.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.Nullable;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+import org.opensearch.neuralsearch.sparse.common.ValueEncoder;
+import org.opensearch.neuralsearch.sparse.data.DocWeight;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensField;
+import org.opensearch.neuralsearch.sparse.quantization.ByteQuantizer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Helper class for managing cache data during segment merges in sparse vector fields.
+ */
+@NoArgsConstructor
+@Log4j2
+public class MergeHelper {
+    /**
+     * Clears cache data for sparse vector fields during segment merge operations.
+     *
+     * @param mergeStateFacade the merge state containing doc values producers and field info
+     * @param fieldInfo specific field to process, or null to process all sparse fields
+     * @param consumer callback to handle cache key removal
+     * @throws IOException if doc values cannot be accessed
+     */
+    public void clearCacheData(
+        @NonNull MergeStateFacade mergeStateFacade,
+        @Nullable FieldInfo fieldInfo,
+        @NonNull Consumer<CacheKey> consumer
+    ) throws IOException {
+        for (DocValuesProducer producer : mergeStateFacade.getDocValuesProducers()) {
+            for (FieldInfo field : mergeStateFacade.getMergeFieldInfos()) {
+                boolean isNotSparse = !SparseTokensField.isSparseField(field);
+                boolean fieldInfoMisMatched = fieldInfo != null && field != fieldInfo;
+                if (isNotSparse || fieldInfoMisMatched) {
+                    continue;
+                }
+                BinaryDocValues binaryDocValues = producer.getBinary(field);
+                if (!(binaryDocValues instanceof SparseBinaryDocValuesPassThrough binaryDocValuesPassThrough)) {
+                    continue;
+                }
+                CacheKey key = new CacheKey(binaryDocValuesPassThrough.getSegmentInfo(), field);
+                consumer.accept(key);
+            }
+        }
+    }
+
+    /**
+     * Retrieves merged posting list for a specific term across all segments.
+     *
+     * @param mergeStateFacade merge state containing producers and doc maps
+     * @param term the term to retrieve postings for
+     * @param fieldInfo field information for the sparse vector field
+     * @param newIdToFieldProducerIndex array to store field producer index for each new doc ID
+     * @param newIdToOldId array to store old doc ID mapping for each new doc ID
+     * @return list of document weights for the term
+     * @throws IOException if postings cannot be accessed
+     */
+    public List<DocWeight> getMergedPostingForATerm(
+        MergeStateFacade mergeStateFacade,
+        BytesRef term,
+        FieldInfo fieldInfo,
+        int[] newIdToFieldProducerIndex,
+        int[] newIdToOldId
+    ) throws IOException {
+        List<DocWeight> docWeights = new ArrayList<>();
+        for (int i = 0; i < mergeStateFacade.getFieldsProducers().length; i++) {
+            // we need this SparseBinaryDocValuesPassThrough to get segment info
+            BinaryDocValues binaryDocValues = mergeStateFacade.getDocValuesProducers()[i].getBinary(fieldInfo);
+            if (!(binaryDocValues instanceof SparseBinaryDocValuesPassThrough)) {
+                continue;
+            }
+            FieldsProducer fieldsProducer = mergeStateFacade.getFieldsProducers()[i];
+            Terms terms = fieldsProducer.terms(fieldInfo.getName());
+            if (terms == null) {
+                continue;
+            }
+
+            TermsEnum termsEnum = terms.iterator();
+            if (termsEnum == null) {
+                continue;
+            }
+
+            if (!termsEnum.seekExact(term)) {
+                continue;
+            }
+            PostingsEnum postings = termsEnum.postings(null);
+            if (postings == null) {
+                continue;
+            }
+            boolean isSparsePostings = postings instanceof SparsePostingsEnum;
+            int docId = postings.nextDoc();
+            for (; docId != PostingsEnum.NO_MORE_DOCS; docId = postings.nextDoc()) {
+                if (docId == -1) {
+                    continue;
+                }
+                int newDocId = mergeStateFacade.getDocMaps()[i].get(docId);
+                if (newDocId == -1) {
+                    continue;
+                }
+                if (newDocId >= newIdToFieldProducerIndex.length) {
+                    throw new IndexOutOfBoundsException("newDocId is larger than array size!");
+                }
+                newIdToFieldProducerIndex[newDocId] = i;
+                newIdToOldId[newDocId] = docId;
+                int freq = postings.freq();
+                byte freqByte = 0;
+                if (isSparsePostings) {
+                    // SparsePostingsEnum.freq() already transform byte freq to int
+                    freqByte = (byte) freq;
+                } else {
+                    // decode to float first
+                    freqByte = ByteQuantizer.quantizeFloatToByte(ValueEncoder.decodeFeatureValue(freq));
+                }
+                docWeights.add(new DocWeight(newDocId, freqByte));
+            }
+        }
+        return docWeights;
+    }
+
+    /**
+     * Collects all unique terms from segments being merged.
+     *
+     * @param mergeStateFacade merge state containing field producers
+     * @param fieldInfo field information for the sparse vector field
+     * @return set of all unique terms across segments
+     * @throws IOException if terms cannot be accessed
+     */
+    public Set<BytesRef> getAllTerms(MergeStateFacade mergeStateFacade, FieldInfo fieldInfo) throws IOException {
+        Set<BytesRef> allTerms = new HashSet<>();
+        for (int i = 0; i < mergeStateFacade.getFieldsProducers().length; i++) {
+            FieldsProducer fieldsProducer = mergeStateFacade.getFieldsProducers()[i];
+            // we need this SparseBinaryDocValuesPassThrough to get segment info
+            BinaryDocValues binaryDocValues = mergeStateFacade.getDocValuesProducers()[i].getBinary(fieldInfo);
+            if (!(binaryDocValues instanceof SparseBinaryDocValuesPassThrough)) {
+                continue;
+            }
+
+            Terms terms = fieldsProducer.terms(fieldInfo.getName());
+            if (terms instanceof SparseTerms sparseTerms) {
+                allTerms.addAll(sparseTerms.getReader().getTerms());
+            } else {
+                // fieldsProducer could be a delegate one as we need to merge normal segments into seis segment
+                TermsEnum termsEnum = terms.iterator();
+                while (true) {
+                    BytesRef term = termsEnum.next();
+                    if (term == null) {
+                        break;
+                    }
+                    allTerms.add(BytesRef.deepCopyOf(term));
+                }
+            }
+        }
+        return allTerms;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/MergeHelper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/MergeHelper.java
@@ -184,4 +184,13 @@ public class MergeHelper {
     public MergeStateFacade convertToMergeStateFacade(MergeState mergeState) {
         return new MergeStateFacade(mergeState);
     }
+
+    /**
+     * Create a new SparseDocValuesReader instance
+     * @param mergeStateFacade {@link MergeStateFacade}
+     * @return {@link SparseDocValuesReader}
+     */
+    public SparseDocValuesReader newSparseDocValuesReader(MergeStateFacade mergeStateFacade) {
+        return new SparseDocValuesReader(mergeStateFacade);
+    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/MergeHelper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/MergeHelper.java
@@ -11,6 +11,7 @@ import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
@@ -173,5 +174,14 @@ public class MergeHelper {
             }
         }
         return allTerms;
+    }
+
+    /**
+     * A helper function to create merge state facade which enables better testability.
+     * @param mergeState {@link MergeState}
+     * @return {@link MergeStateFacade}
+     */
+    public MergeStateFacade convertToMergeStateFacade(MergeState mergeState) {
+        return new MergeStateFacade(mergeState);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValues.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValues.java
@@ -38,6 +38,10 @@ public class SparseBinaryDocValues extends BinaryDocValues {
 
     @Override
     public int nextDoc() throws IOException {
+        if (docIDMerger == null) {
+            docID = NO_MORE_DOCS;
+            return docID;
+        }
         current = docIDMerger.next();
         if (current == null) {
             docID = NO_MORE_DOCS;

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValues.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValues.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.Getter;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocIDMerger;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.accessor.SparseVectorReader;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCache;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCacheItem;
+import org.opensearch.neuralsearch.sparse.data.SparseVector;
+
+import java.io.IOException;
+
+/**
+ * This is a customized BinaryDocValues for sparse vector. It is used to merge doc values from multiple segments.
+ */
+public class SparseBinaryDocValues extends BinaryDocValues {
+    private final DocIDMerger<BinaryDocValuesSub> docIDMerger;
+
+    @Getter
+    private long totalLiveDocs;
+    private BinaryDocValuesSub current;
+    private int docID = -1;
+
+    SparseBinaryDocValues(DocIDMerger<BinaryDocValuesSub> docIdMerger) {
+        this.docIDMerger = docIdMerger;
+    }
+
+    @Override
+    public int docID() {
+        return docID;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        current = docIDMerger.next();
+        if (current == null) {
+            docID = NO_MORE_DOCS;
+        } else {
+            docID = current.mappedDocID;
+        }
+        return docID;
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long cost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BytesRef binaryValue() throws IOException {
+        return current.getValues().binaryValue();
+    }
+
+    public SparseVector cachedSparseVector() throws IOException {
+        if (this.current == null) return null;
+        CacheKey key = this.current.getKey();
+        if (key == null) return null;
+        ForwardIndexCacheItem index = ForwardIndexCache.getInstance().get(key);
+        if (index == null) return null;
+        // Simply read the cache without CacheGatedForwardIndexReader
+        SparseVectorReader reader = index.getReader();
+        int oldDocId = this.current.getDocId();
+        return reader.read(oldDocId);
+    }
+
+    /**
+     * Builder pattern like setter for setting totalLiveDocs. We can use setter also. But this way the code is clean.
+     * @param totalLiveDocs int
+     * @return {@link SparseBinaryDocValues}
+     */
+    public SparseBinaryDocValues setTotalLiveDocs(long totalLiveDocs) {
+        this.totalLiveDocs = totalLiveDocs;
+        return this;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.accessor.SparseVectorReader;
+import org.opensearch.neuralsearch.sparse.data.SparseVector;
+
+import java.io.IOException;
+
+@AllArgsConstructor
+public class SparseBinaryDocValuesPassThrough extends BinaryDocValues implements SparseVectorReader {
+
+    private final BinaryDocValues delegate;
+    @Getter
+    private final SegmentInfo segmentInfo;
+
+    @Override
+    public BytesRef binaryValue() throws IOException {
+        return this.delegate.binaryValue();
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        return this.delegate.advanceExact(target);
+    }
+
+    @Override
+    public int docID() {
+        return this.delegate.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return this.delegate.nextDoc();
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        return this.delegate.advance(target);
+    }
+
+    @Override
+    public long cost() {
+        return this.delegate.cost();
+    }
+
+    @Override
+    public SparseVector read(int docId) throws IOException {
+        if (!advanceExact(docId)) {
+            return null;
+        }
+        BytesRef bytesRef = binaryValue();
+        if (bytesRef == null) {
+            return null;
+        }
+        return new SparseVector(bytesRef);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThrough.java
@@ -52,7 +52,7 @@ public class SparseBinaryDocValuesPassThrough extends BinaryDocValues implements
     }
 
     @Override
-    public SparseVector read(int docId) throws IOException {
+    public synchronized SparseVector read(int docId) throws IOException {
         if (!advanceExact(docId)) {
             return null;
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseCodec.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseCodec.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.lucene101.Lucene101Codec;
+
+/**
+ * SparseCodec is used to encode and decode sparse vector related data structures.
+ */
+public class SparseCodec extends FilterCodec {
+    private static final String NAME = "Sparse10010Codec";
+    public static final Codec DEFAULT_DELEGATE = new Lucene101Codec();
+
+    public SparseCodec() {
+        this(DEFAULT_DELEGATE);
+    }
+
+    /**
+     * Sole constructor. When subclassing this codec, create a no-arg ctor and pass the delegate codec
+     * and a unique name to this ctor.
+     *
+     * @param delegate the delegate codec
+     */
+    public SparseCodec(Codec delegate) {
+        super(NAME, delegate);
+    }
+
+    @Override
+    public DocValuesFormat docValuesFormat() {
+        return new SparseDocValuesFormat(delegate.docValuesFormat());
+    }
+
+    @Override
+    public PostingsFormat postingsFormat() {
+        return new SparsePostingsFormat(this.delegate.postingsFormat());
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseCodecService.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseCodecService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.opensearch.index.codec.CodecService;
+import org.opensearch.index.codec.CodecServiceConfig;
+
+/**
+ * It vends SparseCodec to engine to provide sparse vector codec.
+ */
+public class SparseCodecService extends CodecService {
+
+    public SparseCodecService(CodecServiceConfig codecServiceConfig) {
+        super(codecServiceConfig.getMapperService(), codecServiceConfig.getIndexSettings(), codecServiceConfig.getLogger());
+    }
+
+    @Override
+    public Codec codec(String name) {
+        return new SparseCodec(super.codec(name));
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.accessor.SparseVectorWriter;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCache;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+import org.opensearch.neuralsearch.sparse.common.PredicateUtils;
+import org.opensearch.neuralsearch.sparse.data.SparseVector;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensField;
+
+import java.io.IOException;
+
+/**
+ * A DocValuesConsumer that writes sparse doc values to a segment.
+ */
+@Log4j2
+public class SparseDocValuesConsumer extends DocValuesConsumer {
+    private final DocValuesConsumer delegate;
+    private final SegmentWriteState state;
+    private final MergeHelper mergeHelper;
+
+    public SparseDocValuesConsumer(
+        @NonNull SegmentWriteState state,
+        @NonNull DocValuesConsumer delegate,
+        @NonNull MergeHelper mergeHelper
+    ) {
+        super();
+        this.delegate = delegate;
+        this.state = state;
+        this.mergeHelper = mergeHelper;
+    }
+
+    @Override
+    public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        this.delegate.addNumericField(field, valuesProducer);
+    }
+
+    @Override
+    public void addBinaryField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        this.delegate.addBinaryField(field, valuesProducer);
+        // check field is the sparse field, otherwise return
+        if (!SparseTokensField.isSparseField(field)) {
+            return;
+        }
+        addBinary(field, valuesProducer, false);
+    }
+
+    private void addBinary(FieldInfo field, DocValuesProducer valuesProducer, boolean isMerge) throws IOException {
+        if (!PredicateUtils.shouldRunSeisPredicate.test(this.state.segmentInfo, field)) {
+            return;
+        }
+        BinaryDocValues binaryDocValues = valuesProducer.getBinary(field);
+        CacheKey key = new CacheKey(this.state.segmentInfo, field);
+        int docCount = this.state.segmentInfo.maxDoc();
+        SparseVectorWriter writer = ForwardIndexCache.getInstance().getOrCreate(key, docCount).getWriter();
+        if (writer == null) {
+            throw new IllegalStateException("Forward index writer is null");
+        }
+        int docId = binaryDocValues.nextDoc();
+        while (docId != DocIdSetIterator.NO_MORE_DOCS) {
+            boolean written = false;
+            if (isMerge) {
+                SparseBinaryDocValues sparseBinaryDocValues = (SparseBinaryDocValues) binaryDocValues;
+                SparseVector vector = sparseBinaryDocValues.cachedSparseVector();
+                if (vector != null) {
+                    writer.insert(docId, vector);
+                    written = true;
+                }
+            }
+            if (!written) {
+                BytesRef bytesRef = binaryDocValues.binaryValue();
+                writer.insert(docId, new SparseVector(bytesRef));
+            }
+            docId = binaryDocValues.nextDoc();
+        }
+        if (isMerge) {
+            if (valuesProducer instanceof SparseDocValuesReader reader) {
+                mergeHelper.clearCacheData(
+                    new MergeStateFacade(reader.getMergeState()),
+                    field,
+                    ForwardIndexCache.getInstance()::removeIndex
+                );
+            }
+        }
+    }
+
+    @Override
+    public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        this.delegate.addSortedField(field, valuesProducer);
+    }
+
+    @Override
+    public void addSortedNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        this.delegate.addSortedNumericField(field, valuesProducer);
+    }
+
+    @Override
+    public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        this.delegate.addSortedSetField(field, valuesProducer);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.delegate.close();
+    }
+
+    @Override
+    public void merge(MergeState mergeState) throws IOException {
+        this.delegate.merge(mergeState);
+        try {
+            assert mergeState != null;
+            assert mergeState.mergeFieldInfos != null;
+            for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
+                DocValuesType type = fieldInfo.getDocValuesType();
+                if (type == DocValuesType.BINARY && SparseTokensField.isSparseField(fieldInfo)) {
+                    addBinary(fieldInfo, new SparseDocValuesReader(mergeState), true);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Merge sparse doc values error", e);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -90,11 +90,7 @@ public class SparseDocValuesConsumer extends DocValuesConsumer {
         }
         if (isMerge) {
             if (valuesProducer instanceof SparseDocValuesReader reader) {
-                mergeHelper.clearCacheData(
-                    new MergeStateFacade(reader.getMergeState()),
-                    field,
-                    ForwardIndexCache.getInstance()::removeIndex
-                );
+                mergeHelper.clearCacheData(reader.getMergeStateFacade(), field, ForwardIndexCache.getInstance()::removeIndex);
             }
         }
     }
@@ -124,11 +120,12 @@ public class SparseDocValuesConsumer extends DocValuesConsumer {
         this.delegate.merge(mergeState);
         try {
             assert mergeState != null;
-            assert mergeState.mergeFieldInfos != null;
-            for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
+            MergeStateFacade mergeStateFacade = mergeHelper.convertToMergeStateFacade(mergeState);
+            assert mergeStateFacade.getMergeFieldInfos() != null;
+            for (FieldInfo fieldInfo : mergeStateFacade.getMergeFieldInfos()) {
                 DocValuesType type = fieldInfo.getDocValuesType();
                 if (type == DocValuesType.BINARY && SparseTokensField.isSparseField(fieldInfo)) {
-                    addBinary(fieldInfo, new SparseDocValuesReader(mergeState), true);
+                    addBinary(fieldInfo, new SparseDocValuesReader(mergeStateFacade), true);
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumer.java
@@ -126,7 +126,7 @@ public class SparseDocValuesConsumer extends DocValuesConsumer {
             for (FieldInfo fieldInfo : mergeFieldInfos) {
                 DocValuesType type = fieldInfo.getDocValuesType();
                 if (type == DocValuesType.BINARY && SparseTokensField.isSparseField(fieldInfo)) {
-                    addSparseVectorBinary(fieldInfo, new SparseDocValuesReader(mergeStateFacade), true);
+                    addSparseVectorBinary(fieldInfo, mergeHelper.newSparseDocValuesReader(mergeStateFacade), true);
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesFormat.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesFormat.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+import java.io.IOException;
+
+/**
+ * SparseDocValuesFormat is used to encode and decode sparse vector related data structures.
+ */
+public class SparseDocValuesFormat extends DocValuesFormat {
+    private final DocValuesFormat delegate;
+
+    public SparseDocValuesFormat(DocValuesFormat delegate) {
+        super(delegate.getName());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+        return new SparseDocValuesConsumer(state, delegate.fieldsConsumer(state), new MergeHelper());
+    }
+
+    @Override
+    public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+        return new SparseDocValuesProducer(state, delegate.fieldsProducer(state));
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducer.java
@@ -18,13 +18,20 @@ import org.apache.lucene.index.SortedSetDocValues;
 import java.io.IOException;
 
 /**
- *
+ * DocValues producer for sparse vector fields that wraps a delegate producer
+ * and provides sparse-specific binary doc values handling.
  */
 public class SparseDocValuesProducer extends DocValuesProducer {
     private final DocValuesProducer delegate;
     @Getter
     private final SegmentReadState state;
 
+    /**
+     * Creates a new sparse doc values producer.
+     *
+     * @param state the segment read state
+     * @param delegate the underlying doc values producer to delegate to
+     */
     public SparseDocValuesProducer(SegmentReadState state, DocValuesProducer delegate) {
         super();
         this.state = state;
@@ -36,6 +43,9 @@ public class SparseDocValuesProducer extends DocValuesProducer {
         return this.delegate.getNumeric(field);
     }
 
+    /**
+     * Returns binary doc values for sparse vector fields with pass-through handling.
+     */
     @Override
     public BinaryDocValues getBinary(FieldInfo field) throws IOException {
         return new SparseBinaryDocValuesPassThrough(this.delegate.getBinary(field), this.getState().segmentInfo);

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.Getter;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class SparseDocValuesProducer extends DocValuesProducer {
+    private final DocValuesProducer delegate;
+    @Getter
+    private final SegmentReadState state;
+
+    public SparseDocValuesProducer(SegmentReadState state, DocValuesProducer delegate) {
+        super();
+        this.state = state;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(FieldInfo field) throws IOException {
+        return this.delegate.getNumeric(field);
+    }
+
+    @Override
+    public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+        return new SparseBinaryDocValuesPassThrough(this.delegate.getBinary(field), this.getState().segmentInfo);
+    }
+
+    @Override
+    public SortedDocValues getSorted(FieldInfo field) throws IOException {
+        return this.delegate.getSorted(field);
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+        return this.delegate.getSortedNumeric(field);
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
+        return this.delegate.getSortedSet(field);
+    }
+
+    @Override
+    public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+        return this.delegate.getSkipper(field);
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        this.delegate.checkIntegrity();
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.delegate.close();
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.Getter;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocIDMerger;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.EmptyDocValuesProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.Bits;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * It produces SparseDocValues when segments merge happens. It does the actual work for sparse vector merge.
+ */
+public class SparseDocValuesReader extends EmptyDocValuesProducer {
+    @Getter
+    private final MergeState mergeState;
+
+    public SparseDocValuesReader(MergeState state) {
+        this.mergeState = state;
+    }
+
+    @Override
+    public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+        long totalLiveDocs = 0;
+        List<BinaryDocValuesSub> subs = new ArrayList<>(this.mergeState.docValuesProducers.length);
+        for (int i = 0; i < this.mergeState.docValuesProducers.length; i++) {
+            BinaryDocValues values = null;
+            DocValuesProducer docValuesProducer = mergeState.docValuesProducers[i];
+            if (docValuesProducer != null) {
+                FieldInfo readerFieldInfo = mergeState.fieldInfos[i].fieldInfo(field.getName());
+                if (readerFieldInfo != null && readerFieldInfo.getDocValuesType() == DocValuesType.BINARY) {
+                    values = docValuesProducer.getBinary(readerFieldInfo);
+                }
+                if (values != null) {
+                    CacheKey key = null;
+                    if (values instanceof SparseBinaryDocValuesPassThrough sparseBinaryDocValuesPassThrough) {
+                        key = new CacheKey(sparseBinaryDocValuesPassThrough.getSegmentInfo(), field);
+                    }
+                    totalLiveDocs = totalLiveDocs + getLiveDocsCount(values, this.mergeState.liveDocs[i]);
+                    // docValues will be consumed when liveDocs are not null, hence resetting the docsValues
+                    // pointer.
+                    values = this.mergeState.liveDocs[i] != null ? docValuesProducer.getBinary(readerFieldInfo) : values;
+                    subs.add(new BinaryDocValuesSub(mergeState.docMaps[i], values, key));
+                }
+            }
+        }
+        return new SparseBinaryDocValues(DocIDMerger.of(subs, mergeState.needsIndexSort)).setTotalLiveDocs(totalLiveDocs);
+    }
+
+    private long getLiveDocsCount(final BinaryDocValues binaryDocValues, final Bits liveDocsBits) throws IOException {
+        long liveDocs = 0;
+        if (liveDocsBits != null) {
+            int docId;
+            for (docId = binaryDocValues.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = binaryDocValues.nextDoc()) {
+                if (liveDocsBits.get(docId)) {
+                    liveDocs++;
+                }
+            }
+        } else {
+            liveDocs = binaryDocValues.cost();
+        }
+        return liveDocs;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
@@ -64,7 +64,7 @@ public class SparsePostingsConsumer extends FieldsConsumer {
             state,
             mergeHelper,
             VERSION_CURRENT,
-            new ClusteredPostingTermsWriter(CODEC_NAME, VERSION_CURRENT),
+            new ClusteredPostingTermsWriter(CODEC_NAME, VERSION_CURRENT, new CodecUtilWrapper()),
             new SparseTermsLuceneWriter(CODEC_NAME, VERSION_CURRENT, new CodecUtilWrapper())
         );
     }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
@@ -4,12 +4,45 @@
  */
 package org.opensearch.neuralsearch.sparse.codec;
 
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.neuralsearch.sparse.cache.ClusteredPostingCache;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+import org.opensearch.neuralsearch.sparse.common.PredicateUtils;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensField;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 /**
  * This class is responsible for writing sparse postings to the index
  */
-public class SparsePostingsConsumer {
+@Log4j2
+public class SparsePostingsConsumer extends FieldsConsumer {
+    private final FieldsConsumer delegate;
+    private final SegmentWriteState state;
+    private final MergeHelper mergeHelper;
 
     static final String CODEC_NAME = "SparsePostingsProducer";
+    private final IndexOutput termsOut;
+    private final IndexOutput postingOut;
+    private final SparseTermsLuceneWriter sparseTermsLuceneWriter;
 
     // Initial format
     public static final int VERSION_START = 1;
@@ -18,4 +51,156 @@ public class SparsePostingsConsumer {
     /** Extension of terms file */
     static final String TERMS_EXTENSION = "sit";
     static final String POSTING_EXTENSION = "sip";
+
+    private final ClusteredPostingTermsWriter clusteredPostingTermsWriter;
+    private long termsStartFp = 0;
+    private long postingStartFp = 0;
+    private boolean fromMerge = false;
+
+    public SparsePostingsConsumer(@NonNull FieldsConsumer delegate, @NonNull SegmentWriteState state, @NonNull MergeHelper mergeHelper)
+        throws IOException {
+        this(delegate, state, mergeHelper, VERSION_CURRENT);
+    }
+
+    public SparsePostingsConsumer(
+        @NonNull FieldsConsumer delegate,
+        @NonNull SegmentWriteState state,
+        @NonNull MergeHelper mergeHelper,
+        int version
+    ) throws IOException {
+        super();
+        this.delegate = delegate;
+        this.state = state;
+        this.mergeHelper = mergeHelper;
+
+        final String termsFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, TERMS_EXTENSION);
+        final String postingFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, POSTING_EXTENSION);
+
+        clusteredPostingTermsWriter = new ClusteredPostingTermsWriter(CODEC_NAME, version);
+        sparseTermsLuceneWriter = new SparseTermsLuceneWriter(CODEC_NAME, version);
+
+        boolean success = false;
+        IndexOutput termsOut = null;
+        IndexOutput postingOut = null;
+        try {
+            termsOut = state.directory.createOutput(termsFileName, state.context);
+            sparseTermsLuceneWriter.init(termsOut, state);
+            postingOut = state.directory.createOutput(postingFileName, state.context);
+            clusteredPostingTermsWriter.init(postingOut, state);
+
+            success = true;
+        } finally {
+            if (!success) {
+                IOUtils.closeWhileHandlingException(termsOut, postingOut);
+                this.termsOut = null;
+                this.postingOut = null;
+            } else {
+                this.termsOut = termsOut;
+                this.postingOut = postingOut;
+                termsStartFp = termsOut.getFilePointer();
+                postingStartFp = postingOut.getFilePointer();
+            }
+        }
+    }
+
+    private void writeSparseTerms(Fields fields, NormsProducer norms, List<String> sparseFields) throws IOException {
+        this.sparseTermsLuceneWriter.writeFieldCount(sparseFields.size());
+
+        String lastField = null;
+        for (String field : sparseFields) {
+            assert lastField == null || lastField.compareTo(field) < 0;
+            lastField = field;
+            this.sparseTermsLuceneWriter.writeFieldNumber(this.state.fieldInfos.fieldInfo(field).number);
+
+            Terms terms = fields.terms(field);
+            if (terms == null) {
+                this.sparseTermsLuceneWriter.writeTermsSize(0);
+                continue;
+            }
+
+            this.clusteredPostingTermsWriter.setFieldAndMaxDoc(
+                this.state.fieldInfos.fieldInfo(field),
+                this.state.segmentInfo.maxDoc(),
+                false
+            );
+
+            TermsEnum termsEnum = terms.iterator();
+            List<BytesRef> termsList = new ArrayList<>();
+            List<BlockTermState> states = new ArrayList<>();
+            while (true) {
+                BytesRef term = termsEnum.next();
+                if (term == null) {
+                    break;
+                }
+                BlockTermState state = this.clusteredPostingTermsWriter.write(term, termsEnum, norms);
+                termsList.add(term.clone());
+                states.add(state);
+            }
+            this.sparseTermsLuceneWriter.writeTermsSize(termsList.size());
+            for (int i = 0; i < termsList.size(); ++i) {
+                this.sparseTermsLuceneWriter.writeTerm(termsList.get(i), states.get(i));
+            }
+        }
+    }
+
+    @Override
+    public void write(Fields fields, NormsProducer norms) throws IOException {
+        List<String> nonSparseFields = new ArrayList<>();
+        List<String> sparseFields = new ArrayList<>();
+        for (String field : fields) {
+            FieldInfo fieldInfo = this.state.fieldInfos.fieldInfo(field);
+            if (SparseTokensField.isSparseField(fieldInfo)
+                && PredicateUtils.shouldRunSeisPredicate.test(this.state.segmentInfo, fieldInfo)) {
+                sparseFields.add(field);
+            } else {
+                nonSparseFields.add(field);
+            }
+        }
+        if (!nonSparseFields.isEmpty()) {
+            Fields maskedFields = new FilterLeafReader.FilterFields(fields) {
+                @Override
+                public Iterator<String> iterator() {
+                    return nonSparseFields.iterator();
+                }
+            };
+            this.delegate.write(maskedFields, norms);
+        }
+        // if this is not a merge, write the sparse fields, if it's from merge, we handle it from merge()
+        if (!this.fromMerge && !sparseFields.isEmpty()) {
+            writeSparseTerms(fields, norms, sparseFields);
+        }
+    }
+
+    @Override
+    public void merge(MergeState mergeState, NormsProducer norms) throws IOException {
+        this.fromMerge = true;
+        // merge non-sparse fields
+        super.merge(mergeState, norms);
+        // merge sparse fields
+        try {
+            MergeStateFacade mergeStateFacade = new MergeStateFacade(mergeState);
+            SparsePostingsReader sparsePostingsReader = new SparsePostingsReader(mergeStateFacade, new MergeHelper());
+            sparsePostingsReader.merge(this.sparseTermsLuceneWriter, this.clusteredPostingTermsWriter);
+            mergeHelper.clearCacheData(mergeStateFacade, null, ClusteredPostingCache.getInstance()::removeIndex);
+        } catch (Exception e) {
+            log.error("Merge sparse postings error", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.delegate.close();
+        boolean success = false;
+        try {
+            this.sparseTermsLuceneWriter.close(this.termsStartFp);
+            this.clusteredPostingTermsWriter.close(this.postingStartFp);
+            success = true;
+        } finally {
+            if (success) {
+                IOUtils.close(termsOut, postingOut);
+            } else {
+                IOUtils.closeWhileHandlingException(termsOut, postingOut);
+            }
+        }
+    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
@@ -77,7 +77,7 @@ public class SparsePostingsConsumer extends FieldsConsumer {
         final String postingFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, POSTING_EXTENSION);
 
         clusteredPostingTermsWriter = new ClusteredPostingTermsWriter(CODEC_NAME, version);
-        sparseTermsLuceneWriter = new SparseTermsLuceneWriter(CODEC_NAME, version);
+        sparseTermsLuceneWriter = new SparseTermsLuceneWriter(CODEC_NAME, version, new CodecUtilWrapper());
 
         boolean success = false;
         IndexOutput termsOut = null;

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumer.java
@@ -140,8 +140,9 @@ public class SparsePostingsConsumer extends FieldsConsumer {
                 if (term == null) {
                     break;
                 }
-                BlockTermState state = this.clusteredPostingTermsWriter.write(term, termsEnum, norms);
-                termsList.add(term.clone());
+                BytesRef clonedTerm = term.clone();
+                BlockTermState state = this.clusteredPostingTermsWriter.write(clonedTerm, termsEnum, norms);
+                termsList.add(clonedTerm);
                 states.add(state);
             }
             this.sparseTermsLuceneWriter.writeTermsSize(termsList.size());
@@ -187,7 +188,7 @@ public class SparsePostingsConsumer extends FieldsConsumer {
         // merge sparse fields
         try {
             MergeStateFacade mergeStateFacade = mergeHelper.convertToMergeStateFacade(mergeState);
-            SparsePostingsReader sparsePostingsReader = new SparsePostingsReader(mergeStateFacade, new MergeHelper());
+            SparsePostingsReader sparsePostingsReader = new SparsePostingsReader(mergeStateFacade, mergeHelper);
             sparsePostingsReader.merge(this.sparseTermsLuceneWriter, this.clusteredPostingTermsWriter);
             mergeHelper.clearCacheData(mergeStateFacade, null, ClusteredPostingCache.getInstance()::removeIndex);
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnum.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnum.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.Getter;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.common.DocWeightIterator;
+import org.opensearch.neuralsearch.sparse.common.IteratorWrapper;
+import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+import org.opensearch.neuralsearch.sparse.quantization.ByteQuantizer;
+
+import java.io.IOException;
+
+/**
+ * PostingsEnum for sparse vector
+ */
+public class SparsePostingsEnum extends PostingsEnum {
+    @Getter
+    private final PostingClusters clusters;
+    @Getter
+    private final CacheKey cacheKey;
+    private IteratorWrapper<DocumentCluster> currentCluster;
+    private DocWeightIterator currentDocWeight;
+
+    public SparsePostingsEnum(PostingClusters clusters, CacheKey cacheKey) throws IOException {
+        this.clusters = clusters;
+        this.cacheKey = cacheKey;
+        currentCluster = clusterIterator();
+        currentDocWeight = currentCluster.next().getDisi();
+    }
+
+    public IteratorWrapper<DocumentCluster> clusterIterator() {
+        return this.clusters.iterator();
+    }
+
+    public int size() {
+        return clusters.getSize();
+    }
+
+    @Override
+    public int freq() throws IOException {
+        assert this.currentDocWeight != null;
+        return ByteQuantizer.getUnsignedByte(this.currentDocWeight.weight());
+    }
+
+    @Override
+    public int nextPosition() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int startOffset() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int endOffset() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BytesRef getPayload() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int docID() {
+        if (currentDocWeight == null) {
+            return -1;
+        }
+        return currentDocWeight.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        assert currentDocWeight != null;
+        int doc = currentDocWeight.nextDoc();
+        while (doc == DocIdSetIterator.NO_MORE_DOCS) {
+            if (!currentCluster.hasNext()) {
+                return DocIdSetIterator.NO_MORE_DOCS;
+            }
+            currentDocWeight = currentCluster.next().getDisi();
+            doc = currentDocWeight.nextDoc();
+        }
+        return doc;
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long cost() {
+        return 0;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnum.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnum.java
@@ -18,7 +18,7 @@ import org.opensearch.neuralsearch.sparse.quantization.ByteQuantizer;
 import java.io.IOException;
 
 /**
- * PostingsEnum for sparse vector
+ * An enumerator for seismic's posting list with clusters, it traverses clusters and docs.
  */
 public class SparsePostingsEnum extends PostingsEnum {
     @Getter

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormat.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormat.java
@@ -30,6 +30,10 @@ public class SparsePostingsFormat extends PostingsFormat {
 
     @Override
     public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
-        return new SparsePostingsProducer(this.delegate.fieldsProducer(state), state, () -> new SparseTermsLuceneReader(state));
+        return new SparsePostingsProducer(
+            this.delegate.fieldsProducer(state),
+            state,
+            () -> new SparseTermsLuceneReader(state, new CodecUtilWrapper())
+        );
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormat.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormat.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+import java.io.IOException;
+
+/**
+ * Format for sparse vector postings.
+ */
+public class SparsePostingsFormat extends PostingsFormat {
+    private final PostingsFormat delegate;
+
+    public SparsePostingsFormat(PostingsFormat delegate) {
+        super(delegate.getName());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+        return new SparsePostingsConsumer(this.delegate.fieldsConsumer(state), state, new MergeHelper());
+    }
+
+    @Override
+    public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
+        return new SparsePostingsProducer(this.delegate.fieldsProducer(state), state, () -> new SparseTermsLuceneReader(state));
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.Terms;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.common.PredicateUtils;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensField;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+/**
+ * SparsePostingsProducer vends SparseTerms for each sparse field.
+ * It is used to read sparse postings from the index.
+ */
+@Getter
+public class SparsePostingsProducer extends FieldsProducer {
+
+    private final FieldsProducer delegate;
+    private final SegmentReadState state;
+    private final Supplier<SparseTermsLuceneReader> readerSupplier;
+    private SparseTermsLuceneReader reader;
+
+    // use supplier for lazy load
+    public SparsePostingsProducer(
+        FieldsProducer delegate,
+        SegmentReadState state,
+        @NonNull Supplier<SparseTermsLuceneReader> readerSupplier
+    ) {
+        super();
+        this.delegate = delegate;
+        this.state = state;
+        this.readerSupplier = readerSupplier;
+        this.reader = null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (this.delegate != null) {
+            this.delegate.close();
+        }
+        if (this.reader != null) {
+            this.reader.close();
+        }
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        this.delegate.checkIntegrity();
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return this.delegate.iterator();
+    }
+
+    @Override
+    public Terms terms(String field) throws IOException {
+        FieldInfo fieldInfo = this.state.fieldInfos.fieldInfo(field);
+        if (!SparseTokensField.isSparseField(fieldInfo) || !PredicateUtils.shouldRunSeisPredicate.test(this.state.segmentInfo, fieldInfo)) {
+            return delegate.terms(field);
+        }
+        CacheKey key = new CacheKey(this.state.segmentInfo, fieldInfo);
+        if (reader == null) {
+            reader = readerSupplier.get();
+        }
+        return new SparseTerms(key, reader, field);
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReader.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.algorithm.ClusterTrainingExecutor;
+import org.opensearch.neuralsearch.sparse.algorithm.seismic.BatchClusteringTask;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+import org.opensearch.neuralsearch.sparse.common.PredicateUtils;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensField;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_N_POSTINGS;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_POSTING_MINIMUM_LENGTH;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_POSTING_PRUNE_RATIO;
+
+/**
+ * Merge sparse postings
+ */
+@Log4j2
+@AllArgsConstructor
+public class SparsePostingsReader {
+    private final MergeStateFacade mergeStateFacade;
+    private final MergeHelper mergeHelper;
+    // this is a magic number for now which is effective
+    private static final int BATCH_SIZE = 50;
+
+    public void merge(SparseTermsLuceneWriter sparseTermsLuceneWriter, ClusteredPostingTermsWriter clusteredPostingTermsWriter)
+        throws Exception {
+        int docCount = 0;
+        for (int n : mergeStateFacade.getMaxDocs()) {
+            docCount += n;
+        }
+        log.debug("Merge total doc: {}", docCount);
+        List<FieldInfo> sparseFieldInfos = new ArrayList<>();
+        for (FieldInfo fieldInfo : mergeStateFacade.getMergeFieldInfos()) {
+            if (SparseTokensField.isSparseField(fieldInfo)
+                && PredicateUtils.shouldRunSeisPredicate.test(mergeStateFacade.getSegmentInfo(), fieldInfo)) {
+                sparseFieldInfos.add(fieldInfo);
+            }
+        }
+
+        try {
+            sparseTermsLuceneWriter.writeFieldCount(sparseFieldInfos.size());
+            for (FieldInfo fieldInfo : sparseFieldInfos) {
+                log.debug("Merge field: {}", fieldInfo.name);
+                sparseTermsLuceneWriter.writeFieldNumber(fieldInfo.getFieldNumber());
+
+                CacheKey key = new CacheKey(mergeStateFacade.getSegmentInfo(), fieldInfo);
+                float clusterRatio = Float.parseFloat(fieldInfo.attributes().get(CLUSTER_RATIO_FIELD));
+                int nPostings;
+                if (Integer.parseInt(fieldInfo.attributes().get(N_POSTINGS_FIELD)) == DEFAULT_N_POSTINGS) {
+                    nPostings = Math.max((int) (DEFAULT_POSTING_PRUNE_RATIO * docCount), DEFAULT_POSTING_MINIMUM_LENGTH);
+                } else {
+                    nPostings = Integer.parseInt(fieldInfo.attributes().get(N_POSTINGS_FIELD));
+                }
+                float summaryPruneRatio = Float.parseFloat(fieldInfo.attributes().get(SUMMARY_PRUNE_RATIO_FIELD));
+
+                // get all terms of old segments from CacheClusteredPosting
+                Set<BytesRef> allTerms = mergeHelper.getAllTerms(mergeStateFacade, fieldInfo);
+                sparseTermsLuceneWriter.writeTermsSize(allTerms.size());
+                clusteredPostingTermsWriter.setFieldAndMaxDoc(fieldInfo, docCount, true);
+
+                List<CompletableFuture<List<Pair<BytesRef, PostingClusters>>>> futures = new ArrayList<>(
+                    Math.round((float) allTerms.size() / BATCH_SIZE)
+                );
+                int index = 0;
+                List<BytesRef> termBatch = new ArrayList<>(BATCH_SIZE);
+                for (BytesRef term : allTerms) {
+                    termBatch.add(term);
+                    if (termBatch.size() == BATCH_SIZE || index == allTerms.size() - 1) {
+                        if (clusterRatio == 0) {
+                            futures.add(
+                                CompletableFuture.completedFuture(
+                                    new BatchClusteringTask(
+                                        termBatch,
+                                        key,
+                                        summaryPruneRatio,
+                                        clusterRatio,
+                                        nPostings,
+                                        mergeStateFacade,
+                                        fieldInfo,
+                                        mergeHelper
+                                    ).get()
+                                )
+                            );
+                        } else {
+                            futures.add(
+                                CompletableFuture.supplyAsync(
+                                    new BatchClusteringTask(
+                                        termBatch,
+                                        key,
+                                        summaryPruneRatio,
+                                        clusterRatio,
+                                        nPostings,
+                                        mergeStateFacade,
+                                        fieldInfo,
+                                        mergeHelper
+                                    ),
+                                    ClusterTrainingExecutor.getInstance().getExecutor()
+                                )
+                            );
+                        }
+                        termBatch = new ArrayList<>(BATCH_SIZE);
+                    }
+                    ++index;
+                }
+                for (int j = 0; j < futures.size(); ++j) {
+                    try {
+                        List<Pair<BytesRef, PostingClusters>> clusters = futures.get(j).join();
+                        futures.set(j, null);
+                        for (Pair<BytesRef, PostingClusters> p : clusters) {
+                            BlockTermState state = clusteredPostingTermsWriter.write(p.getLeft(), p.getRight());
+                            sparseTermsLuceneWriter.writeTerm(p.getLeft(), state);
+                        }
+                    } catch (CancellationException | CompletionException ex) {
+                        log.error("Thread of running clustering from {}th term batch during merge has exception", j, ex);
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            clusteredPostingTermsWriter.closeWithException();
+            sparseTermsLuceneWriter.closeWithException();
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTerms.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTerms.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.Getter;
+import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.ImpactsEnum;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.neuralsearch.sparse.cache.CacheGatedPostingsReader;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ClusteredPostingCache;
+import org.opensearch.neuralsearch.sparse.cache.ClusteredPostingCacheItem;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Sparse terms implementation
+ */
+@Getter
+public class SparseTerms extends Terms {
+    private final CacheKey cacheKey;
+    private final CacheGatedPostingsReader reader;
+
+    public SparseTerms(CacheKey cacheKey, SparseTermsLuceneReader sparseTermsLuceneReader, String field) {
+        this.cacheKey = cacheKey;
+        ClusteredPostingCacheItem clusteredPostingCacheItem = ClusteredPostingCache.getInstance().getOrCreate(cacheKey);
+        this.reader = new CacheGatedPostingsReader(
+            field,
+            clusteredPostingCacheItem.getReader(),
+            clusteredPostingCacheItem.getWriter(),
+            sparseTermsLuceneReader
+        );
+    }
+
+    @Override
+    public TermsEnum iterator() throws IOException {
+        return new SparseTermsEnum();
+    }
+
+    @Override
+    public long size() throws IOException {
+        return this.reader.size();
+    }
+
+    @Override
+    public long getSumTotalTermFreq() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public long getSumDocFreq() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public int getDocCount() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public boolean hasFreqs() {
+        return false;
+    }
+
+    @Override
+    public boolean hasOffsets() {
+        return false;
+    }
+
+    @Override
+    public boolean hasPositions() {
+        return false;
+    }
+
+    @Override
+    public boolean hasPayloads() {
+        return false;
+    }
+
+    class SparseTermsEnum extends BaseTermsEnum {
+        private BytesRef currentTerm;
+        // iterator now only used for next()
+        private Iterator<BytesRef> termIterator;
+
+        SparseTermsEnum() throws IOException {
+            Set<BytesRef> terms = reader.getTerms();
+            if (terms != null) {
+                termIterator = terms.iterator();
+            }
+        }
+
+        @Override
+        public SeekStatus seekCeil(BytesRef text) throws IOException {
+            if (reader.read(text) == null) {
+                return SeekStatus.NOT_FOUND;
+            }
+            currentTerm = text.clone();
+            return SeekStatus.FOUND;
+        }
+
+        @Override
+        public void seekExact(long ord) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BytesRef term() throws IOException {
+            return this.currentTerm;
+        }
+
+        @Override
+        public long ord() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int docFreq() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long totalTermFreq() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PostingsEnum postings(PostingsEnum reuse, int flags) throws IOException {
+            if (currentTerm == null) {
+                return null;
+            }
+            PostingClusters clusters = reader.read(currentTerm);
+            if (clusters != null) {
+                return new SparsePostingsEnum(clusters, cacheKey);
+            }
+            return null;
+        }
+
+        @Override
+        public ImpactsEnum impacts(int flags) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BytesRef next() throws IOException {
+            if (termIterator == null || !termIterator.hasNext()) {
+                this.currentTerm = null;
+                return null;
+            }
+            this.currentTerm = termIterator.next();
+            return this.currentTerm;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneReader.java
@@ -13,9 +13,9 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.neuralsearch.sparse.data.DocWeight;
 import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
 import org.opensearch.neuralsearch.sparse.data.PostingClusters;
-import org.opensearch.neuralsearch.sparse.data.DocWeight;
 import org.opensearch.neuralsearch.sparse.data.SparseVector;
 
 import java.io.IOException;

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneReader.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneReader.java
@@ -90,7 +90,7 @@ public class SparseTermsLuceneReader extends FieldsProducer {
                     long fileOffset = termsIn.readVLong();
                     terms.put(term, fileOffset);
                 }
-                fieldToTerms.put(state.fieldInfos.fieldInfo(fieldId).name, terms);
+                fieldToTerms.put(state.fieldInfos.fieldInfo(fieldId).getName(), terms);
             }
             success = true;
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriter.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class SparseTermsLuceneWriter {
     private IndexOutput termsOut;
-    private final String codec_name;
+    private final String codecName;
     private final int version;
     private final CodecUtilWrapper codecUtilWrapper;
 
@@ -33,7 +33,7 @@ public class SparseTermsLuceneWriter {
      */
     public void init(IndexOutput termsOut, SegmentWriteState state) throws IOException {
         this.termsOut = termsOut;
-        codecUtilWrapper.writeIndexHeader(termsOut, codec_name, version, state.segmentInfo.getId(), state.segmentSuffix);
+        codecUtilWrapper.writeIndexHeader(termsOut, codecName, version, state.segmentInfo.getId(), state.segmentSuffix);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriter.java
@@ -4,8 +4,8 @@
  */
 package org.opensearch.neuralsearch.sparse.codec;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.lucene.codecs.BlockTermState;
-import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.BytesRef;
@@ -17,21 +17,12 @@ import java.io.IOException;
  * Writer for sparse terms in Lucene index format.
  * Handles writing field metadata, terms, and block term states to index output.
  */
+@RequiredArgsConstructor
 public class SparseTermsLuceneWriter {
     private IndexOutput termsOut;
-    private final int version;
     private final String codec_name;
-
-    /**
-     * Creates a new sparse terms writer.
-     *
-     * @param codec_name the codec name
-     * @param version the codec version
-     */
-    public SparseTermsLuceneWriter(String codec_name, int version) {
-        this.codec_name = codec_name;
-        this.version = version;
-    }
+    private final int version;
+    private final CodecUtilWrapper codecUtilWrapper;
 
     /**
      * Initializes the writer with output stream and writes index header.
@@ -42,7 +33,7 @@ public class SparseTermsLuceneWriter {
      */
     public void init(IndexOutput termsOut, SegmentWriteState state) throws IOException {
         this.termsOut = termsOut;
-        CodecUtil.writeIndexHeader(termsOut, codec_name, version, state.segmentInfo.getId(), state.segmentSuffix);
+        codecUtilWrapper.writeIndexHeader(termsOut, codec_name, version, state.segmentInfo.getId(), state.segmentSuffix);
     }
 
     /**
@@ -53,7 +44,7 @@ public class SparseTermsLuceneWriter {
      */
     public void close(long startFp) throws IOException {
         this.termsOut.writeLong(startFp);
-        CodecUtil.writeFooter(this.termsOut);
+        codecUtilWrapper.writeFooter(this.termsOut);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.util.io.IOUtils;
+
+import java.io.IOException;
+
+/**
+ * Writer for sparse terms in Lucene index format.
+ * Handles writing field metadata, terms, and block term states to index output.
+ */
+public class SparseTermsLuceneWriter {
+    private IndexOutput termsOut;
+    private final int version;
+    private final String codec_name;
+
+    /**
+     * Creates a new sparse terms writer.
+     *
+     * @param codec_name the codec name
+     * @param version the codec version
+     */
+    public SparseTermsLuceneWriter(String codec_name, int version) {
+        this.codec_name = codec_name;
+        this.version = version;
+    }
+
+    /**
+     * Initializes the writer with output stream and writes index header.
+     *
+     * @param termsOut the index output stream
+     * @param state the segment write state
+     * @throws IOException if an I/O error occurs
+     */
+    public void init(IndexOutput termsOut, SegmentWriteState state) throws IOException {
+        this.termsOut = termsOut;
+        CodecUtil.writeIndexHeader(termsOut, codec_name, version, state.segmentInfo.getId(), state.segmentSuffix);
+    }
+
+    /**
+     * Closes the writer and writes footer with start file pointer.
+     *
+     * @param startFp the start file pointer
+     * @throws IOException if an I/O error occurs
+     */
+    public void close(long startFp) throws IOException {
+        this.termsOut.writeLong(startFp);
+        CodecUtil.writeFooter(this.termsOut);
+    }
+
+    /**
+     * Writes the number of fields.
+     *
+     * @param fieldCount the field count
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeFieldCount(int fieldCount) throws IOException {
+        termsOut.writeVInt(fieldCount);
+    }
+
+    /**
+     * Writes the field number.
+     *
+     * @param fieldNumber the field number
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeFieldNumber(int fieldNumber) throws IOException {
+        termsOut.writeVInt(fieldNumber);
+    }
+
+    /**
+     * Writes the total size of terms.
+     *
+     * @param termsSize the terms size
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeTermsSize(long termsSize) throws IOException {
+        termsOut.writeVLong(termsSize);
+    }
+
+    /**
+     * Writes a term with its block term state.
+     *
+     * @param term the term bytes
+     * @param state the block term state
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeTerm(BytesRef term, BlockTermState state) throws IOException {
+        this.termsOut.writeVInt(term.length);
+        this.termsOut.writeBytes(term.bytes, term.offset, term.length);
+        this.termsOut.writeVLong(state.blockFilePointer);
+    }
+
+    /**
+     * Closes the writer while handling any exceptions.
+     */
+    public void closeWithException() {
+        IOUtils.closeWhileHandlingException(this.termsOut);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeStateFacade.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeStateFacade.java
@@ -7,8 +7,10 @@ package org.opensearch.neuralsearch.sparse.common;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -38,5 +40,13 @@ public class MergeStateFacade {
 
     public Bits[] getLiveDocs() {
         return mergeState.liveDocs;
+    }
+
+    public FieldsProducer[] getFieldsProducers() {
+        return mergeState.fieldsProducers;
+    }
+
+    public SegmentInfo getSegmentInfo() {
+        return mergeState.segmentInfo;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeStateFacade.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/MergeStateFacade.java
@@ -49,4 +49,12 @@ public class MergeStateFacade {
     public SegmentInfo getSegmentInfo() {
         return mergeState.segmentInfo;
     }
+
+    public FieldInfos[] getFieldInfos() {
+        return mergeState.fieldInfos;
+    }
+
+    public boolean needIndexSort() {
+        return mergeState.needsIndexSort;
+    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensField.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensField.java
@@ -8,6 +8,8 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexableFieldType;
 
+import java.util.Optional;
+
 /**
  * Lucene field for sparse token storage.
  */
@@ -28,6 +30,6 @@ public class SparseTokensField extends Field {
         if (field == null) {
             return false;
         }
-        return field.attributes().containsKey(SPARSE_FIELD);
+        return Optional.ofNullable(field.attributes().get(SPARSE_FIELD)).map(Boolean::parseBoolean).orElse(false);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapper.java
@@ -24,7 +24,6 @@ import org.opensearch.neuralsearch.sparse.algorithm.SparseAlgoType;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -164,10 +163,17 @@ public class SparseTokensFieldMapper extends ParametrizedFieldMapper {
                     }
                     FeatureField featureField = new FeatureField(name(), feature, value);
                     context.doc().addWithKey(key, featureField);
-                    byte[] featureBytes = feature.getBytes(StandardCharsets.UTF_8);
-                    dos.writeInt(featureBytes.length);
-                    dos.write(featureBytes);
-                    dos.writeFloat(value);
+
+                    try {
+                        int tokenIndex = Integer.parseInt(feature);
+                        if (tokenIndex < 0) {
+                            throw new IllegalArgumentException("[" + CONTENT_TYPE + "]" + " fields should be text of non-negative integer");
+                        }
+                        dos.writeInt(tokenIndex);
+                        dos.writeFloat(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("[" + CONTENT_TYPE + "]" + " fields should be valid integer");
+                    }
                 } else {
                     throw new IllegalArgumentException(
                         "["

--- a/src/test/java/org/opensearch/neuralsearch/sparse/AbstractSparseTestBase.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/AbstractSparseTestBase.java
@@ -19,10 +19,17 @@ import org.opensearch.core.common.breaker.CircuitBreaker;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.APPROXIMATE_THRESHOLD_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.mapper.SparseTokensField.SPARSE_FIELD;
 
 public class AbstractSparseTestBase extends OpenSearchQueryTestCase {
 
@@ -145,5 +152,15 @@ public class AbstractSparseTestBase extends OpenSearchQueryTestCase {
 
     protected PostingClusters preparePostingClusters() {
         return new PostingClusters(prepareClusterList());
+    }
+
+    protected Map<String, String> prepareAttributes(boolean sparse, int threshold, float ratio, int posting, float summary) {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(SPARSE_FIELD, String.valueOf(sparse));
+        attributes.put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(threshold));
+        attributes.put(CLUSTER_RATIO_FIELD, String.valueOf(ratio));
+        attributes.put(N_POSTINGS_FIELD, String.valueOf(posting));
+        attributes.put(SUMMARY_PRUNE_RATIO_FIELD, String.valueOf(summary));
+        return attributes;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/AbstractSparseTestBase.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/AbstractSparseTestBase.java
@@ -5,9 +5,11 @@
 package org.opensearch.neuralsearch.sparse;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.index.SegmentInfo;
 import org.junit.Before;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 import org.opensearch.neuralsearch.sparse.accessor.SparseVectorReader;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
 import org.opensearch.neuralsearch.sparse.common.DocWeightIterator;
 import org.opensearch.neuralsearch.sparse.data.DocWeight;
 import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
@@ -22,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -162,5 +165,9 @@ public class AbstractSparseTestBase extends OpenSearchQueryTestCase {
         attributes.put(N_POSTINGS_FIELD, String.valueOf(posting));
         attributes.put(SUMMARY_PRUNE_RATIO_FIELD, String.valueOf(summary));
         return attributes;
+    }
+
+    protected CacheKey prepareUniqueCacheKey(SegmentInfo segmentInfo) {
+        return new CacheKey(segmentInfo, UUID.randomUUID().toString());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
@@ -9,6 +9,7 @@ import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DirectoryReader;
@@ -17,11 +18,14 @@ import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentCommitInfo;
@@ -45,7 +49,12 @@ import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.mapper.ContentPath;
+import org.opensearch.neuralsearch.sparse.codec.SparseBinaryDocValuesPassThrough;
+import org.opensearch.neuralsearch.sparse.common.SparseConstants;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensField;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,6 +63,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 
 import static org.apache.lucene.tests.util.LuceneTestCase.random;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -352,6 +362,77 @@ public class TestsPrepareUtils {
         );
     }
 
+    /**
+     * Creates a MergeState with SparseBinaryDocValuesPassThrough
+     */
+    public static MergeState prepareMergeStateWithPassThroughValues(boolean withLiveDocs) throws IOException {
+        FieldInfo fieldInfo = prepareKeyFieldInfo();
+        MergeState.DocMap[] docMaps = new MergeState.DocMap[1];
+        docMaps[0] = docID -> docID;
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+
+        // Create a mocked BinaryDocValues
+        BinaryDocValues mockBinaryDocValues = TestsPrepareUtils.prepareBinaryDocValues();
+
+        // Create a SparseBinaryDocValuesPassThrough
+        SparseBinaryDocValuesPassThrough passThrough = new SparseBinaryDocValuesPassThrough(mockBinaryDocValues, segmentInfo);
+
+        // Create a DocValuesProducer that returns the passThrough
+        DocValuesProducer mockProducer = mock(DocValuesProducer.class);
+        when(mockProducer.getBinary(any(FieldInfo.class))).thenReturn(passThrough);
+
+        DocValuesProducer[] docValuesProducers = new DocValuesProducer[1];
+        docValuesProducers[0] = mockProducer;
+
+        // Create FieldInfos
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+        FieldInfos[] fieldInfosArray = new FieldInfos[1];
+        fieldInfosArray[0] = fieldInfos;
+
+        // Create FieldsProducer
+        FieldsProducer fieldsProducer = TestsPrepareUtils.prepareFieldsProducer();
+        FieldsProducer[] fieldsProducers = new FieldsProducer[1];
+        fieldsProducers[0] = fieldsProducer;
+
+        // Create live docs if needed
+        Bits[] liveDocs = new Bits[1];
+        if (withLiveDocs) {
+            liveDocs[0] = new Bits() {
+                @Override
+                public boolean get(int index) {
+                    return index % 2 == 0; // Only even document IDs are live
+                }
+
+                @Override
+                public int length() {
+                    return 10;
+                }
+            };
+        } else {
+            liveDocs[0] = null;
+        }
+
+        // Create MergeState
+        return new MergeState(
+            docMaps,
+            segmentInfo,
+            fieldInfos,                // mergeFieldInfos
+            null,                      // storedFieldsReaders
+            null,                      // termVectorsReaders
+            null,                      // normsProducers
+            docValuesProducers,        // docValuesProducers
+            fieldInfosArray,           // fieldInfos
+            liveDocs,                  // liveDocs
+            fieldsProducers,           // fieldsProducers
+            null,                      // pointsReaders
+            null,                      // knnVectorsReaders
+            new int[] { 10 },          // maxDocs
+            null,                      // infoStream
+            null,                      // executor
+            false                      // needsIndexSort
+        );
+    }
+
     public static IndexableFieldType prepareIndexableFieldType() {
         return new IndexableFieldType() {
             @Override
@@ -494,23 +575,104 @@ public class TestsPrepareUtils {
         return new SegmentWriteState(InfoStream.getDefault(), directory, segmentInfo, fieldInfos, null, ioContext);
     }
 
+    public static SegmentWriteState prepareSegmentWriteState(Directory directory, FieldInfos fieldInfos) {
+        SegmentInfo segmentInfo = prepareSegmentInfo();
+        IOContext ioContext = IOContext.DEFAULT;
+
+        return new SegmentWriteState(InfoStream.getDefault(), directory, segmentInfo, fieldInfos, null, ioContext);
+    }
+
     public static BytesRef prepareValidSparseVectorBytes() {
         // Create a valid sparse vector BytesRef with token "1" -> 0.5f
         try {
-            java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
-            java.io.DataOutputStream dos = new java.io.DataOutputStream(baos);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            DataOutputStream dos = new DataOutputStream(baos);
 
             // Write one token-value pair: "1" -> 0.5f
-            String token = "1";
-            byte[] tokenBytes = token.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-            dos.writeInt(tokenBytes.length);
-            dos.write(tokenBytes);
+            dos.writeInt(1);
             dos.writeFloat(0.5f);
-
             dos.close();
             return new BytesRef(baos.toByteArray());
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static DirectoryReader prepareIndexReaderWithSparseField(int docNumbers) throws IOException {
+        Directory directory = new ByteBuffersDirectory();
+        IndexWriterConfig config = new IndexWriterConfig(new MockAnalyzer(random()));
+        IndexWriter writer = new IndexWriter(directory, config);
+
+        // Create custom field type for sparse field
+        FieldType sparseFieldType = new FieldType();
+        sparseFieldType.setStored(false);
+        sparseFieldType.setTokenized(false);
+        sparseFieldType.setIndexOptions(IndexOptions.DOCS);
+        sparseFieldType.setDocValuesType(DocValuesType.BINARY);
+
+        // Add required attributes for sparse field
+        sparseFieldType.putAttribute(SparseTokensField.SPARSE_FIELD, "true");
+        sparseFieldType.putAttribute(SparseConstants.APPROXIMATE_THRESHOLD_FIELD, "10");
+        sparseFieldType.freeze();
+
+        // Create documents with sparse field
+        for (int i = 0; i < docNumbers; i++) {
+            Document doc = new Document();
+            BytesRef sparseValue = TestsPrepareUtils.prepareValidSparseVectorBytes();
+            Field sparseField = new Field("sparse_field", sparseValue, sparseFieldType);
+            doc.add(sparseField);
+            writer.addDocument(doc);
+        }
+
+        writer.close();
+        DirectoryReader baseReader = DirectoryReader.open(directory);
+        return new TestDirectoryReaderWrapper(baseReader);
+    }
+
+    /**
+     * Wrapper to ensure sparse field BinaryDocValues are wrapped with SparseBinaryDocValuesPassThrough.
+     * This mimics the behavior of the neural-search codec in production.
+     */
+    private static class TestDirectoryReaderWrapper extends FilterDirectoryReader {
+
+        public TestDirectoryReaderWrapper(DirectoryReader in) throws IOException {
+            super(in, new SubReaderWrapper() {
+                @Override
+                public LeafReader wrap(LeafReader reader) {
+                    return new FilterLeafReader(reader) {
+                        @Override
+                        public BinaryDocValues getBinaryDocValues(String field) throws IOException {
+                            BinaryDocValues original = super.getBinaryDocValues(field);
+                            if (original != null && field.equals("sparse_field")) {
+                                // Wrap with SparseBinaryDocValuesPassThrough for sparse fields
+                                SegmentInfo segmentInfo = prepareSegmentInfo();
+                                return new SparseBinaryDocValuesPassThrough(original, segmentInfo);
+                            }
+                            return original;
+                        }
+
+                        @Override
+                        public CacheHelper getCoreCacheHelper() {
+                            return in.getCoreCacheHelper();
+                        }
+
+                        @Override
+                        public CacheHelper getReaderCacheHelper() {
+                            return in.getReaderCacheHelper();
+                        }
+                    };
+                }
+            });
+        }
+
+        @Override
+        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+            return new TestDirectoryReaderWrapper(in);
+        }
+
+        @Override
+        public CacheHelper getReaderCacheHelper() {
+            return in.getReaderCacheHelper();
         }
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
@@ -42,7 +42,6 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.StringHelper;
@@ -63,7 +62,6 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 
 import static org.apache.lucene.tests.util.LuceneTestCase.random;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -294,143 +292,6 @@ public class TestsPrepareUtils {
             false                      // needsIndexSort
         );
         return mergeState;
-    }
-
-    /**
-     * Creates a MergeState with mocked BinaryDocValues
-     */
-    public static MergeState prepareMergeStateWithMockedBinaryDocValues(boolean withLiveDocs, boolean nullLiveDocs) throws IOException {
-        MergeState.DocMap[] docMaps = new MergeState.DocMap[1];
-        docMaps[0] = docID -> docID;
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
-
-        // Create a DocValuesProducer that returns mocked BinaryDocValues
-        DocValuesProducer docValuesProducer = prepareDocValuesProducer(prepareBinaryDocValues());
-
-        DocValuesProducer[] docValuesProducers = new DocValuesProducer[1];
-        docValuesProducers[0] = docValuesProducer;
-
-        // Create FieldInfos
-        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { prepareKeyFieldInfo() });
-        FieldInfos[] fieldInfosArray = new FieldInfos[1];
-        fieldInfosArray[0] = fieldInfos;
-
-        // Create FieldsProducer
-        FieldsProducer fieldsProducer = TestsPrepareUtils.prepareFieldsProducer();
-        FieldsProducer[] fieldsProducers = new FieldsProducer[1];
-        fieldsProducers[0] = fieldsProducer;
-
-        // Create live docs if needed
-        Bits[] liveDocs = new Bits[1];
-        if (withLiveDocs) {
-            liveDocs[0] = new Bits() {
-                @Override
-                public boolean get(int index) {
-                    return index % 2 == 0; // Only even document IDs are live
-                }
-
-                @Override
-                public int length() {
-                    return 10;
-                }
-            };
-        } else {
-            liveDocs[0] = null;
-        }
-        if (nullLiveDocs) {
-            liveDocs = null;
-        }
-
-        // Create MergeState
-        return new MergeState(
-            docMaps,
-            segmentInfo,
-            fieldInfos,                // mergeFieldInfos
-            null,                      // storedFieldsReaders
-            null,                      // termVectorsReaders
-            null,                      // normsProducers
-            docValuesProducers,        // docValuesProducers
-            fieldInfosArray,           // fieldInfos
-            liveDocs,                  // liveDocs
-            fieldsProducers,           // fieldsProducers
-            null,                      // pointsReaders
-            null,                      // knnVectorsReaders
-            new int[] { 10 },          // maxDocs
-            null,                      // infoStream
-            null,                      // executor
-            false                      // needsIndexSort
-        );
-    }
-
-    /**
-     * Creates a MergeState with SparseBinaryDocValuesPassThrough
-     */
-    public static MergeState prepareMergeStateWithPassThroughValues(boolean withLiveDocs) throws IOException {
-        FieldInfo fieldInfo = prepareKeyFieldInfo();
-        MergeState.DocMap[] docMaps = new MergeState.DocMap[1];
-        docMaps[0] = docID -> docID;
-        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
-
-        // Create a mocked BinaryDocValues
-        BinaryDocValues mockBinaryDocValues = TestsPrepareUtils.prepareBinaryDocValues();
-
-        // Create a SparseBinaryDocValuesPassThrough
-        SparseBinaryDocValuesPassThrough passThrough = new SparseBinaryDocValuesPassThrough(mockBinaryDocValues, segmentInfo);
-
-        // Create a DocValuesProducer that returns the passThrough
-        DocValuesProducer mockProducer = mock(DocValuesProducer.class);
-        when(mockProducer.getBinary(any(FieldInfo.class))).thenReturn(passThrough);
-
-        DocValuesProducer[] docValuesProducers = new DocValuesProducer[1];
-        docValuesProducers[0] = mockProducer;
-
-        // Create FieldInfos
-        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
-        FieldInfos[] fieldInfosArray = new FieldInfos[1];
-        fieldInfosArray[0] = fieldInfos;
-
-        // Create FieldsProducer
-        FieldsProducer fieldsProducer = TestsPrepareUtils.prepareFieldsProducer();
-        FieldsProducer[] fieldsProducers = new FieldsProducer[1];
-        fieldsProducers[0] = fieldsProducer;
-
-        // Create live docs if needed
-        Bits[] liveDocs = new Bits[1];
-        if (withLiveDocs) {
-            liveDocs[0] = new Bits() {
-                @Override
-                public boolean get(int index) {
-                    return index % 2 == 0; // Only even document IDs are live
-                }
-
-                @Override
-                public int length() {
-                    return 10;
-                }
-            };
-        } else {
-            liveDocs[0] = null;
-        }
-
-        // Create MergeState
-        return new MergeState(
-            docMaps,
-            segmentInfo,
-            fieldInfos,                // mergeFieldInfos
-            null,                      // storedFieldsReaders
-            null,                      // termVectorsReaders
-            null,                      // normsProducers
-            docValuesProducers,        // docValuesProducers
-            fieldInfosArray,           // fieldInfos
-            liveDocs,                  // liveDocs
-            fieldsProducers,           // fieldsProducers
-            null,                      // pointsReaders
-            null,                      // knnVectorsReaders
-            new int[] { 10 },          // maxDocs
-            null,                      // infoStream
-            null,                      // executor
-            false                      // needsIndexSort
-        );
     }
 
     public static IndexableFieldType prepareIndexableFieldType() {

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/BatchClusteringTaskTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/BatchClusteringTaskTests.java
@@ -55,7 +55,7 @@ public class BatchClusteringTaskTests extends AbstractSparseTestBase {
         MockitoAnnotations.openMocks(this);
         terms = Arrays.asList(new BytesRef("term1"), new BytesRef("term2"));
         when(fieldInfo.getName()).thenReturn("test_field");
-        key = new CacheKey(segmentInfo, fieldInfo);
+        key = prepareUniqueCacheKey(segmentInfo);
         when(mergeStateFacade.getMaxDocs()).thenReturn(new int[] { 5, 6 });
         when(mergeHelper.getMergedPostingForATerm(any(), any(), any(), any(), any())).thenReturn(
             preparePostings(1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10)

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/BatchClusteringTaskTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/BatchClusteringTaskTests.java
@@ -92,17 +92,11 @@ public class BatchClusteringTaskTests extends AbstractSparseTestBase {
     }
 
     public void testGetWithNullMergeStateThenThrowException() {
-        // Test behavior with null merge state - should throw NullPointerException within constructor
-        NullPointerException nullPointerException = assertThrows(
-            NullPointerException.class,
-            () -> new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, null, null, null)
-        );
-        assertNotNull(nullPointerException);
+        assertThrows(NullPointerException.class, () -> new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, null, null, null));
     }
 
     @SneakyThrows
     public void testGetWithNonNullMergeState() {
-
         // Create BatchClusteringTask
         BatchClusteringTask task = new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, mergeStateFacade, fieldInfo, mergeHelper);
 
@@ -124,9 +118,6 @@ public class BatchClusteringTaskTests extends AbstractSparseTestBase {
             PostingClusters clusters = pair.getRight();
             assertNotNull("PostingClusters should not be null", clusters);
             assertNotNull("Clusters list should not be null", clusters.getClusters());
-
-            // Additional cluster validation
-            assertTrue("Should have non-negative cluster count", clusters.getClusters().size() >= 0);
         }
     }
 
@@ -177,8 +168,7 @@ public class BatchClusteringTaskTests extends AbstractSparseTestBase {
         // Modify original terms
         originalTerms.get(0).bytes[0] = (byte) 'M';
 
-        // The task should still have the original values due to deep copy
-        // We can't easily test the get() method output, but we can verify the task was created properly
-        assertNotNull("Task should be created and maintain its own copy of terms", task);
+        assertNotSame(originalTerms, task.getTerms());
+        assertEquals("original1", task.getTerms().get(0).utf8ToString());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/BatchClusteringTaskTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/BatchClusteringTaskTests.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm.seismic;
+
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.codec.MergeHelper;
+import org.opensearch.neuralsearch.sparse.codec.SparseBinaryDocValuesPassThrough;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BatchClusteringTaskTests extends AbstractSparseTestBase {
+    private List<BytesRef> terms;
+    private CacheKey key;
+    @Mock
+    private MergeStateFacade mergeStateFacade;
+    @Mock
+    private MergeHelper mergeHelper;
+    @Mock
+    private FieldInfo fieldInfo;
+    @Mock
+    private SegmentInfo segmentInfo;
+    @Mock
+    private DocValuesProducer docValuesProducer;
+    @Mock
+    private SparseBinaryDocValuesPassThrough binaryDocValuesPassThrough;
+
+    @Before
+    @Override
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        terms = Arrays.asList(new BytesRef("term1"), new BytesRef("term2"));
+        when(fieldInfo.getName()).thenReturn("test_field");
+        key = new CacheKey(segmentInfo, fieldInfo);
+        when(mergeStateFacade.getMaxDocs()).thenReturn(new int[] { 5, 6 });
+        when(mergeHelper.getMergedPostingForATerm(any(), any(), any(), any(), any())).thenReturn(
+            preparePostings(1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10)
+        );
+        when(mergeStateFacade.getDocValuesProducers()).thenReturn(new DocValuesProducer[] { docValuesProducer });
+        when(docValuesProducer.getBinary(any())).thenReturn(binaryDocValuesPassThrough);
+        when(binaryDocValuesPassThrough.read(anyInt())).thenReturn(createVector(1, 2, 3, 4, 5, 6))
+            .thenReturn(createVector(7, 8, 9, 10, 11, 12))
+            .thenReturn(null);
+        when(binaryDocValuesPassThrough.getSegmentInfo()).thenReturn(segmentInfo);
+    }
+
+    public void testConstructorDeepCopiesTerms() throws Exception {
+        // Setup
+        List<BytesRef> originalTerms = Arrays.asList(new BytesRef("term1"), new BytesRef("term2"));
+
+        // Execute - create task with null mergeState to test constructor
+        BatchClusteringTask task = new BatchClusteringTask(originalTerms, key, 0.5f, 0.3f, 10, mergeStateFacade, null, mergeHelper);
+
+        // Verify task is created
+        assertNotNull("Task should be created successfully", task);
+
+        List<BytesRef> taskTerms = task.getTerms();
+
+        // Verify deep copy by checking actual content
+        assertEquals("First term should be 'term1'", "term1", taskTerms.get(0).utf8ToString());
+
+        // Modify original terms to verify deep copy
+        originalTerms.get(0).bytes[0] = (byte) 'X';
+
+        // Verify task's terms remain unchanged (proving deep copy worked)
+        assertEquals("Task's first term should still be 'term1'", "term1", taskTerms.get(0).utf8ToString());
+        assertNotEquals("Original term should now be different", "term1", originalTerms.get(0).utf8ToString());
+    }
+
+    public void testGetWithNullMergeStateThenThrowException() {
+        // Test behavior with null merge state - should throw NullPointerException within constructor
+        NullPointerException nullPointerException = assertThrows(
+            NullPointerException.class,
+            () -> new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, null, null, null)
+        );
+        assertNotNull(nullPointerException);
+    }
+
+    @SneakyThrows
+    public void testGetWithNonNullMergeState() {
+
+        // Create BatchClusteringTask
+        BatchClusteringTask task = new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, mergeStateFacade, fieldInfo, mergeHelper);
+
+        // Execute and examine the result
+        List<Pair<BytesRef, PostingClusters>> result = task.get();
+
+        // Verify the returned clusters
+        assertNotNull("Result should not be null", result);
+        assertEquals("Should return clusters for each term", terms.size(), result.size());
+
+        for (int i = 0; i < result.size(); i++) {
+            Pair<BytesRef, PostingClusters> pair = result.get(i);
+
+            // Verify term matches
+            assertNotNull("Term should not be null", pair.getLeft());
+            assertEquals("Term should match input", terms.get(i).utf8ToString(), pair.getLeft().utf8ToString());
+
+            // Verify clusters
+            PostingClusters clusters = pair.getRight();
+            assertNotNull("PostingClusters should not be null", clusters);
+            assertNotNull("Clusters list should not be null", clusters.getClusters());
+
+            // Additional cluster validation
+            assertTrue("Should have non-negative cluster count", clusters.getClusters().size() >= 0);
+        }
+    }
+
+    @SneakyThrows
+    public void testGetWithNonNullMergeStateZeroMaxDocs() {
+        when(mergeStateFacade.getMaxDocs()).thenReturn(new int[]{0});
+        // Create BatchClusteringTask
+        BatchClusteringTask task = new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, mergeStateFacade, fieldInfo, mergeHelper);
+
+        // Execute and examine the result
+        List<Pair<BytesRef, PostingClusters>> result = task.get();
+
+        // Verify the returned clusters
+        assertNotNull("Result should not be null", result);
+        // Should trigger early quit schema to return an empty list
+        assertEquals("Should return an empty list", 0, result.size());
+    }
+
+    public void testThrowIOException() throws IOException {
+        doThrow(new IOException()).when(mergeHelper).getMergedPostingForATerm(any(), any(), any(), any(), any());
+        // Create BatchClusteringTask
+        BatchClusteringTask task = new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, mergeStateFacade, fieldInfo, mergeHelper);
+
+        // Execute and examine the result
+        assertThrows(RuntimeException.class, () -> task.get());
+    }
+
+    public void testNotSeismicBinaryDocValues() throws IOException {
+        BinaryDocValues docValues = mock(BinaryDocValues.class);
+        when(docValuesProducer.getBinary(any())).thenReturn(docValues);
+        // Create BatchClusteringTask
+        BatchClusteringTask task = new BatchClusteringTask(terms, key, 0.5f, 0.3f, 10, mergeStateFacade, fieldInfo, mergeHelper);
+
+        // Execute and examine the result
+        List<Pair<BytesRef, PostingClusters>> result = task.get();
+        assertEquals(2, result.size());
+        for (int i = 0; i < 2; ++i) {
+            assertTrue(result.get(i).getRight().getClusters().isEmpty());
+        }
+    }
+
+    public void testTermsDeepCopyInGet() {
+        // Test that the terms are properly deep copied and used in get() method
+        List<BytesRef> originalTerms = Arrays.asList(new BytesRef("original1"), new BytesRef("original2"));
+
+        BatchClusteringTask task = new BatchClusteringTask(originalTerms, key, 0.5f, 0.3f, 10, mergeStateFacade, null, mergeHelper);
+
+        // Modify original terms
+        originalTerms.get(0).bytes[0] = (byte) 'M';
+
+        // The task should still have the original values due to deep copy
+        // We can't easily test the get() method output, but we can verify the task was created properly
+        assertNotNull("Task should be created and maintain its own copy of terms", task);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/ClusteringTaskTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/algorithm/seismic/ClusteringTaskTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.algorithm.seismic;
+
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.core.common.breaker.CircuitBreaker;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.CircuitBreakerManager;
+import org.opensearch.neuralsearch.sparse.data.DocWeight;
+import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ClusteringTaskTests extends AbstractSparseTestBase {
+    private BytesRef term;
+    private List<DocWeight> docs;
+    private CacheKey key;
+    private SeismicPostingClusterer seismicPostingClusterer;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        term = new BytesRef("test_term");
+        key = mock(CacheKey.class);
+        docs = Arrays.asList(new DocWeight(1, (byte) 1), new DocWeight(2, (byte) 2));
+        seismicPostingClusterer = mock(SeismicPostingClusterer.class);
+        CircuitBreakerManager.setCircuitBreaker(mock(CircuitBreaker.class));
+    }
+
+    public void testConstructor_withValidInputs_createsTask() {
+        ClusteringTask task = new ClusteringTask(term, docs, key, seismicPostingClusterer);
+
+        assertNotNull(task);
+    }
+
+    public void testConstructor_withEmptyDocs_createsTask() {
+        docs = Collections.emptyList();
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, seismicPostingClusterer);
+
+        assertNotNull(task);
+    }
+
+    public void testGet_withValidClustering_returnsPostingClusters() throws IOException {
+        List<DocumentCluster> expectedClusters = Arrays.asList(mock(DocumentCluster.class), mock(DocumentCluster.class));
+        when(seismicPostingClusterer.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, seismicPostingClusterer);
+        PostingClusters result = task.get();
+
+        assertNotNull(result);
+        assertNotNull(result.getClusters());
+        assertEquals(2, result.getClusters().size());
+        verify(seismicPostingClusterer, times(1)).cluster(any());
+    }
+
+    public void testGet_withEmptyDocs_returnsPostingClusters() throws IOException {
+        docs = Collections.emptyList();
+
+        List<DocumentCluster> expectedClusters = Collections.emptyList();
+        when(seismicPostingClusterer.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, seismicPostingClusterer);
+        PostingClusters result = task.get();
+
+        assertNotNull(result);
+        assertNotNull(result.getClusters());
+        assertEquals(0, result.getClusters().size());
+        verify(seismicPostingClusterer, times(1)).cluster(any());
+    }
+
+    public void testGet_withIOException_throwsRuntimeException() throws IOException {
+        doThrow(new IOException("Test exception")).when(seismicPostingClusterer).cluster(any());
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, seismicPostingClusterer);
+
+        try {
+            task.get();
+            fail("Expected RuntimeException to be thrown");
+        } catch (RuntimeException e) {
+            assertTrue(e.getCause() instanceof IOException);
+            assertEquals("Test exception", e.getCause().getMessage());
+        }
+    }
+
+    public void testGet_callsClusteringWithCorrectDocs() throws IOException {
+        docs = Arrays.asList(new DocWeight(1, (byte) 1), new DocWeight(2, (byte) 2), new DocWeight(3, (byte) 3));
+
+        List<DocumentCluster> expectedClusters = Arrays.asList(mock(DocumentCluster.class));
+        when(seismicPostingClusterer.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, seismicPostingClusterer);
+        task.get();
+
+        verify(seismicPostingClusterer, times(1)).cluster(docs);
+    }
+
+    public void testGet_withSingleDoc_returnsPostingClusters() throws IOException {
+        docs = Arrays.asList(new DocWeight(42, (byte) 5));
+
+        List<DocumentCluster> expectedClusters = Arrays.asList(mock(DocumentCluster.class));
+        when(seismicPostingClusterer.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(term, docs, key, seismicPostingClusterer);
+        PostingClusters result = task.get();
+
+        assertNotNull(result);
+        assertNotNull(result.getClusters());
+        assertEquals(1, result.getClusters().size());
+        verify(seismicPostingClusterer, times(1)).cluster(docs);
+    }
+
+    public void testGet_preservesOriginalTermBytes() throws IOException {
+        BytesRef originalTerm = new BytesRef("original_term");
+
+        List<DocumentCluster> expectedClusters = Arrays.asList(mock(DocumentCluster.class));
+        when(seismicPostingClusterer.cluster(any())).thenReturn(expectedClusters);
+
+        ClusteringTask task = new ClusteringTask(originalTerm, docs, key, seismicPostingClusterer);
+
+        // Modify original term to ensure deep copy was made
+        originalTerm.bytes[0] = (byte) 'X';
+
+        PostingClusters result = task.get();
+
+        assertNotNull(result);
+        assertNotNull(result.getClusters());
+        assertEquals(1, result.getClusters().size());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/cache/AbstractLruCacheTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/cache/AbstractLruCacheTests.java
@@ -4,10 +4,11 @@
  */
 package org.opensearch.neuralsearch.sparse.cache;
 
+import org.apache.lucene.index.SegmentInfo;
 import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
-import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -252,7 +253,7 @@ public class AbstractLruCacheTests extends AbstractSparseTestBase {
     /**
      * A concrete implementation of LruCacheKey for testing
      */
-    private static class TestLruCacheKey implements LruCacheKey {
+    private class TestLruCacheKey implements LruCacheKey {
 
         private String name;
         private CacheKey cacheKey;
@@ -264,7 +265,7 @@ public class AbstractLruCacheTests extends AbstractSparseTestBase {
         @Override
         public CacheKey getCacheKey() {
             if (cacheKey == null) {
-                cacheKey = new CacheKey(TestsPrepareUtils.prepareSegmentInfo(), TestsPrepareUtils.prepareKeyFieldInfo());
+                cacheKey = prepareUniqueCacheKey(mock(SegmentInfo.class));
             }
             return cacheKey;
         }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/cache/LruDocumentCacheTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/cache/LruDocumentCacheTests.java
@@ -5,10 +5,13 @@
 package org.opensearch.neuralsearch.sparse.cache;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.index.SegmentInfo;
 import org.junit.Before;
 import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
 import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
 import org.opensearch.neuralsearch.sparse.data.SparseVector;
+
+import static org.mockito.Mockito.mock;
 
 public class LruDocumentCacheTests extends AbstractSparseTestBase {
 
@@ -21,8 +24,8 @@ public class LruDocumentCacheTests extends AbstractSparseTestBase {
         super.setUp();
 
         // Prepare forward index and cache key
-        cacheKey1 = new CacheKey(TestsPrepareUtils.prepareSegmentInfo(), "test_field_1");
-        cacheKey2 = new CacheKey(TestsPrepareUtils.prepareSegmentInfo(), "test_field_2");
+        cacheKey1 = prepareUniqueCacheKey(mock(SegmentInfo.class));
+        cacheKey2 = prepareUniqueCacheKey(mock(SegmentInfo.class));
         ForwardIndexCache.getInstance().getOrCreate(cacheKey1, 10);
         ForwardIndexCache.getInstance().getOrCreate(cacheKey2, 10);
     }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/cache/LruTermCacheTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/cache/LruTermCacheTests.java
@@ -45,9 +45,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         ClusteredPostingCache.getInstance().getOrCreate(cacheKey2);
     }
 
-    /**
-     * Test that getInstance returns the singleton instance
-     */
     public void test_getInstance_returnsSingletonInstance() {
         LruTermCache instance1 = LruTermCache.getInstance();
         LruTermCache instance2 = LruTermCache.getInstance();
@@ -56,9 +53,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertSame(instance1, instance2);
     }
 
-    /**
-     * Test that doEviction correctly evicts a term
-     */
     @SneakyThrows
     public void test_doEviction_erasesTerm() {
         LruTermCache.TermKey termKey = new LruTermCache.TermKey(cacheKey1, term1);
@@ -80,9 +74,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertEquals(expectedCluster.ramBytesUsed() + RamUsageEstimator.shallowSizeOf(term1) + term1.bytes.length, bytesFreed);
     }
 
-    /**
-     * Test that doEviction does nothing when the key is not within the clustered posting cache
-     */
     @SneakyThrows
     public void test_doEviction_withNonExistentKey() {
         CacheKey nonExistentCacheKey = new CacheKey(TestsPrepareUtils.prepareSegmentInfo(), "non_existent_field");
@@ -95,9 +86,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertEquals(0, bytesFreed);
     }
 
-    /**
-     * Test that evict correctly evicts terms until enough memory is freed
-     */
     @SneakyThrows
     public void test_evict_untilEnoughMemoryFreed() {
         // Add terms to the cache, this will update the access order
@@ -136,9 +124,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertEquals(posting3.getClusters(), remainingPosting.getClusters());
     }
 
-    /**
-     * Test that removeIndex correctly removes all terms for an index
-     */
     public void test_removeIndex_removesAllTermsForIndex() {
         // Add terms to the cache for different indices
         LruTermCache.TermKey termKey1 = new LruTermCache.TermKey(cacheKey1, term1);
@@ -159,17 +144,11 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertEquals(term3, remainingTerm.getTerm());
     }
 
-    /**
-     * Test that removeIndex throws NullPointerException when key is null
-     */
     public void test_removeIndex_withNullKey() {
         NullPointerException exception = expectThrows(NullPointerException.class, () -> lruTermCache.removeIndex(null));
         assertEquals("cacheKey is marked non-null but is null", exception.getMessage());
     }
 
-    /**
-     * Test TermKey equals
-     */
     public void test_TermKey_equals_returnsTrue_whenSame() {
         LruTermCache.TermKey key1 = new LruTermCache.TermKey(cacheKey1, term1);
         LruTermCache.TermKey key2 = new LruTermCache.TermKey(cacheKey1, term1);
@@ -177,9 +156,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertEquals(key1, key2);
     }
 
-    /**
-     * Test TermKey equals
-     */
     public void test_TermKey_equals_returnsFalse_withDifferentTerm() {
         LruTermCache.TermKey key1 = new LruTermCache.TermKey(cacheKey1, term1);
         LruTermCache.TermKey key2 = new LruTermCache.TermKey(cacheKey1, term2);
@@ -187,9 +163,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertNotEquals(key1, key2);
     }
 
-    /**
-     * Test TermKey equals
-     */
     public void test_TermKey_equals_returnsFalse_withDifferentCacheKey() {
         LruTermCache.TermKey key1 = new LruTermCache.TermKey(cacheKey1, term1);
         LruTermCache.TermKey key2 = new LruTermCache.TermKey(cacheKey2, term1);
@@ -197,9 +170,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertNotEquals(key1, key2);
     }
 
-    /**
-     * Test TermKey hashCode
-     */
     public void test_TermKey_hashCodeEquals_returnsEqualValues_whenSame() {
         LruTermCache.TermKey key1 = new LruTermCache.TermKey(cacheKey1, term1);
         LruTermCache.TermKey key2 = new LruTermCache.TermKey(cacheKey1, term1);
@@ -207,9 +177,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertEquals(key1.hashCode(), key2.hashCode());
     }
 
-    /**
-     * Test TermKey hashCode
-     */
     public void test_TermKey_hashCodeEquals_returnsDifferentValues_withDifferentTerm() {
         LruTermCache.TermKey key1 = new LruTermCache.TermKey(cacheKey1, term1);
         LruTermCache.TermKey key2 = new LruTermCache.TermKey(cacheKey1, term2);
@@ -217,9 +184,6 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertNotEquals(key1.hashCode(), key2.hashCode());
     }
 
-    /**
-     * Test TermKey hashCode
-     */
     public void test_TermKey_hashCodeEquals_returnsDifferentValues_withDifferentCacheKey() {
         LruTermCache.TermKey key1 = new LruTermCache.TermKey(cacheKey1, term1);
         LruTermCache.TermKey key2 = new LruTermCache.TermKey(cacheKey2, term1);
@@ -227,27 +191,18 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         assertNotEquals(key1.hashCode(), key2.hashCode());
     }
 
-    /**
-     * Test TermKey get CacheKey
-     */
     public void test_TermKey_getCacheKey() {
         LruTermCache.TermKey key = new LruTermCache.TermKey(cacheKey1, term1);
 
         assertEquals(cacheKey1, key.getCacheKey());
     }
 
-    /**
-     * Test TermKey get Term
-     */
     public void test_TermKey_getTerm() {
         LruTermCache.TermKey key = new LruTermCache.TermKey(cacheKey1, term1);
 
         assertEquals(term1, key.getTerm());
     }
 
-    /**
-     * Clear the LRU Term Cache and Clustered Posting Cache to avoid impact on other tests
-     */
     @Override
     public void tearDown() throws Exception {
         lruTermCache.evict(Long.MAX_VALUE);

--- a/src/test/java/org/opensearch/neuralsearch/sparse/cache/LruTermCacheTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/cache/LruTermCacheTests.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.sparse.cache;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.junit.Before;
@@ -14,6 +15,8 @@ import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
 import org.opensearch.neuralsearch.sparse.data.PostingClusters;
 
 import java.util.List;
+
+import static org.mockito.Mockito.mock;
 
 public class LruTermCacheTests extends AbstractSparseTestBase {
 
@@ -29,8 +32,8 @@ public class LruTermCacheTests extends AbstractSparseTestBase {
         super.setUp();
 
         // Prepare cache keys
-        cacheKey1 = new CacheKey(TestsPrepareUtils.prepareSegmentInfo(), "test_field_1");
-        cacheKey2 = new CacheKey(TestsPrepareUtils.prepareSegmentInfo(), "test_field_2");
+        cacheKey1 = prepareUniqueCacheKey(mock(SegmentInfo.class));
+        cacheKey2 = prepareUniqueCacheKey(mock(SegmentInfo.class));
 
         // Prepare terms
         term1 = new BytesRef("term1");

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/BinaryDocValuesSubTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/BinaryDocValuesSubTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.MergeState;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.when;
+
+public class BinaryDocValuesSubTests extends AbstractSparseTestBase {
+
+    @Mock
+    private MergeState.DocMap mockDocMap;
+    @Mock
+    private BinaryDocValues mockBinaryDocValues;
+    @Mock
+    private CacheKey mockCacheKey;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void testConstructor_success() {
+        when(mockBinaryDocValues.docID()).thenReturn(-1);
+
+        BinaryDocValuesSub sub = new BinaryDocValuesSub(mockDocMap, mockBinaryDocValues, mockCacheKey);
+
+        assertNotNull(sub);
+        assertEquals(mockBinaryDocValues, sub.getValues());
+        assertEquals(mockCacheKey, sub.getKey());
+        assertEquals(0, sub.getDocId());
+    }
+
+    public void testConstructor_withNullValues() {
+        IllegalStateException exception = expectThrows(
+            IllegalStateException.class,
+            () -> new BinaryDocValuesSub(mockDocMap, null, mockCacheKey)
+        );
+
+        assertEquals("Doc values is either null or docID is not -1 ", exception.getMessage());
+    }
+
+    public void testConstructor_withInvalidDocID() {
+        when(mockBinaryDocValues.docID()).thenReturn(5);
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class,
+            () -> new BinaryDocValuesSub(mockDocMap, mockBinaryDocValues, mockCacheKey));
+
+        assertEquals("Doc values is either null or docID is not -1 ", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testNextDoc_success() {
+        when(mockBinaryDocValues.docID()).thenReturn(-1);
+        when(mockBinaryDocValues.nextDoc()).thenReturn(10);
+
+        BinaryDocValuesSub sub = new BinaryDocValuesSub(mockDocMap, mockBinaryDocValues, mockCacheKey);
+        int result = sub.nextDoc();
+
+        assertEquals(10, result);
+        assertEquals(10, sub.getDocId());
+    }
+
+    @SneakyThrows
+    public void testNextDoc_throwsIOException() {
+        when(mockBinaryDocValues.docID()).thenReturn(-1);
+        IOException expectedException = new IOException("Test exception");
+        when(mockBinaryDocValues.nextDoc()).thenThrow(expectedException);
+
+        BinaryDocValuesSub sub = new BinaryDocValuesSub(mockDocMap, mockBinaryDocValues, mockCacheKey);
+
+        IOException exception = expectThrows(IOException.class, sub::nextDoc);
+        assertEquals("Test exception", exception.getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriterTests.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+import org.opensearch.neuralsearch.sparse.data.DocWeight;
+import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+
+public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
+
+    private static final int VERSION = 1;
+    private static final String CODEC_NAME = "test_codec";
+
+    private FieldInfo mockFieldInfo;
+    private SegmentWriteState mockWriteState;
+    private ClusteredPostingTermsWriter clusteredPostingTermsWriter;
+
+    @Mock
+    private Codec mockCodec;
+
+    @Mock
+    private DocValuesFormat mockDocValuesFormat;
+
+    @Mock
+    private DocValuesProducer mockDocValuesProducer;
+
+    @Mock
+    private BinaryDocValues mockBinaryDocValues;
+
+    @Mock
+    private Directory mockDirectory;
+
+    @Mock
+    private IndexOutput mockIndexOutput;
+
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        // configure mocks
+        clusteredPostingTermsWriter = new ClusteredPostingTermsWriter(CODEC_NAME, VERSION);
+        SegmentInfo mockSegmentInfo = spy(TestsPrepareUtils.prepareSegmentInfo());
+        mockWriteState = TestsPrepareUtils.prepareSegmentWriteState(mockSegmentInfo);
+        mockFieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+        mockFieldInfo.attributes().put(CLUSTER_RATIO_FIELD, String.valueOf(0.1f));
+        mockFieldInfo.attributes().put(N_POSTINGS_FIELD, String.valueOf(-1));
+        mockFieldInfo.attributes().put(SUMMARY_PRUNE_RATIO_FIELD, String.valueOf(0.4f));
+
+        when(mockSegmentInfo.getCodec()).thenReturn(mockCodec);
+        when(mockCodec.docValuesFormat()).thenReturn(mockDocValuesFormat);
+        when(mockDocValuesFormat.fieldsProducer(any(SegmentReadState.class))).thenReturn(mockDocValuesProducer);
+        when(mockDocValuesProducer.getBinary(any(FieldInfo.class))).thenReturn(mockBinaryDocValues);
+        when(mockDirectory.createOutput(any(String.class), any())).thenReturn(mockIndexOutput);
+    }
+
+    /**
+     * Tests the constructor with codec name and version.
+     */
+    public void test_constructor() {
+        ClusteredPostingTermsWriter writer = new ClusteredPostingTermsWriter(CODEC_NAME, VERSION);
+        assertNotNull("ClusteredPostingTermsWriter should be created", writer);
+    }
+
+    /**
+     * Test case for the write method that takes a BytesRef, TermsEnum, and NormsProducer.
+     * It verifies that the method calls the superclass writeTerm method.
+     */
+    @SneakyThrows
+    public void test_write_withTermsEnum() {
+        clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+
+        TermsEnum mockTermsEnum = mock(TermsEnum.class);
+        NormsProducer mockNormsProducer = mock(NormsProducer.class);
+
+        // Mock the super.writeTerm() to return our expected state
+        BytesRef testText = new BytesRef("test");
+        BlockTermState expectedState = new Lucene101PostingsFormat.IntBlockTermState();
+        doReturn(expectedState).when(clusteredPostingTermsWriter)
+            .writeTerm(eq(testText), eq(mockTermsEnum), any(FixedBitSet.class), eq(mockNormsProducer));
+
+        BlockTermState result = clusteredPostingTermsWriter.write(testText, mockTermsEnum, mockNormsProducer);
+
+        assertSame("Should return the BlockTermState from writeTerm", expectedState, result);
+        verify(clusteredPostingTermsWriter).writeTerm(eq(testText), eq(mockTermsEnum), any(FixedBitSet.class), eq(mockNormsProducer));
+    }
+
+    /**
+     * Test case for the write method with PostingClusters parameter.
+     * This test verifies that the method correctly writes the given PostingClusters
+     * to the IndexOutput and returns a new BlockTermState.
+     */
+    @SneakyThrows
+    public void test_write_withPostingClusters() {
+        clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+
+        BytesRef text = new BytesRef("test_term");
+        PostingClusters postingClusters = mock(PostingClusters.class);
+        BlockTermState result = clusteredPostingTermsWriter.write(text, postingClusters);
+
+        // Verify that the result is non-null and writePostingClusters gets called
+        assertNotNull("BlockTermState should not be null", result);
+        verify(mockIndexOutput, atLeastOnce()).writeVLong(anyLong());
+    }
+
+    /**
+     * Test the setFieldAndMaxDoc method without a merge operation.
+     * This test verifies that when isMerge is false, the setPostingClustering method is called.
+     */
+    @SneakyThrows
+    public void test_setFieldAndMaxDoc_withoutMerge() {
+        clusteredPostingTermsWriter = spy(this.clusteredPostingTermsWriter);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+
+        // Mock the superclass setField method
+        clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
+
+        // Verify setField was called
+        verify(clusteredPostingTermsWriter).setField(mockFieldInfo);
+
+        // Verify that setPostingClustering gets called
+        verify(mockDocValuesFormat, times(1)).fieldsProducer(any(SegmentReadState.class));
+    }
+
+    /**
+     * Test the setFieldAndMaxDoc method without a merge operation.
+     * The N_POSTINGS_FIELD has a non-default value.
+     * This test verifies that when isMerge is true, the setPostingClustering method is called.
+     */
+    @SneakyThrows
+    public void test_setFieldAndMaxDoc_withoutMerge_andNPostingValue() {
+        clusteredPostingTermsWriter = spy(this.clusteredPostingTermsWriter);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+        mockFieldInfo.attributes().put(N_POSTINGS_FIELD, String.valueOf(160));
+
+        // Mock the superclass setField method
+        clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
+
+        // Verify setField was called
+        verify(clusteredPostingTermsWriter).setField(mockFieldInfo);
+
+        // Verify that setPostingClustering gets called
+        verify(mockDocValuesFormat, times(1)).fieldsProducer(any(SegmentReadState.class));
+    }
+
+    /**
+     * Test the setFieldAndMaxDoc method without a merge operation.
+     * The fields producer will throw an exception.
+     * This test verifies that when isMerge is true, the setPostingClustering method is called.
+     */
+    @SneakyThrows
+    public void test_setFieldAndMaxDoc_withoutMerge_andFieldsProducerThrowException() {
+        clusteredPostingTermsWriter = spy(this.clusteredPostingTermsWriter);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+
+        // Mock the fields producer throw exception
+        when(mockDocValuesFormat.fieldsProducer(any(SegmentReadState.class))).thenThrow(new IOException("mock_exception"));
+
+        // Mock the superclass setField method
+        clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
+
+        // Verify setField was called
+        verify(clusteredPostingTermsWriter).setField(mockFieldInfo);
+
+        // Verify that setPostingClustering gets called
+        verify(mockDocValuesFormat, times(1)).fieldsProducer(any(SegmentReadState.class));
+    }
+
+    /**
+     * Test the setFieldAndMaxDoc method with a merge operation.
+     * This test verifies that when isMerge is true, the setPostingClustering method is not called.
+     */
+    @SneakyThrows
+    public void test_setFieldAndMaxDoc_withMerge() {
+        clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+
+        // Mock the superclass setField method
+        doNothing().when(clusteredPostingTermsWriter).setField(any(FieldInfo.class));
+
+        clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, true);
+
+        // Verify setField was called
+        verify(clusteredPostingTermsWriter).setField(mockFieldInfo);
+
+        // Verify that setPostingClustering was not called
+        verify(mockDocValuesFormat, never()).fieldsProducer(any(SegmentReadState.class));
+    }
+
+    /**
+     * Tests the newTermState method
+     */
+    @SneakyThrows
+    public void test_newTermState() {
+        BlockTermState state = clusteredPostingTermsWriter.newTermState();
+        assertNotNull("Term state should not be null", state);
+    }
+
+    /**
+     * Test case for the startTerm method.
+     * This test verifies that the startTerm method does not throw exception
+     */
+    public void test_startTerm() throws IOException {
+        NumericDocValues mockNorms = mock(NumericDocValues.class);
+        clusteredPostingTermsWriter.startTerm(mockNorms);
+    }
+
+    /**
+     * Test case for the finishTerm method.
+     * This test verifies that the startTerm method does not throw exception
+     */
+    @SneakyThrows
+    public void test_finishTerm_writesPostingClusters() {
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+
+        // set up postingClusters containing a cluster with empty summary
+        List<DocumentCluster> documentClusterList = prepareClusterList();
+        List<DocWeight> docWeights = new ArrayList<>();
+        docWeights.add(new DocWeight(3, (byte) 4));
+        documentClusterList.add(new DocumentCluster(null, docWeights, false));
+        PostingClusters postingClusters = new PostingClusters(documentClusterList);
+
+        // set up for finish term
+        clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
+        clusteredPostingTermsWriter.write(new BytesRef("test_term"), postingClusters);
+
+        // reset mockIndexOutput because write function also write posting clusters
+        reset(mockIndexOutput);
+
+        BlockTermState state = clusteredPostingTermsWriter.newTermState();
+        clusteredPostingTermsWriter.finishTerm(state);
+
+        // Verify the output was written
+        verify(mockIndexOutput, atLeastOnce()).writeVLong(anyLong());
+    }
+
+    /**
+     * Test case for startDoc method with a valid docID.
+     * This test verifies that the method correctly handles a non-negative docID.
+     */
+    @SneakyThrows
+    public void test_startDoc_withValidDocId() {
+        clusteredPostingTermsWriter.startDoc(1, 10);
+        // No assertion needed, we're just verifying it doesn't throw an exception
+    }
+
+    /**
+     * Test case for startDoc method when docID is -1.
+     * This test verifies that an IllegalStateException is thrown when an invalid docID is provided.
+     */
+    public void test_startDoc_withInvalidDocID() {
+        Exception exception = expectThrows(IllegalStateException.class, () -> { clusteredPostingTermsWriter.startDoc(-1, 10); });
+        assertEquals("docId must be set before startDoc", exception.getMessage());
+    }
+
+    /**
+     * Test case for addPosition method
+     * This test verifies that an UnsupportedOperationException is thrown.
+     */
+    public void test_addPosition_thenThrownUnsupportedOperation() {
+        assertThrows(UnsupportedOperationException.class, () -> clusteredPostingTermsWriter.addPosition(0, new BytesRef(), 0, 0));
+    }
+
+    /**
+     * Test case for finishDoc method
+     * This test verifies that no exception is thrown.
+     */
+    @SneakyThrows
+    public void test_finishDoc() {
+        clusteredPostingTermsWriter.finishDoc();
+    }
+
+    /**
+     * Tests the init method with mocked objects.
+     */
+    @SneakyThrows
+    public void test_init() {
+        clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+    }
+
+    /**
+     * Test case for encodeTerm method
+     * This test verifies that an UnsupportedOperationException is thrown.
+     */
+    public void test_encodeTerm_thenThrowUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> clusteredPostingTermsWriter.encodeTerm(null, null, null, false));
+    }
+
+    /**
+     * Test case for the close() method when docValuesProducer is null.
+     * This test verifies that the method closes the postingOut
+     */
+    @SneakyThrows
+    public void test_close_whenDocValuesProducerNull() {
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+        clusteredPostingTermsWriter.close();
+
+        verify(mockDocValuesProducer, never()).close();
+    }
+
+    /**
+     * Test case for the close() method when docValuesProducer is not null.
+     * This test verifies that the close() method properly closes both the IndexOutput and DocValuesProducer.
+     */
+    public void test_close_whenDocValuesProducerNonNull() throws IOException {
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+        clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
+        clusteredPostingTermsWriter.close();
+
+        verify(mockDocValuesProducer, times(1)).close();
+    }
+
+    /**
+     * Test the closeWithException method when docValuesProducer is null.
+     * This tests the edge case where the docValuesProducer field is not initialized.
+     */
+    @SneakyThrows
+    public void test_closeWithException_whenDocValuesProducerNull() {
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+        clusteredPostingTermsWriter.closeWithException();
+
+        // Verify that IOUtils.closeWhileHandlingException calls only postingOut
+        verify(mockIndexOutput, times(1)).close();
+        verify(mockDocValuesProducer, never()).close();
+    }
+
+    /**
+     * Test case for closeWithException method when docValuesProducer is not null.
+     * This test verifies that IOUtils.closeWhileHandlingException is called for both
+     * postingOut and docValuesProducer when closeWithException is invoked.
+     */
+    @SneakyThrows
+    public void test_closeWithException_whenDocValuesProducerNonNull() {
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+        clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
+        clusteredPostingTermsWriter.closeWithException();
+
+        // Verify that IOUtils.closeWhileHandlingException calls with both postingOut and docValuesProducer
+        verify(mockIndexOutput, times(1)).close();
+        verify(mockDocValuesProducer, times(1)).close();
+    }
+
+    /**
+     * Test case for the close(long startFp) method.
+     * This test verifies that the method writes postingOut and calls this.close()
+     */
+    @SneakyThrows
+    public void test_close_withStartFp() {
+        clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
+        clusteredPostingTermsWriter.close(100L);
+
+        // Verify startFp was written
+        verify(mockIndexOutput).writeLong(eq(100L));
+
+        // Verify calls this.close()
+        verify(clusteredPostingTermsWriter, times(1)).close();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriterTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
@@ -95,7 +94,6 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         MockitoAnnotations.openMocks(this);
 
         // configure mocks
-        clusteredPostingTermsWriter = new ClusteredPostingTermsWriter(CODEC_NAME, VERSION, mockCodecUtilWrapper);
         mockWriteState = TestsPrepareUtils.prepareSegmentWriteState(mockSegmentInfo);
         when(mockFieldInfo.attributes()).thenReturn(prepareAttributes(true, 10, 0.1f, -1, 0.4f));
 
@@ -105,24 +103,13 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         when(mockDocValuesProducer.getBinary(any(FieldInfo.class))).thenReturn(mockBinaryDocValues);
         when(mockDirectory.createOutput(any(String.class), any())).thenReturn(mockIndexOutput);
         when(mockFieldInfo.getIndexOptions()).thenReturn(mockIndexOptions);
+        clusteredPostingTermsWriter = new ClusteredPostingTermsWriter(CODEC_NAME, VERSION, mockCodecUtilWrapper);
+        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
     }
 
-    /**
-     * Tests the constructor with codec name and version.
-     */
-    public void test_constructor() {
-        ClusteredPostingTermsWriter writer = new ClusteredPostingTermsWriter(CODEC_NAME, VERSION, mockCodecUtilWrapper);
-        assertNotNull("ClusteredPostingTermsWriter should be created", writer);
-    }
-
-    /**
-     * Test case for the write method that takes a BytesRef, TermsEnum, and NormsProducer.
-     * It verifies that the method calls the superclass writeTerm method.
-     */
     @SneakyThrows
     public void test_write_withTermsEnum() {
         clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
 
         TermsEnum mockTermsEnum = mock(TermsEnum.class);
         NormsProducer mockNormsProducer = mock(NormsProducer.class);
@@ -139,16 +126,8 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         verify(clusteredPostingTermsWriter).writeTerm(eq(testText), eq(mockTermsEnum), any(FixedBitSet.class), eq(mockNormsProducer));
     }
 
-    /**
-     * Test case for the write method with PostingClusters parameter.
-     * This test verifies that the method correctly writes the given PostingClusters
-     * to the IndexOutput and returns a new BlockTermState.
-     */
     @SneakyThrows
     public void test_write_withPostingClusters() {
-        clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
-
         BytesRef text = new BytesRef("test_term");
         PostingClusters postingClusters = mock(PostingClusters.class);
         BlockTermState result = clusteredPostingTermsWriter.write(text, postingClusters);
@@ -158,115 +137,57 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         verify(mockIndexOutput, atLeastOnce()).writeVLong(anyLong());
     }
 
-    /**
-     * Test the setFieldAndMaxDoc method without a merge operation.
-     * This test verifies that when isMerge is false, the setPostingClustering method is called.
-     */
     @SneakyThrows
     public void test_setFieldAndMaxDoc_withoutMerge() {
         clusteredPostingTermsWriter = spy(this.clusteredPostingTermsWriter);
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
 
-        // Mock the superclass setField method
         clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
 
-        // Verify setField was called
         verify(clusteredPostingTermsWriter).setField(mockFieldInfo);
-
-        // Verify that setPostingClustering gets called
         verify(mockDocValuesFormat, times(1)).fieldsProducer(any(SegmentReadState.class));
     }
 
-    /**
-     * Test the setFieldAndMaxDoc method without a merge operation.
-     * The N_POSTINGS_FIELD has a non-default value.
-     * This test verifies that when isMerge is true, the setPostingClustering method is called.
-     */
     @SneakyThrows
     public void test_setFieldAndMaxDoc_withoutMerge_andNPostingValue() {
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
         when(mockFieldInfo.attributes()).thenReturn(prepareAttributes(true, 10, 1.0f, 160, 1.0f));
 
-        // Mock the superclass setField method
         clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
 
-        // Verify setField was called
         verify(mockFieldInfo).getIndexOptions();
-
-        // Verify that setPostingClustering gets called
         verify(mockDocValuesFormat, times(1)).fieldsProducer(any(SegmentReadState.class));
     }
 
-    /**
-     * Test the setFieldAndMaxDoc method without a merge operation.
-     * The fields producer will throw an exception.
-     * This test verifies that when isMerge is true, the setPostingClustering method is called.
-     */
     @SneakyThrows
     public void test_setFieldAndMaxDoc_withoutMerge_andFieldsProducerThrowException() {
         clusteredPostingTermsWriter = spy(this.clusteredPostingTermsWriter);
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
 
         // Mock the fields producer throw exception
         when(mockDocValuesFormat.fieldsProducer(any(SegmentReadState.class))).thenThrow(new IOException("mock_exception"));
-
-        // Mock the superclass setField method
         clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
 
-        // Verify setField was called
         verify(clusteredPostingTermsWriter).setField(mockFieldInfo);
-
-        // Verify that setPostingClustering gets called
         verify(mockDocValuesFormat, times(1)).fieldsProducer(any(SegmentReadState.class));
     }
 
-    /**
-     * Test the setFieldAndMaxDoc method with a merge operation.
-     * This test verifies that when isMerge is true, the setPostingClustering method is not called.
-     */
     @SneakyThrows
     public void test_setFieldAndMaxDoc_withMerge() {
         clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
 
         // Mock the superclass setField method
         doNothing().when(clusteredPostingTermsWriter).setField(any(FieldInfo.class));
-
         clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, true);
 
-        // Verify setField was called
         verify(clusteredPostingTermsWriter).setField(mockFieldInfo);
-
-        // Verify that setPostingClustering was not called
         verify(mockDocValuesFormat, never()).fieldsProducer(any(SegmentReadState.class));
     }
 
-    /**
-     * Tests the newTermState method
-     */
     @SneakyThrows
     public void test_newTermState() {
-        BlockTermState state = clusteredPostingTermsWriter.newTermState();
-        assertNotNull("Term state should not be null", state);
+        assertNotNull(clusteredPostingTermsWriter.newTermState());
     }
 
-    /**
-     * Test case for the startTerm method.
-     * This test verifies that the startTerm method does not throw exception
-     */
-    public void test_startTerm() throws IOException {
-        NumericDocValues mockNorms = mock(NumericDocValues.class);
-        clusteredPostingTermsWriter.startTerm(mockNorms);
-    }
-
-    /**
-     * Test case for the finishTerm method.
-     * This test verifies that the startTerm method does not throw exception
-     */
     @SneakyThrows
     public void test_finishTerm_writesPostingClusters() {
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
-
         // set up postingClusters containing a cluster with empty summary
         List<DocumentCluster> documentClusterList = prepareClusterList();
         List<DocWeight> docWeights = new ArrayList<>();
@@ -288,48 +209,27 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         verify(mockIndexOutput, atLeastOnce()).writeVLong(anyLong());
     }
 
-    /**
-     * Test case for startDoc method with a valid docID.
-     * This test verifies that the method correctly handles a non-negative docID.
-     */
     @SneakyThrows
     public void test_startDoc_withValidDocId() {
         clusteredPostingTermsWriter.startDoc(1, 10);
         // No assertion needed, we're just verifying it doesn't throw an exception
     }
 
-    /**
-     * Test case for startDoc method when docID is -1.
-     * This test verifies that an IllegalStateException is thrown when an invalid docID is provided.
-     */
     public void test_startDoc_withInvalidDocID() {
-        Exception exception = expectThrows(IllegalStateException.class, () -> { clusteredPostingTermsWriter.startDoc(-1, 10); });
-        assertEquals("docId must be set before startDoc", exception.getMessage());
+        expectThrows(IllegalStateException.class, () -> { clusteredPostingTermsWriter.startDoc(-1, 10); });
     }
 
-    /**
-     * Test case for addPosition method
-     * This test verifies that an UnsupportedOperationException is thrown.
-     */
     public void test_addPosition_thenThrownUnsupportedOperation() {
         assertThrows(UnsupportedOperationException.class, () -> clusteredPostingTermsWriter.addPosition(0, new BytesRef(), 0, 0));
     }
 
-    /**
-     * Test case for finishDoc method
-     * This test verifies that no exception is thrown.
-     */
     @SneakyThrows
     public void test_finishDoc() {
         clusteredPostingTermsWriter.finishDoc();
     }
 
-    /**
-     * Tests the init method with mocked objects.
-     */
     @SneakyThrows
     public void test_init() {
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
         verify(mockCodecUtilWrapper).writeIndexHeader(
             eq(mockIndexOutput),
             eq(CODEC_NAME),
@@ -339,32 +239,18 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         );
     }
 
-    /**
-     * Test case for encodeTerm method
-     * This test verifies that an UnsupportedOperationException is thrown.
-     */
     public void test_encodeTerm_thenThrowUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> clusteredPostingTermsWriter.encodeTerm(null, null, null, false));
     }
 
-    /**
-     * Test case for the close() method when docValuesProducer is null.
-     * This test verifies that the method closes the postingOut
-     */
     @SneakyThrows
     public void test_close_whenDocValuesProducerNull() {
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
         clusteredPostingTermsWriter.close();
 
         verify(mockDocValuesProducer, never()).close();
     }
 
-    /**
-     * Test case for the close() method when docValuesProducer is not null.
-     * This test verifies that the close() method properly closes both the IndexOutput and DocValuesProducer.
-     */
     public void test_close_whenDocValuesProducerNonNull() throws IOException {
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
         clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
         clusteredPostingTermsWriter.close();
 
@@ -372,13 +258,8 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         verify(mockCodecUtilWrapper).writeFooter(any());
     }
 
-    /**
-     * Test the closeWithException method when docValuesProducer is null.
-     * This tests the edge case where the docValuesProducer field is not initialized.
-     */
     @SneakyThrows
     public void test_closeWithException_whenDocValuesProducerNull() {
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
         clusteredPostingTermsWriter.closeWithException();
 
         // Verify that IOUtils.closeWhileHandlingException calls only postingOut
@@ -386,14 +267,8 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         verify(mockDocValuesProducer, never()).close();
     }
 
-    /**
-     * Test case for closeWithException method when docValuesProducer is not null.
-     * This test verifies that IOUtils.closeWhileHandlingException is called for both
-     * postingOut and docValuesProducer when closeWithException is invoked.
-     */
     @SneakyThrows
     public void test_closeWithException_whenDocValuesProducerNonNull() {
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
         clusteredPostingTermsWriter.setFieldAndMaxDoc(mockFieldInfo, 100, false);
         clusteredPostingTermsWriter.closeWithException();
 
@@ -402,14 +277,9 @@ public class ClusteredPostingTermsWriterTests extends AbstractSparseTestBase {
         verify(mockDocValuesProducer, times(1)).close();
     }
 
-    /**
-     * Test case for the close(long startFp) method.
-     * This test verifies that the method writes postingOut and calls this.close()
-     */
     @SneakyThrows
     public void test_close_withStartFp() {
         clusteredPostingTermsWriter = spy(clusteredPostingTermsWriter);
-        clusteredPostingTermsWriter.init(mockIndexOutput, mockWriteState);
         clusteredPostingTermsWriter.close(100L);
 
         // Verify startFp was written

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/MergeHelperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/MergeHelperTests.java
@@ -304,4 +304,10 @@ public class MergeHelperTests extends AbstractSparseTestBase {
         MergeState mergeState = mock(MergeState.class);
         assertNotNull(mergeHelper.convertToMergeStateFacade(mergeState));
     }
+
+    public void test_newSparseDocValuesReader() {
+        SparseDocValuesReader reader = mergeHelper.newSparseDocValuesReader(mergeStateFacade);
+        assertNotNull(reader);
+        assertSame(reader.getMergeStateFacade(), mergeStateFacade);
+    }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/MergeHelperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/MergeHelperTests.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.cache.CacheGatedPostingsReader;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+import org.opensearch.neuralsearch.sparse.data.DocWeight;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.mapper.SparseTokensField.SPARSE_FIELD;
+
+public class MergeHelperTests extends AbstractSparseTestBase {
+    @Mock
+    private MergeStateFacade mergeStateFacade;
+    @Mock
+    private FieldInfo sparseFieldInfo;
+    @Mock
+    private FieldInfo nonSparseFieldInfo;
+    @Mock
+    private SparseBinaryDocValuesPassThrough binaryDocValuePassThrough;
+    @Mock
+    private DocValuesProducer docValuesProducer;
+    @Mock
+    private SegmentInfo segmentInfo;
+    @Mock
+    private Terms mockTerms;
+    @Mock
+    private TermsEnum mockTermsEnum;
+    @Mock
+    private SparseTerms mockSparseTerms;
+    @Mock
+    private CacheGatedPostingsReader mockCacheGatedPostingsReader;
+    @Mock
+    private FieldsProducer mockFieldsProducer;
+    @Mock
+    private SparsePostingsEnum mockSparsePostingsEnum;
+    @Mock
+    private PostingsEnum mockPostingsEnum;
+    @Mock
+    private PostingClusters mockPostingClusters;
+    @Mock
+    private MergeHelper mergeHelper;
+    @Mock
+    private MergeState.DocMap mockDocMap;
+    @Mock
+    private FieldInfo mockFieldInfo;
+    private static final BytesRef term = new BytesRef("term");
+    private static final Set<BytesRef> terms = Set.of(term);
+
+    @SneakyThrows
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        mergeHelper = new MergeHelper();
+
+        when(mergeStateFacade.getFieldsProducers()).thenReturn(new FieldsProducer[] { mockFieldsProducer });
+        when(mergeStateFacade.getDocValuesProducers()).thenReturn(new DocValuesProducer[] { docValuesProducer });
+        when(docValuesProducer.getBinary(any())).thenReturn(binaryDocValuePassThrough);
+
+        when(mockFieldsProducer.terms(anyString())).thenReturn(mockTerms);
+        when(mockTerms.iterator()).thenReturn(mockTermsEnum);
+        when(mockTermsEnum.seekExact(any())).thenReturn(true);
+        when(mockTermsEnum.postings(isNull())).thenReturn(mockSparsePostingsEnum);
+        when(mockSparsePostingsEnum.nextDoc()).thenReturn(1).thenReturn(2).thenReturn(PostingsEnum.NO_MORE_DOCS);
+        when(mockSparsePostingsEnum.freq()).thenReturn(1).thenReturn(2);
+        when(mergeStateFacade.getDocMaps()).thenReturn(new MergeState.DocMap[] { mockDocMap });
+        when(mockDocMap.get(eq(1))).thenReturn(1);
+        when(mockDocMap.get(eq(2))).thenReturn(2);
+        when(mockFieldInfo.getName()).thenReturn("field_name");
+
+        // Setup sparse field
+        Map<String, String> sparseAttributes = new HashMap<>();
+        sparseAttributes.put(SPARSE_FIELD, "true");
+        when(sparseFieldInfo.attributes()).thenReturn(sparseAttributes);
+
+        // Setup non-sparse field
+        when(nonSparseFieldInfo.attributes()).thenReturn(new HashMap<>());
+
+        List<FieldInfo> fields = Arrays.asList(sparseFieldInfo, nonSparseFieldInfo);
+        FieldInfos fieldInfos = mock(FieldInfos.class);
+        when(fieldInfos.iterator()).thenReturn(fields.iterator());
+        when(mergeStateFacade.getMergeFieldInfos()).thenReturn(fieldInfos);
+
+        // configure sparse term
+        when(mockSparseTerms.getReader()).thenReturn(mockCacheGatedPostingsReader);
+        when(mockCacheGatedPostingsReader.read(any(BytesRef.class))).thenReturn(mockPostingClusters);
+        when(mockCacheGatedPostingsReader.getTerms()).thenReturn(terms);
+    }
+
+    public void testClearCacheData_withValidSparseField_callsConsumer() throws IOException {
+        SparseBinaryDocValuesPassThrough mockBinaryDocValues = mock(SparseBinaryDocValuesPassThrough.class);
+        when(mockBinaryDocValues.getSegmentInfo()).thenReturn(segmentInfo);
+        when(docValuesProducer.getBinary(sparseFieldInfo)).thenReturn(mockBinaryDocValues);
+
+        List<CacheKey> capturedKeys = new ArrayList<>();
+        Consumer<CacheKey> consumer = capturedKeys::add;
+
+        mergeHelper.clearCacheData(mergeStateFacade, sparseFieldInfo, consumer);
+
+        assertEquals("Consumer should be called when fieldInfo matches", 1, capturedKeys.size());
+    }
+
+    public void testClearInMemoryData_withNullFieldInfo_processesAllSparseFields() throws IOException {
+        SparseBinaryDocValuesPassThrough mockBinaryDocValues = mock(SparseBinaryDocValuesPassThrough.class);
+        when(mockBinaryDocValues.getSegmentInfo()).thenReturn(segmentInfo);
+        when(docValuesProducer.getBinary(sparseFieldInfo)).thenReturn(mockBinaryDocValues);
+
+        List<CacheKey> capturedKeys = new ArrayList<>();
+        Consumer<CacheKey> consumer = capturedKeys::add;
+
+        mergeHelper.clearCacheData(mergeStateFacade, null, consumer);
+
+        assertEquals("Consumer should be called for sparse field", 1, capturedKeys.size());
+    }
+
+    public void testClearInMemoryData_withNonSparseFieldInfo_processesAllSparseFields() throws IOException {
+        SparseBinaryDocValuesPassThrough mockBinaryDocValues = mock(SparseBinaryDocValuesPassThrough.class);
+        when(mockBinaryDocValues.getSegmentInfo()).thenReturn(segmentInfo);
+        when(docValuesProducer.getBinary(sparseFieldInfo)).thenReturn(mockBinaryDocValues);
+
+        List<CacheKey> capturedKeys = new ArrayList<>();
+        Consumer<CacheKey> consumer = capturedKeys::add;
+
+        mergeHelper.clearCacheData(mergeStateFacade, nonSparseFieldInfo, consumer);
+
+        assertEquals("Consumer should NOT be called for sparse field when fieldInfo doesn't match", 0, capturedKeys.size());
+    }
+
+    public void testClearInMemoryData_withNonSparseBinaryDocValues_skipsField() throws IOException {
+        BinaryDocValues mockBinaryDocValues = mock(BinaryDocValues.class);
+        when(docValuesProducer.getBinary(sparseFieldInfo)).thenReturn(mockBinaryDocValues);
+
+        List<CacheKey> capturedKeys = new ArrayList<>();
+        Consumer<CacheKey> consumer = capturedKeys::add;
+
+        mergeHelper.clearCacheData(mergeStateFacade, nonSparseFieldInfo, consumer);
+
+        assertEquals("Consumer should NOT be called for non-SparseBinaryDocValuesPassThrough", 0, capturedKeys.size());
+    }
+
+    public void testClearInMemoryData_withEmptyMergeState_doesNotCallConsumer() throws IOException {
+        when(mergeStateFacade.getDocValuesProducers()).thenReturn(new DocValuesProducer[]{});
+
+        List<CacheKey> capturedKeys = new ArrayList<>();
+        Consumer<CacheKey> consumer = capturedKeys::add;
+
+        mergeHelper.clearCacheData(mergeStateFacade, sparseFieldInfo, consumer);
+
+        assertEquals("Consumer should NOT be called with empty producers", 0, capturedKeys.size());
+    }
+
+    public void test_getMergedPostingForATerm_unexpectedType() throws IOException {
+        BinaryDocValues binaryDocValues = mock(BinaryDocValues.class);
+        when(docValuesProducer.getBinary(any())).thenReturn(binaryDocValues);
+
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]);
+        verify(docValuesProducer).getBinary(any());
+        assertTrue(CollectionUtils.isEmpty(result));
+    }
+
+    public void test_getMergedPostingForATerm_nullTerm() throws IOException {
+        when(mockFieldsProducer.terms(anyString())).thenReturn(null);
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]);
+        verify(mockFieldsProducer).terms(anyString());
+        assertTrue(CollectionUtils.isEmpty(result));
+    }
+
+    public void test_getMergedPostingForATerm_nullTermsEnum() throws IOException {
+        when(mockTerms.iterator()).thenReturn(null);
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]);
+        verify(mockTerms).iterator();
+        assertTrue(CollectionUtils.isEmpty(result));
+    }
+
+    public void test_getMergedPostingForATerm_seekExactFalse() throws IOException {
+        when(mockTermsEnum.seekExact(any())).thenReturn(false);
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]);
+        verify(mockTermsEnum).seekExact(any());
+        assertTrue(CollectionUtils.isEmpty(result));
+    }
+
+    public void test_getMergedPostingForATerm_postingIsNull() throws IOException {
+        when(mockTermsEnum.postings(isNull())).thenReturn(null);
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]);
+        verify(mockTermsEnum).postings(isNull());
+        assertTrue(CollectionUtils.isEmpty(result));
+    }
+
+    public void test_getMergedPostingForATerm_postingNextDocNoMoreDocs() throws IOException {
+        when(mockSparsePostingsEnum.nextDoc()).thenReturn(PostingsEnum.NO_MORE_DOCS);
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]);
+        assertTrue(CollectionUtils.isEmpty(result));
+    }
+
+    public void test_getMergedPostingForATerm_postingNextDocIsMinus1() throws IOException {
+        when(mockSparsePostingsEnum.nextDoc()).thenReturn(-1).thenReturn(PostingsEnum.NO_MORE_DOCS);
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]);
+        assertTrue(CollectionUtils.isEmpty(result));
+    }
+
+    public void test_getMergedPostingForATerm_postingNewDocIsMinus1() throws IOException {
+        when(mockSparsePostingsEnum.nextDoc()).thenReturn(1).thenReturn(PostingsEnum.NO_MORE_DOCS);
+        when(mockDocMap.get(eq(1))).thenReturn(-1);
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]);
+        assertTrue(CollectionUtils.isEmpty(result));
+    }
+
+    public void test_getMergedPostingForATerm_postingNewDocOutOfBound() throws IOException {
+        when(mockSparsePostingsEnum.nextDoc()).thenReturn(1).thenReturn(PostingsEnum.NO_MORE_DOCS);
+        when(mockDocMap.get(eq(1))).thenReturn(10000);
+        expectThrows(IndexOutOfBoundsException.class, () -> mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[2], new int[2]));
+    }
+
+    public void test_getMergedPostingForATerm_happyCase_expectedType() throws IOException {
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[3], new int[3]);
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getDocID());
+        assertEquals(1, result.get(0).getIntWeight());
+        assertEquals(2, result.get(1).getDocID());
+        assertEquals(2, result.get(1).getIntWeight());
+    }
+
+    public void test_getMergedPostingForATerm_happyCase_unexpectedType() throws IOException {
+        when(mockPostingsEnum.nextDoc()).thenReturn(1).thenReturn(2).thenReturn(PostingsEnum.NO_MORE_DOCS);
+        when(mockPostingsEnum.freq()).thenReturn(32512).thenReturn(32768);
+        when(mockTermsEnum.postings(isNull())).thenReturn(mockPostingsEnum);
+        List<DocWeight> result = mergeHelper.getMergedPostingForATerm(mergeStateFacade, term, mockFieldInfo, new int[3], new int[3]);
+        assertEquals(2, result.size());
+        assertEquals(1, result.get(0).getDocID());
+        assertEquals(85, result.get(0).getIntWeight());
+        assertEquals(2, result.get(1).getDocID());
+        assertEquals(170, result.get(1).getIntWeight());
+    }
+
+    public void test_getAllTerms_emptyFieldProducer() throws IOException {
+        when(mergeStateFacade.getFieldsProducers()).thenReturn(new FieldsProducer[0]);
+        assertTrue(CollectionUtils.isEmpty(mergeHelper.getAllTerms(mergeStateFacade, mockFieldInfo)));
+    }
+
+    public void test_getAllTerms_unexpectedBinaryDocValueType() throws IOException {
+        BinaryDocValues binaryDocValues = mock(BinaryDocValues.class);
+        when(docValuesProducer.getBinary(any())).thenReturn(binaryDocValues);
+        Set<BytesRef> allTerms = mergeHelper.getAllTerms(mergeStateFacade, mockFieldInfo);
+        assertTrue(CollectionUtils.isEmpty(allTerms));
+        verify(docValuesProducer).getBinary(any());
+    }
+
+    public void test_getAllTerms_isNotSparseTerm() throws IOException {
+        when(mockTermsEnum.next()).thenReturn(term).thenReturn(null);
+        Set<BytesRef> allTerms = mergeHelper.getAllTerms(mergeStateFacade, mockFieldInfo);
+        assertEquals(terms, allTerms);
+    }
+
+    public void test_getAllTerms_isSparseTerm() throws IOException {
+        SparseTerms sparseTerms = mock(SparseTerms.class);
+        when(mockFieldsProducer.terms(anyString())).thenReturn(sparseTerms);
+        when(sparseTerms.iterator()).thenReturn(mockTermsEnum);
+        when(sparseTerms.getReader()).thenReturn(mockCacheGatedPostingsReader);
+        when(mockCacheGatedPostingsReader.getTerms()).thenReturn(terms);
+        Set<BytesRef> allTerms = mergeHelper.getAllTerms(mergeStateFacade, mockFieldInfo);
+        assertEquals(terms, allTerms);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/MergeHelperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/MergeHelperTests.java
@@ -299,4 +299,9 @@ public class MergeHelperTests extends AbstractSparseTestBase {
         Set<BytesRef> allTerms = mergeHelper.getAllTerms(mergeStateFacade, mockFieldInfo);
         assertEquals(terms, allTerms);
     }
+
+    public void test_convertToMergeStateFacade() {
+        MergeState mergeState = mock(MergeState.class);
+        assertNotNull(mergeHelper.convertToMergeStateFacade(mergeState));
+    }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThroughTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesPassThroughTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+import org.opensearch.neuralsearch.sparse.data.SparseVector;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparseBinaryDocValuesPassThroughTests extends AbstractSparseTestBase {
+
+    private BinaryDocValues mockDelegate;
+    private SegmentInfo mockSegmentInfo;
+    private SparseBinaryDocValuesPassThrough sparseBinaryDocValuesPassThrough;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        mockDelegate = mock(BinaryDocValues.class);
+        mockSegmentInfo = mock(SegmentInfo.class);
+        sparseBinaryDocValuesPassThrough = new SparseBinaryDocValuesPassThrough(mockDelegate, mockSegmentInfo);
+    }
+
+    public void testConstructor_InitializesFieldsCorrectly() {
+        SparseBinaryDocValuesPassThrough sparseBinaryDocValuesPassThrough = new SparseBinaryDocValuesPassThrough(
+            mockDelegate,
+            mockSegmentInfo
+        );
+
+        assertSame(mockSegmentInfo, sparseBinaryDocValuesPassThrough.getSegmentInfo());
+    }
+
+    public void testGetSegmentInfo() {
+        SegmentInfo result = sparseBinaryDocValuesPassThrough.getSegmentInfo();
+
+        assertEquals(mockSegmentInfo, result);
+    }
+
+    public void testBinaryValue() throws IOException {
+        BytesRef expectedBytesRef = new BytesRef("test_binary_value");
+        when(mockDelegate.binaryValue()).thenReturn(expectedBytesRef);
+
+        BytesRef result = sparseBinaryDocValuesPassThrough.binaryValue();
+
+        assertEquals(expectedBytesRef, result);
+        verify(mockDelegate, times(1)).binaryValue();
+    }
+
+    public void testAdvanceExact() throws IOException {
+        int targetDoc = 1;
+        when(mockDelegate.advanceExact(targetDoc)).thenReturn(true);
+
+        boolean result = sparseBinaryDocValuesPassThrough.advanceExact(targetDoc);
+
+        assertTrue(result);
+        verify(mockDelegate, times(1)).advanceExact(targetDoc);
+    }
+
+    public void testDocID() {
+        int expectedDocId = 1;
+        when(mockDelegate.docID()).thenReturn(expectedDocId);
+
+        int result = sparseBinaryDocValuesPassThrough.docID();
+
+        assertEquals(expectedDocId, result);
+        verify(mockDelegate, times(1)).docID();
+    }
+
+    public void testNextDoc() throws IOException {
+        int expectedNextDoc = 1;
+        when(mockDelegate.nextDoc()).thenReturn(expectedNextDoc);
+
+        int result = sparseBinaryDocValuesPassThrough.nextDoc();
+
+        assertEquals(expectedNextDoc, result);
+        verify(mockDelegate, times(1)).nextDoc();
+    }
+
+    public void testAdvance() throws IOException {
+        int targetDoc = 1;
+        int expectedAdvancedDoc = 2;
+        when(mockDelegate.advance(targetDoc)).thenReturn(expectedAdvancedDoc);
+
+        int result = sparseBinaryDocValuesPassThrough.advance(targetDoc);
+
+        assertEquals(expectedAdvancedDoc, result);
+        verify(mockDelegate, times(1)).advance(targetDoc);
+    }
+
+    public void testCost() {
+        long expectedCost = 1000L;
+        when(mockDelegate.cost()).thenReturn(expectedCost);
+
+        long result = sparseBinaryDocValuesPassThrough.cost();
+
+        assertEquals(expectedCost, result);
+        verify(mockDelegate, times(1)).cost();
+    }
+
+    public void testRead_WhenAdvanceExactReturnsFalse() throws IOException {
+        int docId = 1;
+        when(mockDelegate.advanceExact(docId)).thenReturn(false);
+
+        SparseVector result = sparseBinaryDocValuesPassThrough.read(docId);
+
+        assertNull(result);
+        verify(mockDelegate, times(1)).advanceExact(docId);
+        verify(mockDelegate, never()).binaryValue();
+    }
+
+    public void testRead_WhenBinaryValueReturnsNull() throws IOException {
+        int docId = 1;
+        when(mockDelegate.advanceExact(docId)).thenReturn(true);
+        when(mockDelegate.binaryValue()).thenReturn(null);
+
+        SparseVector result = sparseBinaryDocValuesPassThrough.read(docId);
+
+        assertNull(result);
+        verify(mockDelegate, times(1)).advanceExact(docId);
+        verify(mockDelegate, times(1)).binaryValue();
+    }
+
+    public void testRead_WhenBinaryValueReturnsBytesRef() throws IOException {
+        int docId = 42;
+        BytesRef bytesRef = TestsPrepareUtils.prepareValidSparseVectorBytes();
+        when(mockDelegate.advanceExact(docId)).thenReturn(true);
+        when(mockDelegate.binaryValue()).thenReturn(bytesRef);
+
+        SparseVector result = sparseBinaryDocValuesPassThrough.read(docId);
+
+        assertNotNull(result);
+        verify(mockDelegate, times(1)).advanceExact(docId);
+        verify(mockDelegate, times(1)).binaryValue();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesTests.java
@@ -54,6 +54,14 @@ public class SparseBinaryDocValuesTests extends AbstractSparseTestBase {
         assertEquals(SparseBinaryDocValues.NO_MORE_DOCS, sparseBinaryDocValues.docID());
     }
 
+    public void testNextDoc_WithNullDocIDMerger() throws IOException {
+        sparseBinaryDocValues = new SparseBinaryDocValues(null);
+        int result = sparseBinaryDocValues.nextDoc();
+
+        assertEquals(SparseBinaryDocValues.NO_MORE_DOCS, result);
+        assertEquals(SparseBinaryDocValues.NO_MORE_DOCS, sparseBinaryDocValues.docID());
+    }
+
     public void testAdvance() {
         expectThrows(UnsupportedOperationException.class, () -> sparseBinaryDocValues.advance(5));
     }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseBinaryDocValuesTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocIDMerger;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCache;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCacheItem;
+import org.opensearch.neuralsearch.sparse.data.SparseVector;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SparseBinaryDocValuesTests extends AbstractSparseTestBase {
+
+    private DocIDMerger<BinaryDocValuesSub> docIDMerger;
+    private BinaryDocValuesSub binaryDocValuesSub;
+    private BinaryDocValues binaryDocValues;
+    private SparseBinaryDocValues sparseBinaryDocValues;
+
+    @Before
+    @Override
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        docIDMerger = mock(DocIDMerger.class);
+        binaryDocValuesSub = mock(BinaryDocValuesSub.class);
+        binaryDocValues = mock(BinaryDocValues.class);
+        sparseBinaryDocValues = new SparseBinaryDocValues(docIDMerger);
+    }
+
+    public void testInitialDocID() {
+        assertEquals(-1, sparseBinaryDocValues.docID());
+    }
+
+    public void testNextDoc_WithNullCurrent() throws IOException {
+        when(docIDMerger.next()).thenReturn(null);
+
+        int result = sparseBinaryDocValues.nextDoc();
+
+        assertEquals(SparseBinaryDocValues.NO_MORE_DOCS, result);
+        assertEquals(SparseBinaryDocValues.NO_MORE_DOCS, sparseBinaryDocValues.docID());
+    }
+
+    public void testAdvance() {
+        expectThrows(UnsupportedOperationException.class, () -> sparseBinaryDocValues.advance(5));
+    }
+
+    public void testAdvanceExact() {
+        expectThrows(UnsupportedOperationException.class, () -> sparseBinaryDocValues.advanceExact(5));
+    }
+
+    public void testCost() {
+        expectThrows(UnsupportedOperationException.class, () -> sparseBinaryDocValues.cost());
+    }
+
+    public void testBinaryValue() throws IOException {
+        BytesRef bytesRef = new BytesRef("test");
+        when(docIDMerger.next()).thenReturn(binaryDocValuesSub);
+        when(binaryDocValuesSub.getValues()).thenReturn(binaryDocValues);
+        when(binaryDocValues.binaryValue()).thenReturn(bytesRef);
+
+        sparseBinaryDocValues.nextDoc();
+        BytesRef result = sparseBinaryDocValues.binaryValue();
+
+        assertEquals(bytesRef, result);
+    }
+
+    public void testCachedSparseVector_WithNullCurrent() throws IOException {
+        assertNull(sparseBinaryDocValues.cachedSparseVector());
+    }
+
+    public void testCachedSparseVector_WithNullKey() throws IOException {
+        when(docIDMerger.next()).thenReturn(binaryDocValuesSub);
+        when(binaryDocValuesSub.getKey()).thenReturn(null);
+
+        sparseBinaryDocValues.nextDoc();
+        SparseVector result = sparseBinaryDocValues.cachedSparseVector();
+
+        assertNull(result);
+    }
+
+    public void testCachedSparseVector_WithNonNullKey() throws IOException {
+        FieldInfo fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+        SegmentInfo segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        when(docIDMerger.next()).thenReturn(binaryDocValuesSub);
+        CacheKey testKey = new CacheKey(segmentInfo, fieldInfo);
+        when(binaryDocValuesSub.getKey()).thenReturn(testKey);
+        sparseBinaryDocValues.nextDoc();
+        SparseVector result = sparseBinaryDocValues.cachedSparseVector();
+
+        assertNull(result); // index retrieved by this key is null, so it should return null
+    }
+
+    public void testCachedSparseVector_WithExistingIndex() throws IOException {
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        CacheKey testKey = new CacheKey(segmentInfo, fieldInfo);
+
+        // Create an actual index with some data
+        ForwardIndexCacheItem index = ForwardIndexCache.getInstance().getOrCreate(testKey, 10);
+        SparseVector testVector = createVector(1, 2, 3, 4);
+        index.getWriter().insert(5, testVector);
+
+        when(docIDMerger.next()).thenReturn(binaryDocValuesSub);
+        when(binaryDocValuesSub.getKey()).thenReturn(testKey);
+        when(binaryDocValuesSub.getDocId()).thenReturn(5);
+
+        sparseBinaryDocValues.nextDoc();
+        SparseVector result = sparseBinaryDocValues.cachedSparseVector();
+
+        assertEquals(testVector, result);
+
+        // Clean up
+        ForwardIndexCache.getInstance().removeIndex(testKey);
+    }
+
+    public void testCachedSparseVector_WithExistingIndexButNoVector() throws IOException {
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        CacheKey testKey = new CacheKey(segmentInfo, fieldInfo);
+
+        // Create an index but don't insert any data
+        ForwardIndexCache.getInstance().getOrCreate(testKey, 10);
+
+        when(docIDMerger.next()).thenReturn(binaryDocValuesSub);
+        when(binaryDocValuesSub.getKey()).thenReturn(testKey);
+        when(binaryDocValuesSub.getDocId()).thenReturn(3);
+
+        sparseBinaryDocValues.nextDoc();
+        SparseVector result = sparseBinaryDocValues.cachedSparseVector();
+
+        assertNull(result); // No vector at docId 3
+
+        // Clean up
+        ForwardIndexCache.getInstance().removeIndex(testKey);
+    }
+
+    public void testSetTotalLiveDocs() {
+        SparseBinaryDocValues result = sparseBinaryDocValues.setTotalLiveDocs(100L);
+
+        assertEquals(100L, sparseBinaryDocValues.getTotalLiveDocs());
+        assertEquals(sparseBinaryDocValues, result);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseCodecServiceTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseCodecServiceTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.Codec;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.codec.CodecService;
+import org.opensearch.index.codec.CodecServiceConfig;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparseCodecServiceTests extends AbstractSparseTestBase {
+
+    @Mock
+    private MapperService mockMapperService;
+
+    @Mock
+    private IndexSettings mockIndexSettings;
+
+    @Mock
+    private Logger mockLogger;
+
+    @Mock
+    private CodecServiceConfig mockCodecServiceConfig;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        when(mockCodecServiceConfig.getMapperService()).thenReturn(mockMapperService);
+        when(mockCodecServiceConfig.getIndexSettings()).thenReturn(mockIndexSettings);
+        when(mockCodecServiceConfig.getLogger()).thenReturn(mockLogger);
+    }
+
+    public void testConstructor() {
+        SparseCodecService service = new SparseCodecService(mockCodecServiceConfig);
+
+        assertNotNull(service);
+        verify(mockCodecServiceConfig, times(1)).getMapperService();
+        verify(mockCodecServiceConfig, times(1)).getIndexSettings();
+        verify(mockCodecServiceConfig, times(1)).getLogger();
+    }
+
+    public void testCodec() {
+        String codecName = CodecService.DEFAULT_CODEC;
+
+        SparseCodecService service = new SparseCodecService(mockCodecServiceConfig);
+        Codec result = service.codec(codecName);
+
+        assertNotNull(result);
+        assertTrue(result instanceof SparseCodec);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseCodecTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseCodecTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparseCodecTests extends AbstractSparseTestBase {
+
+    @Mock
+    private Codec mockDelegate;
+    @Mock
+    PostingsFormat mockPostingsFormat;
+    @Mock
+    DocValuesFormat mockDocValuesFormat;
+
+    private SparseCodec sparseCodec;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        when(mockDelegate.postingsFormat()).thenReturn(mockPostingsFormat);
+        when(mockDelegate.docValuesFormat()).thenReturn(mockDocValuesFormat);
+        when(mockPostingsFormat.getName()).thenReturn("mockPostingsFormat");
+        when(mockDocValuesFormat.getName()).thenReturn("mockDocValuesFormat");
+
+        sparseCodec = new SparseCodec(mockDelegate);
+    }
+
+    public void testConstructor_withoutDelegate() {
+        SparseCodec codec = new SparseCodec();
+
+        assertNotNull(codec);
+        assertEquals("Sparse10010Codec", codec.getName());
+    }
+
+    public void testConstructor_withDelegate() {
+        SparseCodec codec = new SparseCodec(mockDelegate);
+
+        assertNotNull(codec);
+        assertEquals("Sparse10010Codec", codec.getName());
+    }
+
+    public void testDocValuesFormat_returnsDelegate() {
+        DocValuesFormat result = sparseCodec.docValuesFormat();
+
+        assertNotNull(result);
+        assertTrue(result instanceof SparseDocValuesFormat);
+
+        verify(mockDelegate, times(1)).docValuesFormat();
+    }
+
+    public void testPostingsFormat_returnsDelegate() {
+        PostingsFormat result = sparseCodec.postingsFormat();
+
+        assertNotNull(result);
+        assertTrue(result instanceof SparsePostingsFormat);
+
+        verify(mockDelegate, times(1)).postingsFormat();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumerTests.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -188,6 +189,13 @@ public class SparseDocValuesConsumerTests extends AbstractSparseTestBase {
         sparseDocValuesConsumer.close();
 
         verify(delegate, times(1)).close();
+    }
+
+    @SneakyThrows
+    public void testMerge_mergeFieldInfosIsNull() {
+        when(mockMergeStateFacade.getMergeFieldInfos()).thenReturn(null);
+        sparseDocValuesConsumer.merge(mergeState);
+        verify(segmentInfo, never()).maxDoc();
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumerTests.java
@@ -85,9 +85,10 @@ public class SparseDocValuesConsumerTests extends AbstractSparseTestBase {
 
         when(fieldInfos.iterator()).thenReturn(List.of(sparseFieldInfo, nonSparseFieldInfo).iterator());
         when(mockMergeStateFacade.getMergeFieldInfos()).thenReturn(fieldInfos);
+        when(mockMergeStateFacade.getFieldInfos()).thenReturn(new FieldInfos[] { fieldInfos });
 
         docValuesProducer = mock(DocValuesProducer.class);
-        cacheKey = new CacheKey(segmentInfo, sparseFieldInfo);
+        cacheKey = prepareUniqueCacheKey(segmentInfo);
         sparseDocValuesConsumer = new SparseDocValuesConsumer(segmentWriteState, delegate, mockMergeHelper);
     }
 
@@ -201,6 +202,7 @@ public class SparseDocValuesConsumerTests extends AbstractSparseTestBase {
     @SneakyThrows
     public void testMerge_WithSparseField() {
         FieldInfo mergeFieldInfo = mock(FieldInfo.class);
+        when(mergeFieldInfo.getDocValuesType()).thenReturn(DocValuesType.BINARY);
         when(mergeFieldInfo.attributes()).thenReturn(
             Map.of(SPARSE_FIELD, String.valueOf(true), APPROXIMATE_THRESHOLD_FIELD, String.valueOf(10))
         );

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesConsumerTests.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentWriteState;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCache;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCacheItem;
+import org.opensearch.neuralsearch.sparse.data.SparseVector;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.APPROXIMATE_THRESHOLD_FIELD;
+import static org.opensearch.neuralsearch.sparse.mapper.SparseTokensField.SPARSE_FIELD;
+
+public class SparseDocValuesConsumerTests extends AbstractSparseTestBase {
+
+    @Mock
+    private DocValuesConsumer delegate;
+    @Mock
+    private FieldInfo sparseFieldInfo;
+    @Mock
+    private FieldInfo nonSparseFieldInfo;
+    @Mock
+    private MergeHelper mockMergeHelper;
+
+    private SegmentWriteState segmentWriteState;
+    private SegmentInfo segmentInfo;
+    private DocValuesProducer docValuesProducer;
+    private CacheKey cacheKey;
+    private SparseDocValuesConsumer sparseDocValuesConsumer;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        segmentWriteState = TestsPrepareUtils.prepareSegmentWriteState();
+        segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        sparseDocValuesConsumer = new SparseDocValuesConsumer(segmentWriteState, delegate, mockMergeHelper);
+
+        // Setup sparse field
+        Map<String, String> sparseAttributes = new HashMap<>();
+        sparseAttributes.put(SPARSE_FIELD, String.valueOf(true));
+        sparseAttributes.put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(50));
+        when(sparseFieldInfo.attributes()).thenReturn(sparseAttributes);
+        when(sparseFieldInfo.getDocValuesType()).thenReturn(DocValuesType.BINARY);
+
+        when(nonSparseFieldInfo.attributes()).thenReturn(new HashMap<>());
+        when(nonSparseFieldInfo.getDocValuesType()).thenReturn(DocValuesType.BINARY);
+
+        docValuesProducer = mock(DocValuesProducer.class);
+        cacheKey = new CacheKey(segmentInfo, sparseFieldInfo);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        // Clean up any created indices
+        if (cacheKey != null) {
+            ForwardIndexCache.getInstance().removeIndex(cacheKey);
+        }
+        super.tearDown();
+    }
+
+    @SneakyThrows
+    public void testAddNumericField() {
+        sparseDocValuesConsumer.addNumericField(sparseFieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addNumericField(sparseFieldInfo, docValuesProducer);
+    }
+
+    @SneakyThrows
+    public void testAddBinaryField_NonSparseField() {
+        sparseDocValuesConsumer.addBinaryField(nonSparseFieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addBinaryField(nonSparseFieldInfo, docValuesProducer);
+        // Should not create forward index for non-sparse field
+        assertNull(ForwardIndexCache.getInstance().get(new CacheKey(segmentInfo, nonSparseFieldInfo)));
+    }
+
+    @SneakyThrows
+    public void testAddBinaryField_SparseFieldBelowThreshold() {
+        // Create new segmentInfo with lower maxDoc
+        segmentInfo = TestsPrepareUtils.prepareSegmentInfo(30);
+        cacheKey = new CacheKey(segmentInfo, sparseFieldInfo);
+
+        // Create new SegmentWriteState with the updated segmentInfo
+        segmentWriteState = TestsPrepareUtils.prepareSegmentWriteState(segmentInfo);
+        sparseDocValuesConsumer = new SparseDocValuesConsumer(segmentWriteState, delegate, mockMergeHelper);
+
+        sparseDocValuesConsumer.addBinaryField(sparseFieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addBinaryField(sparseFieldInfo, docValuesProducer);
+        // Should not create forward index when below threshold
+        assertNull(ForwardIndexCache.getInstance().get(cacheKey));
+    }
+
+    @SneakyThrows
+    public void testAddBinaryField_SparseFieldAboveThreshold() {
+        // Create new segmentInfo with higher maxDoc
+        segmentInfo = TestsPrepareUtils.prepareSegmentInfo(100);
+        cacheKey = new CacheKey(segmentInfo, sparseFieldInfo);
+
+        // Create new SegmentWriteState with the updated segmentInfo
+        segmentWriteState = TestsPrepareUtils.prepareSegmentWriteState(segmentInfo);
+        sparseDocValuesConsumer = new SparseDocValuesConsumer(segmentWriteState, delegate, mockMergeHelper);
+
+        BinaryDocValues binaryDocValues = mock(BinaryDocValues.class);
+        when(binaryDocValues.nextDoc()).thenReturn(0, 1, BinaryDocValues.NO_MORE_DOCS);
+        when(binaryDocValues.binaryValue()).thenReturn(TestsPrepareUtils.prepareValidSparseVectorBytes());
+        when(docValuesProducer.getBinary(sparseFieldInfo)).thenReturn(binaryDocValues);
+
+        sparseDocValuesConsumer.addBinaryField(sparseFieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addBinaryField(sparseFieldInfo, docValuesProducer);
+
+        // Verify forward index was created and populated
+        ForwardIndexCacheItem index = ForwardIndexCache.getInstance().get(cacheKey);
+        assertNotNull(index);
+
+        // Verify vectors were inserted
+        SparseVector vector0 = index.getReader().read(0);
+        SparseVector vector1 = index.getReader().read(1);
+        assertNotNull(vector0);
+        assertNotNull(vector1);
+    }
+
+    @SneakyThrows
+    public void testAddSortedField() {
+        sparseDocValuesConsumer.addSortedField(sparseFieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addSortedField(sparseFieldInfo, docValuesProducer);
+    }
+
+    @SneakyThrows
+    public void testAddSortedNumericField() {
+        sparseDocValuesConsumer.addSortedNumericField(sparseFieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addSortedNumericField(sparseFieldInfo, docValuesProducer);
+    }
+
+    @SneakyThrows
+    public void testAddSortedSetField() {
+        sparseDocValuesConsumer.addSortedSetField(sparseFieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addSortedSetField(sparseFieldInfo, docValuesProducer);
+    }
+
+    @SneakyThrows
+    public void testClose() {
+        sparseDocValuesConsumer.close();
+
+        verify(delegate, times(1)).close();
+    }
+
+    @SneakyThrows
+    public void testMerge_WithSparseField() {
+        FieldInfo mergeFieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+        mergeFieldInfo.putAttribute(SPARSE_FIELD, String.valueOf(true));
+        mergeFieldInfo.putAttribute(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(10));
+
+        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(true, false);
+
+        // Need a second binary doc values object because getLiveDocsCount consumes the pointer
+        SparseBinaryDocValuesPassThrough sparseBinaryDocValues1 = mock(SparseBinaryDocValuesPassThrough.class);
+        when(sparseBinaryDocValues1.docID()).thenReturn(-1);
+        when(sparseBinaryDocValues1.nextDoc()).thenReturn(0, SparseBinaryDocValues.NO_MORE_DOCS);
+        when(sparseBinaryDocValues1.getSegmentInfo()).thenReturn(segmentInfo);
+
+        SparseBinaryDocValues sparseBinaryDocValues2 = mock(SparseBinaryDocValues.class);
+        when(sparseBinaryDocValues2.docID()).thenReturn(-1);
+        when(sparseBinaryDocValues2.nextDoc()).thenReturn(0, SparseBinaryDocValues.NO_MORE_DOCS);
+
+        // write cached vector
+        SparseVector vector = createVector(1, 2, 3, 4);
+        cacheKey = new CacheKey(segmentInfo, mergeFieldInfo);
+        ForwardIndexCacheItem index = ForwardIndexCache.getInstance().getOrCreate(cacheKey, 10);
+        index.getWriter().insert(0, vector);
+
+        when(docValuesProducer.getBinary(any(FieldInfo.class))).thenReturn(sparseBinaryDocValues1, sparseBinaryDocValues2);
+
+        mergeState.mergeFieldInfos = new FieldInfos(new FieldInfo[] { mergeFieldInfo });
+        mergeState.docValuesProducers[0] = docValuesProducer;
+
+        sparseDocValuesConsumer.merge(mergeState);
+
+        // verify cache is written
+        verify(delegate, times(1)).merge(mergeState);
+        assertEquals(vector, index.getReader().read(0));
+    }
+
+    @SneakyThrows
+    public void testMerge_WithNonSparseField() {
+        MergeState mergeState = mock(MergeState.class);
+        FieldInfos mergeFieldInfos = mock(FieldInfos.class);
+        when(mergeFieldInfos.iterator()).thenReturn(List.of(nonSparseFieldInfo).iterator());
+        mergeState.mergeFieldInfos = mergeFieldInfos;
+
+        sparseDocValuesConsumer.merge(mergeState);
+
+        verify(delegate, times(1)).merge(mergeState);
+        // Should not create forward index for non-sparse field
+        assertNull(ForwardIndexCache.getInstance().get(new CacheKey(segmentInfo, nonSparseFieldInfo)));
+    }
+
+    @SneakyThrows
+    public void testMerge_WithException() {
+        MergeState mergeState = mock(MergeState.class);
+        // Don't set mergeFieldInfos to null as it causes assertion error
+        // Instead test with empty field infos
+        FieldInfos emptyFieldInfos = mock(FieldInfos.class);
+        when(emptyFieldInfos.iterator()).thenReturn(java.util.Collections.emptyIterator());
+        mergeState.mergeFieldInfos = emptyFieldInfos;
+
+        // Should not throw exception, just log error
+        sparseDocValuesConsumer.merge(mergeState);
+
+        verify(delegate, times(1)).merge(mergeState);
+    }
+
+    @SneakyThrows
+    public void testAddBinary_WithSparseBinaryDocValues() {
+        // Create new segmentInfo with higher maxDoc
+        segmentInfo = TestsPrepareUtils.prepareSegmentInfo(100);
+        cacheKey = new CacheKey(segmentInfo, sparseFieldInfo);
+
+        // Create new SegmentWriteState with the updated segmentInfo
+        segmentWriteState = TestsPrepareUtils.prepareSegmentWriteState(segmentInfo);
+        sparseDocValuesConsumer = new SparseDocValuesConsumer(segmentWriteState, delegate, mockMergeHelper);
+
+        // Create SparseBinaryDocValues for merge scenario
+        SparseBinaryDocValues sparseBinaryDocValues = mock(SparseBinaryDocValues.class);
+        when(sparseBinaryDocValues.nextDoc()).thenReturn(0, 1, SparseBinaryDocValues.NO_MORE_DOCS);
+
+        SparseVector mockVector = createVector(1, 2, 3, 4);
+        when(sparseBinaryDocValues.cachedSparseVector()).thenReturn(mockVector);
+        when(sparseBinaryDocValues.binaryValue()).thenReturn(TestsPrepareUtils.prepareValidSparseVectorBytes());
+        when(docValuesProducer.getBinary(sparseFieldInfo)).thenReturn(sparseBinaryDocValues);
+
+        sparseDocValuesConsumer.addBinaryField(sparseFieldInfo, docValuesProducer);
+
+        // Verify forward index was created
+        ForwardIndexCacheItem index = ForwardIndexCache.getInstance().get(cacheKey);
+        assertNotNull(index);
+
+        // Verify cached vector was used
+        SparseVector storedVector = index.getReader().read(0);
+        assertNotNull(storedVector);
+    }
+
+    @SneakyThrows
+    public void testAddBinary_WriterIsNull() {
+        // This test covers the normal case since writer null is hard to trigger
+        BinaryDocValues binaryDocValues = mock(BinaryDocValues.class);
+        when(binaryDocValues.nextDoc()).thenReturn(BinaryDocValues.NO_MORE_DOCS);
+        when(docValuesProducer.getBinary(sparseFieldInfo)).thenReturn(binaryDocValues);
+
+        sparseDocValuesConsumer.addBinaryField(sparseFieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addBinaryField(sparseFieldInfo, docValuesProducer);
+    }
+
+    @SneakyThrows
+    public void testMerge_WithSparseDocValuesReader() {
+        // Create a real MergeState to test the SparseDocValuesReader instanceof check
+        MergeState realMergeState = TestsPrepareUtils.prepareMergeState(false);
+
+        // This will trigger the merge logic and test the instanceof SparseDocValuesReader check
+        sparseDocValuesConsumer.merge(realMergeState);
+
+        verify(delegate, times(1)).merge(realMergeState);
+    }
+
+    @SneakyThrows
+    public void testMerge_WithRealException() {
+        MergeState mergeState = mock(MergeState.class);
+        FieldInfos mergeFieldInfos = mock(FieldInfos.class);
+        // Create an iterator that throws exception
+        when(mergeFieldInfos.iterator()).thenThrow(new RuntimeException("Test exception"));
+        mergeState.mergeFieldInfos = mergeFieldInfos;
+
+        // Should not throw exception, just log error
+        sparseDocValuesConsumer.merge(mergeState);
+
+        verify(delegate, times(1)).merge(mergeState);
+    }
+
+    @SneakyThrows
+    public void testMerge_WithSparseFieldAndReader() {
+        // Create segmentInfo above threshold
+        SegmentInfo newSegmentInfo = TestsPrepareUtils.prepareSegmentInfo(100);
+        SegmentWriteState newState = TestsPrepareUtils.prepareSegmentWriteState(newSegmentInfo);
+        SparseDocValuesConsumer newConsumer = new SparseDocValuesConsumer(newState, delegate, mockMergeHelper);
+
+        // Create MergeState with sparse field
+        MergeState mergeState = mock(MergeState.class);
+        FieldInfos mergeFieldInfos = mock(FieldInfos.class);
+        when(mergeFieldInfos.iterator()).thenReturn(List.of(sparseFieldInfo).iterator());
+        mergeState.mergeFieldInfos = mergeFieldInfos;
+
+        // This will trigger the merge logic with sparse field processing
+        newConsumer.merge(mergeState);
+
+        verify(delegate, times(1)).merge(mergeState);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesFormatTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesFormatTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparseDocValuesFormatTests extends AbstractSparseTestBase {
+
+    private DocValuesFormat mockDelegate;
+    private SparseDocValuesFormat sparseDocValuesFormat;
+    private SegmentWriteState mockWriteState;
+    private SegmentReadState mockReadState;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        mockDelegate = mock(DocValuesFormat.class);
+        when(mockDelegate.getName()).thenReturn("TestFormat");
+
+        this.sparseDocValuesFormat = new SparseDocValuesFormat(mockDelegate);
+        mockWriteState = mock(SegmentWriteState.class);
+        mockReadState = mock(SegmentReadState.class);
+    }
+
+    public void testConstructor() {
+        SparseDocValuesFormat sparseDocValuesFormat = new SparseDocValuesFormat(mockDelegate);
+        // Verify that the format name is inherited from delegate
+        assertEquals("TestFormat", sparseDocValuesFormat.getName());
+    }
+
+    public void testFieldsConsumer() throws IOException {
+        // Setup
+        DocValuesConsumer mockDelegateConsumer = mock(DocValuesConsumer.class);
+        when(mockDelegate.fieldsConsumer(mockWriteState)).thenReturn(mockDelegateConsumer);
+
+        // Execute
+        DocValuesConsumer result = sparseDocValuesFormat.fieldsConsumer(mockWriteState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparseDocValuesConsumer);
+        verify(mockDelegate).fieldsConsumer(mockWriteState);
+    }
+
+    public void testFieldsProducer() throws IOException {
+        // Setup
+        DocValuesProducer mockDelegateProducer = mock(DocValuesProducer.class);
+        when(mockDelegate.fieldsProducer(mockReadState)).thenReturn(mockDelegateProducer);
+
+        // Execute
+        DocValuesProducer result = sparseDocValuesFormat.fieldsProducer(mockReadState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparseDocValuesProducer);
+        verify(mockDelegate).fieldsProducer(mockReadState);
+    }
+
+    public void testFieldsConsumerIOException() throws IOException {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsConsumer(mockWriteState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { sparseDocValuesFormat.fieldsConsumer(mockWriteState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    public void testFieldsProducerIOException() throws IOException {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsProducer(mockReadState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { sparseDocValuesFormat.fieldsProducer(mockReadState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesProducerTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparseDocValuesProducerTests extends AbstractSparseTestBase {
+
+    private DocValuesProducer mockDelegate;
+    private SegmentReadState segmentReadState;
+    private SparseDocValuesProducer producer;
+    private FieldInfo fieldInfo;
+    private SegmentInfo segmentInfo;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        mockDelegate = mock(DocValuesProducer.class);
+
+        // Mock components for SegmentReadState
+        Directory mockDir = mock(Directory.class);
+        segmentInfo = TestsPrepareUtils.prepareSegmentInfo();
+        FieldInfos mockFieldInfos = mock(FieldInfos.class);
+        IOContext ioContext = IOContext.DEFAULT;
+
+        // Create a real SegmentReadState with mocked components
+        segmentReadState = new SegmentReadState(
+            mockDir,         // directory
+            segmentInfo,     // segmentInfo
+            mockFieldInfos,  // fieldInfos
+            ioContext        // context
+        );
+
+        producer = new SparseDocValuesProducer(segmentReadState, mockDelegate);
+        fieldInfo = TestsPrepareUtils.prepareKeyFieldInfo();
+    }
+
+    public void testGetNumeric() throws IOException {
+        // Setup
+        NumericDocValues mockNumeric = mock(NumericDocValues.class);
+        when(mockDelegate.getNumeric(fieldInfo)).thenReturn(mockNumeric);
+
+        // Execute
+        NumericDocValues result = producer.getNumeric(fieldInfo);
+
+        // Verify
+        assertEquals(mockNumeric, result);
+        verify(mockDelegate).getNumeric(fieldInfo);
+    }
+
+    public void testGetBinary() throws IOException {
+        // Setup
+        BinaryDocValues mockBinary = mock(BinaryDocValues.class);
+        when(mockDelegate.getBinary(fieldInfo)).thenReturn(mockBinary);
+
+        // Execute
+        BinaryDocValues result = producer.getBinary(fieldInfo);
+
+        // Verify
+        assertTrue(result instanceof SparseBinaryDocValuesPassThrough);
+        SparseBinaryDocValuesPassThrough passThrough = (SparseBinaryDocValuesPassThrough) result;
+        assertEquals(segmentReadState.segmentInfo, passThrough.getSegmentInfo());
+        verify(mockDelegate).getBinary(fieldInfo);
+    }
+
+    public void testGetSorted() throws IOException {
+        // Setup
+        SortedDocValues mockSorted = mock(SortedDocValues.class);
+        when(mockDelegate.getSorted(fieldInfo)).thenReturn(mockSorted);
+
+        // Execute
+        SortedDocValues result = producer.getSorted(fieldInfo);
+
+        // Verify
+        assertEquals(mockSorted, result);
+        verify(mockDelegate).getSorted(fieldInfo);
+    }
+
+    public void testGetSortedNumeric() throws IOException {
+        // Setup
+        SortedNumericDocValues mockSortedNumeric = mock(SortedNumericDocValues.class);
+        when(mockDelegate.getSortedNumeric(fieldInfo)).thenReturn(mockSortedNumeric);
+
+        // Execute
+        SortedNumericDocValues result = producer.getSortedNumeric(fieldInfo);
+
+        // Verify
+        assertEquals(mockSortedNumeric, result);
+        verify(mockDelegate).getSortedNumeric(fieldInfo);
+    }
+
+    public void testGetSortedSet() throws IOException {
+        // Setup
+        SortedSetDocValues mockSortedSet = mock(SortedSetDocValues.class);
+        when(mockDelegate.getSortedSet(fieldInfo)).thenReturn(mockSortedSet);
+
+        // Execute
+        SortedSetDocValues result = producer.getSortedSet(fieldInfo);
+
+        // Verify
+        assertEquals(mockSortedSet, result);
+        verify(mockDelegate).getSortedSet(fieldInfo);
+    }
+
+    public void testGetSkipper() throws IOException {
+        // Setup
+        DocValuesSkipper mockSkipper = mock(DocValuesSkipper.class);
+        when(mockDelegate.getSkipper(fieldInfo)).thenReturn(mockSkipper);
+
+        // Execute
+        DocValuesSkipper result = producer.getSkipper(fieldInfo);
+
+        // Verify
+        assertEquals(mockSkipper, result);
+        verify(mockDelegate).getSkipper(fieldInfo);
+    }
+
+    public void testCheckIntegrity() throws IOException {
+        // Execute
+        producer.checkIntegrity();
+
+        // Verify
+        verify(mockDelegate).checkIntegrity();
+    }
+
+    public void testClose() throws IOException {
+        // Execute
+        producer.close();
+
+        // Verify
+        verify(mockDelegate).close();
+    }
+
+    public void testGetState() {
+        // Execute
+        SegmentReadState result = producer.getState();
+
+        // Verify
+        assertEquals(segmentReadState, result);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReaderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReaderTests.java
@@ -4,89 +4,131 @@
  */
 package org.opensearch.neuralsearch.sparse.codec;
 
+import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.MergeState;
-import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.Bits;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SparseDocValuesReaderTests extends OpenSearchTestCase {
 
     private SparseDocValuesReader sparseDocValuesReader;
+    @Mock
     private FieldInfo fieldInfo;
+    @Mock
+    private FieldInfos fieldInfos;
+    @Mock
+    private MergeStateFacade mockMergeStateFacade;
+    @Mock
+    private DocValuesProducer mockDocValuesProducer;
+    @Mock
+    private SparseBinaryDocValuesPassThrough mockBinaryDocValues;
+    @Mock
+    private SparseBinaryDocValuesPassThrough mockBinaryDocValues2;
+    @Mock
+    private SegmentInfo mockSegmentInfo;
+    @Mock
+    private MergeState.DocMap mockDocMap;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        fieldInfo = mock(FieldInfo.class);
+        MockitoAnnotations.openMocks(this);
         when(fieldInfo.getName()).thenReturn("test_field");
+        when(mockMergeStateFacade.getDocValuesProducers()).thenReturn(new DocValuesProducer[] { mockDocValuesProducer });
+        when(mockMergeStateFacade.getFieldInfos()).thenReturn(new FieldInfos[] { fieldInfos });
+        when(fieldInfos.fieldInfo(anyString())).thenReturn(fieldInfo);
+        when(fieldInfo.getDocValuesType()).thenReturn(DocValuesType.BINARY);
+        when(mockDocValuesProducer.getBinary(any())).thenReturn(mockBinaryDocValues, mockBinaryDocValues2);
+        when(mockBinaryDocValues.getSegmentInfo()).thenReturn(mockSegmentInfo);
+        Bits bits = mock(Bits.class);
+        when(bits.get(anyInt())).thenReturn(true);
+        when(mockMergeStateFacade.getLiveDocs()).thenReturn(new Bits[] { bits });
+        when(mockBinaryDocValues.nextDoc()).thenReturn(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, NO_MORE_DOCS);
+        when(mockBinaryDocValues.docID()).thenReturn(-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, NO_MORE_DOCS);
+        when(mockBinaryDocValues2.nextDoc()).thenReturn(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, NO_MORE_DOCS);
+        when(mockBinaryDocValues2.docID()).thenReturn(-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, NO_MORE_DOCS);
+        when(mockMergeStateFacade.getDocMaps()).thenReturn(new MergeState.DocMap[] { mockDocMap });
+        when(mockDocMap.get(eq(1))).thenReturn(1);
+        when(mockDocMap.get(eq(2))).thenReturn(2);
+        sparseDocValuesReader = new SparseDocValuesReader(mockMergeStateFacade);
     }
 
-    public void testGetBinary_StandardMergeState() throws IOException {
-        // Setup with standard merge state
-        boolean isWithLiveDocs = false;
-        boolean isNullLiveDocs = false;
-        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(isWithLiveDocs, isNullLiveDocs);
-        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
-
+    public void testGetBinary_emptyDocValuesProducers() throws IOException {
+        when(mockMergeStateFacade.getDocValuesProducers()).thenReturn(new DocValuesProducer[0]);
         // Execute
         BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
 
-        // Verify
-        assertNotNull(result);
-        assertTrue(result instanceof SparseBinaryDocValues);
-        assertEquals(10L, ((SparseBinaryDocValues) result).getTotalLiveDocs()); // return cost here
+        assertEquals(NO_MORE_DOCS, result.nextDoc());
     }
 
-    public void testGetBinary_MergeStateWithoutLiveDocs() throws IOException {
-        // Setup with merge state without LiveDocs
-        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(false, true);
-        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
-
-        expectThrows(NullPointerException.class, () -> { BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo); });
-    }
-
-    public void testGetBinary_WithLiveDocs() throws IOException {
-        // Setup with merge state that has live docs
-        boolean isWithLiveDocs = true;
-        boolean isNullLiveDocs = false;
-        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(isWithLiveDocs, isNullLiveDocs);
-        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
-
+    public void testGetBinary_nullDocValuesProducers() throws IOException {
+        when(mockMergeStateFacade.getDocValuesProducers()).thenReturn(new DocValuesProducer[] { null });
         // Execute
         BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
 
-        // Verify
-        assertNotNull(result);
-        assertTrue(result instanceof SparseBinaryDocValues);
-        assertEquals(5L, ((SparseBinaryDocValues) result).getTotalLiveDocs()); // Only 5 docs (0,2,4,6,8) are live
+        assertEquals(NO_MORE_DOCS, result.nextDoc());
     }
 
-    public void testGetBinary_WithPassThroughValues() throws IOException {
-        // Setup with merge state that has SparseBinaryDocValuesPassThrough
-        boolean isWithLiveDocs = false;
-        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithPassThroughValues(isWithLiveDocs);
-        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
-
+    public void testGetBinary_nullFieldInfo() throws IOException {
+        when(fieldInfos.fieldInfo(anyString())).thenReturn(null);
         // Execute
         BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
 
-        // Verify
-        assertNotNull(result);
-        assertTrue(result instanceof SparseBinaryDocValues);
-        assertEquals(10L, ((SparseBinaryDocValues) result).getTotalLiveDocs()); // return cost here
+        assertEquals(NO_MORE_DOCS, result.nextDoc());
+        verify(fieldInfos).fieldInfo(anyString());
+        verify(mockDocValuesProducer, never()).getBinary(any());
     }
 
-    public void testGetMergeState() throws IOException {
-        boolean isWithLiveDocs = true;
-        boolean isNullLiveDocs = false;
-        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(isWithLiveDocs, isNullLiveDocs);
-        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
-        assertEquals(mergeState, sparseDocValuesReader.getMergeState());
+    public void testGetBinary_getDocValuesTypeNotBinary() throws IOException {
+        when(fieldInfo.getDocValuesType()).thenReturn(DocValuesType.NUMERIC);
+        // Execute
+        BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
+
+        assertEquals(NO_MORE_DOCS, result.nextDoc());
+        verify(fieldInfo).getDocValuesType();
+        verify(mockDocValuesProducer, never()).getBinary(any());
+    }
+
+    public void testGetBinary_binaryDocValuesTypeUnexpected() throws IOException {
+        BinaryDocValues docValues = mock(BinaryDocValues.class);
+        when(mockDocValuesProducer.getBinary(any())).thenReturn(docValues);
+        when(docValues.nextDoc()).thenReturn(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, NO_MORE_DOCS);
+        when(docValues.docID()).thenReturn(-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, NO_MORE_DOCS);
+        BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
+        verify(mockBinaryDocValues, never()).getSegmentInfo();
+        verify(mockMergeStateFacade, times(2)).getLiveDocs();
+    }
+
+    public void testGetBinary_happyCase() throws IOException {
+        BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
+        verify(mockBinaryDocValues).getSegmentInfo();
+        verify(mockMergeStateFacade, times(2)).getLiveDocs();
+        assertEquals(0, result.nextDoc());
+    }
+
+    public void testGetMergeState() {
+        sparseDocValuesReader = new SparseDocValuesReader(mockMergeStateFacade);
+        assertEquals(mockMergeStateFacade, sparseDocValuesReader.getMergeStateFacade());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReaderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReaderTests.java
@@ -49,6 +49,8 @@ public class SparseDocValuesReaderTests extends OpenSearchTestCase {
     private SegmentInfo mockSegmentInfo;
     @Mock
     private MergeState.DocMap mockDocMap;
+    @Mock
+    private Bits bits;
 
     @Override
     public void setUp() throws Exception {
@@ -61,7 +63,6 @@ public class SparseDocValuesReaderTests extends OpenSearchTestCase {
         when(fieldInfo.getDocValuesType()).thenReturn(DocValuesType.BINARY);
         when(mockDocValuesProducer.getBinary(any())).thenReturn(mockBinaryDocValues, mockBinaryDocValues2);
         when(mockBinaryDocValues.getSegmentInfo()).thenReturn(mockSegmentInfo);
-        Bits bits = mock(Bits.class);
         when(bits.get(anyInt())).thenReturn(true);
         when(mockMergeStateFacade.getLiveDocs()).thenReturn(new Bits[] { bits });
         when(mockBinaryDocValues.nextDoc()).thenReturn(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, NO_MORE_DOCS);

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReaderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseDocValuesReaderTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SparseDocValuesReaderTests extends OpenSearchTestCase {
+
+    private SparseDocValuesReader sparseDocValuesReader;
+    private FieldInfo fieldInfo;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getName()).thenReturn("test_field");
+    }
+
+    public void testGetBinary_StandardMergeState() throws IOException {
+        // Setup with standard merge state
+        boolean isWithLiveDocs = false;
+        boolean isNullLiveDocs = false;
+        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(isWithLiveDocs, isNullLiveDocs);
+        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
+
+        // Execute
+        BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparseBinaryDocValues);
+        assertEquals(10L, ((SparseBinaryDocValues) result).getTotalLiveDocs()); // return cost here
+    }
+
+    public void testGetBinary_MergeStateWithoutLiveDocs() throws IOException {
+        // Setup with merge state without LiveDocs
+        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(false, true);
+        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
+
+        expectThrows(NullPointerException.class, () -> { BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo); });
+    }
+
+    public void testGetBinary_WithLiveDocs() throws IOException {
+        // Setup with merge state that has live docs
+        boolean isWithLiveDocs = true;
+        boolean isNullLiveDocs = false;
+        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(isWithLiveDocs, isNullLiveDocs);
+        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
+
+        // Execute
+        BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparseBinaryDocValues);
+        assertEquals(5L, ((SparseBinaryDocValues) result).getTotalLiveDocs()); // Only 5 docs (0,2,4,6,8) are live
+    }
+
+    public void testGetBinary_WithPassThroughValues() throws IOException {
+        // Setup with merge state that has SparseBinaryDocValuesPassThrough
+        boolean isWithLiveDocs = false;
+        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithPassThroughValues(isWithLiveDocs);
+        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
+
+        // Execute
+        BinaryDocValues result = sparseDocValuesReader.getBinary(fieldInfo);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparseBinaryDocValues);
+        assertEquals(10L, ((SparseBinaryDocValues) result).getTotalLiveDocs()); // return cost here
+    }
+
+    public void testGetMergeState() throws IOException {
+        boolean isWithLiveDocs = true;
+        boolean isNullLiveDocs = false;
+        MergeState mergeState = TestsPrepareUtils.prepareMergeStateWithMockedBinaryDocValues(isWithLiveDocs, isNullLiveDocs);
+        sparseDocValuesReader = new SparseDocValuesReader(mergeState);
+        assertEquals(mergeState, sparseDocValuesReader.getMergeState());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsConsumerTests.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.APPROXIMATE_THRESHOLD_FIELD;
+import static org.opensearch.neuralsearch.sparse.mapper.SparseTokensField.SPARSE_FIELD;
+
+public class SparsePostingsConsumerTests extends AbstractSparseTestBase {
+
+    private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
+
+    @Mock
+    private FieldsConsumer mockDelegate;
+
+    @Mock
+    private Directory mockDirectory;
+
+    @Mock
+    private IndexOutput mockTermsOutput;
+
+    @Mock
+    private IndexOutput mockPostingOutput;
+
+    @Mock
+    private Fields mockFields;
+
+    @Mock
+    private NormsProducer mockNormsProducer;
+
+    @Mock
+    private MergeHelper mockedMergeHelper;
+    MockedConstruction<SparseTermsLuceneWriter> mockedSparseTermsWriter;
+    MockedConstruction<ClusteredPostingTermsWriter> mockedClusteredWriter;
+
+    private FieldInfos mockFieldInfos;
+    private SegmentWriteState mockWriteState;
+    private SparsePostingsConsumer sparsePostingsConsumer;
+
+    @Before
+    @Override
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        // configure mocks
+        when(mockDirectory.createOutput(anyString(), any())).thenReturn(mockTermsOutput, mockPostingOutput);
+        mockFieldInfos = mock(FieldInfos.class);
+        mockWriteState = TestsPrepareUtils.prepareSegmentWriteState(mockDirectory, mockFieldInfos);
+        mockedClusteredWriter = mockConstruction(ClusteredPostingTermsWriter.class);
+        mockedSparseTermsWriter = mockConstruction(SparseTermsLuceneWriter.class);
+        sparsePostingsConsumer = new SparsePostingsConsumer(mockDelegate, mockWriteState, mockedMergeHelper);
+    }
+
+    @After
+    @Override
+    @SneakyThrows
+    public void tearDown() {
+        if (mockedClusteredWriter != null) {
+            mockedClusteredWriter.close();
+        }
+        if (mockedSparseTermsWriter != null) {
+            mockedSparseTermsWriter.close();
+        }
+        super.tearDown();
+    }
+
+    public void test_constructor_throwsNPE_whenParametersAreNull() {
+        expectThrows(NullPointerException.class, () -> { new SparsePostingsConsumer(null, mockWriteState, mockedMergeHelper); });
+
+        expectThrows(NullPointerException.class, () -> { new SparsePostingsConsumer(mockDelegate, null, mockedMergeHelper); });
+
+        expectThrows(NullPointerException.class, () -> { new SparsePostingsConsumer(mockDelegate, mockWriteState, null); });
+    }
+
+    /**
+     * Test constructor with default version
+     */
+    public void test_constructor_withDefaultVersion() throws IOException {
+        SparsePostingsConsumer consumer = new SparsePostingsConsumer(mockDelegate, mockWriteState, mockedMergeHelper);
+        assertNotNull("Consumer should be created", consumer);
+    }
+
+    /**
+     * Test constructor with specific version
+     */
+    public void test_constructor_withSpecificVersion() throws IOException {
+        int version = 1;
+        SparsePostingsConsumer consumer = new SparsePostingsConsumer(mockDelegate, mockWriteState, mockedMergeHelper, version);
+        assertNotNull("Consumer should be created", consumer);
+    }
+
+    /**
+     * Test constructor handles IOException properly
+     */
+    public void test_constructor_withIOException() throws IOException {
+        when(mockDirectory.createOutput(anyString(), any())).thenThrow(new IOException("Test exception"));
+
+        IOException exception = expectThrows(IOException.class, () -> {
+            new SparsePostingsConsumer(mockDelegate, mockWriteState, mockedMergeHelper);
+        });
+
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    /**
+     * Test write method with no sparse fields
+     */
+    public void test_write_withNonSparseFields() throws IOException {
+        // Get the constructed mock instances
+        List<SparseTermsLuceneWriter> sparseTermsWriters = mockedSparseTermsWriter.constructed();
+        SparseTermsLuceneWriter sparseTermsWriter = sparseTermsWriters.get(0);
+
+        // Setup field info with non-sparse fields
+        List<String> fieldNames = List.of("non_sparse_field1", "non_sparse_field2");
+        when(mockFields.iterator()).thenReturn(fieldNames.iterator());
+        FieldInfo mockFieldInfo = mock(FieldInfo.class);
+        when(mockFieldInfos.fieldInfo(anyString())).thenReturn(mockFieldInfo);
+
+        // Set up the delegate to capture the Fields argument
+        ArgumentCaptor<Fields> fieldsCaptor = ArgumentCaptor.forClass(Fields.class);
+
+        // Call write
+        sparsePostingsConsumer.write(mockFields, mockNormsProducer);
+
+        // Verify delegate was called and sparse writer was not used
+        verify(mockDelegate).write(fieldsCaptor.capture(), eq(mockNormsProducer));
+        verify(sparseTermsWriter, never()).writeFieldCount(any(Integer.class));
+
+        // Verify the masked fields have the correct iterator
+        Fields capturedFields = fieldsCaptor.getValue();
+        Iterator<String> iterator = capturedFields.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals("non_sparse_field1", iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals("non_sparse_field2", iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    /**
+     * Test write method with sparse fields and terms
+     */
+    @SneakyThrows
+    public void test_write_withSparseFields_andTerms() {
+        // Get the constructed mock instances
+        List<SparseTermsLuceneWriter> sparseTermsWriters = mockedSparseTermsWriter.constructed();
+        SparseTermsLuceneWriter sparseTermsWriter = sparseTermsWriters.get(0);
+
+        // Setup field info with sparse fields
+        FieldInfo mockFieldInfo = mock(FieldInfo.class);
+        when(mockFieldInfo.getName()).thenReturn(SPARSE_FIELD);
+        Map<String, String> sparseAttributes = new HashMap<>();
+        sparseAttributes.put(SPARSE_FIELD, String.valueOf(true));
+        sparseAttributes.put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(1));
+        when(mockFieldInfo.attributes()).thenReturn(sparseAttributes);
+
+        // Setup fieldInfos mock
+        when(mockFieldInfos.fieldInfo(anyString())).thenReturn(mockFieldInfo);
+
+        // Setup fields mock
+        List<String> fieldNames = List.of(TEST_SPARSE_FIELD_NAME);
+        when(mockFields.iterator()).thenReturn(fieldNames.iterator());
+
+        // Setup terms mock
+        Terms mockedTerms = mock(Terms.class);
+        when(mockFields.terms(TEST_SPARSE_FIELD_NAME)).thenReturn(mockedTerms);
+        TermsEnum mockedTermsEnum = mock(TermsEnum.class);
+        when(mockedTerms.iterator()).thenReturn(mockedTermsEnum);
+        BytesRef term1 = new BytesRef("term1");
+        BytesRef term2 = new BytesRef("term2");
+        when(mockedTermsEnum.next()).thenReturn(term1).thenReturn(term2).thenReturn(null);
+
+        // Call write
+        sparsePostingsConsumer.write(mockFields, mockNormsProducer);
+
+        verify(sparseTermsWriter, times(1)).writeFieldCount(1);
+        verify(sparseTermsWriter, times(1)).writeTermsSize(2);
+    }
+
+    /**
+     * Test write method with sparse fields and empty terms
+     */
+    @SneakyThrows
+    public void test_write_withSparseFields_andEmptyTerms() {
+        // Get the constructed mock instances
+        List<SparseTermsLuceneWriter> sparseTermsWriters = mockedSparseTermsWriter.constructed();
+        SparseTermsLuceneWriter sparseTermsWriter = sparseTermsWriters.get(0);
+
+        // Setup field info with sparse fields
+        FieldInfo mockFieldInfo = mock(FieldInfo.class);
+        when(mockFieldInfo.getName()).thenReturn(SPARSE_FIELD);
+        Map<String, String> sparseAttributes = new HashMap<>();
+        sparseAttributes.put(SPARSE_FIELD, String.valueOf(true));
+        sparseAttributes.put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(1));
+        when(mockFieldInfo.attributes()).thenReturn(sparseAttributes);
+
+        // Setup fieldInfos mock
+        when(mockFieldInfos.fieldInfo(anyString())).thenReturn(mockFieldInfo);
+
+        // Setup fields mock
+        List<String> fieldNames = List.of(TEST_SPARSE_FIELD_NAME);
+        when(mockFields.iterator()).thenReturn(fieldNames.iterator());
+        when(mockFields.terms(TEST_SPARSE_FIELD_NAME)).thenReturn(null);
+
+        // Call write
+        sparsePostingsConsumer.write(mockFields, mockNormsProducer);
+
+        verify(sparseTermsWriter, times(1)).writeFieldCount(1);
+        verify(sparseTermsWriter, times(1)).writeTermsSize(0);
+    }
+
+    /**
+     * Test merge method
+     */
+    @SneakyThrows
+    public void test_merge() {
+        MergeState mockMergeState = TestsPrepareUtils.prepareMergeState(true);
+
+        sparsePostingsConsumer.merge(mockMergeState, mockNormsProducer);
+
+        verify(mockedMergeHelper, times(1)).clearCacheData(any(), any(), any());
+    }
+
+    /**
+     * Test merge method handles exceptions
+     */
+    @SneakyThrows
+    public void test_merge_withExceptions() {
+        // mock exception thrown from SparsePostingsReader merge
+        MergeState mockMergeState = TestsPrepareUtils.prepareMergeState(true);
+        MockedConstruction<SparsePostingsReader> mockedReader = Mockito.mockConstruction(SparsePostingsReader.class, (mock, context) -> {
+            doThrow(new IOException("Test exception")).when(mock).merge(any(), any());
+        });
+
+        sparsePostingsConsumer.merge(mockMergeState, mockNormsProducer);
+
+        verify(mockedMergeHelper, never()).clearCacheData(any(), any(), any());
+        mockedReader.close();
+    }
+
+    /**
+     * Test close method with successful close
+     */
+    @SneakyThrows
+    public void test_close() {
+        // Get the constructed mock instances
+        List<ClusteredPostingTermsWriter> clusteredWriters = mockedClusteredWriter.constructed();
+        List<SparseTermsLuceneWriter> sparseTermsWriters = mockedSparseTermsWriter.constructed();
+        SparseTermsLuceneWriter sparseTermsWriter = sparseTermsWriters.get(0);
+        ClusteredPostingTermsWriter clusteredWriter = clusteredWriters.get(0);
+
+        // Call the close method
+        sparsePostingsConsumer.close();
+
+        // Verify delegate, writers and outputs call the close method
+        verify(mockDelegate).close();
+        verify(sparseTermsWriter).close(anyLong());
+        verify(clusteredWriter).close(anyLong());
+        verify(mockTermsOutput).close();
+        verify(mockPostingOutput).close();
+    }
+
+    /**
+     * Test close method handles exceptions from writers
+     */
+    @SneakyThrows
+    public void test_close_withExceptions() {
+        // Mock exception thrown from sparseTermsLuceneWriter close
+        List<SparseTermsLuceneWriter> sparseTermsWriters = mockedSparseTermsWriter.constructed();
+        SparseTermsLuceneWriter sparseTermsWriter = sparseTermsWriters.get(0);
+        doThrow(new IOException("Test exception")).when(sparseTermsWriter).close(anyLong());
+
+        // Verify exception message
+        IOException exception = expectThrows(IOException.class, () -> { sparsePostingsConsumer.close(); });
+        assertEquals("Test exception", exception.getMessage());
+
+        // Verify delegate and outputs call the close method
+        verify(mockDelegate).close();
+        verify(mockTermsOutput).close();
+        verify(mockPostingOutput).close();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnumTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsEnumTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.common.DocWeightIterator;
+import org.opensearch.neuralsearch.sparse.common.IteratorWrapper;
+import org.opensearch.neuralsearch.sparse.data.DocumentCluster;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+import org.opensearch.neuralsearch.sparse.quantization.ByteQuantizer;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparsePostingsEnumTests extends AbstractSparseTestBase {
+
+    @Mock
+    private CacheKey mockCacheKey;
+    @Mock
+    private PostingClusters mockClusters;
+    @Mock
+    private DocumentCluster mockDocumentCluster;
+    @Mock
+    private DocWeightIterator mockDocWeightIterator;
+    @Mock
+    private IteratorWrapper<DocumentCluster> mockClusterIterator;
+
+    private SparsePostingsEnum sparsePostingsEnum;
+
+    @Before
+    @Override
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        when(mockClusters.iterator()).thenReturn(mockClusterIterator);
+        when(mockClusterIterator.next()).thenReturn(mockDocumentCluster);
+        when(mockClusterIterator.hasNext()).thenReturn(true);
+        when(mockDocumentCluster.getDisi()).thenReturn(mockDocWeightIterator);
+        when(mockDocWeightIterator.docID()).thenReturn(0);
+
+        sparsePostingsEnum = new SparsePostingsEnum(mockClusters, mockCacheKey);
+    }
+
+    @SneakyThrows
+    public void testConstructor() {
+        SparsePostingsEnum sparsePostingsEnum = new SparsePostingsEnum(mockClusters, mockCacheKey);
+
+        assertEquals(mockClusters, sparsePostingsEnum.getClusters());
+        assertEquals(mockCacheKey, sparsePostingsEnum.getCacheKey());
+    }
+
+    public void testClusterIterator() {
+        // reset mockClusters because setUp calls it
+        reset(mockClusters);
+        when(mockClusters.iterator()).thenReturn(mockClusterIterator);
+
+        IteratorWrapper<DocumentCluster> result = sparsePostingsEnum.clusterIterator();
+
+        verify(mockClusters, times(1)).iterator();
+        assertEquals(mockClusterIterator, result);
+    }
+
+    public void testSize() {
+        int expectedSize = 100;
+        when(mockClusters.getSize()).thenReturn(expectedSize);
+
+        assertEquals(expectedSize, sparsePostingsEnum.size());
+        verify(mockClusters, times(1)).getSize();
+    }
+
+    public void testFreq() throws IOException {
+        byte expectedWeight = 100;
+        when(mockDocWeightIterator.weight()).thenReturn(expectedWeight);
+
+        int result = sparsePostingsEnum.freq();
+
+        verify(mockDocWeightIterator, times(1)).weight();
+        assertEquals(ByteQuantizer.getUnsignedByte(expectedWeight), result);
+    }
+
+    public void testNextPosition() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.nextPosition());
+        assertNull(exception.getMessage());
+    }
+
+    public void testStartOffset() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.startOffset());
+        assertNull(exception.getMessage());
+
+    }
+
+    public void testEndOffset() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.endOffset());
+        assertNull(exception.getMessage());
+    }
+
+    public void testGetPayload() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.getPayload());
+        assertNull(exception.getMessage());
+    }
+
+    public void testDocID() {
+        int expectedDocID = 10;
+        when(mockDocWeightIterator.docID()).thenReturn(expectedDocID);
+
+        assertEquals(expectedDocID, sparsePostingsEnum.docID());
+        verify(mockDocWeightIterator, times(1)).docID();
+    }
+
+    @SneakyThrows
+    public void testDocID_currentDocWeightNull() {
+        when(mockClusters.iterator()).thenReturn(mockClusterIterator);
+        when(mockClusterIterator.next()).thenReturn(mockDocumentCluster);
+        when(mockClusterIterator.hasNext()).thenReturn(true);
+        when(mockDocumentCluster.getDisi()).thenReturn(null);
+
+        sparsePostingsEnum = new SparsePostingsEnum(mockClusters, mockCacheKey);
+
+        // -1 is the default value when current doc weight is null
+        assertEquals(-1, sparsePostingsEnum.docID());
+        verify(mockDocWeightIterator, never()).docID();
+    }
+
+    public void testNextDoc_noMoreDocs() throws IOException {
+        when(mockDocWeightIterator.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(mockClusterIterator.hasNext()).thenReturn(false);
+
+        int result = sparsePostingsEnum.nextDoc();
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, result);
+        verify(mockDocWeightIterator).nextDoc();
+        verify(mockClusterIterator).hasNext();
+    }
+
+    public void testNextDoc_currentCluster() throws IOException {
+        int expectedDocId = 10;
+        when(mockDocWeightIterator.nextDoc()).thenReturn(expectedDocId);
+
+        int result = sparsePostingsEnum.nextDoc();
+
+        assertEquals(expectedDocId, result);
+        verify(mockDocWeightIterator).nextDoc();
+    }
+
+    public void testNextDoc_nextCluster() throws IOException {
+        // reset mockDocWeightIterator and mockClusterIterator because setUp calls it
+        reset(mockDocWeightIterator);
+        reset(mockClusterIterator);
+
+        when(mockDocWeightIterator.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+        when(mockClusterIterator.hasNext()).thenReturn(true);
+
+        // configure the next cluster
+        int expectedDocId = 10;
+        DocWeightIterator mockSecondDocWeightIterator = mock(DocWeightIterator.class);
+        DocumentCluster mockSecondCluster = mock(DocumentCluster.class);
+        when(mockSecondCluster.getDisi()).thenReturn(mockSecondDocWeightIterator);
+        when(mockSecondDocWeightIterator.nextDoc()).thenReturn(expectedDocId);
+
+        when(mockClusterIterator.next()).thenReturn(mockSecondCluster);
+
+        int result = sparsePostingsEnum.nextDoc();
+
+        assertEquals(expectedDocId, result);
+        verify(mockDocWeightIterator, times(1)).nextDoc();
+        verify(mockClusterIterator, times(1)).next();
+        verify(mockSecondDocWeightIterator, times(1)).nextDoc();
+    }
+
+    public void testAdvance() {
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> sparsePostingsEnum.advance(5));
+        assertNull(exception.getMessage());
+    }
+
+    public void testCost() {
+        assertEquals(0, sparsePostingsEnum.cost());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormatTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsFormatTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparsePostingsFormatTests extends AbstractSparseTestBase {
+
+    private PostingsFormat mockDelegate;
+    private SparsePostingsFormat sparsePostingsFormat;
+    private SegmentWriteState mockWriteState;
+    private SegmentReadState mockReadState;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        mockDelegate = mock(PostingsFormat.class);
+        when(mockDelegate.getName()).thenReturn("TestPostingsFormat");
+
+        this.sparsePostingsFormat = new SparsePostingsFormat(mockDelegate);
+
+        // Use TestsPrepareUtils to create real objects since SegmentInfo.name is final
+        mockWriteState = TestsPrepareUtils.prepareSegmentWriteState();
+
+        mockReadState = mock(SegmentReadState.class);
+    }
+
+    public void testConstructor() {
+        SparsePostingsFormat sparsePostingsFormat = new SparsePostingsFormat(mockDelegate);
+        // Verify that the format name is inherited from delegate
+        assertEquals("TestPostingsFormat", sparsePostingsFormat.getName());
+    }
+
+    @SneakyThrows
+    public void testFieldsConsumer() {
+        // Setup
+        FieldsConsumer mockDelegateConsumer = mock(FieldsConsumer.class);
+        when(mockDelegate.fieldsConsumer(mockWriteState)).thenReturn(mockDelegateConsumer);
+
+        // Execute
+        FieldsConsumer result = this.sparsePostingsFormat.fieldsConsumer(mockWriteState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparsePostingsConsumer);
+        verify(mockDelegate).fieldsConsumer(mockWriteState);
+    }
+
+    @SneakyThrows
+    public void testFieldsConsumerIOException() {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsConsumer(mockWriteState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { this.sparsePostingsFormat.fieldsConsumer(mockWriteState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testFieldsProducer() {
+        // Setup
+        FieldsProducer mockDelegateProducer = mock(FieldsProducer.class);
+        when(mockDelegate.fieldsProducer(mockReadState)).thenReturn(mockDelegateProducer);
+
+        // Execute
+        FieldsProducer result = this.sparsePostingsFormat.fieldsProducer(mockReadState);
+
+        // Verify
+        assertNotNull(result);
+        assertTrue(result instanceof SparsePostingsProducer);
+        verify(mockDelegate).fieldsProducer(mockReadState);
+    }
+
+    @SneakyThrows
+    public void testFieldsProducerIOException() {
+        // Setup
+        IOException expectedException = new IOException("Test exception");
+        when(mockDelegate.fieldsProducer(mockReadState)).thenThrow(expectedException);
+
+        // Execute & Verify
+        IOException exception = expectThrows(IOException.class, () -> { this.sparsePostingsFormat.fieldsProducer(mockReadState); });
+        assertEquals("Test exception", exception.getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducerTests.java
@@ -18,7 +18,6 @@ import org.junit.Before;
 import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
 import org.opensearch.neuralsearch.sparse.cache.CacheKey;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -44,8 +43,8 @@ public class SparsePostingsProducerTests extends AbstractSparseTestBase {
     private Supplier<SparseTermsLuceneReader> readerSupplier = () -> mockReader;
 
     @Before
-    public void init() throws IOException {
-
+    public void setUp() {
+        super.setUp();
         mockDelegate = mock(FieldsProducer.class);
 
         // Setup segment info

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsProducerTests.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.APPROXIMATE_THRESHOLD_FIELD;
+import static org.opensearch.neuralsearch.sparse.mapper.SparseTokensField.SPARSE_FIELD;
+
+public class SparsePostingsProducerTests extends AbstractSparseTestBase {
+
+    private FieldsProducer mockDelegate;
+    private SegmentReadState segmentReadState;
+    private SparsePostingsProducer producer;
+    private FieldInfo sparseFieldInfo;
+    private SegmentInfo segmentInfo;
+    private FieldInfos fieldInfos;
+    private SparseTermsLuceneReader mockReader;
+    private Supplier<SparseTermsLuceneReader> readerSupplier = () -> mockReader;
+
+    @Before
+    public void init() throws IOException {
+
+        mockDelegate = mock(FieldsProducer.class);
+
+        // Setup segment info
+        segmentInfo = mock(SegmentInfo.class);
+        when(segmentInfo.maxDoc()).thenReturn(10);
+
+        // Setup field infos using real FieldInfo objects
+        sparseFieldInfo = mock(FieldInfo.class);
+        when(sparseFieldInfo.getName()).thenReturn(SPARSE_FIELD);
+        Map<String, String> sparseAttributes = new HashMap<>();
+        sparseAttributes.put(SPARSE_FIELD, "true");
+        sparseAttributes.put(APPROXIMATE_THRESHOLD_FIELD, "10");
+        when(sparseFieldInfo.attributes()).thenReturn(sparseAttributes);
+
+        // Setup field infos
+        fieldInfos = mock(FieldInfos.class);
+        when(fieldInfos.fieldInfo(sparseFieldInfo.getName())).thenReturn(sparseFieldInfo);
+
+        // Setup segment read state
+        Directory mockDir = mock(Directory.class);
+        segmentReadState = new SegmentReadState(mockDir, segmentInfo, fieldInfos, IOContext.DEFAULT);
+        mockReader = mock(SparseTermsLuceneReader.class);
+
+        producer = new SparsePostingsProducer(mockDelegate, segmentReadState, readerSupplier);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        if (producer != null) {
+            producer.close();
+        }
+        super.tearDown();
+    }
+
+    @SneakyThrows
+    public void testConstructor() {
+        SparsePostingsProducer localProducer = new SparsePostingsProducer(mockDelegate, segmentReadState, readerSupplier);
+        assertNotNull(localProducer);
+        assertEquals(mockDelegate, localProducer.getDelegate());
+        assertEquals(segmentReadState, localProducer.getState());
+        expectThrows(NullPointerException.class, () -> new SparsePostingsProducer(mockDelegate, segmentReadState, null));
+    }
+
+    @SneakyThrows
+    public void testClose_WithDelegate() {
+        producer.close();
+
+        verify(mockDelegate, times(1)).close();
+    }
+
+    @SneakyThrows
+    public void testClose_WithNullDelegate() {
+        SparsePostingsProducer producerWithNullDelegate = new SparsePostingsProducer(null, segmentReadState, readerSupplier);
+
+        // Should not throw exception
+        producerWithNullDelegate.close();
+    }
+
+    @SneakyThrows
+    public void testClose_WithReader() {
+        // First call terms() to initialize reader
+        Terms mockTerms = mock(Terms.class);
+        when(mockDelegate.terms(sparseFieldInfo.getName())).thenReturn(mockTerms);
+
+        producer.terms(sparseFieldInfo.getName());
+        assertNotNull(producer.getReader());
+
+        producer.close();
+
+        verify(mockDelegate, times(1)).close();
+    }
+
+    @SneakyThrows
+    public void testCheckIntegrity() {
+        producer.checkIntegrity();
+
+        verify(mockDelegate, times(1)).checkIntegrity();
+    }
+
+    @SneakyThrows
+    public void testIterator() {
+        Iterator<String> mockIterator = Arrays.asList("field1", "field2").iterator();
+        when(mockDelegate.iterator()).thenReturn(mockIterator);
+
+        Iterator<String> result = producer.iterator();
+
+        assertEquals(mockIterator, result);
+        verify(mockDelegate, times(1)).iterator();
+    }
+
+    @SneakyThrows
+    public void testTerms_SparseFieldBelowThreshold() {
+        // Create segment info with low maxDoc
+        SegmentInfo lowThresholdSegmentInfo = mock(SegmentInfo.class);
+        when(lowThresholdSegmentInfo.maxDoc()).thenReturn(3);
+
+        SegmentReadState lowThresholdState = new SegmentReadState(
+            segmentReadState.directory,
+            lowThresholdSegmentInfo,
+            fieldInfos,
+            segmentReadState.context
+        );
+
+        SparsePostingsProducer lowThresholdProducer = new SparsePostingsProducer(mockDelegate, lowThresholdState, readerSupplier);
+
+        Terms mockTerms = mock(Terms.class);
+        when(mockDelegate.terms(sparseFieldInfo.getName())).thenReturn(mockTerms);
+
+        Terms result = lowThresholdProducer.terms(sparseFieldInfo.getName());
+
+        assertEquals(mockTerms, result);
+        verify(mockDelegate, times(1)).terms(sparseFieldInfo.getName());
+        assertNull(lowThresholdProducer.getReader());
+        lowThresholdProducer.close();
+    }
+
+    @SneakyThrows
+    public void testTerms_SparseFieldAboveThreshold() {
+        Terms result = producer.terms(sparseFieldInfo.getName());
+
+        assertNotNull(result);
+        assertTrue(result instanceof SparseTerms);
+        assertNotNull(producer.getReader());
+
+        SparseTerms sparseTerms = (SparseTerms) result;
+        CacheKey expectedKey = new CacheKey(segmentInfo, sparseFieldInfo);
+        assertEquals(expectedKey, sparseTerms.getCacheKey());
+    }
+
+    @SneakyThrows
+    public void testTerms_nullSupplier() {
+        producer = new SparsePostingsProducer(mockDelegate, segmentReadState, () -> null);
+        expectThrows(NullPointerException.class, () -> producer.terms(sparseFieldInfo.getName()));
+    }
+
+    @SneakyThrows
+    public void testTerms_NullFieldInfo() {
+        when(fieldInfos.fieldInfo("unknown_field")).thenReturn(null);
+
+        Terms mockTerms = mock(Terms.class);
+        when(mockDelegate.terms("unknown_field")).thenReturn(mockTerms);
+
+        Terms result = producer.terms("unknown_field");
+
+        assertEquals(mockTerms, result);
+        verify(mockDelegate, times(1)).terms("unknown_field");
+    }
+
+    @SneakyThrows
+    public void testTerms_SparseFieldWithNullAttributes() {
+        when(fieldInfos.fieldInfo("unknown_field")).thenReturn(null);
+
+        Terms mockTerms = mock(Terms.class);
+        when(mockDelegate.terms("unknown_field")).thenReturn(mockTerms);
+
+        Terms result = producer.terms("unknown_field");
+
+        assertEquals(mockTerms, result);
+        verify(mockDelegate, times(1)).terms("unknown_field");
+    }
+
+    @SneakyThrows
+    public void testSize() {
+        int result = producer.size();
+        assertEquals(0, result);
+    }
+
+    @SneakyThrows
+    public void testGetters() {
+        assertEquals(mockDelegate, producer.getDelegate());
+        assertEquals(segmentReadState, producer.getState());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReaderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReaderTests.java
@@ -101,7 +101,6 @@ public class SparsePostingsReaderTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testMerge_success() {
-
         reader.merge(mockSparseTermsWriter, mockClusteredWriter);
 
         verify(mockSparseTermsWriter, times(1)).writeFieldCount(1);

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReaderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReaderTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.algorithm.ClusterTrainingExecutor;
+import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.APPROXIMATE_THRESHOLD_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
+import static org.opensearch.neuralsearch.sparse.mapper.SparseTokensField.SPARSE_FIELD;
+
+public class SparsePostingsReaderTests extends AbstractSparseTestBase {
+
+    @Mock
+    private ThreadPool mockThreadPool;
+    @Mock
+    private ExecutorService mockExecutor;
+    @Mock
+    private FieldsProducer mockFieldsProducer;
+    @Mock
+    private SparseTermsLuceneWriter mockSparseTermsWriter;
+    @Mock
+    private ClusteredPostingTermsWriter mockClusteredWriter;
+    @Mock
+    private MergeHelper mergeHelper;
+    @Mock
+    private MergeStateFacade mockMergeState;
+    @Mock
+    private FieldInfo mockSparseFieldInfo;
+    @Mock
+    private FieldInfo mockNonSparseFieldInfo;
+    @Mock
+    private FieldInfos mockFieldInfos;
+    @Mock
+    private SegmentInfo mockSegmentInfo;
+
+    private SparsePostingsReader reader;
+    private static final Set<BytesRef> TERMS = Set.of(new BytesRef("term"));
+
+    @Before
+    @Override
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        // configure executor service for cluster training running
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(mockExecutor).execute(any(Runnable.class));
+
+        when(mockThreadPool.executor(anyString())).thenReturn(mockExecutor);
+        ClusterTrainingExecutor.getInstance().initialize(mockThreadPool);
+
+        // configure merge state
+        Map<String, String> attributes = prepareAttributes(true, 10, 0.1f, 200, 0.4f);
+        when(mockSparseFieldInfo.attributes()).thenReturn(attributes);
+        attributes = prepareAttributes(false, 10, 0.1f, -1, 0.4f);
+        when(mockNonSparseFieldInfo.attributes()).thenReturn(attributes);
+        when(mockMergeState.getFieldsProducers()).thenReturn(new FieldsProducer[] { mockFieldsProducer });
+        when(mockFieldInfos.iterator()).thenReturn(List.of(mockSparseFieldInfo, mockNonSparseFieldInfo).iterator());
+        when(mockMergeState.getMergeFieldInfos()).thenReturn(mockFieldInfos);
+        when(mockMergeState.getMaxDocs()).thenReturn(new int[] { 5, 5 });
+        when(mockMergeState.getSegmentInfo()).thenReturn(mockSegmentInfo);
+        when(mockSegmentInfo.maxDoc()).thenReturn(10);
+        when(mergeHelper.getAllTerms(any(), any())).thenReturn(TERMS);
+        reader = new SparsePostingsReader(mockMergeState, mergeHelper);
+    }
+
+    public void testConstructor() {
+        assertNotNull(reader);
+    }
+
+    @SneakyThrows
+    public void testMerge_success() {
+
+        reader.merge(mockSparseTermsWriter, mockClusteredWriter);
+
+        verify(mockSparseTermsWriter, times(1)).writeFieldCount(1);
+        verify(mockSparseTermsWriter, times(1)).writeFieldNumber(anyInt());
+        verify(mockSparseTermsWriter, times(1)).writeTermsSize(1L);
+        verify(mockExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @SneakyThrows
+    public void testMerge_withDefaultNPosting() {
+        Map<String, String> attributes = prepareAttributes(true, 10, 0.1f, -1, 0.4f);
+        when(mockSparseFieldInfo.attributes()).thenReturn(attributes);
+
+        SparsePostingsReader reader = new SparsePostingsReader(mockMergeState, mergeHelper);
+        reader.merge(mockSparseTermsWriter, mockClusteredWriter);
+
+        verify(mockSparseTermsWriter, times(1)).writeFieldCount(1);
+        verify(mockSparseTermsWriter, times(1)).writeFieldNumber(anyInt());
+        verify(mockSparseTermsWriter, times(1)).writeTermsSize(1L);
+        verify(mockExecutor, times(1)).execute(any(Runnable.class));
+    }
+
+    @SneakyThrows
+    public void testMerge_withNonSparseTerm() {
+        when(mockFieldInfos.iterator()).thenReturn(List.of(mockNonSparseFieldInfo).iterator());
+        when(mockMergeState.getMergeFieldInfos()).thenReturn(mockFieldInfos);
+        reader.merge(mockSparseTermsWriter, mockClusteredWriter);
+
+        verify(mockSparseTermsWriter, times(1)).writeFieldCount(0);
+        verify(mockSparseTermsWriter, never()).writeFieldNumber(anyInt());
+        verify(mockSparseTermsWriter, never()).writeTermsSize(1L);
+        verify(mockExecutor, never()).execute(any(Runnable.class));
+    }
+
+    @SneakyThrows
+    public void testMerge_withIOException() {
+        doThrow(new IOException("Test exception")).when(mockSparseTermsWriter).writeFieldCount(1);
+        Exception exception = expectThrows(IOException.class, () -> reader.merge(mockSparseTermsWriter, mockClusteredWriter));
+        assertEquals("Test exception", exception.getMessage());
+        verify(mockSparseTermsWriter, times(1)).closeWithException();
+        verify(mockClusteredWriter, times(1)).closeWithException();
+        verify(mockExecutor, never()).execute(any(Runnable.class));
+    }
+
+    @SneakyThrows
+    public void testMerge_ClusterDocCountSmallerThanThreshold() {
+        Map<String, String> attributes = prepareAttributes(true, 100, 0.1f, -1, 0.4f);
+        when(mockSparseFieldInfo.attributes()).thenReturn(attributes);
+        reader.merge(mockSparseTermsWriter, mockClusteredWriter);
+
+        verify(mockSparseTermsWriter, times(1)).writeFieldCount(0);
+        verify(mockSparseTermsWriter, never()).writeFieldNumber(anyInt());
+        verify(mockSparseTermsWriter, never()).writeTermsSize(anyLong());
+        verify(mockExecutor, never()).execute(any(Runnable.class));
+    }
+
+    @SneakyThrows
+    public void testMerge_ZeroClusterRatio() {
+        Map<String, String> attributes = prepareAttributes(true, 10, 0f, -1, 0.4f);
+        when(mockSparseFieldInfo.attributes()).thenReturn(attributes);
+        reader.merge(mockSparseTermsWriter, mockClusteredWriter);
+
+        verify(mockSparseTermsWriter, times(1)).writeFieldCount(1);
+        verify(mockSparseTermsWriter, times(1)).writeFieldNumber(anyInt());
+        verify(mockSparseTermsWriter, times(1)).writeTermsSize(1L);
+        verify(mockExecutor, never()).execute(any(Runnable.class));
+    }
+
+    Map<String, String> prepareAttributes(boolean sparse, int threshold, float ratio, int posting, float summary) {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(SPARSE_FIELD, String.valueOf(sparse));
+        attributes.put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(threshold));
+        attributes.put(CLUSTER_RATIO_FIELD, String.valueOf(ratio));
+        attributes.put(N_POSTINGS_FIELD, String.valueOf(posting));
+        attributes.put(SUMMARY_PRUNE_RATIO_FIELD, String.valueOf(summary));
+        return attributes;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReaderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparsePostingsReaderTests.java
@@ -19,7 +19,6 @@ import org.opensearch.neuralsearch.sparse.common.MergeStateFacade;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,11 +34,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.APPROXIMATE_THRESHOLD_FIELD;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.CLUSTER_RATIO_FIELD;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.N_POSTINGS_FIELD;
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.SUMMARY_PRUNE_RATIO_FIELD;
-import static org.opensearch.neuralsearch.sparse.mapper.SparseTokensField.SPARSE_FIELD;
 
 public class SparsePostingsReaderTests extends AbstractSparseTestBase {
 
@@ -176,13 +170,4 @@ public class SparsePostingsReaderTests extends AbstractSparseTestBase {
         verify(mockExecutor, never()).execute(any(Runnable.class));
     }
 
-    Map<String, String> prepareAttributes(boolean sparse, int threshold, float ratio, int posting, float summary) {
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put(SPARSE_FIELD, String.valueOf(sparse));
-        attributes.put(APPROXIMATE_THRESHOLD_FIELD, String.valueOf(threshold));
-        attributes.put(CLUSTER_RATIO_FIELD, String.valueOf(ratio));
-        attributes.put(N_POSTINGS_FIELD, String.valueOf(posting));
-        attributes.put(SUMMARY_PRUNE_RATIO_FIELD, String.valueOf(summary));
-        return attributes;
-    }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriterTests.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -46,6 +47,7 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
     private SparseTermsLuceneWriter writer;
     private SegmentWriteState mockSegmentWriteState;
 
+    @SneakyThrows
     @Before
     @Override
     public void setUp() {
@@ -54,10 +56,12 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
         mockSegmentWriteState = TestsPrepareUtils.prepareSegmentWriteState();
         writer = new SparseTermsLuceneWriter(CODEC_NAME, VERSION, mockCodecUtilWrapper);
+        writer.init(mockIndexOutput, mockSegmentWriteState);
     }
 
     @SneakyThrows
     public void testConstructor() {
+        mockCodecUtilWrapper = mock(CodecUtilWrapper.class);
         SparseTermsLuceneWriter testWriter = new SparseTermsLuceneWriter(CODEC_NAME, VERSION, mockCodecUtilWrapper);
         assertNotNull(testWriter);
 
@@ -74,8 +78,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testInit_success() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
-
         verify(mockCodecUtilWrapper).writeIndexHeader(
             eq(mockIndexOutput),
             eq(CODEC_NAME),
@@ -96,7 +98,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testClose_success() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         writer.close(START_FP);
 
         verify(mockIndexOutput, times(1)).writeLong(START_FP);
@@ -105,7 +106,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testClose_throwsIOException() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         IOException expectedException = new IOException("Test exception");
         doThrow(expectedException).when(mockIndexOutput).writeLong(anyLong());
 
@@ -115,7 +115,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testWriteFieldCount_success() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         writer.writeFieldCount(FIELD_COUNT);
 
         verify(mockIndexOutput, times(1)).writeVInt(FIELD_COUNT);
@@ -123,7 +122,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testWriteFieldCount_throwsIOException() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         IOException expectedException = new IOException("Test exception");
         doThrow(expectedException).when(mockIndexOutput).writeVInt(anyInt());
 
@@ -133,7 +131,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testWriteFieldNumber_success() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         writer.writeFieldNumber(FIELD_NUMBER);
 
         verify(mockIndexOutput, times(1)).writeVInt(FIELD_NUMBER);
@@ -141,7 +138,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testWriteFieldNumber_throwsIOException() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         IOException expectedException = new IOException("Test exception");
         doThrow(expectedException).when(mockIndexOutput).writeVInt(anyInt());
 
@@ -151,7 +147,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testWriteTermsSize_success() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         writer.writeTermsSize(TERMS_SIZE);
 
         verify(mockIndexOutput, times(1)).writeVLong(TERMS_SIZE);
@@ -159,7 +154,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testWriteTermsSize_throwsIOException() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         IOException expectedException = new IOException("Test exception");
         doThrow(expectedException).when(mockIndexOutput).writeVLong(anyLong());
 
@@ -169,7 +163,6 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
     @SneakyThrows
     public void testWriteTerm_success() {
-        writer.init(mockIndexOutput, mockSegmentWriteState);
         BytesRef term = new BytesRef("test_term");
 
         writer.writeTerm(term, mockBlockTermState);
@@ -188,5 +181,11 @@ public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
 
         IOException exception = expectThrows(IOException.class, () -> writer.writeTerm(term, mockBlockTermState));
         assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testCloseWithException() {
+        writer.closeWithException();
+        verify(mockIndexOutput).close();
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsLuceneWriterTests.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.BlockTermState;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.TestsPrepareUtils;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SparseTermsLuceneWriterTests extends AbstractSparseTestBase {
+
+    private static final String CODEC_NAME = "TestCodec";
+    private static final int VERSION = 1;
+    private static final long START_FP = 100L;
+    private static final int FIELD_COUNT = 5;
+    private static final int FIELD_NUMBER = 10;
+    private static final long TERMS_SIZE = 1000L;
+
+    @Mock
+    private IndexOutput mockIndexOutput;
+    @Mock
+    private BlockTermState mockBlockTermState;
+
+    private MockedStatic<CodecUtil> codecUtilMock;
+    private MockedStatic<IOUtils> ioUtilsMock;
+    private SparseTermsLuceneWriter writer;
+    private SegmentWriteState mockSegmentWriteState;
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        ioUtilsMock = Mockito.mockStatic(IOUtils.class);
+        codecUtilMock = Mockito.mockStatic(CodecUtil.class);
+
+        mockSegmentWriteState = TestsPrepareUtils.prepareSegmentWriteState();
+        writer = new SparseTermsLuceneWriter(CODEC_NAME, VERSION);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        codecUtilMock.close();
+        ioUtilsMock.close();
+        super.tearDown();
+    }
+
+    @SneakyThrows
+    public void testConstructor() {
+        SparseTermsLuceneWriter testWriter = new SparseTermsLuceneWriter(CODEC_NAME, VERSION);
+        assertNotNull(testWriter);
+
+        // verify constructor correctly sets codec name and version
+        testWriter.init(mockIndexOutput, mockSegmentWriteState);
+        codecUtilMock.verify(
+            () -> CodecUtil.writeIndexHeader(
+                eq(mockIndexOutput),
+                eq(CODEC_NAME),
+                eq(VERSION),
+                any(byte[].class),
+                eq(mockSegmentWriteState.segmentSuffix)
+            ),
+            times(1)
+        );
+    }
+
+    @SneakyThrows
+    public void testInit_success() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+
+        codecUtilMock.verify(
+            () -> CodecUtil.writeIndexHeader(
+                eq(mockIndexOutput),
+                eq(CODEC_NAME),
+                eq(VERSION),
+                any(byte[].class),
+                eq(mockSegmentWriteState.segmentSuffix)
+            ),
+            times(1)
+        );
+    }
+
+    @SneakyThrows
+    public void testInit_throwsIOException() {
+        IOException expectedException = new IOException("Test exception");
+        codecUtilMock.when(() -> CodecUtil.writeIndexHeader(any(DataOutput.class), anyString(), anyInt(), any(byte[].class), anyString()))
+            .thenThrow(expectedException);
+
+        IOException exception = expectThrows(IOException.class, () -> writer.init(mockIndexOutput, mockSegmentWriteState));
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testClose_success() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        writer.close(START_FP);
+
+        verify(mockIndexOutput, times(1)).writeLong(START_FP);
+        codecUtilMock.verify(() -> CodecUtil.writeFooter(mockIndexOutput), times(1));
+    }
+
+    @SneakyThrows
+    public void testClose_throwsIOException() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        IOException expectedException = new IOException("Test exception");
+        doThrow(expectedException).when(mockIndexOutput).writeLong(anyLong());
+
+        IOException exception = expectThrows(IOException.class, () -> writer.close(START_FP));
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testWriteFieldCount_success() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        writer.writeFieldCount(FIELD_COUNT);
+
+        verify(mockIndexOutput, times(1)).writeVInt(FIELD_COUNT);
+    }
+
+    @SneakyThrows
+    public void testWriteFieldCount_throwsIOException() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        IOException expectedException = new IOException("Test exception");
+        doThrow(expectedException).when(mockIndexOutput).writeVInt(anyInt());
+
+        IOException exception = expectThrows(IOException.class, () -> writer.writeFieldCount(FIELD_COUNT));
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testWriteFieldNumber_success() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        writer.writeFieldNumber(FIELD_NUMBER);
+
+        verify(mockIndexOutput, times(1)).writeVInt(FIELD_NUMBER);
+    }
+
+    @SneakyThrows
+    public void testWriteFieldNumber_throwsIOException() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        IOException expectedException = new IOException("Test exception");
+        doThrow(expectedException).when(mockIndexOutput).writeVInt(anyInt());
+
+        IOException exception = expectThrows(IOException.class, () -> writer.writeFieldNumber(FIELD_NUMBER));
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testWriteTermsSize_success() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        writer.writeTermsSize(TERMS_SIZE);
+
+        verify(mockIndexOutput, times(1)).writeVLong(TERMS_SIZE);
+    }
+
+    @SneakyThrows
+    public void testWriteTermsSize_throwsIOException() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        IOException expectedException = new IOException("Test exception");
+        doThrow(expectedException).when(mockIndexOutput).writeVLong(anyLong());
+
+        IOException exception = expectThrows(IOException.class, () -> writer.writeTermsSize(TERMS_SIZE));
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testWriteTerm_success() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        BytesRef term = new BytesRef("test_term");
+
+        writer.writeTerm(term, mockBlockTermState);
+
+        verify(mockIndexOutput, times(1)).writeVInt(term.length);
+        verify(mockIndexOutput, times(1)).writeBytes(term.bytes, term.offset, term.length);
+        verify(mockIndexOutput, times(1)).writeVLong(mockBlockTermState.blockFilePointer);
+    }
+
+    @SneakyThrows
+    public void testWriteTerm_throwsIOException() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        BytesRef term = new BytesRef("test_term");
+        IOException expectedException = new IOException("Test exception");
+        doThrow(expectedException).when(mockIndexOutput).writeVInt(anyInt());
+
+        IOException exception = expectThrows(IOException.class, () -> writer.writeTerm(term, mockBlockTermState));
+        assertEquals("Test exception", exception.getMessage());
+    }
+
+    @SneakyThrows
+    public void testCloseWithException() {
+        writer.init(mockIndexOutput, mockSegmentWriteState);
+        writer.closeWithException();
+
+        ioUtilsMock.verify(() -> IOUtils.closeWhileHandlingException(mockIndexOutput), times(1));
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsTests.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ClusteredPostingCache;
+import org.opensearch.neuralsearch.sparse.data.PostingClusters;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparseTermsTests extends AbstractSparseTestBase {
+
+    private static final String TEST_FIELD = "test_field";
+
+    @Mock
+    private CacheKey mockCacheKey;
+    @Mock
+    private SparseTermsLuceneReader mockReader;
+
+    private Set<BytesRef> terms;
+    private SparseTerms sparseTerms;
+
+    @Before
+    @Override
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+
+        terms = new HashSet<>();
+        terms.add(new BytesRef("term"));
+        when(mockReader.getTerms(TEST_FIELD)).thenReturn(terms);
+        ClusteredPostingCache.getInstance().getOrCreate(mockCacheKey);
+        sparseTerms = new SparseTerms(mockCacheKey, mockReader, TEST_FIELD);
+    }
+
+    @After
+    @Override
+    @SneakyThrows
+    public void tearDown() {
+        ClusteredPostingCache.getInstance().removeIndex(mockCacheKey);
+        super.tearDown();
+    }
+
+    @SneakyThrows
+    public void testConstructor() {
+        SparseTerms sparseTerms = new SparseTerms(mockCacheKey, mockReader, TEST_FIELD);
+        assertNotNull(sparseTerms);
+        assertEquals(mockCacheKey, sparseTerms.getCacheKey());
+        // verify that sparseTerms.reader creates successfully by calling size
+        assertEquals(1, sparseTerms.size());
+    }
+
+    public void testIterator() throws IOException {
+        TermsEnum termsEnum = sparseTerms.iterator();
+
+        assertNotNull(termsEnum);
+        assertTrue(termsEnum instanceof SparseTerms.SparseTermsEnum);
+    }
+
+    public void testSize() throws IOException {
+        int expectedSize = terms.size();
+
+        assertEquals(expectedSize, sparseTerms.size());
+        verify(mockReader, times(1)).getTerms(TEST_FIELD);
+    }
+
+    public void testGetSumTotalTermFreq() throws IOException {
+        assertEquals(0, sparseTerms.getSumTotalTermFreq());
+    }
+
+    public void testGetSumDocFreq() throws IOException {
+        assertEquals(0, sparseTerms.getSumDocFreq());
+    }
+
+    public void testGetDocCount() throws IOException {
+        assertEquals(0, sparseTerms.getDocCount());
+    }
+
+    public void testHasFreqs() {
+        assertFalse(sparseTerms.hasFreqs());
+    }
+
+    public void testHasOffsets() {
+        assertFalse(sparseTerms.hasOffsets());
+    }
+
+    public void testHasPositions() {
+        assertFalse(sparseTerms.hasPositions());
+    }
+
+    public void testHasPayloads() {
+        assertFalse(sparseTerms.hasPayloads());
+    }
+
+    public void testSparseTermsEnum_constructor() throws IOException {
+        TermsEnum termsEnum = sparseTerms.iterator();
+
+        assertNotNull(termsEnum);
+        verify(mockReader, times(1)).getTerms(TEST_FIELD);
+        assertNotNull(termsEnum.next());
+    }
+
+    public void testSparseTermsEnum_constructor_NullTerms() throws IOException {
+        when(mockReader.getTerms(TEST_FIELD)).thenReturn(null);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+
+        assertNotNull(termsEnum);
+        verify(mockReader, times(1)).getTerms(TEST_FIELD);
+        assertNull(termsEnum.next());
+    }
+
+    public void testSparseTermsEnum_seekCeil_notFound() throws IOException {
+        BytesRef term = new BytesRef("term");
+        when(mockReader.read(TEST_FIELD, term)).thenReturn(null);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+        TermsEnum.SeekStatus status = termsEnum.seekCeil(term);
+
+        assertEquals(TermsEnum.SeekStatus.NOT_FOUND, status);
+        assertNull(termsEnum.term());
+        verify(mockReader, times(1)).read(TEST_FIELD, term);
+    }
+
+    public void testSparseTermsEnum_seekCeil_found() throws IOException {
+        BytesRef term = new BytesRef("term");
+        PostingClusters mockClusters = mock(PostingClusters.class);
+        when(mockReader.read(TEST_FIELD, term)).thenReturn(mockClusters);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+        TermsEnum.SeekStatus status = termsEnum.seekCeil(term);
+
+        assertEquals(TermsEnum.SeekStatus.FOUND, status);
+        assertEquals(term, termsEnum.term());
+        verify(mockReader, times(1)).read(TEST_FIELD, term);
+    }
+
+    public void testSparseTermsEnum_seekExact() throws IOException {
+        TermsEnum termsEnum = sparseTerms.iterator();
+
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> termsEnum.seekExact(5L));
+        assertNull(exception.getMessage());
+    }
+
+    public void testSparseTermsEnum_term() throws IOException {
+        BytesRef term = new BytesRef("term1");
+        PostingClusters mockClusters = mock(PostingClusters.class);
+        when(mockReader.read(TEST_FIELD, term)).thenReturn(mockClusters);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+        termsEnum.seekCeil(term);
+
+        assertEquals(term, termsEnum.term());
+    }
+
+    public void testSparseTermsEnum_ord() throws IOException {
+        TermsEnum termsEnum = sparseTerms.iterator();
+
+        Exception exception = expectThrows(UnsupportedOperationException.class, termsEnum::ord);
+        assertNull(exception.getMessage());
+    }
+
+    public void testSparseTermsEnum_docFreq() throws IOException {
+        TermsEnum termsEnum = sparseTerms.iterator();
+
+        Exception exception = expectThrows(UnsupportedOperationException.class, termsEnum::docFreq);
+        assertNull(exception.getMessage());
+    }
+
+    public void testSparseTermsEnum_totalTermFreq() throws IOException {
+        TermsEnum termsEnum = sparseTerms.iterator();
+
+        Exception exception = expectThrows(UnsupportedOperationException.class, termsEnum::totalTermFreq);
+        assertNull(exception.getMessage());
+    }
+
+    public void testSparseTermsEnum_postings_nullCurrentTerm() throws IOException {
+        TermsEnum termsEnum = sparseTerms.iterator();
+        PostingsEnum postingsEnum = termsEnum.postings(null, 0);
+
+        assertNull(postingsEnum);
+        verify(mockReader, never()).read(anyString(), any(BytesRef.class));
+    }
+
+    public void testSparseTermsEnum_postings_nullClusters() throws IOException {
+        BytesRef term = new BytesRef("term");
+        when(mockReader.read(TEST_FIELD, term)).thenReturn(null);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+        termsEnum.next();
+
+        PostingsEnum postingsEnum = termsEnum.postings(null, 0);
+
+        assertNull(postingsEnum);
+        verify(mockReader, times(1)).read(TEST_FIELD, term);
+    }
+
+    public void testSparseTermsEnum_postings_withClusters() throws IOException {
+        BytesRef term = new BytesRef("term");
+        PostingClusters mockClusters = preparePostingClusters();
+        when(mockReader.read(TEST_FIELD, term)).thenReturn(mockClusters);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+        termsEnum.next();
+
+        PostingsEnum postingsEnum = termsEnum.postings(null, 0);
+
+        assertNotNull(postingsEnum);
+        verify(mockReader, times(1)).read(TEST_FIELD, term);
+    }
+
+    public void testSparseTermsEnum_impacts() throws IOException {
+        TermsEnum termsEnum = sparseTerms.iterator();
+
+        Exception exception = expectThrows(UnsupportedOperationException.class, () -> termsEnum.impacts(0));
+        assertNull(exception.getMessage());
+    }
+
+    public void testSparseTermsEnum_next_withTerms() throws IOException {
+        Set<BytesRef> terms = new HashSet<>();
+        BytesRef term1 = new BytesRef("term1");
+        terms.add(term1);
+        when(mockReader.getTerms(TEST_FIELD)).thenReturn(terms);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+        BytesRef nextTerm = termsEnum.next();
+
+        assertEquals(term1, nextTerm);
+        assertEquals(term1, termsEnum.term());
+    }
+
+    public void testSparseTermsEnum_next_noMoreTerms() throws IOException {
+        Set<BytesRef> terms = new HashSet<>();
+        when(mockReader.getTerms(TEST_FIELD)).thenReturn(terms);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+        BytesRef nextTerm = termsEnum.next();
+
+        assertNull(nextTerm);
+    }
+
+    public void testSparseTermsEnum_next_nullIterator() throws IOException {
+        when(mockReader.getTerms(TEST_FIELD)).thenReturn(null);
+
+        TermsEnum termsEnum = sparseTerms.iterator();
+        BytesRef nextTerm = termsEnum.next();
+
+        assertNull(nextTerm);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/SparseTermsTests.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.sparse.codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.junit.After;
@@ -34,10 +35,11 @@ public class SparseTermsTests extends AbstractSparseTestBase {
     private static final String TEST_FIELD = "test_field";
 
     @Mock
-    private CacheKey mockCacheKey;
+    private SegmentInfo mockSegmentInfo;
     @Mock
     private SparseTermsLuceneReader mockReader;
 
+    private CacheKey cacheKey;
     private Set<BytesRef> terms;
     private SparseTerms sparseTerms;
 
@@ -50,24 +52,25 @@ public class SparseTermsTests extends AbstractSparseTestBase {
 
         terms = new HashSet<>();
         terms.add(new BytesRef("term"));
+        cacheKey = prepareUniqueCacheKey(mockSegmentInfo);
         when(mockReader.getTerms(TEST_FIELD)).thenReturn(terms);
-        ClusteredPostingCache.getInstance().getOrCreate(mockCacheKey);
-        sparseTerms = new SparseTerms(mockCacheKey, mockReader, TEST_FIELD);
+        ClusteredPostingCache.getInstance().getOrCreate(cacheKey);
+        sparseTerms = new SparseTerms(cacheKey, mockReader, TEST_FIELD);
     }
 
     @After
     @Override
     @SneakyThrows
     public void tearDown() {
-        ClusteredPostingCache.getInstance().removeIndex(mockCacheKey);
+        ClusteredPostingCache.getInstance().removeIndex(cacheKey);
         super.tearDown();
     }
 
     @SneakyThrows
     public void testConstructor() {
-        SparseTerms sparseTerms = new SparseTerms(mockCacheKey, mockReader, TEST_FIELD);
+        SparseTerms sparseTerms = new SparseTerms(cacheKey, mockReader, TEST_FIELD);
         assertNotNull(sparseTerms);
-        assertEquals(mockCacheKey, sparseTerms.getCacheKey());
+        assertEquals(cacheKey, sparseTerms.getCacheKey());
         // verify that sparseTerms.reader creates successfully by calling size
         assertEquals(1, sparseTerms.size());
     }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/common/ValueEncoderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/common/ValueEncoderTests.java
@@ -76,9 +76,7 @@ public class ValueEncoderTests extends AbstractSparseTestBase {
             int encoded = ValueEncoder.encodeFeatureValue(original);
             float decoded = ValueEncoder.decodeFeatureValue(encoded);
 
-            // Due to precision loss in encoding, we check that the relationship is maintained
-            assertTrue("Encoded value should be non-negative", encoded >= 0);
-            assertTrue("Decoded value should be non-negative", decoded >= 0.0f);
+            assertEquals(original, decoded, DELTA_FOR_ASSERTION);
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/sparse/data/DocumentClusterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/data/DocumentClusterTests.java
@@ -17,9 +17,9 @@ import java.util.Map;
 public class DocumentClusterTests extends AbstractSparseTestBase {
 
     public void testConstructor_withValidInputs_createsCluster() {
-        Map<String, Float> summaryMap = new HashMap<>();
-        summaryMap.put("1", 0.5f);
-        summaryMap.put("2", 0.8f);
+        Map<Integer, Float> summaryMap = new HashMap<>();
+        summaryMap.put(1, 0.5f);
+        summaryMap.put(2, 0.8f);
         SparseVector summary = new SparseVector(summaryMap);
         List<DocWeight> docs = Arrays.asList(new DocWeight(10, (byte) 2), new DocWeight(5, (byte) 1));
 
@@ -41,8 +41,8 @@ public class DocumentClusterTests extends AbstractSparseTestBase {
     }
 
     public void testConstructor_sortsDocumentsByDocId() {
-        Map<String, Float> summaryMap = new HashMap<>();
-        summaryMap.put("1", 1.0f);
+        Map<Integer, Float> summaryMap = new HashMap<>();
+        summaryMap.put(1, 1.0f);
         SparseVector summary = new SparseVector(summaryMap);
         List<DocWeight> docs = Arrays.asList(new DocWeight(10, (byte) 2), new DocWeight(5, (byte) 1), new DocWeight(15, (byte) 3));
 
@@ -120,9 +120,9 @@ public class DocumentClusterTests extends AbstractSparseTestBase {
     }
 
     public void testRamBytesUsed_withSummary_includesSummarySize() {
-        Map<String, Float> summaryMap = new HashMap<>();
-        summaryMap.put("1", 0.5f);
-        summaryMap.put("2", 0.8f);
+        Map<Integer, Float> summaryMap = new HashMap<>();
+        summaryMap.put(1, 0.5f);
+        summaryMap.put(2, 0.8f);
         SparseVector summary = new SparseVector(summaryMap);
         List<DocWeight> docs = Arrays.asList(new DocWeight(1, (byte) 1));
 
@@ -140,8 +140,8 @@ public class DocumentClusterTests extends AbstractSparseTestBase {
     }
 
     public void testGetChildResources_withSummary_returnsSummary() {
-        Map<String, Float> summaryMap = new HashMap<>();
-        summaryMap.put("1", 1.0f);
+        Map<Integer, Float> summaryMap = new HashMap<>();
+        summaryMap.put(1, 1.0f);
         SparseVector summary = new SparseVector(summaryMap);
         List<DocWeight> docs = Arrays.asList(new DocWeight(1, (byte) 1));
 
@@ -152,8 +152,8 @@ public class DocumentClusterTests extends AbstractSparseTestBase {
     }
 
     public void testEquals_withSameValues_returnsTrue() {
-        Map<String, Float> summaryMap = new HashMap<>();
-        summaryMap.put("1", 1.0f);
+        Map<Integer, Float> summaryMap = new HashMap<>();
+        summaryMap.put(1, 1.0f);
         SparseVector summary = new SparseVector(summaryMap);
         List<DocWeight> docs = Arrays.asList(new DocWeight(1, (byte) 1));
 
@@ -164,8 +164,8 @@ public class DocumentClusterTests extends AbstractSparseTestBase {
     }
 
     public void testEquals_withDifferentShouldNotSkip_returnsFalse() {
-        Map<String, Float> summaryMap = new HashMap<>();
-        summaryMap.put("1", 1.0f);
+        Map<Integer, Float> summaryMap = new HashMap<>();
+        summaryMap.put(1, 1.0f);
         SparseVector summary = new SparseVector(summaryMap);
         List<DocWeight> docs = Arrays.asList(new DocWeight(1, (byte) 1));
 
@@ -176,8 +176,8 @@ public class DocumentClusterTests extends AbstractSparseTestBase {
     }
 
     public void testHashCode_withSameValues_returnsSameHashCode() {
-        Map<String, Float> summaryMap = new HashMap<>();
-        summaryMap.put("1", 1.0f);
+        Map<Integer, Float> summaryMap = new HashMap<>();
+        summaryMap.put(1, 1.0f);
         SparseVector summary = new SparseVector(summaryMap);
         List<DocWeight> docs = Arrays.asList(new DocWeight(1, (byte) 1));
 
@@ -188,12 +188,12 @@ public class DocumentClusterTests extends AbstractSparseTestBase {
     }
 
     public void testSetSummary_updatesCorrectly() {
-        Map<String, Float> originalSummaryMap = new HashMap<>();
-        originalSummaryMap.put("1", 1.0f);
+        Map<Integer, Float> originalSummaryMap = new HashMap<>();
+        originalSummaryMap.put(1, 1.0f);
         SparseVector originalSummary = new SparseVector(originalSummaryMap);
 
-        Map<String, Float> newSummaryMap = new HashMap<>();
-        newSummaryMap.put("2", 2.0f);
+        Map<Integer, Float> newSummaryMap = new HashMap<>();
+        newSummaryMap.put(2, 2.0f);
         SparseVector newSummary = new SparseVector(newSummaryMap);
 
         List<DocWeight> docs = Arrays.asList(new DocWeight(1, (byte) 1));
@@ -205,8 +205,8 @@ public class DocumentClusterTests extends AbstractSparseTestBase {
     }
 
     public void testSetShouldNotSkip_updatesCorrectly() {
-        Map<String, Float> summaryMap = new HashMap<>();
-        summaryMap.put("1", 1.0f);
+        Map<Integer, Float> summaryMap = new HashMap<>();
+        summaryMap.put(1, 1.0f);
         SparseVector summary = new SparseVector(summaryMap);
         List<DocWeight> docs = Arrays.asList(new DocWeight(1, (byte) 1));
 

--- a/src/test/java/org/opensearch/neuralsearch/sparse/data/SparseVectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/data/SparseVectorTests.java
@@ -13,7 +13,6 @@ import org.opensearch.neuralsearch.sparse.quantization.ByteQuantizer;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -56,10 +55,10 @@ public class SparseVectorTests extends AbstractSparseTestBase {
 
     public void testConstructorWithMap() {
         // Create map
-        Map<String, Float> map = new HashMap<>();
-        map.put("3", 0.1f);
-        map.put("1", 0.2f);
-        map.put("2", 0.3f);
+        Map<Integer, Float> map = new HashMap<>();
+        map.put(3, 0.1f);
+        map.put(1, 0.2f);
+        map.put(2, 0.3f);
 
         // Create sparse vector
         SparseVector vector = new SparseVector(map);
@@ -84,10 +83,10 @@ public class SparseVectorTests extends AbstractSparseTestBase {
 
     public void testConstructorWithBytesRef() throws IOException {
         // Create map and serialize to BytesRef
-        Map<String, Float> map = new HashMap<>();
-        map.put("3", 0.1f);
-        map.put("1", 0.2f);
-        map.put("2", 0.3f);
+        Map<Integer, Float> map = new HashMap<>();
+        map.put(3, 0.1f);
+        map.put(1, 0.2f);
+        map.put(2, 0.3f);
 
         BytesRef bytesRef = serializeMap(map);
 
@@ -307,14 +306,12 @@ public class SparseVectorTests extends AbstractSparseTestBase {
         Assert.assertNotEquals(vector1, vector3);
     }
 
-    private BytesRef serializeMap(Map<String, Float> map) throws IOException {
+    private BytesRef serializeMap(Map<Integer, Float> map) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
 
-        for (Map.Entry<String, Float> entry : map.entrySet()) {
-            byte[] keyBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
-            dos.writeInt(keyBytes.length);
-            dos.write(keyBytes);
+        for (Map.Entry<Integer, Float> entry : map.entrySet()) {
+            dos.writeInt(entry.getKey());
             dos.writeFloat(entry.getValue());
         }
 

--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldMapperTests.java
@@ -286,7 +286,7 @@ public class SparseTokensFieldMapperTests extends AbstractSparseTestBase {
         when(parser.nextToken()).thenReturn(XContentParser.Token.FIELD_NAME)
             .thenReturn(valueToken)
             .thenReturn(XContentParser.Token.END_OBJECT);
-        when(parser.currentName()).thenReturn("feature1");
+        when(parser.currentName()).thenReturn("1");
         when(parser.floatValue(true)).thenReturn(0.5f);
         when(doc.getByKey(any())).thenReturn(null);
 

--- a/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/mapper/SparseTokensFieldTests.java
@@ -44,4 +44,12 @@ public class SparseTokensFieldTests extends AbstractSparseTestBase {
         assertFalse("Should return false for null field", SparseTokensField.isSparseField(null));
     }
 
+    public void testIsSparseFieldWithFalseResult() {
+        FieldInfo mockField = TestsPrepareUtils.prepareKeyFieldInfo();
+        mockField.putAttribute(SPARSE_FIELD, "false");
+
+        boolean result = SparseTokensField.isSparseField(mockField);
+
+        assertFalse("Should return false for field with false attribute", result);
+    }
 }


### PR DESCRIPTION
### Description
This PR contains:
1. Codec of Seismic
    1. PostingsFormat for consuming and producing terms and postings (inverted index)
    2. DocValuesFormat for consuming and producing binary doc values (forward index)
2. Lucene reader/writer for seismis's special posting format (with clusters)
3. Segment merge logic 
4. Update SparseVector to consume int value

#### Notes:
1. ~~This PR contains changes in #1528 , will rebase after it's merged~~
2. The logic to wire this codec to plugin's codec interface will be submitted later.
3. This PR doesn't mock static.
4. Skip change-log

Here are our plan for submitting PRs:
- [x] Basic classes
- [x] Clustering algorithms & field mapper
- [x] **Codec**
- [ ] Query
- [x] Cache
- [ ] BWCs
- [ ] Interfaces

**We target version 3.3 release.**

### Related Issues
RFC: #1335 
Design: #1390 