### PR TITLE
[Agentic Search] Add stats for agentic processors

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
@@ -97,10 +97,12 @@ public enum InfoStatName implements StatName {
     /** Counts agentic query translator processors */
     AGENTIC_QUERY_TRANSLATOR_PROCESSORS(
         "agentic_query_translator_processors",
-        "processors.search",
+        "processors.search.agentic",
         InfoStatType.INFO_COUNTER,
         Version.V_3_2_0
-    ),;
+    ),
+    /** Counts agentic context processors */
+    AGENTIC_CONTEXT_PROCESSORS("agentic_context_processors", "processors.search.agentic", InfoStatType.INFO_COUNTER, Version.V_3_3_0);
 
     private final String nameString;
     private final String path;

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
@@ -8,6 +8,7 @@ import org.opensearch.neuralsearch.processor.NeuralQueryEnricherProcessor;
 import org.opensearch.neuralsearch.processor.NeuralSparseTwoPhaseProcessor;
 import org.opensearch.neuralsearch.processor.SparseEncodingProcessor;
 import org.opensearch.neuralsearch.processor.AgenticQueryTranslatorProcessor;
+import org.opensearch.neuralsearch.processor.AgenticContextResponseProcessor;
 import com.google.common.annotations.VisibleForTesting;
 import org.opensearch.neuralsearch.processor.NormalizationProcessor;
 import org.opensearch.neuralsearch.processor.RRFProcessor;
@@ -220,6 +221,7 @@ public class InfoStatsManager {
                         Map<String, Object> processorConfig = asMap(entry.getValue());
                         switch (processorType) {
                             case RerankProcessor.TYPE -> countRerankProcessorStats(stats, processorConfig);
+                            case AgenticContextResponseProcessor.TYPE -> increment(stats, InfoStatName.AGENTIC_CONTEXT_PROCESSORS);
                         }
                     }
                 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/AgenticContextResponseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/AgenticContextResponseProcessorTests.java
@@ -13,6 +13,7 @@ import org.opensearch.search.SearchExtBuilder;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.neuralsearch.util.TestUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,6 +26,12 @@ public class AgenticContextResponseProcessorTests extends OpenSearchTestCase {
 
     private static final String PROCESSOR_TAG = "test-tag";
     private static final String DESCRIPTION = "test-description";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        TestUtils.initializeEventStatsManager();
+    }
 
     public void testConstructor() {
         AgenticContextResponseProcessor processor = new AgenticContextResponseProcessor(PROCESSOR_TAG, DESCRIPTION, false, true, false);


### PR DESCRIPTION
### Description
```
"agentic": {
                    "agentic_context_processors": 2,
                    "agentic_query_translator_processors": 2
                },
```

### Related Issues
Part of https://github.com/opensearch-project/neural-search/issues/1525

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
