### PR TITLE
Publish plugin jar to maven

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -42,3 +42,4 @@ jobs:
       - name: publish snapshots to maven
         run: |
           ./gradlew publishPluginZipPublicationToSnapshotsRepository
+          ./gradlew publishNebulaPublicationToSnapshotsRepository


### PR DESCRIPTION
### Description
Neural-search needs to publish jar artifact. Currently that's missing and other opensearch plugins cannot have compile time dependency on neural-search classes.

Example of same changes in other plugins:
https://github.com/opensearch-project/k-NN/blob/main/.github/workflows/maven-publish.yml
https://github.com/opensearch-project/job-scheduler/blob/main/.github/workflows/maven-publish.yml

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
