### PR TITLE
Fixed runtime error when number of shards greater than default batch reduce size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [HYBRID]: Fix for Hybrid Query with Collapse bugs([#1702](https://github.com/opensearch-project/neural-search/pull/1702))
 - [HYBRID]: Fix position overflow of docIds in HybridBulkScorer to increase search relevance ([#1706](https://github.com/opensearch-project/neural-search/pull/1706))
 - [HYBRID]: Fix logic of RRF score calculation as per document global rank in the subquery ([#1718](https://github.com/opensearch-project/neural-search/pull/1718))
+- [HYBRID]: Fix runtime error when number of shards greater than default batch reduce size ([#1738](https://github.com/opensearch-project/neural-search/pull/1738))
 
 ### Infrastructure
 - [BWC]: Enable BWC tests after upgrading to Grade 9 ([#1729](https://github.com/opensearch-project/neural-search/pull/1729))

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -144,6 +144,8 @@ import org.opensearch.neuralsearch.transport.NeuralSparseWarmupTransportAction;
 
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.neuralsearch.util.PipelineServiceUtil;
+import org.opensearch.neuralsearch.search.HybridQuerySearchRequestFilter;
+import org.opensearch.action.support.ActionFilter;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.EnginePlugin;
 import org.opensearch.plugins.ExtensiblePlugin;
@@ -504,5 +506,13 @@ public class NeuralSearch extends Plugin
     @Override
     public List<QueryCollectorContextSpecFactory> getCollectorContextSpecFactories() {
         return List.of(new HybridQueryCollectorContextSpecFactory());
+    }
+
+    /**
+     * Register action filters to intercept search requests.
+     */
+    @Override
+    public List<ActionFilter> getActionFilters() {
+        return List.of(new HybridQuerySearchRequestFilter());
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search;
+
+import org.opensearch.core.action.ActionListener;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import org.opensearch.action.search.SearchAction;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.tasks.Task;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * An ActionFilter that automatically disables batched reduction for hybrid queries.
+ *
+ * This filter intercepts all search requests and checks if they contain a hybrid query.
+ * If a hybrid query is detected, it unconditionally sets batchedReduceSize to Integer.MAX_VALUE
+ * to disable batched reduction, regardless of any user-specified value.
+ *
+ * This prevents the "topDocs already consumed" error that occurs when:
+ * 1. Hybrid query is executed
+ * 2. Batched reduction triggers (QueryPhaseResultConsumer.consume)
+ * 3. TopDocs are consumed before NormalizationProcessor can access them
+ *
+ * Note: The batched_reduce_size parameter is not honored for hybrid queries because
+ * batched reduction is fundamentally incompatible with hybrid query processing.
+ * The NormalizationProcessor requires access to all shard results simultaneously
+ * to perform score normalization and combination.
+ *
+ * This filter works transparently without any pipeline or query configuration.
+ *
+ */
+@Log4j2
+public class HybridQuerySearchRequestFilter implements ActionFilter {
+
+    /**
+     * Value to disable batched reduction.
+     * Setting batchedReduceSize to Integer.MAX_VALUE effectively disables batched reduction
+     * since the buffer will never reach this threshold.
+     */
+    private static final int DISABLE_BATCHED_REDUCE = Integer.MAX_VALUE;
+
+    /**
+     * Order of this filter in the filter chain.
+     * Lower values execute first. We use 0 to ensure this runs early.
+     */
+    @Override
+    public int order() {
+        return 0;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <Request extends org.opensearch.action.ActionRequest, Response extends ActionResponse> void apply(
+        Task task,
+        String action,
+        Request request,
+        ActionListener<Response> listener,
+        ActionFilterChain<Request, Response> chain
+    ) {
+        // only intercept search actions
+        if (SearchAction.NAME.equals(action) && request instanceof SearchRequest) {
+            SearchRequest searchRequest = (SearchRequest) request;
+
+            // unconditionally disable batched reduction for hybrid queries
+            // batched reduction is incompatible with hybrid query processing
+            if (containsHybridQuery(searchRequest)) {
+                if (searchRequest.getBatchedReduceSize() != DISABLE_BATCHED_REDUCE) {
+                    log.debug(
+                        String.format(
+                            Locale.ROOT,
+                            "Hybrid query detected, disabling batched reduction to prevent 'topDocs already consumed' error. "
+                                + "Original batched_reduce_size: %d, new value: %d. "
+                                + "Note: batched_reduce_size is not honored for hybrid queries.",
+                            searchRequest.getBatchedReduceSize(),
+                            DISABLE_BATCHED_REDUCE
+                        )
+                    );
+                    searchRequest.setBatchedReduceSize(DISABLE_BATCHED_REDUCE);
+                }
+            }
+        }
+        chain.proceed(task, action, request, listener);
+    }
+
+    /**
+     * Check if the search request contains a hybrid query.
+     *
+     * @param searchRequest the search request to check
+     * @return true if the request contains a hybrid query
+     */
+    private boolean containsHybridQuery(SearchRequest searchRequest) {
+        if (Objects.isNull(searchRequest.source())) {
+            return false;
+        }
+
+        QueryBuilder query = searchRequest.source().query();
+        if (Objects.isNull(query)) {
+            return false;
+        }
+
+        // direct check for HybridQueryBuilder
+        return query instanceof HybridQueryBuilder;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -34,8 +34,10 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.breaker.BreakerSettings;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.ingest.Processor;
+import org.opensearch.action.support.ActionFilter;
 import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
 import org.opensearch.neuralsearch.mappingtransformer.SemanticMappingTransformer;
+import org.opensearch.neuralsearch.search.HybridQuerySearchRequestFilter;
 import org.opensearch.neuralsearch.processor.NeuralQueryEnricherProcessor;
 import org.opensearch.neuralsearch.processor.NeuralSparseTwoPhaseProcessor;
 import org.opensearch.neuralsearch.processor.NormalizationProcessor;
@@ -370,5 +372,13 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
         Optional<CodecServiceFactory> result = plugin.getCustomCodecServiceFactory(indexSettings);
 
         assertFalse(result.isPresent());
+    }
+
+    public void testGetActionFilters_shouldReturnHybridQuerySearchRequestFilter() {
+        List<ActionFilter> actionFilters = plugin.getActionFilters();
+
+        assertNotNull(actionFilters);
+        assertEquals(1, actionFilters.size());
+        assertTrue(actionFilters.get(0) instanceof HybridQuerySearchRequestFilter);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.opensearch.action.bulk.BulkAction;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.search.SearchAction;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.tasks.Task;
+
+public class HybridQuerySearchRequestFilterTests extends OpenSearchQueryTestCase {
+
+    private HybridQuerySearchRequestFilter filter;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        filter = new HybridQuerySearchRequestFilter();
+    }
+
+    public void testOrder_thenReturnsZero() {
+        assertEquals(0, filter.order());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenHybridQueryWithDefaultBatchReduceSize_thenDisablesBatchedReduction() {
+        // Setup
+        HybridQueryBuilder hybridQuery = new HybridQueryBuilder();
+        hybridQuery.add(new MatchQueryBuilder("field", "value"));
+        hybridQuery.add(new MatchAllQueryBuilder());
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(hybridQuery);
+        searchRequest.source(sourceBuilder);
+
+        // Verify default batch reduce size before filter
+        assertEquals(SearchRequest.DEFAULT_BATCHED_REDUCE_SIZE, searchRequest.getBatchedReduceSize());
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        // Verify batch reduce size was changed to MAX_VALUE
+        assertEquals(Integer.MAX_VALUE, searchRequest.getBatchedReduceSize());
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenHybridQueryWithCustomBatchReduceSize_thenOverridesUserConfig() {
+        // Setup - user explicitly set a custom batch reduce size
+        int customBatchReduceSize = 1024;
+
+        HybridQueryBuilder hybridQuery = new HybridQueryBuilder();
+        hybridQuery.add(new MatchQueryBuilder("field", "value"));
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(hybridQuery);
+        searchRequest.source(sourceBuilder);
+        searchRequest.setBatchedReduceSize(customBatchReduceSize);
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        // Verify batch reduce size was overridden - batched reduction is incompatible with hybrid queries
+        assertEquals(Integer.MAX_VALUE, searchRequest.getBatchedReduceSize());
+
+        // Verify chain.proceed was called
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenNonHybridQuery_thenDoesNotModifyBatchReduceSize() {
+        // Setup with regular match query (not hybrid)
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(new MatchQueryBuilder("field", "value"));
+        searchRequest.source(sourceBuilder);
+
+        int originalBatchReduceSize = searchRequest.getBatchedReduceSize();
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        // Verify batch reduce size was not changed
+        assertEquals(originalBatchReduceSize, searchRequest.getBatchedReduceSize());
+
+        // Verify chain.proceed was called
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenNullSource_thenDoesNotModifyRequest() {
+        // Setup with null source
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        // source is null by default
+
+        int originalBatchReduceSize = searchRequest.getBatchedReduceSize();
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        // Verify batch reduce size was not changed
+        assertEquals(originalBatchReduceSize, searchRequest.getBatchedReduceSize());
+
+        // Verify chain.proceed was called
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenNullQuery_thenDoesNotModifyRequest() {
+        // Setup with source but null query
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        // query is null
+        searchRequest.source(sourceBuilder);
+
+        int originalBatchReduceSize = searchRequest.getBatchedReduceSize();
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        // Verify batch reduce size was not changed
+        assertEquals(originalBatchReduceSize, searchRequest.getBatchedReduceSize());
+
+        // Verify chain.proceed was called
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenNonSearchAction_thenDoesNotModifyRequest() {
+        // Setup with non-search action (e.g., bulk)
+        BulkRequest bulkRequest = new BulkRequest();
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<BulkRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute with bulk action
+        filter.apply(task, BulkAction.NAME, bulkRequest, listener, chain);
+
+        // Verify chain.proceed was called (request passed through unchanged)
+        verify(chain).proceed(eq(task), eq(BulkAction.NAME), eq(bulkRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenMatchAllQuery_thenDoesNotModifyBatchReduceSize() {
+        // Setup with match_all query (not hybrid)
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(new MatchAllQueryBuilder());
+        searchRequest.source(sourceBuilder);
+
+        int originalBatchReduceSize = searchRequest.getBatchedReduceSize();
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        // Verify batch reduce size was not changed
+        assertEquals(originalBatchReduceSize, searchRequest.getBatchedReduceSize());
+
+        // Verify chain.proceed was called
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenHybridQueryWithSmallBatchReduceSize_thenOverridesUserConfig() {
+        // Setup - user explicitly set batchReduceSize to a small value that would cause failures
+        HybridQueryBuilder hybridQuery = new HybridQueryBuilder();
+        hybridQuery.add(new MatchQueryBuilder("field", "value"));
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(hybridQuery);
+        searchRequest.source(sourceBuilder);
+        searchRequest.setBatchedReduceSize(100); // small value that would cause hybrid query to fail
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        // Verify batch reduce size was overridden - hybrid queries don't honor this setting
+        assertEquals(Integer.MAX_VALUE, searchRequest.getBatchedReduceSize());
+
+        // Verify chain.proceed was called
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenSearchActionNameButNotSearchRequestType_thenPassesThrough() {
+        // Setup - edge case where action name is SearchAction but request is not SearchRequest
+        // This tests the "request instanceof SearchRequest" check
+        BulkRequest bulkRequest = new BulkRequest();
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<BulkRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute with search action name but non-search request type
+        // This is an edge case that shouldn't happen in normal operation but tests the instanceof check
+        filter.apply(task, SearchAction.NAME, bulkRequest, listener, chain);
+
+        // Verify chain.proceed was called (request passed through unchanged)
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(bulkRequest), eq(listener));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenEmptyHybridQuery_thenDisablesBatchedReduction() {
+        // Setup - hybrid query with no sub-queries (edge case)
+        HybridQueryBuilder hybridQuery = new HybridQueryBuilder();
+        // Note: HybridQueryBuilder can exist without sub-queries
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(hybridQuery);
+        searchRequest.source(sourceBuilder);
+
+        // Verify default batch reduce size before filter
+        assertEquals(SearchRequest.DEFAULT_BATCHED_REDUCE_SIZE, searchRequest.getBatchedReduceSize());
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        // Execute
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        // Verify batch reduce size was changed to MAX_VALUE (still a hybrid query even if empty)
+        assertEquals(Integer.MAX_VALUE, searchRequest.getBatchedReduceSize());
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+}


### PR DESCRIPTION
### Description
Added request filter that is programmatically increase the number of batched reduce shards setting  DEFAULT_BATCHED_REDUCE_SIZE/512. This way the merge of Shard results by the opensearch core is delayed. This is critical for hybrid query with current design because such merges corrupt the internal format of results (multiple collections per sub-query) and lead to runtime exception (see original issue for detailed scenario). 
Request filter works at a single search request level, no global changes so other query types are not effected. Side effect of this change can be an increase in latency for hybrid query when index has more than 512 shards.  

I've manually tested scenario described in original GH issue. Automation is not feasible because it's failing with such high number of shards.

```
{
    "took": 64,
    "timed_out": false,
    "_shards": {
        "total": 513,
        "successful": 513,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 93,
            "relation": "eq"
        },
        "max_score": 1.0,
        "hits": [
            {
                "_index": "test_index",
                "_id": "EhFg_JsBpmoBypRqgN4-",
                "_score": 1.0,
                "_source": {
                    "id": "s100",
                    "passage_text": "Garibaldian quickset",
                    "imdb": 9.8,
                    "actor": "jackie"
                }
            },
            {
                "_index": "test_index",
                "_id": "ExFg_JsBpmoBypRqgN4-",
                "_score": 1.0,
                "_source": {
                    "id": "s101",
                    "passage_text": "Garibaldian quickset quickset",
                    "imdb": 10,
                    "actor": "jackie"
                }
            },....
}
```

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/1733

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
