### PR TITLE
SEISMIC: ingestion

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -29,7 +29,7 @@ public class SparseIndexEventListener implements IndexEventListener {
     @Override
     /**
      * This function is used to remove data from cache when index is removed.
-     * The parameter reason is not used, because all kind os its enum will have to go through this cache removing procedure.
+     * The parameter reason is not used, because all kinds of its enum will have to go through this cache removing procedure.
      * @param indexService The index service for the removed index
      * @param reason The reason for the index removal
      */

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -27,6 +27,12 @@ import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldType;
 @Log4j2
 public class SparseIndexEventListener implements IndexEventListener {
     @Override
+    /**
+     * This function is used to remove data from cache when index is removed.
+     * The parameter reason is not used, because all kind os its enum will have to go through this cache removing procedure.
+     * @param indexService The index service for the removed index
+     * @param reason The reason for the index removal
+     */
     public void beforeIndexRemoved(IndexService indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason reason) {
         for (IndexShard shard : indexService) {
             try (MapperService mapperService = shard.mapperService()) {

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.sparse;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.opensearch.index.IndexService;
@@ -18,8 +19,14 @@ import org.opensearch.neuralsearch.sparse.cache.CacheKey;
 import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCache;
 import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldType;
 
+/**
+ * Event listener for sparse index operations that handles cache cleanup during index removal.
+ * Clears forward index and clustered posting caches for sparse token fields when indices are removed.
+ */
 @AllArgsConstructor
+@Log4j2
 public class SparseIndexEventListener implements IndexEventListener {
+    @Override
     public void beforeIndexRemoved(IndexService indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason reason) {
         for (IndexShard shard : indexService) {
             try (MapperService mapperService = shard.mapperService()) {
@@ -36,6 +43,7 @@ public class SparseIndexEventListener implements IndexEventListener {
                     }
                 }
             } catch (Exception e) {
+                log.error("An error occurred during remove index from cache", e);
                 throw new RuntimeException(e);
             }
         }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse;
+
+import lombok.AllArgsConstructor;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.shard.IndexEventListener;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.cluster.IndicesClusterStateService;
+import org.opensearch.neuralsearch.sparse.cache.ClusteredPostingCache;
+import org.opensearch.neuralsearch.sparse.cache.CacheKey;
+import org.opensearch.neuralsearch.sparse.cache.ForwardIndexCache;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldType;
+
+@AllArgsConstructor
+public class SparseIndexEventListener implements IndexEventListener {
+    public void beforeIndexRemoved(IndexService indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason reason) {
+        for (IndexShard shard : indexService) {
+            try (MapperService mapperService = shard.mapperService()) {
+                SegmentInfos segmentInfos = shard.getSegmentInfosSnapshot().get();
+                for (int i = 0; i < segmentInfos.size(); i++) {
+                    SegmentInfo segmentInfo = segmentInfos.info(i).info;
+                    for (MappedFieldType fieldType : mapperService.fieldTypes()) {
+                        if (fieldType instanceof SparseTokensFieldType) {
+                            String fieldName = fieldType.name();
+                            CacheKey key = new CacheKey(segmentInfo, fieldName);
+                            ForwardIndexCache.getInstance().onIndexRemoval(key);
+                            ClusteredPostingCache.getInstance().onIndexRemoval(key);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -1,0 +1,1 @@
+org.opensearch.neuralsearch.sparse.codec.SparseCodec

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -182,7 +182,7 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
 
     public void testGetSettings() {
         List<Setting<?>> settings = plugin.getSettings();
-        assertEquals(7, settings.size());
+        assertEquals(8, settings.size());
     }
 
     public void testRequestProcessors() {
@@ -221,7 +221,7 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
 
     public void testGetMappers_shouldReturnMappers() {
         final Map<String, Mapper.TypeParser> typeParserMap = plugin.getMappers();
-        assertEquals(1, typeParserMap.size());
+        assertEquals(2, typeParserMap.size());
         assertTrue(typeParserMap.get(SemanticFieldMapper.CONTENT_TYPE) instanceof SemanticFieldMapper.TypeParser);
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseBaseIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseBaseIT.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse;
+
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.Before;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.cluster.routing.Murmur3HashFunction;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+import org.opensearch.neuralsearch.plugin.NeuralSearch;
+import org.opensearch.neuralsearch.sparse.common.SparseConstants;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldMapper;
+import org.opensearch.neuralsearch.stats.metrics.MetricStatName;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Base Integration tests for seismic feature
+ */
+public abstract class SparseBaseIT extends BaseNeuralSearchIT {
+
+    protected static final String ALGO_NAME = SparseConstants.SEISMIC;
+    protected static final String SPARSE_MEMORY_USAGE_METRIC_NAME = MetricStatName.MEMORY_SPARSE_MEMORY_USAGE.getNameString();
+    protected static final String SPARSE_MEMORY_USAGE_METRIC_PATH = MetricStatName.MEMORY_SPARSE_MEMORY_USAGE.getFullPath();
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    protected void createSparseIndex(
+        String indexName,
+        String fieldName,
+        int nPostings,
+        float alpha,
+        float clusterRatio,
+        int approximateThreshold
+    ) throws IOException {
+        createSparseIndex(indexName, fieldName, nPostings, alpha, clusterRatio, approximateThreshold, 1, 0);
+    }
+
+    protected void createSparseIndex(
+        String indexName,
+        String fieldName,
+        int nPostings,
+        float alpha,
+        float clusterRatio,
+        int approximateThreshold,
+        int shards,
+        int replicas
+    ) throws IOException {
+        Request request = configureSparseIndex(
+            indexName,
+            fieldName,
+            nPostings,
+            alpha,
+            clusterRatio,
+            approximateThreshold,
+            shards,
+            replicas
+        );
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    private Request configureSparseIndex(
+        String indexName,
+        String fieldName,
+        int nPostings,
+        float alpha,
+        float clusterRatio,
+        int approximateThreshold,
+        int shards,
+        int replicas
+    ) throws IOException {
+        String indexSettings = prepareIndexSettings(shards, replicas);
+        String indexMappings = prepareIndexMapping(nPostings, alpha, clusterRatio, approximateThreshold, fieldName);
+        Request request = new Request("PUT", "/" + indexName);
+        String body = String.format(
+            Locale.ROOT,
+            "{\n" + "  \"settings\": %s,\n" + "  \"mappings\": %s\n" + "}",
+            indexSettings,
+            indexMappings
+        );
+        request.setJsonEntity(body);
+        return request;
+    }
+
+    protected String convertTokensToText(Map<String, Float> tokens) {
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, Float> entry : tokens.entrySet()) {
+            if (!first) {
+                builder.append(",");
+            }
+            builder.append("\"");
+            builder.append(entry.getKey());
+            builder.append("\": ");
+            builder.append(entry.getValue());
+            first = false;
+        }
+        return builder.toString();
+    }
+
+    protected String prepareIndexSettings() throws IOException {
+        return prepareIndexSettings(1, 0);
+    }
+
+    protected String prepareIndexSettings(int shards, int replicas) throws IOException {
+        XContentBuilder settingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("index")
+            .field("number_of_routing_shards", shards) // Shard routing setting
+            .field("sparse", true)
+            .field("number_of_shards", shards)
+            .field("number_of_replicas", replicas)
+            .endObject()
+            .endObject();
+        return settingBuilder.toString();
+    }
+
+    protected void forceMerge(String indexName) throws IOException, ParseException {
+        Request request = new Request("POST", "/" + indexName + "/_forcemerge?max_num_segments=1");
+        Response response = client().performRequest(request);
+        String str = EntityUtils.toString(response.getEntity());
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    protected String prepareIndexMapping(int nPostings, float alpha, float clusterRatio, int approximateThreshold, String sparseFieldName)
+        throws IOException {
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(sparseFieldName)
+            .field("type", SparseTokensFieldMapper.CONTENT_TYPE)
+            .startObject("method")
+            .field("name", ALGO_NAME) // Integer: length of posting list
+            .startObject("parameters")
+            .field("n_postings", nPostings) // Integer: length of posting list
+            .field("summary_prune_ratio", alpha) // Float
+            .field("cluster_ratio", clusterRatio) // Float: cluster ratio
+            .field("approximate_threshold", approximateThreshold)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        return mappingBuilder.toString();
+    }
+
+    @SneakyThrows
+    protected void prepareMultiShardReplicasIndex(String TEST_INDEX_NAME, String TEST_SPARSE_FIELD_NAME, String TEST_TEXT_FIELD_NAME) {
+        int shards = 3;
+        int docCount = 100;
+        // effective number of replica is capped by the number of OpenSearch nodes minus 1
+        int replicas = Math.min(3, getNodeCount() - 1);
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 100, 0.4f, 0.1f, docCount, shards, replicas);
+        // Verify index exists
+        assertTrue(indexExists(TEST_INDEX_NAME));
+        // Ingest documents
+        List<Map<String, Float>> docs = new ArrayList<>();
+        for (int i = 0; i < docCount; ++i) {
+            Map<String, Float> tokens = new HashMap<>();
+            tokens.put("1000", randomFloat());
+            tokens.put("2000", randomFloat());
+            tokens.put("3000", randomFloat());
+            tokens.put("4000", randomFloat());
+            tokens.put("5000", randomFloat());
+            docs.add(tokens);
+        }
+
+        List<String> routingIds = generateUniqueRoutingIds(shards);
+        for (int i = 0; i < shards; ++i) {
+            ingestDocuments(
+                TEST_INDEX_NAME,
+                TEST_TEXT_FIELD_NAME,
+                TEST_SPARSE_FIELD_NAME,
+                docs,
+                Collections.emptyList(),
+                i * docCount + 1,
+                routingIds.get(i)
+            );
+        }
+
+        forceMerge(TEST_INDEX_NAME);
+        // wait until force merge complete
+        waitForSegmentMerge(TEST_INDEX_NAME, shards, replicas);
+        assertEquals(shards * (replicas + 1), getSegmentCount(TEST_INDEX_NAME));
+    }
+
+    @SneakyThrows
+    protected void prepareMixSeismicRankFeaturesIndex(String TEST_INDEX_NAME, String TEST_SPARSE_FIELD_NAME, String TEST_TEXT_FIELD_NAME) {
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 4, 0.4f, 0.5f, 4);
+
+        ingestDocuments(
+            TEST_INDEX_NAME,
+            TEST_TEXT_FIELD_NAME,
+            TEST_SPARSE_FIELD_NAME,
+            List.of(Map.of("1000", 0.1f, "2000", 0.1f), Map.of("1000", 0.2f, "2000", 0.2f), Map.of("1000", 0.3f, "2000", 0.3f)),
+            null,
+            1
+        );
+        ingestDocuments(
+            TEST_INDEX_NAME,
+            TEST_TEXT_FIELD_NAME,
+            TEST_SPARSE_FIELD_NAME,
+            List.of(
+                Map.of("1000", 0.4f, "2000", 0.4f),
+                Map.of("1000", 0.5f, "2000", 0.5f),
+                Map.of("1000", 0.6f, "2000", 0.6f),
+                Map.of("1000", 0.7f, "2000", 0.7f),
+                Map.of("1000", 0.8f, "2000", 0.8f)
+            ),
+            null,
+            4
+        );
+    }
+
+    @SneakyThrows
+    protected void prepareOnlyRankFeaturesIndex(String TEST_INDEX_NAME, String TEST_SPARSE_FIELD_NAME, String TEST_TEXT_FIELD_NAME) {
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 4, 0.4f, 0.5f, 4);
+
+        ingestDocumentsAndForceMerge(
+            TEST_INDEX_NAME,
+            TEST_TEXT_FIELD_NAME,
+            TEST_SPARSE_FIELD_NAME,
+            List.of(Map.of("1000", 0.1f, "2000", 0.1f), Map.of("1000", 0.2f, "2000", 0.2f), Map.of("1000", 0.3f, "2000", 0.3f))
+        );
+    }
+
+    protected void waitForSegmentMerge(String index) throws InterruptedException {
+        waitForSegmentMerge(index, 1, 0);
+    }
+
+    protected void waitForSegmentMerge(String index, int shards, int replicas) throws InterruptedException {
+        int maxRetry = 30;
+        for (int i = 0; i < maxRetry; ++i) {
+            if (shards * (1 + replicas) == getSegmentCount(index)) {
+                return;
+            }
+            Thread.sleep(1000);
+        }
+    }
+
+    protected int getSegmentCount(String index) {
+        Request request = new Request("GET", "/_cat/segments/" + index);
+        try {
+            Response response = client().performRequest(request);
+            String str = EntityUtils.toString(response.getEntity());
+            String[] lines = str.split("\n");
+            return lines.length;
+        } catch (IOException | ParseException e) {
+            return 0;
+        }
+    }
+
+    protected int getNodeCount() {
+        Request request = new Request("GET", "/_cat/nodes/");
+        try {
+            Response response = client().performRequest(request);
+            String str = EntityUtils.toString(response.getEntity());
+            String[] lines = str.split("\n");
+            return lines.length;
+        } catch (IOException | ParseException e) {
+            return 0;
+        }
+    }
+
+    @SneakyThrows
+    protected void ingestDocumentsAndForceMerge(String index, String textField, String sparseField, List<Map<String, Float>> docTokens) {
+        ingestDocumentsAndForceMerge(index, textField, sparseField, docTokens, null);
+    }
+
+    @SneakyThrows
+    protected void ingestDocumentsAndForceMerge(
+        String index,
+        String textField,
+        String sparseField,
+        List<Map<String, Float>> docTokens,
+        List<String> docTexts
+    ) {
+        ingestDocuments(index, textField, sparseField, docTokens, docTexts, 1);
+
+        forceMerge(index);
+        // wait until force merge complete
+        waitForSegmentMerge(index);
+        assertEquals(1, getSegmentCount(index));
+    }
+
+    protected void ingestDocuments(
+        String index,
+        String textField,
+        String sparseField,
+        List<Map<String, Float>> docTokens,
+        List<String> text,
+        int startingId
+    ) {
+        ingestDocuments(index, textField, sparseField, docTokens, text, startingId, null);
+    }
+
+    protected String prepareSparseBulkIngestPayload(
+        String index,
+        String textField,
+        String sparseField,
+        List<Map<String, Float>> docTokens,
+        List<String> docTexts,
+        int startingId
+    ) {
+        StringBuilder payloadBuilder = new StringBuilder();
+        int size = (StringUtils.isEmpty(sparseField) && docTokens.isEmpty()) ? docTexts.size() : docTokens.size();
+        for (int i = 0; i < size; i++) {
+            payloadBuilder.append(
+                String.format(Locale.ROOT, "{ \"index\": { \"_index\": \"%s\", \"_id\": \"%d\"} }", index, startingId + i)
+            );
+            payloadBuilder.append(System.lineSeparator());
+            String text = CollectionUtils.isEmpty(docTexts) ? "text" : docTexts.get(i);
+            if (StringUtils.isEmpty(sparseField)) {
+                payloadBuilder.append(String.format(Locale.ROOT, "{\"%s\": \"%s\"}", textField, text));
+            } else {
+                Map<String, Float> docToken = docTokens.get(i);
+                String strTokens = convertTokensToText(docToken);
+                payloadBuilder.append(
+                    String.format(Locale.ROOT, "{\"%s\": \"%s\", \"%s\": {%s}}", textField, text, sparseField, strTokens)
+                );
+            }
+            payloadBuilder.append(System.lineSeparator());
+        }
+        return payloadBuilder.toString();
+    }
+
+    protected void ingestDocuments(
+        String index,
+        String textField,
+        String sparseField,
+        List<Map<String, Float>> docTokens,
+        List<String> docTexts,
+        int startingId,
+        String routing
+    ) {
+        String payload = prepareSparseBulkIngestPayload(index, textField, sparseField, docTokens, docTexts, startingId);
+        bulkIngest(payload, null, routing);
+    }
+
+    /**
+     * Iterate from number 0 to 10000 and find num routing ids which can result in different shard id.
+     *
+     * @param num number of routing ids, should be <= shard number.
+     * @return a list of routing ids
+     */
+    protected List<String> generateUniqueRoutingIds(int num) {
+        List<String> routingIds = new ArrayList<>();
+        Set<Integer> uniqueShardIds = new HashSet<>();
+        for (int i = 0; i < 10000; ++i) {
+            String candidate = String.valueOf(i);
+            int hash = Murmur3HashFunction.hash(candidate);
+            int shardId = Math.floorMod(hash, num);
+            if (uniqueShardIds.contains(shardId)) {
+                continue;
+            }
+            uniqueShardIds.add(shardId);
+            routingIds.add(candidate);
+            if (routingIds.size() == num) {
+                break;
+            }
+        }
+        return routingIds;
+    }
+
+    @SneakyThrows
+    protected long[] getSparseMemoryUsageStatsAcrossNodes() {
+        Request request = new Request("GET", NeuralSearch.NEURAL_BASE_URI + "/stats/" + SPARSE_MEMORY_USAGE_METRIC_NAME);
+
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<Map<String, Object>> nodeStatsResponseList = parseNodeStatsResponse(responseBody);
+
+        List<Long> sparseMemoryUsageStats = new ArrayList<>();
+        for (Map<String, Object> nodeStatsResponse : nodeStatsResponseList) {
+            // we do not use breakers.neural_search.estimated_size_in_bytes due to precision limitation by memory stats
+            String stringValue = getNestedValue(nodeStatsResponse, SPARSE_MEMORY_USAGE_METRIC_PATH).toString();
+            sparseMemoryUsageStats.add(parseFractionalSize(stringValue));
+        }
+        return sparseMemoryUsageStats.stream().mapToLong(Long::longValue).toArray();
+    }
+
+    protected static long parseFractionalSize(String value) {
+        value = value.trim().toLowerCase(Locale.ROOT);
+        double number;
+        long multiplier;
+
+        if (value.endsWith("kb")) {
+            number = Double.parseDouble(value.replace("kb", "").trim());
+            multiplier = 1024L;
+        } else if (value.endsWith("mb")) {
+            number = Double.parseDouble(value.replace("mb", "").trim());
+            multiplier = 1024L * 1024L;
+        } else if (value.endsWith("gb")) {
+            number = Double.parseDouble(value.replace("gb", "").trim());
+            multiplier = 1024L * 1024L * 1024L;
+        } else if (value.endsWith("b")) {
+            number = Double.parseDouble(value.replace("b", "").trim());
+            multiplier = 1L;
+        } else {
+            throw new IllegalArgumentException("Unknown size unit: " + value);
+        }
+
+        return Math.round(number * multiplier);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseBaseIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseBaseIT.java
@@ -272,16 +272,12 @@ public abstract class SparseBaseIT extends BaseNeuralSearchIT {
         }
     }
 
-    protected int getNodeCount() {
+    protected int getNodeCount() throws Exception {
         Request request = new Request("GET", "/_cat/nodes/");
-        try {
-            Response response = client().performRequest(request);
-            String str = EntityUtils.toString(response.getEntity());
-            String[] lines = str.split("\n");
-            return lines.length;
-        } catch (IOException | ParseException e) {
-            throw new RuntimeException(e);
-        }
+        Response response = client().performRequest(request);
+        String str = EntityUtils.toString(response.getEntity());
+        String[] lines = str.split("\n");
+        return lines.length;
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListenerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListenerTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.cluster.IndicesClusterStateService;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldType;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.opensearch.common.concurrent.GatedCloseable;
+
+public class SparseIndexEventListenerTests extends AbstractSparseTestBase {
+
+    private SparseIndexEventListener listener;
+
+    @Mock
+    private IndexService indexService;
+    @Mock
+    private IndexShard indexShard;
+    @Mock
+    private MapperService mapperService;
+    @Mock
+    private SegmentInfos segmentInfos;
+
+    @Before
+    @Override
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        listener = new SparseIndexEventListener();
+    }
+
+    public void testBeforeIndexRemoved_withSparseTokensField_clearsCache() throws IOException {
+        SegmentCommitInfo segmentCommitInfo = TestsPrepareUtils.prepareSegmentCommitInfo();
+        SparseTokensFieldType sparseFieldType = mock(SparseTokensFieldType.class);
+        when(sparseFieldType.name()).thenReturn("sparse_field");
+
+        GatedCloseable<SegmentInfos> gatedCloseable = mock(GatedCloseable.class);
+        when(gatedCloseable.get()).thenReturn(segmentInfos);
+
+        when(indexService.iterator()).thenReturn(Arrays.asList(indexShard).iterator());
+        when(indexShard.mapperService()).thenReturn(mapperService);
+        when(indexShard.getSegmentInfosSnapshot()).thenReturn(gatedCloseable);
+        when(segmentInfos.size()).thenReturn(1);
+        when(segmentInfos.info(0)).thenReturn(segmentCommitInfo);
+        when(mapperService.fieldTypes()).thenReturn(Arrays.asList(sparseFieldType));
+
+        listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED);
+
+        verify(mapperService).close();
+    }
+
+    public void testBeforeIndexRemoved_withNonSparseField_doesNotClearCache() throws IOException {
+        SegmentCommitInfo segmentCommitInfo = TestsPrepareUtils.prepareSegmentCommitInfo();
+        MappedFieldType regularFieldType = mock(MappedFieldType.class);
+        when(regularFieldType.name()).thenReturn("regular_field");
+
+        GatedCloseable<SegmentInfos> gatedCloseable = mock(GatedCloseable.class);
+        when(gatedCloseable.get()).thenReturn(segmentInfos);
+
+        when(indexService.iterator()).thenReturn(Arrays.asList(indexShard).iterator());
+        when(indexShard.mapperService()).thenReturn(mapperService);
+        when(indexShard.getSegmentInfosSnapshot()).thenReturn(gatedCloseable);
+        when(segmentInfos.size()).thenReturn(1);
+        when(segmentInfos.info(0)).thenReturn(segmentCommitInfo);
+        when(mapperService.fieldTypes()).thenReturn(Arrays.asList(regularFieldType));
+
+        listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED);
+
+        verify(mapperService).close();
+    }
+
+    public void testBeforeIndexRemoved_withEmptySegments_handlesGracefully() throws IOException {
+        GatedCloseable<SegmentInfos> gatedCloseable = mock(GatedCloseable.class);
+        when(gatedCloseable.get()).thenReturn(segmentInfos);
+
+        when(indexService.iterator()).thenReturn(Arrays.asList(indexShard).iterator());
+        when(indexShard.mapperService()).thenReturn(mapperService);
+        when(indexShard.getSegmentInfosSnapshot()).thenReturn(gatedCloseable);
+        when(segmentInfos.size()).thenReturn(0);
+
+        listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED);
+
+        verify(mapperService).close();
+    }
+
+    public void testBeforeIndexRemoved_withException_throwsRuntimeException() {
+        when(indexService.iterator()).thenReturn(Arrays.asList(indexShard).iterator());
+        when(indexShard.mapperService()).thenThrow(new RuntimeException("Test exception"));
+
+        RuntimeException exception = expectThrows(RuntimeException.class, () ->
+            listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED)
+        );
+
+        assertEquals("java.lang.RuntimeException: Test exception", exception.getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListenerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListenerTests.java
@@ -109,6 +109,6 @@ public class SparseIndexEventListenerTests extends AbstractSparseTestBase {
             listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED)
         );
 
-        assertEquals("java.lang.RuntimeException: Test exception", exception.getMessage());
+        assertTrue(exception.getMessage().contains("Test exception"));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexingIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexingIT.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse;
+
+import org.junit.Before;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.neuralsearch.sparse.mapper.SparseTokensFieldMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Integration tests for sparse index feature
+ */
+public class SparseIndexingIT extends SparseBaseIT {
+
+    private static final String TEST_INDEX_NAME = "test-sparse-index";
+    private static final String NON_SPARSE_TEST_INDEX_NAME = TEST_INDEX_NAME + "_non_sparse";
+    private static final String INVALID_PARAM_TEST_INDEX_NAME = TEST_INDEX_NAME + "_invalid";
+    private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
+    private static final List<String> TEST_TOKENS = List.of("hello", "world", "test", "sparse", "index");
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    /**
+     * Test creating an index with sparse index setting enabled
+     */
+    public void testCreateSparseIndex() throws IOException {
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 100, 0.4f, 0.1f, 8);
+
+        // Verify index exists
+        assertTrue(indexExists(TEST_INDEX_NAME));
+
+        // Verify index settings
+        Request getSettingsRequest = new Request("GET", "/" + TEST_INDEX_NAME + "/_settings");
+        Response getSettingsResponse = client().performRequest(getSettingsRequest);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(getSettingsResponse.getStatusLine().getStatusCode()));
+
+        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), getSettingsResponse.getEntity().getContent()).map();
+
+        Map<String, Object> indexMap = (Map<String, Object>) responseMap.get(TEST_INDEX_NAME);
+        Map<String, Object> settingsMap = (Map<String, Object>) indexMap.get("settings");
+        Map<String, Object> indexSettingsMap = (Map<String, Object>) settingsMap.get("index");
+
+        assertEquals("true", indexSettingsMap.get("sparse"));
+    }
+
+    /**
+     * Test creating an index with sparse index setting disabled (default)
+     */
+    public void testCreateNonSparseIndex() throws IOException {
+        // Create index without sparse index setting (default is false)
+        Settings indexSettings = Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build();
+        String indexMappings = prepareIndexMapping(100, 0.4f, 0.1f, 8, TEST_SPARSE_FIELD_NAME);
+
+        Request request = new Request("PUT", "/" + NON_SPARSE_TEST_INDEX_NAME);
+        String body = String.format(
+            Locale.ROOT,
+            "{\n" + "  \"settings\": %s,\n" + "  \"mappings\": %s\n" + "}",
+            indexSettings,
+            indexMappings
+        );
+        request.setJsonEntity(body);
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        // Verify index exists
+        assertTrue(indexExists(NON_SPARSE_TEST_INDEX_NAME));
+
+        // Verify index settings
+        Request getSettingsRequest = new Request("GET", "/" + NON_SPARSE_TEST_INDEX_NAME + "/_settings");
+        Response getSettingsResponse = client().performRequest(getSettingsRequest);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(getSettingsResponse.getStatusLine().getStatusCode()));
+
+        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), getSettingsResponse.getEntity().getContent()).map();
+
+        Map<String, Object> indexMap = (Map<String, Object>) responseMap.get(NON_SPARSE_TEST_INDEX_NAME);
+        Map<String, Object> settingsMap = (Map<String, Object>) indexMap.get("settings");
+        Map<String, Object> indexSettingsMap = (Map<String, Object>) settingsMap.get("index");
+
+        // Sparse setting should not be present (default is false)
+        assertFalse(indexSettingsMap.containsKey("sparse"));
+    }
+
+    /**
+     * Test that sparse index setting cannot be updated after index creation (it's a final setting)
+     */
+    public void testCannotUpdateSparseIndexSetting() throws IOException {
+        // Create index without sparse index setting (default is false)
+        testCreateNonSparseIndex();
+
+        // Try to update the sparse index setting (should fail because it's final)
+        Request updateSettingsRequest = new Request("PUT", "/" + NON_SPARSE_TEST_INDEX_NAME + "/_settings");
+        updateSettingsRequest.setJsonEntity("{\n" + "  \"index\": {\n" + "    \"sparse\": true\n" + "  }\n" + "}");
+
+        // This should throw an exception because sparse is a final setting
+        expectThrows(IOException.class, () -> { client().performRequest(updateSettingsRequest); });
+    }
+
+    /**
+     * Test error handling when creating a sparse tokens field with invalid parameters
+     */
+    public void testSparseTokensFieldWithInvalidParameters() throws IOException {
+        expectThrows(
+            IOException.class,
+            () -> { createSparseIndex(INVALID_PARAM_TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, -1, 0.4f, 0.1f, 8); }
+        );
+    }
+
+    public void testSparseTokensFieldWithInvalidParameters2() throws IOException {
+        expectThrows(
+            IOException.class,
+            () -> { createSparseIndex(INVALID_PARAM_TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 100, -0.4f, 0.1f, 8); }
+        );
+    }
+
+    public void testSparseTokensFieldWithInvalidParameters3() throws IOException {
+        expectThrows(
+            IOException.class,
+            () -> { createSparseIndex(INVALID_PARAM_TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 100, 0.4f, -0.1f, 8); }
+        );
+    }
+
+    public void testSparseTokensFieldWithInvalidParameters4() throws IOException {
+        expectThrows(
+            IOException.class,
+            () -> { createSparseIndex(INVALID_PARAM_TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 100, 0.4f, 0.1f, -8); }
+        );
+    }
+
+    /**
+     * Test creating sparse tokens field with different method parameters
+     */
+    public void testSparseTokensFieldWithAdditionParameters() throws IOException {
+        // Create index with sparse index setting enabled
+        String indexSettings = prepareIndexSettings();
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(TEST_SPARSE_FIELD_NAME)
+            .field("type", SparseTokensFieldMapper.CONTENT_TYPE)
+            .startObject("method")
+            .field("name", ALGO_NAME) // Integer: length of posting list
+            .startObject("parameters")
+            .field("n_postings", 100) // Integer: length of posting list
+            .field("summary_prune_ratio", 0.1f) // Float
+            .field("cluster_ratio", 0.1f) // Float: cluster ratio
+            .field("approximate_threshold", 8)
+            .field("additional_parameter", 8)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String indexName = TEST_INDEX_NAME + "_method_params";
+        Request request = new Request("PUT", "/" + indexName);
+        String body = String.format(
+            Locale.ROOT,
+            "{\n" + "  \"settings\": %s,\n" + "  \"mappings\": %s\n" + "}",
+            indexSettings,
+            mappingBuilder.toString()
+        );
+        request.setJsonEntity(body);
+        expectThrows(IOException.class, () -> client().performRequest(request));
+    }
+
+    private List<String> getDocIDs(Map<String, Object> searchResults) {
+        Map<String, Object> hits1map = (Map<String, Object>) searchResults.get("hits");
+        List<String> actualIds = new ArrayList<>();
+        List<Object> hits1List = (List<Object>) hits1map.get("hits");
+        for (Object hits1Object : hits1List) {
+            Map<String, Object> mapObject = (Map<String, Object>) hits1Object;
+            String id = mapObject.get("_id").toString();
+            actualIds.add(id);
+        }
+        return actualIds;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexingIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexingIT.java
@@ -29,7 +29,6 @@ public class SparseIndexingIT extends SparseBaseIT {
     private static final String NON_SPARSE_TEST_INDEX_NAME = TEST_INDEX_NAME + "_non_sparse";
     private static final String INVALID_PARAM_TEST_INDEX_NAME = TEST_INDEX_NAME + "_invalid";
     private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
-    private static final List<String> TEST_TOKENS = List.of("hello", "world", "test", "sparse", "index");
 
     @Before
     public void setUp() throws Exception {
@@ -114,7 +113,7 @@ public class SparseIndexingIT extends SparseBaseIT {
     /**
      * Test error handling when creating a sparse tokens field with invalid parameters
      */
-    public void testSparseTokensFieldWithInvalidParameters() throws IOException {
+    public void testSparseTokensFieldWithInvalidParameters1() throws IOException {
         expectThrows(
             IOException.class,
             () -> { createSparseIndex(INVALID_PARAM_TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, -1, 0.4f, 0.1f, 8); }
@@ -154,10 +153,10 @@ public class SparseIndexingIT extends SparseBaseIT {
             .startObject(TEST_SPARSE_FIELD_NAME)
             .field("type", SparseTokensFieldMapper.CONTENT_TYPE)
             .startObject("method")
-            .field("name", ALGO_NAME) // Integer: length of posting list
+            .field("name", ALGO_NAME)
             .startObject("parameters")
             .field("n_postings", 100) // Integer: length of posting list
-            .field("summary_prune_ratio", 0.1f) // Float
+            .field("summary_prune_ratio", 0.1f) // Float: alpha-prune ration for summary
             .field("cluster_ratio", 0.1f) // Float: cluster ratio
             .field("approximate_threshold", 8)
             .field("additional_parameter", 8)

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1289,10 +1289,18 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
     @SneakyThrows
     protected void bulkIngest(final String ingestBulkPayload, final String pipeline) {
+        bulkIngest(ingestBulkPayload, pipeline, null);
+    }
+
+    @SneakyThrows
+    protected void bulkIngest(final String ingestBulkPayload, final String pipeline, final String routing) {
         Map<String, String> params = new HashMap<>();
         params.put("refresh", "true");
         if (Objects.nonNull(pipeline)) {
             params.put("pipeline", pipeline);
+        }
+        if (Objects.nonNull(routing)) {
+            params.put("routing", routing);
         }
         Response response = makeRequest(
             client(),


### PR DESCRIPTION
### Description
This PR includes features that enable ingesting SEISMIC data. With this PR, later our ITs can be smoothly merged into main branch.

Following is an example of how to ingest data with bulk:
```
POST _bulk
{ "create": { "_index": "example", "_id": "2" } }
{ "sparse_embedding": {token1: 0.123, token2: 0.456, ...} }
{ "create": { "_index": "example", "_id": "3" } }
{ "sparse_embedding": {token9: 0.789, token8: 0.321, ...}  }
```

Note:
There will be some unused functions in `SparseBaseIT`, which will benefit our ITs in the future.
1. prepareMultiShardReplicasIndex: `SparseMemoryStatsIT` and `NeuralSparseCacheOperationIT`
2. prepareMixSeismicRankFeaturesIndex: `NeuralSparseCacheOperationIT`
3. prepareOnlyRankFeaturesIndex: `SparseMemoryStatsIT` and `NeuralSparseCacheOperationIT`

Here are our plan for submitting PRs:

- [x] Basic classes
- [x] Clustering algorithms & field mapper
- [x]  Codec
- [x]  Query
- [x]  Cache
- [ ]  BWCs
- [ ]  **Interfaces**
We target version 3.3 release.

### Related Issues
RFC: #1335 
Design: #1390 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
