### PR TITLE
[Agentic Search] Adds validation and logging for agentic query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Semantic Field] Support the sparse two phase processor for the semantic field.
 - [Stats] Add stats for agentic query and agentic query translator processor.
+- [Agentic Search] Adds validation for agentic query
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Semantic Field] Support the sparse two phase processor for the semantic field.
 - [Stats] Add stats for agentic query and agentic query translator processor.
-- [Agentic Search] Adds validation for agentic query
+- [Agentic Search] Adds validations and logging for agentic query
 
 ### Bug Fixes
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
@@ -86,7 +86,6 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
                 agentId,
                 agenticQuery.getQueryText()
             );
-            log.warn(errorMessage);
             requestListener.onFailure(new IllegalArgumentException(errorMessage));
             return;
         }
@@ -138,7 +137,6 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
                         agentId,
                         agenticQuery.getQueryText()
                     );
-                    log.error(errorMessage);
                     throw new IllegalArgumentException(errorMessage);
                 }
 
@@ -151,7 +149,6 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
                         agenticQuery.getQueryText(),
                         MAX_AGENT_RESPONSE_SIZE
                     );
-                    log.error(errorMessage);
                     throw new IllegalArgumentException(errorMessage);
                 }
 
@@ -171,7 +168,6 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
                     agenticQuery.getQueryText(),
                     e.getMessage()
                 );
-                log.error(errorMessage);
                 requestListener.onFailure(new IOException(errorMessage, e));
             }
         }, e -> {
@@ -182,7 +178,6 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
                 agenticQuery.getQueryText(),
                 e.getMessage()
             );
-            log.error(errorMessage);
             requestListener.onFailure(new RuntimeException(errorMessage, e));
         }));
     }

--- a/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
@@ -77,9 +77,6 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
 
         AgenticSearchQueryBuilder agenticQuery = (AgenticSearchQueryBuilder) query;
 
-        // Agentic search request initiated
-        log.info("Agentic search request initiated - Agent ID: [{}], Query: [{}]", agentId, agenticQuery.getQueryText());
-
         // Validate that agentic query is used alone without other search features
         if (hasOtherSearchFeatures(sourceBuilder)) {
             log.warn(
@@ -163,7 +160,6 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
                     request.source(newSourceBuilder);
                 }
 
-                log.info("Agentic search completed successfully - Agent ID: [{}], Query: [{}]", agentId, agenticQuery.getQueryText());
                 requestListener.onResponse(request);
             } catch (IOException e) {
                 log.error(

--- a/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
@@ -127,7 +127,7 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
 
         mlClient.executeAgent(agentId, parameters, ActionListener.wrap(agentResponse -> {
             try {
-                log.info("Generated Query: [{}]", agentResponse);
+                log.debug("Generated Query: [{}]", agentResponse);
 
                 // Validate response size to prevent memory exhaustion
                 if (agentResponse == null) {
@@ -163,9 +163,8 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
             } catch (IOException e) {
                 String errorMessage = String.format(
                     Locale.ROOT,
-                    "Agentic search failed - Parse error - Agent ID: [%s], Query: [%s], Error: [%s]",
+                    "Agentic search failed - Parse error - Agent ID: [%s], Error: [%s]",
                     agentId,
-                    agenticQuery.getQueryText(),
                     e.getMessage()
                 );
                 requestListener.onFailure(new IOException(errorMessage, e));

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridSubQueryScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridSubQueryScorer.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.query;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.apache.lucene.search.Scorable;
 
 import java.io.IOException;
@@ -13,6 +14,7 @@ import java.util.Arrays;
 /**
  * Scorer implementation for Hybrid Query. This object is light and expected to be re-used between different doc ids
  */
+@EqualsAndHashCode(callSuper = true)
 @Data
 public class HybridSubQueryScorer extends Scorable {
     // array of scores from all sub-queries for a single doc id

--- a/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorTests.java
@@ -160,7 +160,9 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
         processor.processRequestAsync(request, mockContext, listener);
 
         verify(mockMLClient).executeAgent(eq(AGENT_ID), any(Map.class), any(ActionListener.class));
-        verify(listener).onFailure(any(RuntimeException.class));
+        ArgumentCaptor<RuntimeException> exceptionCaptor = ArgumentCaptor.forClass(RuntimeException.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("Agentic search failed - Agent execution error"));
     }
 
     public void testProcessRequestAsync_withAgenticQuery_parseFailure() {
@@ -182,7 +184,9 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
         processor.processRequestAsync(request, mockContext, listener);
 
         verify(mockMLClient).executeAgent(eq(AGENT_ID), any(Map.class), any(ActionListener.class));
-        verify(listener).onFailure(any(IOException.class));
+        ArgumentCaptor<IOException> exceptionCaptor = ArgumentCaptor.forClass(IOException.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("Agentic search failed - Parse error"));
     }
 
     public void testProcessRequest_throwsException() {
@@ -264,10 +268,7 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
 
         ArgumentCaptor<IllegalArgumentException> exceptionCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         verify(listener).onFailure(exceptionCaptor.capture());
-        assertEquals(
-            "Agentic search cannot be used with other search features like aggregations, sort, highlighters, etc.",
-            exceptionCaptor.getValue().getMessage()
-        );
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("Agentic search blocked - Invalid usage with other search features"));
         verifyNoInteractions(mockMLClient);
     }
 
@@ -284,10 +285,7 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
 
         ArgumentCaptor<IllegalArgumentException> exceptionCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         verify(listener).onFailure(exceptionCaptor.capture());
-        assertEquals(
-            "Agentic search cannot be used with other search features like aggregations, sort, highlighters, etc.",
-            exceptionCaptor.getValue().getMessage()
-        );
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("Agentic search blocked - Invalid usage with other search features"));
         verifyNoInteractions(mockMLClient);
     }
 
@@ -393,9 +391,8 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
         ArgumentCaptor<RuntimeException> exceptionCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(listener).onFailure(exceptionCaptor.capture());
         RuntimeException exception = exceptionCaptor.getValue();
-        assertEquals("Failed to execute agentic search", exception.getMessage());
+        assertTrue(exception.getMessage().contains("Agentic search blocked - Response size exceeded limit"));
         assertTrue(exception.getCause() instanceof IllegalArgumentException);
-        assertTrue(exception.getCause().getMessage().contains("Agent response is too large"));
     }
 
     public void testProcessRequestAsync_withAgenticQuery_nullResponse() throws IOException {
@@ -417,8 +414,7 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
         ArgumentCaptor<RuntimeException> exceptionCaptor = ArgumentCaptor.forClass(RuntimeException.class);
         verify(listener).onFailure(exceptionCaptor.capture());
         RuntimeException exception = exceptionCaptor.getValue();
-        assertEquals("Failed to execute agentic search", exception.getMessage());
+        assertTrue(exception.getMessage().contains("Agentic search failed - Null response from agent"));
         assertTrue(exception.getCause() instanceof IllegalArgumentException);
-        assertTrue(exception.getCause().getMessage().contains("Agent response is null"));
     }
 }


### PR DESCRIPTION
### Description
Adds validation for agentic query
- Limit MAX_AGENT_RESPONSE_SIZE
-  Sanitized query text for prompt injection
-  Checked for empty agent response
-  Adds logging

### Related Issues
Part of https://github.com/opensearch-project/neural-search/issues/1525

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
