### PR TITLE
[Agentic Search] Fix rest error for agent execution

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java
@@ -58,12 +58,14 @@ public final class AgenticSearchQueryBuilder extends AbstractQueryBuilder<Agenti
     public String queryText;
     public List<String> queryFields;
     public String memoryId;
+    private transient String agentFailureReason;
 
     public AgenticSearchQueryBuilder(StreamInput in) throws IOException {
         super(in);
         this.queryText = in.readString();
         this.queryFields = in.readOptionalStringList();
         this.memoryId = in.readOptionalString();
+        this.agentFailureReason = in.readOptionalString();
     }
 
     public String getQueryText() {
@@ -78,11 +80,20 @@ public final class AgenticSearchQueryBuilder extends AbstractQueryBuilder<Agenti
         return memoryId;
     }
 
+    public void setAgentFailureReason(String reason) {
+        this.agentFailureReason = reason;
+    }
+
+    public String getAgentFailureReason() {
+        return agentFailureReason;
+    }
+
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(this.queryText);
         out.writeOptionalStringCollection(this.queryFields);
         out.writeOptionalString(this.memoryId);
+        out.writeOptionalString(this.agentFailureReason);
     }
 
     @Override
@@ -164,6 +175,10 @@ public final class AgenticSearchQueryBuilder extends AbstractQueryBuilder<Agenti
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
+        if (this.agentFailureReason != null) {
+            throw new IllegalStateException("Agentic search failed: " + this.agentFailureReason);
+        }
+
         throw new IllegalStateException(
             "Agentic search query must be used as top-level query, not nested inside other queries. Should be used with agentic_query_translator search processor"
         );

--- a/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilderTests.java
@@ -313,4 +313,15 @@ public class AgenticSearchQueryBuilderTests extends OpenSearchTestCase {
         AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT);
         assertNull("Memory ID should be null by default", queryBuilder.getMemoryId());
     }
+
+    public void testDoToQuery_withAgentFailureReason() throws IOException {
+        AgenticSearchQueryBuilder queryBuilder = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT);
+        String failureReason = "Agent execution failed";
+        queryBuilder.setAgentFailureReason(failureReason);
+
+        QueryShardContext mockContext = mock(QueryShardContext.class);
+
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> queryBuilder.doToQuery(mockContext));
+        assertEquals("Should throw agent failure exception", "Agentic search failed: " + failureReason, exception.getMessage());
+    }
 }


### PR DESCRIPTION
### Description
The issue arises when verbose_pipeline=true is passed to the search pipeline with an invalid agent-id. The execute agent returns a failure case indicating that the agent is not found, and the search pipeline relies on the agentic query translator processor to generate a DSL query. The failure to do so causes the flow to fail in [doToQuery](https://github.com/opensearch-project/neural-search/blob/main/src/main/java/org/opensearch/neuralsearch/query/AgenticSearchQueryBuilder.java#L167).

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/1526

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
