### PR TITLE
Update lucene101 path & force errorprone version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,12 @@ allprojects {
         sourceCompatibility = targetCompatibility = JavaVersion.VERSION_21
     }
 
+    configurations.all {
+        resolutionStrategy {
+            force("com.google.errorprone:error_prone_annotations:2.21.1")
+        }
+    }
+
     afterEvaluate {
         project.dependencyLicenses.enabled = false
         project.thirdPartyAudit.enabled = false

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriter.java
@@ -11,7 +11,7 @@ import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PushPostingsWriterBase;
-import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
+import org.apache.lucene.backward_codecs.lucene101.Lucene101PostingsFormat;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.NumericDocValues;

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseCodec.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/SparseCodec.java
@@ -8,7 +8,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.PostingsFormat;
-import org.apache.lucene.codecs.lucene101.Lucene101Codec;
+import org.apache.lucene.backward_codecs.lucene101.Lucene101Codec;
 
 /**
  * SparseCodec is used to encode and decode sparse vector related data structures.

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/ClusteredPostingTermsWriterTests.java
@@ -10,7 +10,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.NormsProducer;
-import org.apache.lucene.codecs.lucene101.Lucene101PostingsFormat;
+import org.apache.lucene.backward_codecs.lucene101.Lucene101PostingsFormat;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;


### PR DESCRIPTION
### Description
- lucene101 codec's path has been changed and update it. 
- errorprone's version has conflict force it to 2.21.1 until other dependencies has solve the version conflict

```
Execution failed for task ':compileTestFixturesJava'.
> Could not resolve all files for configuration ':testFixturesCompileClasspath'.
   > Could not resolve com.google.errorprone:error_prone_annotations:2.21.1.
     Required by:
         root project : > com.google.guava:guava:32.1.3-jre
      > Conflict found for module 'com.google.errorprone:error_prone_annotations': between versions 2.41.0 and 2.21.1
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
