### PR TITLE
BWC Test: Remove 2.20 snapshot for BWC tests

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         java: [ 21, 25 ]
         os: [ubuntu-latest]
-        bwc_version : [ "2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.1","2.20.0-SNAPSHOT","3.0.0", "3.1.0", "3.2.0", "3.3.0", "3.4.0" ]
+        bwc_version : [ "2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0", "3.4.0" ]
         opensearch_version : [ "3.5.0-SNAPSHOT" ]
 
     name: NeuralSearch Restart-Upgrade BWC Tests
@@ -62,7 +62,7 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: [ "2.19.1","2.20.0-SNAPSHOT","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0" ]
+        bwc_version: [ "2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0" ]
         opensearch_version: [ "3.5.0-SNAPSHOT" ]
 
     name: NeuralSearch Rolling-Upgrade BWC Tests


### PR DESCRIPTION
### Description
After confirming with @vibrantvarun , BWC tests for 2.20 snapshot is not needed

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
