### PR TITLE
[Agentic Search] Add conversation search support with agentic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 
 ### Enhancements
+- [Agentic Search] Add conversation search support with agentic search ([#1626](https://github.com/opensearch-project/neural-search/pull/1626))
 
 ### Bug Fixes
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
@@ -17,6 +17,7 @@ import org.opensearch.neuralsearch.query.AgenticSearchQueryBuilder;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettingsAccessor;
 import org.opensearch.neuralsearch.stats.events.EventStatName;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
+import org.opensearch.search.SearchExtBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.AbstractProcessor;
 import org.opensearch.search.pipeline.Processor;
@@ -25,6 +26,7 @@ import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.core.action.ActionListener;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -149,8 +151,12 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
 
                     // Parse the agent response to get the new search source
                     BytesReference bytes = new BytesArray(dslQuery);
+                    List<SearchExtBuilder> originalExtBuilders = request.source() != null ? request.source().ext() : null;
                     try (XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry, null, bytes.streamInput())) {
                         SearchSourceBuilder newSourceBuilder = SearchSourceBuilder.fromXContent(parser);
+                        if (originalExtBuilders != null && !originalExtBuilders.isEmpty()) {
+                            newSourceBuilder.ext(originalExtBuilders);
+                        }
                         request.source(newSourceBuilder);
                     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorTests.java
@@ -16,6 +16,7 @@ import org.opensearch.neuralsearch.ml.dto.AgentInfoDTO;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.query.AgenticSearchQueryBuilder;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
+import org.opensearch.search.SearchExtBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
@@ -837,5 +838,64 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
         );
 
         assertEquals("agent_id must contain only alphanumeric characters, hyphens, and underscores", exception.getMessage());
+    }
+
+    public void testProcessRequestAsync_preservesOriginalExtBuilders() throws IOException {
+        List<NamedXContentRegistry.Entry> entries = new ArrayList<>();
+        entries.add(new NamedXContentRegistry.Entry(QueryBuilder.class, new ParseField("match_all"), MatchAllQueryBuilder::fromXContent));
+        NamedXContentRegistry registry = new NamedXContentRegistry(entries);
+
+        AgenticQueryTranslatorProcessor.Factory factory = new AgenticQueryTranslatorProcessor.Factory(
+            mockMLClient,
+            registry,
+            mockSettingsAccessor
+        );
+        Map<String, Object> config = new HashMap<>();
+        config.put("agent_id", AGENT_ID);
+        AgenticQueryTranslatorProcessor testProcessor = factory.create(null, "test-tag", "test-description", false, config, null);
+
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT);
+        SearchRequest request = new SearchRequest("test-index");
+
+        // Create original search source with ext builders
+        SearchSourceBuilder originalSource = new SearchSourceBuilder().query(agenticQuery);
+        List<SearchExtBuilder> originalExtBuilders = new ArrayList<>();
+        originalExtBuilders.add(mock(SearchExtBuilder.class));
+        originalSource.ext(originalExtBuilders);
+        request.source(originalSource);
+
+        ActionListener<SearchRequest> listener = mock(ActionListener.class);
+
+        AgentInfoDTO agentInfo = new AgentInfoDTO("conversational", false, false);
+        doAnswer(invocation -> {
+            ActionListener<AgentInfoDTO> agentInfoListener = invocation.getArgument(1);
+            agentInfoListener.onResponse(agentInfo);
+            return null;
+        }).when(mockMLClient).getAgentDetails(eq(AGENT_ID), any(ActionListener.class));
+
+        String validAgentResponse = "{\"query\": {\"match_all\": {}}}";
+        doAnswer(invocation -> {
+            ActionListener<AgentExecutionDTO> agentListener = invocation.getArgument(5);
+            agentListener.onResponse(new AgentExecutionDTO(validAgentResponse, null, "test-memory-id"));
+            return null;
+        }).when(mockMLClient)
+            .executeAgent(
+                any(SearchRequest.class),
+                any(AgenticSearchQueryBuilder.class),
+                eq(AGENT_ID),
+                eq(agentInfo),
+                any(NamedXContentRegistry.class),
+                any(ActionListener.class)
+            );
+
+        testProcessor.processRequestAsync(request, mockContext, listener);
+
+        verify(listener).onResponse(request);
+
+        // Verify that original ext builders are preserved
+        assertNotNull(request.source());
+        assertNotNull(request.source().ext());
+        assertEquals(1, request.source().ext().size());
+        assertEquals(originalExtBuilders.get(0), request.source().ext().get(0));
     }
 }


### PR DESCRIPTION
### Description
Add conversation search support with agentic search by storing the ext params passed in the request
```json

    "ext": {
        "retrieval_augmented_generation": {
            "answer": "You can find a variety of stylish sneakers under $200, including options like red cushioned, blue lifestyle, classic black, iconic suede, and low-top white sneakers. Prices can vary by brand and retailer, so it's a good idea to explore different stores or online platforms for the best deals and offers.",
            "message_id": "L0rWA5oBxjfdJ-H1juTm"
        }
    }
```

### Related Issues
Part of https://github.com/opensearch-project/neural-search/issues/1525

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
