### PR TITLE
Fix CI build failure: Resolve error_prone_annotations dependency conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,7 +258,9 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ml-plugin', version: "${opensearch_build}"
     secureIntegTestPluginArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
     compileOnly fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
-    compileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
+    compileOnly (group: 'com.google.guava', name: 'guava', version:'32.1.3-jre') {
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
     api group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     compileOnly group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
@@ -285,7 +287,9 @@ dependencies {
     runtimeOnly("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
     testFixturesImplementation "org.opensearch:common-utils:${version}"
     testFixturesImplementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
-    testFixturesCompileOnly group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
+    testFixturesCompileOnly (group: 'com.google.guava', name: 'guava', version:'32.1.3-jre') {
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
     testFixturesImplementation fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
     testImplementation fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
     testImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"


### PR DESCRIPTION
  ### Description
  Fixes CI build failure caused by dependency version conflict between Guava and OpenSearch.

  ### Problem
  - Guava 32.1.3-jre brings error_prone_annotations:2.21.1
  - OpenSearch 3.3.0-SNAPSHOT requires error_prone_annotations:2.41.0
  - Conflict causes compileTestFixturesJava task to fail

  ### Solution
  Exclude error_prone_annotations from Guava dependencies to use OpenSearch's version.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
