### PR TITLE
Fix jdt formatter

### DIFF
--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -7,7 +7,7 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/eclipse/updates/4.29/", "https://ftp.osuosl.org/pub/eclipse/eclipse/updates/4.29/")).configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
```
[Incubating] Problems report is available at: file:///__w/neural-search/neural-search/build/reports/problems/problems-report.html
* What went wrong:
A problem occurred configuring root project 'neural-search'.
> java.io.IOException: Failed to load eclipse jdt formatter: java.lang.RuntimeException: java.net.SocketTimeoutException: Connect timed out

* Try:
> Run with --stacktrace option to get the stack trace.

```
Ref: https://github.com/diffplug/spotless/blob/main/plugin-gradle/README.md#eclipse-jdt

GHA: https://github.com/opensearch-project/neural-search/actions/runs/17371071362/job/49306787336?pr=1539

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
