### PR TITLE
Add Owais Kazi (owaiskazi19) as the maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @sean-zheng-amazon @model-collapse @zane-neo @vibrantvarun @zhichao-aws @yuye-aws @minalsha @bzhangam @chishui
+*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @sean-zheng-amazon @model-collapse @zane-neo @vibrantvarun @zhichao-aws @yuye-aws @minalsha @bzhangam @chishui @owaiskazi19

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Minal Shah              | [minalsha](https://github.com/minalsha)                   | Amazon      |
 | Bo Zhang                | [bzhangam](https://github.com/bzhangam)                   | Amazon      |
 | Liyun Xiu               | [chishui](https://github.com/chishui)                     | Amazon      |
+| Owais Kazi              | [owaiskazi19](https://github.com/owaiskazi19)                 | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
This PR adds @owaiskazi19 as the maintainer of Neural Search Plugin. Owais has done a remarkable job in delivering new features and maintaining the plugin in past few months.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
