### PR TITLE
Use SearchPipelineService for system factory check in batch semantic highlighting

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/highlight/SemanticHighlighter.java
+++ b/src/main/java/org/opensearch/neuralsearch/highlight/SemanticHighlighter.java
@@ -4,10 +4,7 @@
  */
 package org.opensearch.neuralsearch.highlight;
 
-import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
-import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.text.Text;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.neuralsearch.highlight.single.SemanticHighlighterEngine;
@@ -20,7 +17,6 @@ import org.opensearch.search.fetch.subphase.highlight.HighlightField;
 import org.opensearch.search.fetch.subphase.highlight.Highlighter;
 import org.opensearch.search.pipeline.SearchPipelineService;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -30,8 +26,6 @@ import java.util.Map;
 @Log4j2
 public class SemanticHighlighter implements Highlighter {
     private SemanticHighlighterEngine semanticHighlighterEngine;
-    @Setter
-    private ClusterService clusterService;
 
     public void initialize(SemanticHighlighterEngine semanticHighlighterEngine) {
         if (this.semanticHighlighterEngine != null) {
@@ -130,17 +124,6 @@ public class SemanticHighlighter implements Highlighter {
     }
 
     private boolean isSystemProcessorEnabled() {
-        if (clusterService == null) {
-            clusterService = NeuralSearchClusterUtil.instance().getClusterService();
-        }
-
-        Settings clusterSettings = clusterService.state().metadata().settings();
-        List<String> enabledFactories = clusterSettings.getAsList(
-            SearchPipelineService.ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING.getKey()
-        );
-
-        // Check if semantic-highlighter is enabled explicitly or if all factories are enabled with "*"
-        return enabledFactories != null
-            && (enabledFactories.contains(SemanticHighlightingConstants.SYSTEM_FACTORY_TYPE) || enabledFactories.contains("*"));
+        return NeuralSearchClusterUtil.instance().isSystemGeneratedFactoryEnabled(SemanticHighlightingConstants.SYSTEM_FACTORY_TYPE);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -240,7 +240,6 @@ public class NeuralSearch extends Plugin
 
         // Initialize the semantic highlighter
         this.semanticHighlighter.initialize(semanticHighlighterEngine);
-        this.semanticHighlighter.setClusterService(clusterService);
 
         return List.of(clientAccessor, EventStatsManager.instance(), infoStatsManager);
     }
@@ -408,6 +407,8 @@ public class NeuralSearch extends Plugin
     public Map<String, SystemGeneratedProcessor.SystemGeneratedFactory<SearchResponseProcessor>> getSystemGeneratedResponseProcessors(
         Parameters parameters
     ) {
+        NeuralSearchClusterUtil.instance().setSearchPipelineService(parameters.searchPipelineService);
+
         // System-generated semantic highlighting processor that automatically applies when semantic highlighting is detected
         return Map.of(SemanticHighlightingConstants.SYSTEM_FACTORY_TYPE, new SemanticHighlightingFactory(clientAccessor));
     }

--- a/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.Version;
 import org.opensearch.action.IndicesRequest;
@@ -15,6 +16,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.index.Index;
+import org.opensearch.search.pipeline.SearchPipelineService;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +32,8 @@ public class NeuralSearchClusterUtil {
     @Getter
     private ClusterService clusterService;
     private IndexNameExpressionResolver indexNameExpressionResolver;
+    @Setter
+    private SearchPipelineService searchPipelineService;
 
     private static NeuralSearchClusterUtil instance;
 
@@ -88,5 +92,17 @@ public class NeuralSearchClusterUtil {
             throw new IllegalStateException("Failed to extract index mapping", e);
         }
         throw new IllegalStateException("No valid index found to extract mapping");
+    }
+
+    /**
+     * Check if the system generated factory is enabled or not
+     * @param factoryName name of the factory
+     * @return If the factory is enabled or not
+     */
+    public boolean isSystemGeneratedFactoryEnabled(String factoryName) {
+        if (searchPipelineService == null) {
+            throw new IllegalStateException("search pipeline service is not initialized in the neural search cluster util.");
+        }
+        return searchPipelineService.isSystemGeneratedFactoryEnabled(factoryName);
     }
 }


### PR DESCRIPTION
### Description
Refactored semantic highlighting to use SearchPipelineService for checking system factory enablement instead of directly accessing cluster settings. This changes make sure default, persistent and transient levels setting can be read and applied.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
