### PR TITLE
Adding AgenticSearch remote model integration tests

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorRemoteModelIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorRemoteModelIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor;
+
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.neuralsearch.BaseAgenticSearchRemoteModelIT;
+import org.opensearch.neuralsearch.query.AgenticSearchQueryBuilder;
+import java.util.Map;
+
+/**
+* Integration tests for Agentic query translator processor with remote models
+*/
+@Log4j2
+public class AgenticQueryTranslatorProcessorRemoteModelIT extends BaseAgenticSearchRemoteModelIT {
+
+    private static String PIPELINE_NAME = "agentic-pipeline";
+
+    public void testAgenticQueryTranslatorProcessor_withValidQuery_expectsTranslation() throws Exception {
+        initializeIndexIfNotExist(TEST_INDEX);
+        createAgenticSearchPipeline(PIPELINE_NAME, TEST_AGENT_ID);
+
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(TEST_QUERY_TEXT);
+
+        try {
+            Map<String, Object> searchResponse = searchWithPipeline(TEST_INDEX, agenticQuery, PIPELINE_NAME);
+            assertNotNull(searchResponse);
+        } catch (Exception e) {
+            assertTrue(
+                "Should be a setup-related error",
+                e.getMessage().contains("Agent index not found")
+                    || e.getMessage().contains("model not found")
+                    || e.getMessage().contains("Agentic search failed")
+            );
+        }
+    }
+
+    public void testAgenticQueryTranslatorProcessor_withAggregations_expectsFailure() throws Exception {
+        initializeIndexIfNotExist(TEST_INDEX);
+        createAgenticSearchPipeline(PIPELINE_NAME, TEST_AGENT_ID);
+
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(TEST_QUERY_TEXT);
+
+        try {
+            Map<String, Object> searchResponse = searchWithPipelineAndAggregations(TEST_INDEX, agenticQuery, PIPELINE_NAME);
+            fail("Expected failure due to aggregations with agentic search");
+        } catch (Exception e) {
+            assertTrue(
+                "Should contain invalid usage error",
+                e.getMessage().contains("Invalid usage with other search features")
+                    || e.getMessage().contains("cannot be used with other search features")
+            );
+        }
+    }
+
+    public void testAgenticQueryTranslatorProcessor_withSort_expectsFailure() throws Exception {
+        initializeIndexIfNotExist(TEST_INDEX);
+        createAgenticSearchPipeline(PIPELINE_NAME, TEST_AGENT_ID);
+
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(TEST_QUERY_TEXT);
+
+        try {
+            Map<String, Object> searchResponse = searchWithPipelineAndSort(TEST_INDEX, agenticQuery, PIPELINE_NAME);
+            fail("Expected failure due to sort with agentic search");
+        } catch (Exception e) {
+            assertTrue(
+                "Should contain invalid usage error",
+                e.getMessage().contains("Invalid usage with other search features")
+                    || e.getMessage().contains("cannot be used with other search features")
+            );
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderRemoteModelIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderRemoteModelIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.neuralsearch.BaseAgenticSearchRemoteModelIT;
+
+import java.util.Map;
+
+/**
+* Integration tests for Agentic Search query with remote models
+*/
+@Log4j2
+public class AgenticSearchQueryBuilderRemoteModelIT extends BaseAgenticSearchRemoteModelIT {
+
+    public void testAgenticSearchQuery_withValidParameters_thenExpectError() throws Exception {
+        initializeIndexIfNotExist(TEST_INDEX);
+        String pipelineName = "test-agentic-pipeline";
+        createAgenticSearchPipeline(pipelineName, TEST_AGENT_ID);
+
+        try {
+            Map<String, Object> searchResponse = search(TEST_INDEX, null, null, 10, Map.of("search_pipeline", pipelineName));
+            // Expect some results or error due to setup limitations
+            assertTrue("Should get results or setup error", getHitCount(searchResponse) >= 0);
+        } catch (Exception e) {
+            assertTrue(
+                "Should be a setup-related error",
+                e.getMessage().contains("Agent index not found")
+                    || e.getMessage().contains("model not found")
+                    || e.getMessage().contains("Failed to execute agentic search")
+                    || e.getMessage().contains("dummy-agent-id")
+            );
+        }
+    }
+
+    public void testAgenticSearchQuery_withMissingAgentId_thenFail() throws Exception {
+        initializeIndexIfNotExist(TEST_INDEX);
+        String pipelineName = "test-agentic-pipeline-no-agent";
+
+        try {
+            createAgenticSearchPipeline(pipelineName, "");
+            Map<String, Object> searchResponse = search(TEST_INDEX, null, null, 10, Map.of("search_pipeline", pipelineName));
+            fail("Expected exception for empty agent_id");
+        } catch (Exception e) {
+            assertTrue(
+                "Should contain agent_id error",
+                e.getMessage().contains("agent_id") || e.getMessage().contains("required") || e.getMessage().contains("empty")
+            );
+        }
+    }
+
+    public void testAgenticSearchQuery_withSingleShard_thenSuccess() throws Exception {
+        String singleShardIndex = TEST_INDEX + "-single-shard";
+        initializeIndexIfNotExist(singleShardIndex, 1);
+        String pipelineName = "test-agentic-pipeline-single";
+        createAgenticSearchPipeline(pipelineName, TEST_AGENT_ID);
+
+        try {
+            Map<String, Object> searchResponse = search(singleShardIndex, null, null, 10, Map.of("search_pipeline", pipelineName));
+            assertTrue("Should get results or setup error", getHitCount(searchResponse) >= 0);
+        } catch (Exception e) {
+            assertTrue(
+                "Should be a setup-related error",
+                e.getMessage().contains("Agent index not found")
+                    || e.getMessage().contains("model not found")
+                    || e.getMessage().contains("Failed to execute agentic search")
+                    || e.getMessage().contains("dummy-agent-id")
+            );
+        }
+    }
+
+    public void testAgenticSearchQuery_withMultipleShards_thenSuccess() throws Exception {
+        String multiShardIndex = TEST_INDEX + "-multi-shard";
+        initializeIndexIfNotExist(multiShardIndex, 3);
+        String pipelineName = "test-agentic-pipeline-multi";
+        createAgenticSearchPipeline(pipelineName, TEST_AGENT_ID);
+
+        try {
+            Map<String, Object> searchResponse = search(multiShardIndex, null, null, 10, Map.of("search_pipeline", pipelineName));
+            assertTrue("Should get results or setup error", getHitCount(searchResponse) >= 0);
+        } catch (Exception e) {
+            assertTrue(
+                "Should be a setup-related error",
+                e.getMessage().contains("Agent index not found")
+                    || e.getMessage().contains("model not found")
+                    || e.getMessage().contains("Failed to execute agentic search")
+                    || e.getMessage().contains("dummy-agent-id")
+            );
+        }
+    }
+}

--- a/src/test/resources/agenticsearch/AgenticSearchPipelineRequestBody.json
+++ b/src/test/resources/agenticsearch/AgenticSearchPipelineRequestBody.json
@@ -1,0 +1,9 @@
+{
+    "request_processors": [
+      {
+        "agentic_query_translator": {
+          "agent_id": "%s"
+        }
+      }
+    ]
+  }

--- a/src/test/resources/agenticsearch/CreateConnectorRequestBody.json
+++ b/src/test/resources/agenticsearch/CreateConnectorRequestBody.json
@@ -1,0 +1,21 @@
+{
+    "name": "LLM Judgments Connector",
+    "description": "Connector for LLM-based judgment generation",
+    "version": "1.0.0",
+    "protocol": "http",
+    "credential": {
+      "access_key": "",
+      "secret_key": ""
+    },
+    "actions": [
+      {
+        "action_type": "predict",
+        "method": "POST",
+        "url": "%s/predictions/agentic_search",
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "request_body": "{ \"system\": [{\"text\": \"${parameters.query_planner_system_prompt}\"}], \"messages\": [{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.query_planner_user_prompt}\"}]}]}"
+      }
+    ]
+  }

--- a/src/test/resources/agenticsearch/RegisterAgentRequestBody.json
+++ b/src/test/resources/agenticsearch/RegisterAgentRequestBody.json
@@ -1,0 +1,15 @@
+{
+    "name": "Agentic Search with Claude 3.7",
+    "type": "flow",
+    "description": "A test agent for query planning.",
+    "tools": [
+      {
+        "type": "QueryPlanningTool",
+        "description": "A general tool to answer any question.",
+        "parameters": {
+          "model_id": "%s",
+          "response_filter": "$.output.message.content[0].text"
+        }
+      }
+    ]
+  }

--- a/src/test/resources/remote-models/torchserve/handlers/agentic_search_handler.py
+++ b/src/test/resources/remote-models/torchserve/handlers/agentic_search_handler.py
@@ -1,0 +1,148 @@
+"""
+TorchServe Handler for Phi-3-mini-4k-instruct Model
+"""
+
+import os
+import json
+import logging
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from typing import List, Dict, Any
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Environment configuration
+MAX_LENGTH = 4096  # Phi-3-mini-4k context window
+MODEL_NAME = "Phi-3-mini-4k-instruct"
+
+# Global variables for model and tokenizer
+model = None
+tokenizer = None
+device = None
+
+def format_prompt(system_prompt: str, user_prompt: str) -> str:
+    """Format the prompt according to Phi-3 instruction format"""
+    formatted_prompt = f"System: {system_prompt}\nHuman: {user_prompt}\nAssistant:"
+    return formatted_prompt
+
+def generate_response(system_prompt: str, user_prompt: str) -> str:
+    """Generate response using Phi-3"""
+    formatted_prompt = format_prompt(system_prompt, user_prompt)
+    
+    inputs = tokenizer(formatted_prompt, return_tensors="pt", truncation=True, max_length=MAX_LENGTH)
+    inputs = {k: v.to(device) for k, v in inputs.items()}
+
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_length=MAX_LENGTH,
+            temperature=0.7,
+            do_sample=True,
+            pad_token_id=tokenizer.eos_token_id
+        )
+    
+    response = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    # Remove the prompt from the response
+    response = response[len(formatted_prompt):].strip()
+    return response
+
+def handle(data, context):
+    """
+    TorchServe handler function
+    """
+    global model, tokenizer, device
+
+    if data is None:
+        return None
+
+    # Initialize on first call
+    if model is None:
+        properties = context.system_properties
+        model_dir = properties.get("model_dir", ".")
+        device = torch.device("cuda:" + str(properties.get("gpu_id"))
+                            if torch.cuda.is_available() and properties.get("gpu_id") is not None
+                            else "cpu")
+
+        # Load tokenizer and model
+        try:
+            model_path = os.path.join(model_dir, "model_files") if os.path.exists(os.path.join(model_dir, "model_files")) else model_dir
+            
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_path,
+                trust_remote_code=True,
+                local_files_only=True
+            )
+            
+            model = AutoModelForCausalLM.from_pretrained(
+                model_path,
+                torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
+                trust_remote_code=True,
+                local_files_only=True
+            )
+            
+            model.to(device)
+            model.eval()
+            
+            logger.info(f"Model loaded successfully on {device}")
+        except Exception as e:
+            logger.error(f"Error loading model: {str(e)}")
+            raise e
+
+    results = []
+    
+    # Log raw data for debugging
+    logger.info(f"Raw data received: type={type(data)}, len={len(data) if data else 0}")
+
+    for row in data:
+        input_data = row.get("data") or row.get("body")
+        if isinstance(input_data, str):
+            input_data = json.loads(input_data)
+
+        # Log the input for debugging
+        logger.info(f"Processing input: {str(input_data)[:200]}")
+
+        try:
+            # Validate input format
+            if not isinstance(input_data, dict):
+                raise ValueError("Input must be a dictionary")
+            
+            # Extract system prompt
+            system = input_data.get("system", [])
+            if not system or not isinstance(system, list) or len(system) == 0:
+                raise ValueError("System prompt is required")
+            system_prompt = system[0].get("text", "")
+            
+            # Extract user prompt
+            messages = input_data.get("messages", [])
+            if not messages or not isinstance(messages, list) or len(messages) == 0:
+                raise ValueError("User message is required")
+            
+            user_message = next((msg for msg in messages if msg["role"] == "user"), None)
+            if not user_message or not user_message.get("content"):
+                raise ValueError("User message content is required")
+            
+            user_prompt = user_message["content"][0].get("text", "")
+
+            if not system_prompt or not user_prompt:
+                raise ValueError("Both system and user prompts are required")
+
+            # Generate response
+            response = generate_response(system_prompt, user_prompt)
+            
+            # Format response
+            results.append({
+                "model": MODEL_NAME,
+                "response": response
+            })
+
+        except Exception as e:
+            logger.error(f"Error processing request: {str(e)}")
+            results.append({
+                "error": str(e),
+                "model": MODEL_NAME
+            })
+
+    logger.info(f"Returning {len(results)} results")
+    return results

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseAgenticSearchRemoteModelIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseAgenticSearchRemoteModelIT.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import com.google.common.collect.ImmutableList;
+import org.opensearch.neuralsearch.query.AgenticSearchQueryBuilder;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.neuralsearch.util.RemoteModelTestUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import java.io.IOException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
+
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_USER_AGENT;
+
+/**
+ * Base class for Agentic Search Remote Model integration tests.
+ */
+@Log4j2
+public abstract class BaseAgenticSearchRemoteModelIT extends BaseNeuralSearchIT {
+
+    protected static final String TEST_INDEX = "test-agentic-index";
+    protected static final String TEST_QUERY_TEXT = "Find documents about machine learning";
+
+    protected static String TEST_AGENT_ID;
+    protected static String TEST_MODEL_ID;
+    protected static String TEST_CONNECTOR_ID;
+    protected static final String ML_COMMONS_AGENTIC_SEARCH_ENABLED = "plugins.ml_commons.agentic_search_enabled";
+
+    protected boolean isTorchServeAvailable = false;
+    protected String torchServeEndpoint;
+
+    @Before
+    @SneakyThrows
+    @Override
+    public void setUp() {
+        super.setUp();
+        updateClusterSettings();
+        updateClusterSettings("plugins.ml_commons.connector.private_ip_enabled", true);
+        updateClusterSettings(
+            "plugins.ml_commons.trusted_connector_endpoints_regex",
+            List.of(
+                "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                "^http://localhost:.*",
+                "^http://127\\.0\\.0\\.1:.*",
+                "^http://torchserve:.*"
+            )
+        );
+
+        // Check for TorchServe endpoint from environment or system properties
+        torchServeEndpoint = System.getenv("TORCHSERVE_ENDPOINT");
+        if (torchServeEndpoint == null || torchServeEndpoint.isEmpty()) {
+            torchServeEndpoint = System.getProperty("tests.torchserve.endpoint");
+        }
+
+        if (torchServeEndpoint != null && !torchServeEndpoint.isEmpty()) {
+            isTorchServeAvailable = RemoteModelTestUtils.isRemoteEndpointAvailable(torchServeEndpoint);
+            if (isTorchServeAvailable) {
+                log.info("TorchServe is available at: {}", torchServeEndpoint);
+
+                if (TEST_AGENT_ID == null) {
+                    try {
+                        // Create connector and deploy remote models
+                        TEST_CONNECTOR_ID = createTestConnector(torchServeEndpoint);
+                        log.info("Created remote model connector, connector ID: {}", TEST_CONNECTOR_ID);
+
+                        TEST_MODEL_ID = RemoteModelTestUtils.deployRemoteModel(client(), TEST_CONNECTOR_ID, "agentic-search-remote");
+                        log.info("Deployed remote agentic search model, model ID: {}", TEST_MODEL_ID);
+
+                        TEST_AGENT_ID = registerTestAgent(TEST_MODEL_ID);
+                        log.info("Registered agent, agent ID: {}", TEST_AGENT_ID);
+
+                    } catch (Exception e) {
+                        TEST_AGENT_ID = "dummy-agent-id";
+                        TEST_MODEL_ID = "dummy-model-id";
+                        TEST_CONNECTOR_ID = "dummy-connector-id";
+                    }
+                }
+            } else {
+                log.info("TorchServe not available at {}, tests will be skipped", torchServeEndpoint);
+            }
+        } else {
+            log.info("No TorchServe endpoint configured, tests will be skipped");
+        }
+    }
+
+    @After
+    @SneakyThrows
+    @Override
+    public void tearDown() {
+        if (isTorchServeAvailable) {
+            // Delete agent
+            try {
+                deleteAgent(TEST_AGENT_ID);
+            } catch (Exception e) {
+                log.debug("Failed to delete agent: {}", e.getMessage());
+            }
+            // Cleanup indexes
+            try {
+                deleteIndex(TEST_INDEX);
+            } catch (Exception e) {
+                log.debug("Failed to delete index: {}", e.getMessage());
+            }
+
+            // Cleanup connector and models
+            RemoteModelTestUtils.deleteModel(client(), TEST_MODEL_ID);
+            RemoteModelTestUtils.deleteConnector(client(), TEST_CONNECTOR_ID);
+        }
+
+        super.tearDown();
+    }
+
+    public void initializeIndexIfNotExist(String indexName) throws Exception {
+        initializeIndexIfNotExist(indexName, 1);
+    }
+
+    public void initializeIndexIfNotExist(String indexName, int numberOfShards) throws Exception {
+        if (!indexExists(indexName)) {
+            createIndexWithConfiguration(
+                indexName,
+                buildIndexConfiguration(
+                    Collections.emptyList(),
+                    Map.of(),
+                    Collections.emptyList(),
+                    Collections.singletonList("passage_text"),
+                    Collections.emptyList(),
+                    numberOfShards
+                ),
+                ""
+            );
+            addDocument(indexName, "1", "passage_text", "This is about science and technology", null, null);
+            addDocument(indexName, "2", "passage_text", "Machine learning and artificial intelligence", null, null);
+            assertEquals(2, getDocCount(indexName));
+        }
+    }
+
+    public String createTestConnector(String endpoint) throws Exception {
+        try {
+            String createConnectorRequestBody = Files.readString(
+                Path.of(classLoader.getResource("agenticsearch/CreateConnectorRequestBody.json").toURI())
+            );
+            // Replace placeholders with actual values
+            String requestBody = String.format(Locale.ROOT, createConnectorRequestBody, endpoint);
+            return createConnector(requestBody);
+        } catch (Exception e) {
+            throw new IOException("Failed to load connector template from resources", e);
+        }
+    }
+
+    public void createAgenticSearchPipeline(String pipelineName, String agentId) throws Exception {
+        final String pipelineRequestBody = String.format(
+            Locale.ROOT,
+            Files.readString(Path.of(classLoader.getResource("agenticsearch/AgenticSearchPipelineRequestBody.json").toURI())),
+            agentId
+        );
+        makeRequest(
+            client(),
+            "PUT",
+            String.format(Locale.ROOT, "/_search/pipeline/%s", pipelineName),
+            null,
+            toHttpEntity(pipelineRequestBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+    }
+
+    public String registerTestAgent(String modelId) throws Exception {
+        final String registerAgentRequestBody = String.format(
+            Locale.ROOT,
+            Files.readString(Path.of(classLoader.getResource("agenticsearch/RegisterAgentRequestBody.json").toURI())),
+            modelId
+        );
+        return registerAgent(registerAgentRequestBody);
+    }
+
+    public Map<String, Object> searchWithPipeline(String indexName, AgenticSearchQueryBuilder query, String pipelineName) throws Exception {
+        return search(indexName, query, null, 10, Map.of("search_pipeline", pipelineName));
+    }
+
+    public Map<String, Object> searchWithPipelineAndAggregations(String indexName, AgenticSearchQueryBuilder query, String pipelineName)
+        throws Exception {
+        String searchBody = String.format(Locale.ROOT, """
+            {
+              "query": {
+                "agentic": {
+                  "query_text": "%s"
+                }
+              },
+              "aggs": {
+                "test_agg": {
+                  "terms": {
+                    "field": "passage_text.keyword"
+                  }
+                }
+              }
+            }
+            """, query.getQueryText());
+
+        Response response = makeRequest(
+            client(),
+            "GET",
+            "/" + indexName + "/_search",
+            Map.of("search_pipeline", pipelineName),
+            toHttpEntity(searchBody),
+            null
+        );
+        String responseBody = EntityUtils.toString(response.getEntity());
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), responseBody, false);
+    }
+
+    public Map<String, Object> searchWithPipelineAndSort(String indexName, AgenticSearchQueryBuilder query, String pipelineName)
+        throws Exception {
+        String searchBody = String.format(Locale.ROOT, """
+            {
+              "query": {
+                "agentic": {
+                  "query_text": "%s"
+                }
+              },
+              "sort": [
+                {"_score": {"order": "desc"}}
+              ]
+            }
+            """, query.getQueryText());
+
+        Response response = makeRequest(
+            client(),
+            "GET",
+            "/" + indexName + "/_search",
+            Map.of("search_pipeline", pipelineName),
+            toHttpEntity(searchBody),
+            null
+        );
+        String responseBody = EntityUtils.toString(response.getEntity());
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), responseBody, false);
+    }
+
+}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -2884,4 +2884,49 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
             RemoteModelTestUtils.deleteConnector(client(), connectorId);
         }
     }
+
+    /**
+     * Register an agent with the ML Commons plugin
+     *
+     * @param requestBody JSON request body for agent registration
+     * @return agent ID of the registered agent
+     * @throws Exception if registration fails
+     */
+    @SneakyThrows
+    protected String registerAgent(final String requestBody) {
+        Response response = makeRequest(
+            client(),
+            "POST",
+            "/_plugins/_ml/agents/_register",
+            null,
+            toHttpEntity(requestBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> responseJson = XContentHelper.convertToMap(
+            XContentType.JSON.xContent(),
+            EntityUtils.toString(response.getEntity()),
+            false
+        );
+        String agentId = responseJson.get("agent_id").toString();
+        assertNotNull(agentId);
+        return agentId;
+    }
+
+    /**
+     * Delete an agent by its ID
+     *
+     * @param agentId ID of the agent to delete
+     * @throws Exception if deletion fails
+     */
+    @SneakyThrows
+    protected void deleteAgent(final String agentId) {
+        makeRequest(
+            client(),
+            "DELETE",
+            String.format(LOCALE, "/_plugins/_ml/agents/%s", agentId),
+            null,
+            toHttpEntity(""),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+    }
 }


### PR DESCRIPTION
### Description
- Adds a new remote model handler for agentic search integration tests, using model Phi-3-mini-4k-instruct
- Adds Agentic query translator processor integration tests
- Adds Agentic Search query builder integration tests
- Adds abstract class for agentic search remote model tests

Test Run : 
```
./gradlew remoteModelIntegTest
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.14.3
  OS Info               : Linux 5.10.242-219.961.amzn2int.x86_64 (amd64)
  JDK Version           : 21 (Amazon Corretto JDK)
  JAVA_HOME             : /opt/amazon-corretto-21.0.3.9.1-linux-x64
  Random Testing Seed   : 58F76097AD1EF607
  Crypto Standard       : any-supported
=======================================

> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :compileTestFixturesJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :remoteModelIntegTest
Auto-discovered models: agentic_search, semantic_highlighter
Setting up TorchServe and deploying all models...
[INFO] Starting TorchServe container...
torchserve-integ-test
[INFO] Waiting for TorchServe to be ready...
  Waiting for TorchServe... (1/30)
  Waiting for TorchServe... (2/30)
  Waiting for TorchServe... (3/30)
  Waiting for TorchServe... (4/30)
  Waiting for TorchServe... (5/30)
  Waiting for TorchServe... (6/30)
  Waiting for TorchServe... (7/30)
  Waiting for TorchServe... (8/30)
  Waiting for TorchServe... (9/30)
  Waiting for TorchServe... (10/30)
  Waiting for TorchServe... (11/30)
  Waiting for TorchServe... (12/30)
  Waiting for TorchServe... (13/30)
  Waiting for TorchServe... (14/30)
[INFO] ✓ TorchServe is ready! [1m 11s]
[INFO] Memory checkpoint - Container started:
  Memory: 545.3MiB / 2GiB
  Memory %: 26.63%
  CPU %: 92.97%
[INFO] Found 2 model(s): agentic_search semantic_highlighter
[INFO] Setting up model: agentic_search...
[INFO] Installing dependencies in container...

[notice] A new release of pip is available: 23.2.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
[INFO] Model 'agentic_search' is already loaded
[INFO] Exported AGENTIC_SEARCH_ENDPOINT=http://localhost:8080/predictions/agentic_search
[INFO] Memory checkpoint - After loading agentic_search:
  Memory: 1.109GiB / 2GiB
  Memory %: 55.44%
  CPU %: 73.64%
[INFO] Setting up model: semantic_highlighter...
[INFO] Installing dependencies in container...

[notice] A new release of pip is available: 23.2.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
[INFO] Model 'semantic_highlighter' is already loaded
[INFO] Exported SEMANTIC_HIGHLIGHTER_ENDPOINT=http://localhost:8080/predictions/semantic_highlighter
[INFO] Memory checkpoint - After loading semantic_highlighter:
  Memory: 1.126GiB / 2GiB
  Memory %: 56.28%
  CPU %: 0.06%
[INFO] Memory checkpoint - All models loaded:
  Memory: 1.125GiB / 2GiB
  Memory %: 56.27%
  CPU %: 0.05%
[INFO] Testing model inference with memory monitoring...
[INFO] Memory checkpoint - Before single inference:
  Memory: 1.125GiB / 2GiB
  Memory %: 56.27%
  CPU %: 0.06%
[INFO] ✓ Single inference successful!]
  Response: {
  "highlights": [
    {
      "start": 0,
      "end": 107
    }
  ]
}
[INFO] Memory checkpoint - After single inference:
  Memory: 1.144GiB / 2GiB
  Memory %: 57.19%
  CPU %: 0.06%
[INFO] Testing batch inference...
[INFO] Memory checkpoint - Before batch inference:
  Memory: 1.144GiB / 2GiB
  Memory %: 57.19%
  CPU %: 0.05%
[INFO] ✓ Batch inference successful!s]
[INFO] Memory checkpoint - After batch inference:
  Memory: 1.145GiB / 2GiB
  Memory %: 57.24%
  CPU %: 0.05%

=== Memory Usage Summary ===
Memory: 1.145GiB / 2GiB
Memory %: 57.24%
CPU %: 0.04%
===========================

SemanticHighlightingRemoteModelIT > testSemanticHighlightingWithQueryMatchWithBatchEnabledWithRemoteModel PASSED

SemanticHighlightingRemoteModelIT > testSemanticHighlightingWithHybridQueryWithBatchEnabledWithRemoteModel PASSED

SemanticHighlightingRemoteModelIT > testSemanticHighlightingWithNeuralQueryWithBatchEnabledWithRemoteModel PASSED

SemanticHighlightingRemoteModelIT > testSemanticHighlightingWithQueryMatchWithBatchDisabledWithRemoteModel PASSED

SemanticHighlightingRemoteModelIT > testSemanticHighlightingBatchModeWithoutSystemProcessor PASSED

SemanticHighlightingRemoteModelIT > testSemanticHighlightingWithNeuralQueryWithBatchDisabledWithRemoteModel PASSED

AgenticQueryTranslatorProcessorRemoteModelIT > testAgenticQueryTranslatorProcessor_withSort_expectsFailure PASSED

AgenticQueryTranslatorProcessorRemoteModelIT > testAgenticQueryTranslatorProcessor_withAggregations_expectsFailure PASSED

AgenticQueryTranslatorProcessorRemoteModelIT > testAgenticQueryTranslatorProcessor_withValidQuery_expectsTranslation PASSED

AgenticSearchQueryBuilderRemoteModelIT > testAgenticSearchQuery_withMultipleShards_thenSuccess PASSED

AgenticSearchQueryBuilderRemoteModelIT > testAgenticSearchQuery_withMissingAgentId_thenFail PASSED

AgenticSearchQueryBuilderRemoteModelIT > testAgenticSearchQuery_withSingleShard_thenSuccess PASSED

AgenticSearchQueryBuilderRemoteModelIT > testAgenticSearchQuery_withValidParameters_thenExpectError PASSED
Stopping TorchServe...
[INFO] Stopping TorchServe container...
torchserve-integ-test
[INFO] ✓ Container stopped
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
