### PR TITLE
Support k-NN index for exact search in semantic text field

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticInfoFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticInfoFieldConstants.java
@@ -17,6 +17,7 @@ import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
 public class SemanticInfoFieldConstants {
     public static final String KNN_VECTOR_DIMENSION_FIELD_NAME = "dimension";
     public static final String KNN_VECTOR_DATA_TYPE_FIELD_NAME = "data_type";
+    public static final String KNN_VECTOR_INDEX_FIELD_NAME = "index";
     public static final String KNN_VECTOR_METHOD_FIELD_NAME = "method";
     public static final String KNN_VECTOR_METHOD_NAME_FIELD_NAME = "name";
     public static final String KNN_VECTOR_METHOD_DEFAULT_NAME = "hnsw";

--- a/src/test/resources/mappingtransformer/transformedMappingWithIndexField.json
+++ b/src/test/resources/mappingtransformer/transformedMappingWithIndexField.json
@@ -1,0 +1,77 @@
+{
+  "properties": {
+    "semantic_field_with_index": {
+      "dense_embedding_config": {
+        "index": true,
+        "method": {
+          "engine": "lucene",
+          "name": "hnsw"
+        }
+      },
+      "model_id": "textEmbeddingModelId",
+      "type": "semantic"
+    },
+    "semantic_field_with_index_semantic_info": {
+      "properties": {
+        "model": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "index": false
+            },
+            "id": {
+              "type": "text",
+              "index": false
+            },
+            "type": {
+              "type": "text",
+              "index": false
+            }
+          }
+        },
+        "embedding": {
+          "method": {
+            "name": "hnsw",
+            "engine": "lucene",
+            "space_type": "l2"
+          },
+          "index": true,
+          "type": "knn_vector",
+          "dimension": 768
+        }
+      }
+    },
+    "semantic_field_no_index_semantic_info": {
+      "properties": {
+        "model": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "index": false
+            },
+            "id": {
+              "type": "text",
+              "index": false
+            },
+            "type": {
+              "type": "text",
+              "index": false
+            }
+          }
+        },
+        "embedding": {
+          "index": false,
+          "type": "knn_vector",
+          "dimension": 768
+        }
+      }
+    },
+    "semantic_field_no_index": {
+      "dense_embedding_config": {
+        "index": false
+      },
+      "model_id": "textEmbeddingModelId2",
+      "type": "semantic"
+    }
+  }
+}


### PR DESCRIPTION
### Description
If a user has multiple vector fields in a KNN index currently, and wants to perform exact search on certain fields, this k-NN index will allow users to not create graphs on those fields and can do exact search and approximate search at the same time. 
This PR will support the kNN exact search index to semantic text field. 
- k-NN index PR: https://github.com/opensearch-project/k-NN/pull/2768
- feature branch: feature/exact-search-new-experience (based on 3.2)


### Test
- create a multiple vector fields kNN index with semantic type
```json
PUT /my-nlp-index_multiple
{
    "settings":  {
        "index.knn": true 
    },
    "mappings":  {
        "properties":  {
            "id":  {
                "type": "text" 
            },
            "passage_text01":  {
                "type": "semantic",
                "model_id": "{your_model_id}",
                "dense_embedding_config":  {
                    "index": true,
                    "method":  {
                        "engine": "lucene",
                        "name": "hnsw",
                        "parameters":  {
                        }
                    }
                }
            },
            "passage_text02":  {
                "type": "semantic",
                "model_id": "{your_model_id}",
                "dense_embedding_config":  {
                    "index": false 
                }
            }
        }
    }
}
```

- get the index mapping

```json
GET /my-nlp-index_multiple/_mapping
{
	"my-nlp-index_multiple": {
		"mappings": {
			"properties": {
				"id": {
					"type": "text"
				},
				"passage_text01": {
					"type": "semantic",
					"model_id": "{your_model_id}",
					"raw_field_type": "text",
					"dense_embedding_config": {
						"method": {
							"engine": "lucene",
							"name": "hnsw",
							"parameters": {}
						},
						"index": true
					}
				},
				"passage_text01_semantic_info": {
					"properties": {
						"embedding": {
							"type": "knn_vector",
							"dimension": 768,
							"method": {
								"engine": "lucene",
								"space_type": "l2",
								"name": "hnsw",
								"parameters": {}
							}
						},
						"model": {
							"properties": {
								"id": {
									"type": "text",
									"index": false
								},
								"name": {
									"type": "text",
									"index": false
								},
								"type": {
									"type": "text",
									"index": false
								}
							}
						}
					}
				},
				"passage_text02": {
					"type": "semantic",
					"model_id": "CmN6h5kB1prYUG0Dabxz",
					"raw_field_type": "text",
					"dense_embedding_config": {
						"index": false
					}
				},
				"passage_text02_semantic_info": {
					"properties": {
						"embedding": {
							"type": "knn_vector",
							"dimension": 768,
							"index": false
						},
						"model": {
							"properties": {
								"id": {
									"type": "text",
									"index": false
								},
								"name": {
									"type": "text",
									"index": false
								},
								"type": {
									"type": "text",
									"index": false
								}
							}
						}
					}
				}
			}
		}
	}
}
```


### Related Issues
Resolves #1470 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
