### PR TITLE
Add functionality to auto increment bwc version with auto increment PR

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         java: [ 21, 25 ]
         os: [ubuntu-latest]
-        bwc_version : [ "2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.0","2.20.0-SNAPSHOT","3.0.0", "3.1.0", "3.2.0" ]
-        opensearch_version : [ "3.3.0-SNAPSHOT" ]
+        bwc_version : [ "2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.0","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0" ]
+        opensearch_version : [ "3.5.0-SNAPSHOT" ]
 
     name: NeuralSearch Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -62,8 +62,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: [ "2.20.0-SNAPSHOT","3.0.0", "3.1.0", "3.2.0" ]
-        opensearch_version: [ "3.3.0-SNAPSHOT" ]
+        bwc_version: [ "2.20.0-SNAPSHOT","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0" ]
+        opensearch_version: [ "3.5.0-SNAPSHOT" ]
 
     name: NeuralSearch Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: [ "2.20.0-SNAPSHOT","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0" ]
+        bwc_version: [ "2.19.0","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0" ]
         opensearch_version: [ "3.5.0-SNAPSHOT" ]
 
     name: NeuralSearch Rolling-Upgrade BWC Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 
 ### Maintenance
+- [BWC]: Auto Increment BWC version with every release ([#1716](https://github.com/opensearch-project/neural-search/pull/1716))
 
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ buildscript {
 }
 
 plugins{
+    id 'eclipse'
     id "de.undercouch.download" version "5.3.0"
 }
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -515,7 +515,7 @@ task updateVersion {
 
         if (!fileTree("gradle.properties").getSingleFile().text.contains(os_version_without_snapshot)) {
             // Include the current OpenSearch Version before version bump to the bwc_version matrix
-            ant.replaceregexp(file:"gradle.properties", match: oldBWCVersion, replace: oldBWCVersion + '", "' + opensearch_version.tokenize('-')[0], flags:'g', byline:true)
+            ant.replaceregexp(file:"gradle.properties", match: oldBWCVersion, replace: opensearch_version.tokenize('-')[0], flags:'g', byline:true)
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -505,12 +505,16 @@ task updateVersion {
         ext.os_version_major = os_version_without_snapshot.tokenize('.')[0]
         ext.os_version_minor = os_version_without_snapshot.tokenize('.')[1]
         ext.os_version_patch = os_version_without_snapshot.tokenize('.')[2]
+        // Extract the oldBWCVersion from the existing OpenSearch Version (oldBWCVersion = major . (minor-1) . patch)
+        ext.oldBWCVersion = os_version_major + '.' + Integer.toString(Integer.valueOf(os_version_minor) - 1) + '.' + os_version_patch
         // This condition will check if the BWC workflow is already updated or not and will run next steps if not updated
         if (!fileTree(".github/workflows/backwards_compatibility_tests_workflow.yml").getSingleFile().text.contains(os_version_without_snapshot)) {
-            // Extract the oldBWCVersion from the existing OpenSearch Version (oldBWCVersion = major . (minor-1) . patch)
-            ext.oldBWCVersion = os_version_major + '.' + Integer.toString(Integer.valueOf(os_version_minor) - 1) + '.' + os_version_patch
             // Include the current OpenSearch Version before version bump to the bwc_version matrix
             ant.replaceregexp(file:".github/workflows/backwards_compatibility_tests_workflow.yml", match: oldBWCVersion, replace: oldBWCVersion + '", "' + opensearch_version.tokenize('-')[0], flags:'g', byline:true)
+        }
+
+        if (!fileTree("gradle.properties").getSingleFile().text.contains(os_version_without_snapshot)) {
+            // Include the current OpenSearch Version before version bump to the bwc_version matrix
             ant.replaceregexp(file:"gradle.properties", match: oldBWCVersion, replace: oldBWCVersion + '", "' + opensearch_version.tokenize('-')[0], flags:'g', byline:true)
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -491,7 +491,28 @@ task updateVersion {
         ext.newVersion = System.getProperty('newVersion')
         println "Setting version to ${newVersion}."
         // String tokenization to support -SNAPSHOT
+        // Include the required files that needs to be updated with new Version
+        ant.replaceregexp(match: opensearch_version.tokenize('-')[0], replace: newVersion.tokenize('-')[0], flags:'g', byline:true) {
+            fileset(dir: projectDir) {
+                // Include the required files that needs to be updated with new Version
+                include(name: ".github/workflows/backwards_compatibility_tests_workflow.yml")
+                include(name: "gradle.properties")
+            }
+        }
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
+
+        ext.os_version_without_snapshot = opensearch_version.tokenize('-')[0]
+        ext.os_version_major = os_version_without_snapshot.tokenize('.')[0]
+        ext.os_version_minor = os_version_without_snapshot.tokenize('.')[1]
+        ext.os_version_patch = os_version_without_snapshot.tokenize('.')[2]
+        // This condition will check if the BWC workflow is already updated or not and will run next steps if not updated
+        if (!fileTree(".github/workflows/backwards_compatibility_tests_workflow.yml").getSingleFile().text.contains(os_version_without_snapshot)) {
+            // Extract the oldBWCVersion from the existing OpenSearch Version (oldBWCVersion = major . (minor-1) . patch)
+            ext.oldBWCVersion = os_version_major + '.' + Integer.toString(Integer.valueOf(os_version_minor) - 1) + '.' + os_version_patch
+            // Include the current OpenSearch Version before version bump to the bwc_version matrix
+            ant.replaceregexp(file:".github/workflows/backwards_compatibility_tests_workflow.yml", match: oldBWCVersion, replace: oldBWCVersion + '", "' + opensearch_version.tokenize('-')[0], flags:'g', byline:true)
+            ant.replaceregexp(file:"gradle.properties", match: oldBWCVersion, replace: oldBWCVersion + '", "' + opensearch_version.tokenize('-')[0], flags:'g', byline:true)
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=3.3.0-SNAPSHOT
-systemProp.bwc.bundle.version=3.2.0
+systemProp.bwc.version=3.5.0-SNAPSHOT
+systemProp.bwc.bundle.version=3.4.0
 
 # For fixing Spotless check with Java 17
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION
### Description
This PR does 2 things
1. It adds functionality to auto increment the BWC version with auto increment release version PR
2. For this as 3.5 auto increment PR is already cut off so manually increase the version in BWC files.


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
