### PR TITLE
Add support for asymmetric embedding models

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.opensearch.common.CheckedConsumer;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.xcontent.XContentType;
@@ -50,6 +51,8 @@ import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.ml.common.input.execute.agent.AgentMLInput;
 import org.opensearch.ml.common.input.parameter.MLAlgoParams;
+import org.opensearch.ml.common.model.MLModelConfig;
+import org.opensearch.ml.common.model.TextEmbeddingModelConfig;
 import org.opensearch.ml.common.output.MLOutput;
 import org.opensearch.ml.common.output.model.ModelResultFilter;
 import org.opensearch.ml.common.output.model.ModelTensor;
@@ -80,6 +83,8 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class MLCommonsClientAccessor {
     private final MachineLearningNodeClient mlClient;
+    private final Map<String, Boolean> modelAsymmetryCache = new ConcurrentHashMap<>();
+
     private static final Gson gson = new Gson();
 
     /**
@@ -127,13 +132,16 @@ public class MLCommonsClientAccessor {
         @NonNull final TextInferenceRequest inferenceRequest,
         @NonNull final ActionListener<List<List<Number>>> listener
     ) {
-        retryableInference(
-            inferenceRequest,
-            0,
-            () -> createMLTextInput(inferenceRequest.getTargetResponseFilters(), inferenceRequest.getInputTexts()),
-            this::buildVectorFromResponse,
-            listener
-        );
+        checkModelAsymmetryAndThenPredict(inferenceRequest.getModelId(), listener::onFailure, isAsymmetric -> {
+            MLAlgoParams params = isAsymmetric ? inferenceRequest.getMlAlgoParams() : null;
+            retryableInference(
+                inferenceRequest,
+                0,
+                () -> createMLTextInput(inferenceRequest.getTargetResponseFilters(), inferenceRequest.getInputTexts(), params),
+                this::buildVectorFromResponse,
+                listener
+            );
+        });
     }
 
     public void inferenceSentencesWithMapResult(
@@ -141,13 +149,16 @@ public class MLCommonsClientAccessor {
         @Nullable MLAlgoParams mlAlgoParams,
         @NonNull final ActionListener<List<Map<String, ?>>> listener
     ) {
-        retryableInference(inferenceRequest, 0, () -> {
-            MLInput input = createMLTextInput(null, inferenceRequest.getInputTexts());
-            if (mlAlgoParams != null) {
-                input.setParameters(mlAlgoParams);
-            }
-            return input;
-        }, this::buildMapResultFromResponse, listener);
+        checkModelAsymmetryAndThenPredict(inferenceRequest.getModelId(), listener::onFailure, isAsymmetric -> {
+            MLAlgoParams params = isAsymmetric ? (mlAlgoParams != null ? mlAlgoParams : inferenceRequest.getMlAlgoParams()) : mlAlgoParams;
+            retryableInference(
+                inferenceRequest,
+                0,
+                () -> createMLTextInput(null, inferenceRequest.getInputTexts(), params),
+                this::buildMapResultFromResponse,
+                listener
+            );
+        });
     }
 
     /**
@@ -159,13 +170,16 @@ public class MLCommonsClientAccessor {
      * @param listener         {@link ActionListener} which will be called when prediction is completed or errored out.
      */
     public void inferenceSentencesMap(@NonNull MapInferenceRequest inferenceRequest, @NonNull final ActionListener<List<Number>> listener) {
-        retryableInference(
-            inferenceRequest,
-            0,
-            () -> createMLMultimodalInput(inferenceRequest.getTargetResponseFilters(), inferenceRequest.getInputObjects()),
-            this::buildSingleVectorFromResponse,
-            listener
-        );
+        checkModelAsymmetryAndThenPredict(inferenceRequest.getModelId(), listener::onFailure, isAsymmetric -> {
+            MLAlgoParams params = isAsymmetric ? inferenceRequest.getMlAlgoParams() : null;
+            retryableInference(
+                inferenceRequest,
+                0,
+                () -> createMLMultimodalInput(inferenceRequest.getTargetResponseFilters(), inferenceRequest.getInputObjects(), params),
+                this::buildSingleVectorFromResponse,
+                listener
+            );
+        });
     }
 
     /**
@@ -221,10 +235,10 @@ public class MLCommonsClientAccessor {
         ));
     }
 
-    private MLInput createMLTextInput(final List<String> targetResponseFilters, List<String> inputText) {
+    private MLInput createMLTextInput(final List<String> targetResponseFilters, List<String> inputText, MLAlgoParams mlAlgoParams) {
         final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         final MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
-        return new MLInput(FunctionName.TEXT_EMBEDDING, null, inputDataset);
+        return new MLInput(FunctionName.TEXT_EMBEDDING, mlAlgoParams, inputDataset);
     }
 
     private MLInput createMLTextPairsInput(final String query, final List<String> inputText) {
@@ -342,7 +356,11 @@ public class MLCommonsClientAccessor {
         }
     }
 
-    private MLInput createMLMultimodalInput(final List<String> targetResponseFilters, final Map<String, String> input) {
+    private MLInput createMLMultimodalInput(
+        final List<String> targetResponseFilters,
+        final Map<String, String> input,
+        MLAlgoParams mlAlgoParams
+    ) {
         List<String> inputText = new ArrayList<>();
         inputText.add(input.get(INPUT_TEXT));
         if (input.containsKey(INPUT_IMAGE)) {
@@ -350,7 +368,7 @@ public class MLCommonsClientAccessor {
         }
         final ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         final MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
-        return new MLInput(FunctionName.TEXT_EMBEDDING, null, inputDataset);
+        return new MLInput(FunctionName.TEXT_EMBEDDING, mlAlgoParams, inputDataset);
     }
 
     public void getModel(@NonNull final String modelId, @NonNull final ActionListener<MLModel> listener) {
@@ -1063,4 +1081,36 @@ public class MLCommonsClientAccessor {
         return highlights;
     }
 
+    /**
+     * Check if the model is asymmetric and then run the prediction. Model asymmetry is a concept
+     * that is specific to TextEmbeddingModelConfig. If the model is not a TextEmbeddingModel, then
+     * this check is not applicable.
+     *
+     * The asymmetry of a model is static for a given model. To avoid repeated checks for the same
+     * model, we cache the model asymmetry status. Non-TextEmbeddingModels are cached as false.
+     *
+     * @param modelId    The model id to check
+     * @param onFailure The action to take if the model cannot be retrieved
+     * @param runPrediction The action to take if the model is successfully retrieved
+     */
+    private void checkModelAsymmetryAndThenPredict(String modelId, Consumer<Exception> onFailure, Consumer<Boolean> runPrediction) {
+        CheckedConsumer<MLModel, ? extends Exception> checkModelAsymmetryListener = model -> {
+            MLModelConfig modelConfig = model.getModelConfig();
+            if (!(modelConfig instanceof TextEmbeddingModelConfig textEmbeddingModelConfig)) {
+                modelAsymmetryCache.computeIfAbsent(modelId, k -> false);
+                return;
+            }
+            final boolean isAsymmetricModel = textEmbeddingModelConfig.getPassagePrefix() != null
+                || textEmbeddingModelConfig.getQueryPrefix() != null;
+            modelAsymmetryCache.computeIfAbsent(modelId, k -> isAsymmetricModel);
+        };
+        if (modelAsymmetryCache.get(modelId) != null) {
+            runPrediction.accept(modelAsymmetryCache.get(modelId));
+        } else {
+            mlClient.getModel(modelId, null, ActionListener.<MLModel>wrap(mlModel -> {
+                checkModelAsymmetryListener.accept(mlModel);
+                runPrediction.accept(modelAsymmetryCache.get(modelId));
+            }, onFailure));
+        }
+    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -25,6 +25,8 @@ import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.ingest.AbstractBatchingProcessor;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType;
 import org.opensearch.ml.common.input.parameter.MLAlgoParams;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.optimization.InferenceFilter;
@@ -779,7 +781,11 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         BiConsumer<IngestDocument, Exception> handler
     ) {
         mlCommonsClientAccessor.inferenceSentences(
-            TextInferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            TextInferenceRequest.builder()
+                .modelId(this.modelId)
+                .inputTexts(inferenceList)
+                .mlAlgoParams(AsymmetricTextEmbeddingParameters.builder().embeddingContentType(EmbeddingContentType.PASSAGE).build())
+                .build(),
             ActionListener.wrap(vectors -> {
                 setVectorFieldsToDocument(ingestDocument, processMap, vectors);
                 handler.accept(ingestDocument, null);

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceRequest.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceRequest.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.processor;
 
 import java.util.List;
 
+import org.opensearch.ml.common.input.parameter.MLAlgoParams;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,4 +35,9 @@ public abstract class InferenceRequest {
      */
     @Builder.Default
     private List<String> targetResponseFilters = List.of("sentence_embedding");
+    /**
+     * ML algorithm parameters for asymmetric models.
+     * Contains parameters like passage_prefix and query_prefix for asymmetric embedding models.
+     */
+    private MLAlgoParams mlAlgoParams;
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -19,6 +19,8 @@ import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocumentWrapper;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 
 import lombok.extern.log4j.Log4j2;
@@ -105,7 +107,11 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
     @Override
     public void doBatchExecute(List<String> inferenceList, Consumer<List<?>> handler, Consumer<Exception> onException) {
         mlCommonsClientAccessor.inferenceSentences(
-            TextInferenceRequest.builder().modelId(this.modelId).inputTexts(inferenceList).build(),
+            TextInferenceRequest.builder()
+                .modelId(this.modelId)
+                .inputTexts(inferenceList)
+                .mlAlgoParams(AsymmetricTextEmbeddingParameters.builder().embeddingContentType(EmbeddingContentType.PASSAGE).build())
+                .build(),
             ActionListener.wrap(handler::accept, onException)
         );
     }

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java
@@ -91,7 +91,8 @@ import org.opensearch.neuralsearch.query.dto.NeuralQueryBuildStage;
 import org.opensearch.neuralsearch.stats.events.EventStatName;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
-
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -686,11 +687,8 @@ public class NeuralQueryBuilder extends AbstractNeuralQueryBuilder<NeuralQueryBu
             return rewriteQueryWithQueryShardContext(queryShardContext);
         }
 
-        // We can rewrite with a BaseQueryRewriteContext on the shard level:
-        // In SearchService do a quick rewrite to handle AliasFilters rewrite. This happens after the
-        // coordinate rewrite, and we do not need to rewrite the neural query for this case. We will do rewrite later
-        // with queryShardContext.
-        return this;
+        // Fall back to the old logic when both conversions return null
+        return rewriteQueryAgainstKnnField(queryRewriteContext);
     }
 
     private QueryBuilder rewriteQueryWithCoordinatorContext(@NonNull final QueryCoordinatorContext queryRewriteContext) {
@@ -918,7 +916,11 @@ public class NeuralQueryBuilder extends AbstractNeuralQueryBuilder<NeuralQueryBu
 
         queryRewriteContext.registerAsyncAction(
             ((client, actionListener) -> ML_CLIENT.inferenceSentencesMap(
-                MapInferenceRequest.builder().modelId(modelId()).inputObjects(inferenceInput).build(),
+                MapInferenceRequest.builder()
+                    .modelId(modelId())
+                    .inputObjects(inferenceInput)
+                    .mlAlgoParams(AsymmetricTextEmbeddingParameters.builder().embeddingContentType(EmbeddingContentType.QUERY).build())
+                    .build(),
                 ActionListener.wrap(floatList -> {
                     vectorSetOnce.set(vectorAsListToArray(floatList));
                     actionListener.onResponse(null);

--- a/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
@@ -51,6 +51,8 @@ import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.ml.common.transport.execute.MLExecuteTaskResponse;
 import org.opensearch.neuralsearch.constants.TestCommonConstants;
 import org.opensearch.neuralsearch.processor.highlight.SentenceHighlightingRequest;
+import org.opensearch.neuralsearch.processor.TextInferenceRequest;
+import org.opensearch.neuralsearch.processor.MapInferenceRequest;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.NodeNotConnectedException;
 
@@ -78,6 +80,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
     public void testInferenceSentence_whenValidInput_thenSuccess() {
         final List<Number> vector = new ArrayList<>(List.of(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
@@ -86,6 +96,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
         accessor.inferenceSentence(TestCommonConstants.MODEL_ID, TestCommonConstants.SENTENCES_LIST.get(0), singleSentenceResultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(singleSentenceResultListener).onResponse(vector);
         Mockito.verifyNoMoreInteractions(singleSentenceResultListener);
@@ -94,6 +105,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
     public void testInferenceSentences_whenValidInputThenSuccess() {
         final List<List<Number>> vectorList = new ArrayList<>();
         vectorList.add(Arrays.asList(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
@@ -101,6 +120,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onResponse(vectorList);
         Mockito.verifyNoMoreInteractions(resultListener);
@@ -109,6 +129,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
     public void testInferenceSentences_whenResultFromClient_thenEmptyVectorList() {
         final List<List<Number>> vectorList = new ArrayList<>();
         vectorList.add(Collections.emptyList());
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onResponse(createModelTensorOutput(new Float[] {}));
@@ -116,6 +144,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onResponse(vectorList);
         Mockito.verifyNoMoreInteractions(resultListener);
@@ -123,6 +152,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
     public void testInferenceSentences_whenExceptionFromMLClient_thenFailure() {
         final RuntimeException exception = new RuntimeException();
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onFailure(exception);
@@ -130,6 +167,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onFailure(exception);
         Mockito.verifyNoMoreInteractions(resultListener);
@@ -164,6 +202,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             mock(DiscoveryNode.class),
             "Node not connected"
         );
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onFailure(nodeNodeConnectedException);
@@ -171,12 +217,21 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client, times(4)).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onFailure(nodeNodeConnectedException);
     }
 
     public void testInferenceSentences_whenNotConnectionException_thenNoRetry() {
         final IllegalStateException illegalStateException = new IllegalStateException("Illegal state");
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onFailure(illegalStateException);
@@ -184,6 +239,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client, times(1)).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onFailure(illegalStateException);
     }
@@ -191,6 +247,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
     public void testInferenceSentencesWithMapResult_whenValidInput_thenSuccess() {
         final Map<String, Object> map = Map.of("key", "value");
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onResponse(createModelTensorOutput(map));
@@ -198,6 +262,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, null, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onResponse(List.of(map));
         Mockito.verifyNoMoreInteractions(resultListener);
@@ -206,6 +271,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
     public void testInferenceSentencesWithMapResult_whenValidInput_withParameter() {
         final Map<String, Object> map = Map.of("key", "value");
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         MLAlgoParams algoParameter = mock(MLAlgoParams.class);
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
@@ -214,6 +287,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, algoParameter, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), mlInputCaptor.capture(), Mockito.isA(ActionListener.class));
         assertSame(algoParameter, mlInputCaptor.getValue().getParameters());
@@ -224,6 +298,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
     public void testInferenceSentencesWithMapResult_whenTensorOutputListEmpty_thenException() {
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
         final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(Collections.emptyList());
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onResponse(modelTensorOutput);
@@ -231,6 +313,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, null, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(IllegalStateException.class);
         verify(resultListener).onFailure(argumentCaptor.capture());
@@ -247,6 +330,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         final List<ModelTensor> mlModelTensorList = new ArrayList<>();
         tensorsList.add(new ModelTensors(mlModelTensorList));
         final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(tensorsList);
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onResponse(modelTensorOutput);
@@ -254,6 +345,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, null, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(IllegalStateException.class);
         verify(resultListener).onFailure(argumentCaptor.capture());
@@ -273,6 +365,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         mlModelTensorList.add(tensor);
         tensorsList.add(new ModelTensors(mlModelTensorList));
         final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(tensorsList);
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onResponse(modelTensorOutput);
@@ -280,6 +380,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, null, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onResponse(List.of(Map.of("key", "value"), Map.of("key", "value")));
         Mockito.verifyNoMoreInteractions(resultListener);
@@ -290,6 +391,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             mock(DiscoveryNode.class),
             "Node not connected"
         );
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onFailure(nodeNodeConnectedException);
@@ -298,12 +407,21 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, null, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client, times(4)).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onFailure(nodeNodeConnectedException);
     }
 
     public void testInferenceSentencesWithMapResult_whenNotRetryableException_thenFail() {
         final IllegalStateException illegalStateException = new IllegalStateException("Illegal state");
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onFailure(illegalStateException);
@@ -312,12 +430,21 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
         accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, null, resultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client, times(1)).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(resultListener).onFailure(illegalStateException);
     }
 
     public void testInferenceMultimodal_whenValidInput_thenSuccess() {
         final List<Number> vector = new ArrayList<>(List.of(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
@@ -326,6 +453,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
         accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(singleSentenceResultListener).onResponse(vector);
         Mockito.verifyNoMoreInteractions(singleSentenceResultListener);
@@ -337,6 +465,13 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             "Node not connected"
         );
 
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onFailure(nodeNodeConnectedException);
@@ -345,6 +480,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
 
         accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         // Verify client.predict is called 4 times (1 initial + 3 retries)
         verify(client, times(4)).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
 
@@ -360,6 +496,14 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
             mock(DiscoveryNode.class),
             "Node not connected"
         );
+
+        // Mock getModel for asymmetry check
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
         Mockito.doAnswer(invocation -> {
             final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
             actionListener.onFailure(nodeNodeConnectedException);
@@ -367,6 +511,7 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         accessor.inferenceSentencesMap(TestCommonConstants.MAP_INFERENCE_REQUEST, singleSentenceResultListener);
 
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
         verify(client, times(4)).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
         verify(singleSentenceResultListener).onFailure(nodeNodeConnectedException);
     }
@@ -1360,5 +1505,214 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         final ModelTensors modelTensors = new ModelTensors(mlModelTensorList);
         tensorsList.add(modelTensors);
         return new ModelTensorOutput(tensorsList);
+    }
+
+    // Tests for asymmetric model functionality
+    public void testInferenceSentences_whenAsymmetricModel_thenUsesAlgoParams() {
+        final List<List<Number>> vectorList = new ArrayList<>();
+        vectorList.add(Arrays.asList(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+        final MLAlgoParams algoParams = mock(MLAlgoParams.class);
+        final TextInferenceRequest requestWithParams = TextInferenceRequest.builder()
+            .modelId(TestCommonConstants.MODEL_ID)
+            .inputTexts(TestCommonConstants.SENTENCES_LIST)
+            .mlAlgoParams(algoParams)
+            .build();
+
+        // Mock asymmetric model
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            MLModel model = createAsymmetricModel();
+            actionListener.onResponse(model);
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // Mock successful prediction with params
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(requestWithParams, resultListener);
+
+        // Verify getModel called once, predict called once with params
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        verify(client).predict(eq(TestCommonConstants.MODEL_ID), mlInputCaptor.capture(), Mockito.isA(ActionListener.class));
+        assertEquals(algoParams, mlInputCaptor.getValue().getParameters());
+        verify(resultListener).onResponse(vectorList);
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    public void testInferenceSentences_whenSymmetricModel_thenNoParams() {
+        final List<List<Number>> vectorList = new ArrayList<>();
+        vectorList.add(Arrays.asList(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+        final MLAlgoParams algoParams = mock(MLAlgoParams.class);
+        final TextInferenceRequest requestWithParams = TextInferenceRequest.builder()
+            .modelId(TestCommonConstants.MODEL_ID)
+            .inputTexts(TestCommonConstants.SENTENCES_LIST)
+            .mlAlgoParams(algoParams)
+            .build();
+
+        // Mock symmetric model
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            MLModel model = createSymmetricModel();
+            actionListener.onResponse(model);
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // Mock successful prediction
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(requestWithParams, resultListener);
+
+        // Verify getModel called once, predict called once without params
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        verify(client).predict(eq(TestCommonConstants.MODEL_ID), mlInputCaptor.capture(), Mockito.isA(ActionListener.class));
+        assertNull(mlInputCaptor.getValue().getParameters());
+        verify(resultListener).onResponse(vectorList);
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    public void testInferenceSentencesWithMapResult_whenAsymmetricModel_thenUsesParams() {
+        final Map<String, Object> map = Map.of("key", "value");
+        final ActionListener<List<Map<String, ?>>> resultListener = mock(ActionListener.class);
+        final MLAlgoParams externalParams = mock(MLAlgoParams.class);
+
+        // Mock asymmetric model
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createAsymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createModelTensorOutput(map));
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentencesWithMapResult(TestCommonConstants.TEXT_INFERENCE_REQUEST, externalParams, resultListener);
+
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        verify(client).predict(eq(TestCommonConstants.MODEL_ID), mlInputCaptor.capture(), Mockito.isA(ActionListener.class));
+        assertEquals(externalParams, mlInputCaptor.getValue().getParameters());
+        verify(resultListener).onResponse(List.of(map));
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    public void testInferenceSentencesMap_whenAsymmetricModel_thenUsesParams() {
+        final List<Number> vector = new ArrayList<>(List.of(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+        final MLAlgoParams algoParams = mock(MLAlgoParams.class);
+        final MapInferenceRequest requestWithParams = MapInferenceRequest.builder()
+            .modelId(TestCommonConstants.MODEL_ID)
+            .inputObjects(Map.of("text", "test"))
+            .mlAlgoParams(algoParams)
+            .build();
+
+        // Mock asymmetric model
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createAsymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentencesMap(requestWithParams, singleSentenceResultListener);
+
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+        ArgumentCaptor<MLInput> mlInputCaptor = ArgumentCaptor.forClass(MLInput.class);
+        verify(client).predict(eq(TestCommonConstants.MODEL_ID), mlInputCaptor.capture(), Mockito.isA(ActionListener.class));
+        assertEquals(algoParams, mlInputCaptor.getValue().getParameters());
+        verify(singleSentenceResultListener).onResponse(vector);
+        Mockito.verifyNoMoreInteractions(singleSentenceResultListener);
+    }
+
+    public void testCheckModelAsymmetryAndThenPredict_whenCachedByPreviousCall_thenNoGetModelCall() {
+        final List<List<Number>> vectorList = new ArrayList<>();
+        vectorList.add(Arrays.asList(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+
+        // First call to populate cache
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createModelTensorOutput(TestCommonConstants.PREDICT_VECTOR_ARRAY));
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        // First call - should call getModel and predict
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        // Second call - should only call predict (cache hit)
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        // Verify getModel called only once (first call), predict called twice
+        verify(client, times(1)).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+        verify(client, times(2)).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+        verify(resultListener, times(2)).onResponse(vectorList);
+    }
+
+    public void testCheckModelAsymmetryAndThenPredict_whenGetModelFails_thenPropagateError() {
+        final RuntimeException getModelException = new RuntimeException("Failed to get model");
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onFailure(getModelException);
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        verify(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+        verify(client, times(0)).predict(any(), any(), any());
+        verify(resultListener).onFailure(getModelException);
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    private MLModel createAsymmetricModel() {
+        MLModel model = mock(MLModel.class);
+        org.opensearch.ml.common.model.TextEmbeddingModelConfig config = mock(
+            org.opensearch.ml.common.model.TextEmbeddingModelConfig.class
+        );
+        when(config.getPassagePrefix()).thenReturn("passage: ");
+        when(config.getQueryPrefix()).thenReturn("query: ");
+        when(model.getModelConfig()).thenReturn(config);
+        return model;
+    }
+
+    private MLModel createSymmetricModel() {
+        MLModel model = mock(MLModel.class);
+        org.opensearch.ml.common.model.TextEmbeddingModelConfig config = mock(
+            org.opensearch.ml.common.model.TextEmbeddingModelConfig.class
+        );
+        when(config.getPassagePrefix()).thenReturn(null);
+        when(config.getQueryPrefix()).thenReturn(null);
+        when(model.getModelConfig()).thenReturn(config);
+        return model;
+    }
+
+    private MLModel createNonTextEmbeddingModel() {
+        MLModel model = mock(MLModel.class);
+        // Return a non-TextEmbeddingModelConfig to test the instanceof check
+        org.opensearch.ml.common.model.MLModelConfig config = mock(org.opensearch.ml.common.model.MLModelConfig.class);
+        when(model.getModelConfig()).thenReturn(config);
+        return model;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorIT.java
@@ -76,6 +76,15 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
         assertEquals(1, getDocCount(INDEX_NAME));
     }
 
+    public void testAsymmetricTextEmbeddingProcessor() throws Exception {
+        String modelId = uploadAsymmetricTextEmbeddingModel();
+        loadAndWaitForModelToBeReady(modelId);
+        createPipelineProcessor(modelId, PIPELINE_NAME, ProcessorType.TEXT_EMBEDDING);
+        createIndexWithPipeline(INDEX_NAME, "IndexMappings.json", PIPELINE_NAME);
+        ingestDocument(INDEX_NAME, INGEST_DOC1);
+        assertEquals(1, getDocCount(INDEX_NAME));
+    }
+
     public void testTextEmbeddingProcessorWithSkipExisting() throws Exception {
         String modelId = uploadTextEmbeddingModel();
         loadAndWaitForModelToBeReady(modelId);
@@ -461,6 +470,11 @@ public class TextEmbeddingProcessorIT extends BaseNeuralSearchIT {
 
     protected String uploadTextEmbeddingModel() throws Exception {
         String requestBody = Files.readString(Path.of(classLoader.getResource("processor/UploadModelRequestBody.json").toURI()));
+        return registerModelGroupAndUploadModel(requestBody);
+    }
+
+    protected String uploadAsymmetricTextEmbeddingModel() throws Exception {
+        String requestBody = Files.readString(Path.of(classLoader.getResource("processor/UploadAsymmetricModelRequestBody.json").toURI()));
         return registerModelGroupAndUploadModel(requestBody);
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -61,6 +61,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import lombok.SneakyThrows;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters;
+import org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettingsAccessor;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
 import org.opensearch.transport.client.OpenSearchClient;
@@ -2517,5 +2519,168 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
                 assertEquals(insertVector.get(j).floatValue(), updateVector.get(j).floatValue(), 0.0000001f);
             }
         }
+    }
+
+    public void testAsymmetricModelSupport_whenDoBatchExecute_thenUsesPassageEmbeddingContentType() {
+        // Create processor instance
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(false);
+
+        // Mock the ML client to capture the inference request
+        ArgumentCaptor<TextInferenceRequest> requestCaptor = ArgumentCaptor.forClass(TextInferenceRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
+            listener.onResponse(createMockVectorResult());
+            return null;
+        }).when(mlCommonsClientAccessor).inferenceSentences(requestCaptor.capture(), isA(ActionListener.class));
+
+        // Create test inference list
+        List<String> inferenceList = Arrays.asList("test passage 1", "test passage 2");
+        Consumer<List<?>> handler = mock(Consumer.class);
+        Consumer<Exception> onException = mock(Consumer.class);
+
+        // Execute the batch processing
+        processor.doBatchExecute(inferenceList, handler, onException);
+
+        // Verify the request was captured
+        TextInferenceRequest capturedRequest = requestCaptor.getValue();
+        assertNotNull("Request should not be null", capturedRequest);
+        assertEquals("Model ID should match", "mockModelId", capturedRequest.getModelId());
+        assertEquals("Input texts should match", inferenceList, capturedRequest.getInputTexts());
+
+        // Verify asymmetric parameters are set for passage content type
+        assertNotNull("ML algo params should not be null", capturedRequest.getMlAlgoParams());
+        assertTrue(
+            "Should use AsymmetricTextEmbeddingParameters",
+            capturedRequest.getMlAlgoParams() instanceof AsymmetricTextEmbeddingParameters
+        );
+
+        AsymmetricTextEmbeddingParameters params = (AsymmetricTextEmbeddingParameters) capturedRequest.getMlAlgoParams();
+        assertEquals("Should use PASSAGE embedding content type", EmbeddingContentType.PASSAGE, params.getEmbeddingContentType());
+
+        // Verify the handler was called with results
+        verify(handler).accept(any(List.class));
+    }
+
+    public void testAsymmetricModelSupport_whenExecuteWithoutSkipExisting_thenUsesPassageContentType() {
+        Map<String, Object> sourceAndMetadata = new HashMap<>();
+        sourceAndMetadata.put(IndexFieldMapper.NAME, "my_index");
+        sourceAndMetadata.put("key1", "passage text 1");
+        sourceAndMetadata.put("key2", "passage text 2");
+        IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, new HashMap<>());
+
+        // Create processor with skipExisting = false
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(false);
+
+        // Mock the ML client to capture the inference request
+        ArgumentCaptor<TextInferenceRequest> requestCaptor = ArgumentCaptor.forClass(TextInferenceRequest.class);
+        List<List<Float>> modelTensorList = createMockVectorResult();
+        doAnswer(invocation -> {
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
+            listener.onResponse(modelTensorList);
+            return null;
+        }).when(mlCommonsClientAccessor).inferenceSentences(requestCaptor.capture(), isA(ActionListener.class));
+
+        BiConsumer handler = mock(BiConsumer.class);
+        processor.execute(ingestDocument, handler);
+
+        // Verify the request was captured
+        TextInferenceRequest capturedRequest = requestCaptor.getValue();
+        assertNotNull("Request should not be null", capturedRequest);
+        assertEquals("Model ID should match", "mockModelId", capturedRequest.getModelId());
+
+        // Verify asymmetric parameters are set for passage content type
+        assertNotNull("ML algo params should not be null", capturedRequest.getMlAlgoParams());
+        assertTrue(
+            "Should use AsymmetricTextEmbeddingParameters",
+            capturedRequest.getMlAlgoParams() instanceof AsymmetricTextEmbeddingParameters
+        );
+
+        AsymmetricTextEmbeddingParameters params = (AsymmetricTextEmbeddingParameters) capturedRequest.getMlAlgoParams();
+        assertEquals("Should use PASSAGE embedding content type", EmbeddingContentType.PASSAGE, params.getEmbeddingContentType());
+
+        // Verify successful execution
+        verify(handler).accept(any(IngestDocument.class), isNull());
+    }
+
+    public void testAsymmetricModelSupport_whenSubBatchExecuteWithoutSkipExisting_thenUsesPassageContentType() {
+        final int docCount = 3;
+        List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(docCount, false);
+
+        // Mock the ML client to capture the inference request
+        ArgumentCaptor<TextInferenceRequest> requestCaptor = ArgumentCaptor.forClass(TextInferenceRequest.class);
+        List<List<Float>> modelTensorList = createMockVectorWithLength(6); // 2 fields * 3 docs
+        doAnswer(invocation -> {
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
+            listener.onResponse(modelTensorList);
+            return null;
+        }).when(mlCommonsClientAccessor).inferenceSentences(requestCaptor.capture(), isA(ActionListener.class));
+
+        Consumer resultHandler = mock(Consumer.class);
+        processor.subBatchExecute(ingestDocumentWrappers, resultHandler);
+
+        // Verify the request was captured
+        TextInferenceRequest capturedRequest = requestCaptor.getValue();
+        assertNotNull("Request should not be null", capturedRequest);
+        assertEquals("Model ID should match", "mockModelId", capturedRequest.getModelId());
+
+        // Verify asymmetric parameters are set for passage content type
+        assertNotNull("ML algo params should not be null", capturedRequest.getMlAlgoParams());
+        assertTrue(
+            "Should use AsymmetricTextEmbeddingParameters",
+            capturedRequest.getMlAlgoParams() instanceof AsymmetricTextEmbeddingParameters
+        );
+
+        AsymmetricTextEmbeddingParameters params = (AsymmetricTextEmbeddingParameters) capturedRequest.getMlAlgoParams();
+        assertEquals("Should use PASSAGE embedding content type", EmbeddingContentType.PASSAGE, params.getEmbeddingContentType());
+
+        // Verify successful execution
+        ArgumentCaptor<List<IngestDocumentWrapper>> resultCaptor = ArgumentCaptor.forClass(List.class);
+        verify(resultHandler).accept(resultCaptor.capture());
+        assertEquals(docCount, resultCaptor.getValue().size());
+        for (int i = 0; i < docCount; ++i) {
+            assertEquals(ingestDocumentWrappers.get(i).getIngestDocument(), resultCaptor.getValue().get(i).getIngestDocument());
+            assertNull(resultCaptor.getValue().get(i).getException());
+        }
+    }
+
+    public void testAsymmetricModelSupport_whenBatchExecuteWithSkipExisting_thenUsesPassageContentType() {
+        final int docCount = 2;
+        List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(docCount, true);
+
+        // Mock the ML client to capture the inference request
+        ArgumentCaptor<TextInferenceRequest> requestCaptor = ArgumentCaptor.forClass(TextInferenceRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
+            listener.onResponse(createRandomOneDimensionalMockVector(2, 2, 0.0f, 1.0f));
+            return null;
+        }).when(mlCommonsClientAccessor).inferenceSentences(requestCaptor.capture(), isA(ActionListener.class));
+
+        // Mock the document retrieval for skip existing logic
+        mockUpdateMultipleDocuments(ingestDocumentWrappers);
+
+        Consumer resultHandler = mock(Consumer.class);
+        processor.batchExecute(ingestDocumentWrappers, resultHandler);
+
+        // Verify the request was captured
+        TextInferenceRequest capturedRequest = requestCaptor.getValue();
+        assertNotNull("Request should not be null", capturedRequest);
+        assertEquals("Model ID should match", "mockModelId", capturedRequest.getModelId());
+
+        // Verify asymmetric parameters are set for passage content type
+        assertNotNull("ML algo params should not be null", capturedRequest.getMlAlgoParams());
+        assertTrue(
+            "Should use AsymmetricTextEmbeddingParameters",
+            capturedRequest.getMlAlgoParams() instanceof AsymmetricTextEmbeddingParameters
+        );
+
+        AsymmetricTextEmbeddingParameters params = (AsymmetricTextEmbeddingParameters) capturedRequest.getMlAlgoParams();
+        assertEquals("Should use PASSAGE embedding content type", EmbeddingContentType.PASSAGE, params.getEmbeddingContentType());
+
+        // Verify successful execution
+        ArgumentCaptor<List<IngestDocumentWrapper>> resultCaptor = ArgumentCaptor.forClass(List.class);
+        verify(resultHandler).accept(resultCaptor.capture());
+        assertEquals(docCount, resultCaptor.getValue().size());
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderRewriteTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderRewriteTests.java
@@ -1265,7 +1265,12 @@ public class NeuralQueryBuilderRewriteTests extends OpenSearchTestCase {
         final QueryShardContext queryShardContext = mock(QueryShardContext.class);
         when(queryShardContext.fieldMapper(FIELD_NAME)).thenReturn(null);
 
-        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder().fieldName(FIELD_NAME).queryText(QUERY_TEXT).k(K).build();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .queryText(QUERY_TEXT)
+            .modelId(MODEL_ID)
+            .k(K)
+            .build();
 
         // first rewrite on the coordinate level
         QueryBuilder rewritten = neuralQueryBuilder.doRewrite(queryShardContext);

--- a/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/NeuralQueryBuilderTests.java
@@ -15,9 +15,11 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.FilterStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -66,6 +68,17 @@ import static org.opensearch.neuralsearch.query.NeuralQueryBuilder.SEMANTIC_FIEL
 import static org.opensearch.neuralsearch.util.NeuralSearchClusterTestUtils.setUpClusterService;
 import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_FLOATS_ASSERTION;
 import static org.opensearch.neuralsearch.util.TestUtils.xContentBuilderToMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.BiConsumer;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.processor.MapInferenceRequest;
+import org.opensearch.neuralsearch.query.dto.NeuralQueryBuildStage;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 
 public class NeuralQueryBuilderTests extends OpenSearchTestCase {
 
@@ -1147,6 +1160,146 @@ public class NeuralQueryBuilderTests extends OpenSearchTestCase {
         // For radial search, KNNQueryBuilder defaults K to 0 when not specified
         Integer k = returnedKNNQueryBuilder.getK();
         assertEquals("K should be 0 for radial search when not specified", 0, k == null ? 0 : k.intValue());
+    }
+
+    public void testAsymmetricModelSupport_whenRewritingQueryAgainstKnnField_thenUsesQueryEmbeddingContentType() {
+        setUpClusterService();
+
+        // Create a neural query builder with text and image
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .queryText(QUERY_TEXT)
+            .queryImage(IMAGE_TEXT)
+            .modelId(MODEL_ID)
+            .k(K)
+            .build();
+
+        // Mock the ML client to capture the inference request
+        MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
+        NeuralQueryBuilder.initialize(mockMLClient);
+
+        // Create a mock query rewrite context
+        QueryRewriteContext mockContext = mock(QueryRewriteContext.class);
+
+        // Mock the conversion methods to return null so it falls back to the old behavior
+        when(mockContext.convertToCoordinatorContext()).thenReturn(null);
+        when(mockContext.convertToShardContext()).thenReturn(null);
+
+        // Capture the async action registration
+        ArgumentCaptor<BiConsumer> asyncActionCaptor = ArgumentCaptor.forClass(BiConsumer.class);
+        doNothing().when(mockContext).registerAsyncAction(asyncActionCaptor.capture());
+
+        // Trigger the rewrite
+        QueryBuilder rewrittenQuery = neuralQueryBuilder.doRewrite(mockContext);
+
+        // Verify that an async action was registered
+        verify(mockContext).registerAsyncAction(any(BiConsumer.class));
+
+        // Simulate the async action execution
+        BiConsumer<Object, ActionListener<Object>> asyncAction = asyncActionCaptor.getValue();
+        ActionListener<Object> mockActionListener = mock(ActionListener.class);
+
+        // Capture the ML client call
+        ArgumentCaptor<MapInferenceRequest> requestCaptor = ArgumentCaptor.forClass(MapInferenceRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<List<Number>> listener = invocation.getArgument(1);
+            listener.onResponse(List.of(1.0f, 2.0f, 3.0f));
+            return null;
+        }).when(mockMLClient).inferenceSentencesMap(requestCaptor.capture(), any(ActionListener.class));
+
+        // Execute the async action
+        asyncAction.accept(null, mockActionListener);
+
+        // Verify the request contains asymmetric parameters for query content type
+        MapInferenceRequest capturedRequest = requestCaptor.getValue();
+        assertNotNull("Request should not be null", capturedRequest);
+        assertEquals("Model ID should match", MODEL_ID, capturedRequest.getModelId());
+
+        // Verify the input contains both text and image
+        Map<String, String> inputObjects = capturedRequest.getInputObjects();
+        assertEquals("Query text should match", QUERY_TEXT, inputObjects.get("inputText"));
+        assertEquals("Query image should match", IMAGE_TEXT, inputObjects.get("inputImage"));
+
+        // Verify asymmetric parameters are set for query content type
+        assertNotNull("ML algo params should not be null", capturedRequest.getMlAlgoParams());
+        assertTrue(
+            "Should use AsymmetricTextEmbeddingParameters",
+            capturedRequest
+                .getMlAlgoParams() instanceof org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters
+        );
+
+        org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters params =
+            (org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters) capturedRequest.getMlAlgoParams();
+        assertEquals(
+            "Should use QUERY embedding content type",
+            org.opensearch.ml.common.input.parameter.textembedding.AsymmetricTextEmbeddingParameters.EmbeddingContentType.QUERY,
+            params.getEmbeddingContentType()
+        );
+    }
+
+    public void testAsymmetricModelSupport_whenInferenceForSemanticField_thenUsesCorrectContentType() {
+        setUpClusterService();
+
+        // Create a neural query builder for semantic field
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .queryText(QUERY_TEXT)
+            .modelId(MODEL_ID)
+            .embeddingFieldType(KNNVectorFieldMapper.CONTENT_TYPE)
+            .isSemanticField(true)
+            .buildStage(NeuralQueryBuildStage.REWRITE)
+            .build();
+
+        // Mock the ML client
+        MLCommonsClientAccessor mockMLClient = mock(MLCommonsClientAccessor.class);
+        NeuralQueryBuilder.initialize(mockMLClient);
+
+        // Create a mock query rewrite context
+        QueryRewriteContext mockContext = mock(QueryRewriteContext.class);
+
+        // Mock the conversion methods to return null so it falls back to the old behavior
+        when(mockContext.convertToCoordinatorContext()).thenReturn(null);
+        when(mockContext.convertToShardContext()).thenReturn(null);
+
+        // Capture the async action registration
+        ArgumentCaptor<BiConsumer> asyncActionCaptor = ArgumentCaptor.forClass(BiConsumer.class);
+        doNothing().when(mockContext).registerAsyncAction(asyncActionCaptor.capture());
+
+        // Trigger the inference path by calling doRewrite which will internally call inferenceForSemanticField
+        try {
+            neuralQueryBuilder.doRewrite(mockContext);
+        } catch (Exception e) {
+            // Expected to fail due to mocking, but should trigger the inference path
+        }
+
+        // Verify that an async action was registered
+        verify(mockContext).registerAsyncAction(any(BiConsumer.class));
+
+        // Simulate the async action execution
+        BiConsumer<Object, ActionListener<Object>> asyncAction = asyncActionCaptor.getValue();
+        ActionListener<Object> mockActionListener = mock(ActionListener.class);
+
+        // Capture the ML client call
+        ArgumentCaptor<MapInferenceRequest> requestCaptor = ArgumentCaptor.forClass(MapInferenceRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<List<Number>> listener = invocation.getArgument(1);
+            listener.onResponse(List.of(1.0f, 2.0f, 3.0f));
+            return null;
+        }).when(mockMLClient).inferenceSentencesMap(requestCaptor.capture(), any(ActionListener.class));
+
+        // Execute the async action
+        asyncAction.accept(null, mockActionListener);
+
+        // Verify the request uses the correct model ID
+        MapInferenceRequest capturedRequest = requestCaptor.getValue();
+        assertNotNull("Request should not be null", capturedRequest);
+        assertEquals("Model ID should match", MODEL_ID, capturedRequest.getModelId());
+
+        // For semantic field dense model inference, it should not have asymmetric parameters
+        // since the method doesn't explicitly set them for semantic field inference
+        // This test verifies the current behavior
+        Map<String, String> inputObjects = capturedRequest.getInputObjects();
+        assertEquals("Query text should match", QUERY_TEXT, inputObjects.get("inputText"));
     }
 
     public void testPrepareTwoPhase_Query_whenRawTokensAvailable() {

--- a/src/test/resources/processor/UploadAsymmetricModelRequestBody.json
+++ b/src/test/resources/processor/UploadAsymmetricModelRequestBody.json
@@ -1,0 +1,17 @@
+{
+  "name": "traced_small_model",
+  "version": "1.0.0",
+  "model_format": "TORCH_SCRIPT",
+  "model_task_type": "text_embedding",
+  "model_content_hash_value": "e13b74006290a9d0f58c1376f9629d4ebc05a0f9385f40db837452b167ae9021",
+  "model_group_id": "%s",
+  "model_config": {
+    "model_type": "bert",
+    "embedding_dimension": 768,
+    "framework_type": "sentence_transformers",
+    "passage_prefix" : "passage: ",
+    "query_prefix" : "query: ",
+    "all_config": "{\"architectures\":[\"BertModel\"],\"max_position_embeddings\":512,\"model_type\":\"bert\",\"num_attention_heads\":12,\"num_hidden_layers\":6}"
+  },
+  "url": "https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/traced_small_model.zip?raw=true"
+}


### PR DESCRIPTION
### Description
This PR is a rebasing on top of #710 

## E2E Tests
* register a local asymmetric model
```json
curl -XPOST "http://localhost:9200/_plugins/_ml/models/_register" -H 'Content-Type: application/json' -d'
{
  "name": "traced_small_model",
  "version": "1.0.0",
  "model_format": "TORCH_SCRIPT",
  "model_task_type": "text_embedding",
  "model_content_hash_value": "e13b74006290a9d0f58c1376f9629d4ebc05a0f9385f40db837452b167ae9021",
  "model_group_id": "ytHnwJkBA2y8vkecT0nP",
  "model_config": {
    "model_type": "bert",
    "embedding_dimension": 768,
    "framework_type": "sentence_transformers",
    "passage_prefix" : "passage: ",
    "query_prefix" : "query: ",
    "all_config": "{\"architectures\":[\"BertModel\"],\"max_position_embeddings\":512,\"model_type\":\"bert\",\"num_attention_heads\":12,\"num_hidden_layers\":6}"
  },
  "url": "https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/traced_small_model.zip?raw=true"
}'
{"task_id":"zNHnwJkBA2y8vkeckEnm","status":"CREATED"}
```

* test the model
    * The embedding model chosen is asymmetric. To use it, you must declare whether the input is of type QUERY or of type PASSAGE.
```json
curl -XPOST "http://localhost:9200/_plugins/_ml/_predict/text_embedding/3zfSwJkB9yHsUFukoFGN" -H 'Content-Type: application/json' -d'
{
  "parameters": {
    "content_type": "query"
  },
  "text_docs": ["What day is it today?"],
  "target_response": ["sentence_embedding"]
}'
{"inference_results":[{"output":[{"name":"sentence_embedding","data_type":"FLOAT32","shape":[768],"data":[0.4277453,0.36682454,0.57426196,0.53548354,0.5545153,0.68228644,0.37400416,0.6416417,0.6905142,0.5195829,0.46663672,0.3864537,0.419837,0.45926508,0.4904398,0.61876655,0.5276075,0.5057253,0.44570318,0.6018752,0.55649084,0.4044214,0.46216413, ....]}]}]}
```

* create an index
```json
curl -XPUT "http://localhost:9200/nyc_facts" -H 'Content-Type: application/json' -d'
{
  "settings": {
    "index.knn": true,
    "default_pipeline": "asymmetric_embedding_ingest_pipeline",
    "knn.algo_param.ef_search": 100
  },
  "mappings": {
    "properties":  {
      "fact_embedding": {
        "type": "knn_vector",
        "dimension": 768,
        "method": {
          "name": "hnsw",
          "space_type": "l2",
          "engine": "faiss",
          "parameters": {
            "ef_construction": 128,
            "m": 24
          }
        }
      }
    }
  }
}'
{"acknowledged":true,"shards_acknowledged":true,"index":"nyc_facts"}
```

* create an ingest pipeline
```json
curl -XPUT "http://localhost:9200/_ingest/pipeline/asymmetric_embedding_ingest_pipeline" -H 'Content-Type: application/json' -d'
{
    "description": "ingest passage text and generate a embedding using an asymmetric model",
    "processors": [
        {
            "ml_inference": {

                "model_input": "{\"text_docs\":[\"${input_map.text_docs}\"],\"target_response\":[\"sentence_embedding\"],\"parameters\":{\"content_type\":\"query\"}}",
                "function_name": "text_embedding",
                "model_id": "ztHnwJkBA2y8vkeckUng",
                "input_map": [
                    {
                        "text_docs": "description"
                    }
                ],
                "output_map": [
                    {
                        "fact_embedding": "$.inference_results[0].output[0].data",
                        "embedding_size": "$.inference_results.*.output.*.shape[0]"
                    }
                ]
            }
        }
    ]
}'
{"acknowledged":true}
```

* ingest data
```json
curl -XPOST "http://localhost:9200/_bulk" -H 'Content-Type: application/json' -d'
{ "index": { "_index": "nyc_facts" } }
{ "title": "Central Park", "description": "A large public park in the heart of New York City, offering a wide range of recreational activities." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Empire State Building", "description": "An iconic skyscraper in New York City offering breathtaking views from its observation deck." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Statue of Liberty", "description": "A colossal neoclassical sculpture on Liberty Island, symbolizing freedom and democracy in the United States." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Brooklyn Bridge", "description": "A historic suspension bridge connecting Manhattan and Brooklyn, offering pedestrian walkways with great views." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Times Square", "description": "A bustling commercial and entertainment hub in Manhattan, known for its neon lights and Broadway theaters." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Yankee Stadium", "description": "Home to the New York Yankees, this baseball stadium is a historic landmark in the Bronx." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "The Bronx Zoo", "description": "One of the largest zoos in the world, located in the Bronx, featuring diverse animal exhibits and conservation efforts." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "New York Botanical Garden", "description": "A large botanical garden in the Bronx, known for its diverse plant collections and stunning landscapes." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Flushing Meadows-Corona Park", "description": "A major park in Queens, home to the USTA Billie Jean King National Tennis Center and the Unisphere." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Citi Field", "description": "The home stadium of the New York Mets, located in Queens, known for its modern design and fan-friendly atmosphere." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Rockefeller Center", "description": "A famous complex of commercial buildings in Manhattan, home to the NBC studios and the annual ice skating rink." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Queens Botanical Garden", "description": "A peaceful, beautiful botanical garden located in Flushing, Queens, featuring seasonal displays and plant collections." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Arthur Ashe Stadium", "description": "The largest tennis stadium in the world, located in Flushing Meadows-Corona Park, Queens, hosting the U.S. Open." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Wave Hill", "description": "A public garden and cultural center in the Bronx, offering stunning views of the Hudson River and a variety of nature programs." }
{ "index": { "_index": "nyc_facts" } }
{ "title": "Louis Armstrong House", "description": "The former home of jazz legend Louis Armstrong, located in Corona, Queens, now a museum celebrating his life and music." }'
```

* create a search pipeline
```json
curl -XPUT "http://localhost:9200/_search/pipeline/asymmetric_embedding_search_pipeline" -H 'Content-Type: application/json' -d'
{
   "description": "ingest passage text and generate a embedding using an asymmetric model",
   "request_processors": [
      {
        "ml_inference": {
            "query_template": "{\"size\": 3,\"query\": {\"knn\": {\"fact_embedding\": {\"vector\": ${query_embedding},\"k\": 4}}}}",
            "function_name": "text_embedding",
            "model_id": "3zfSwJkB9yHsUFukoFGN",
            "model_input": "{ \"text_docs\": [\"${input_map.query}\"], \"target_response\": [\"sentence_embedding\"], \"parameters\" : {\"content_type\" : \"query\" } }",
            "input_map": [
               {
                  "query": "query.term.fact_embedding.value"
               }
            ],
            "output_map": [
               {
                  "query_embedding": "$.inference_results[0].output[0].data",
                  "embedding_size": "$.inference_results.*.output.*.shape[0]"
               }
            ]
         }
      }
   ]
}'
```

* run a query
```json
curl -XGET "http://localhost:9200/nyc_facts/_search" -H 'Content-Type: application/json' -d'
{
  "_source": {
    "excludes": [
      "fact_embedding"
    ]
  },
  "query": {
    "neural": {
      "fact_embedding": {
        "query_text": "What are some places for sports in NYC?",
        "model_id": "fpb3wJkBt8Q-zKDiG4F6",
        "boost": 1
      }
    }
  }
}'
```



### Related Issues
#620 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
