### PR TITLE
Adding Liyun Xiu(@chishui) as the maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @sean-zheng-amazon @model-collapse @zane-neo @vibrantvarun @zhichao-aws @yuye-aws @minalsha @bzhangam
+*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @sean-zheng-amazon @model-collapse @zane-neo @vibrantvarun @zhichao-aws @yuye-aws @minalsha @bzhangam @chishui

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,7 +22,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Yuye Zhu                | [yuye-aws](https://github.com/yuye-aws)                   | Amazon      |
 | Minal Shah              | [minalsha](https://github.com/minalsha)                   | Amazon      |
 | Bo Zhang                | [bzhangam](https://github.com/bzhangam)                   | Amazon      |
-
+| Liyun Xiu               | [chishui](https://github.com/chishui)                     | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Liyun has been working on batch inference and neural sparse project for 1.5 yrs. He has contributed following to the repo:

**Feature**:

Support batch ingestion in TextEmbeddingProcessor & SparseEncodingProcessor:
https://github.com/opensearch-project/neural-search/pull/744
 
**Neural Sparse Seismic Algorithm**

https://github.com/opensearch-project/neural-search/pull/1514 \
https://github.com/opensearch-project/neural-search/pull/1502
 
**Refactors**

https://github.com/opensearch-project/neural-search/pull/1522 \
https://github.com/opensearch-project/neural-search/pull/820
 
**Bug fixes**

https://github.com/opensearch-project/neural-search/pulls?q=is%3Apr+author%3Achishui+label%3A%22bug%22%2C%22flaky-test%22 \
https://github.com/opensearch-project/neural-search/pull/834
 
**Code Reviews**

https://github.com/opensearch-project/neural-search/pulls?q=is%3Apr+reviewed-by%3Achishui 
 
 

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
