### PR TITLE
Add size-based (byte-aware) batching for neural search ingest processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.x](https://github.com/opensearch-project/neural-search/compare/main...HEAD)
 
 ### Features
+- Add size-based (byte-aware) batching for neural search ingest processors ([#1762](https://github.com/opensearch-project/neural-search/pull/1762))
 
 ### Enhancements
 * Improve error messages for misconfigured remote model connectors to provide actionable guidance on post_process_function configuration ([#1825](https://github.com/opensearch-project/neural-search/pull/1825))
@@ -14,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Fix semantic highlighter crash on documents with missing highlighted fields ([#1810](https://github.com/opensearch-project/neural-search/pull/1810))
 * [Text Chunking] Fix text chunking processor ignoring index max_token_count setting when ingesting via alias ([#1803](https://github.com/opensearch-project/neural-search/pull/1803))
-* Fix sparse ANN search failure due to a core change ([#1855](https://github.com/opensearch-project/neural-search/pull/1855)) 
+* Fix sparse ANN search failure due to a core change ([#1855](https://github.com/opensearch-project/neural-search/pull/1855))
 
 ### Infrastructure
 * Fix flaky integration test failure caused by ML memory circuit breaker during model deployment in distribution pipeline ([#1824](https://github.com/opensearch-project/neural-search/pull/1824))

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -66,6 +68,26 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
     public static final String FIELD_MAP_FIELD = "field_map";
     public static final String SKIP_EXISTING = "skip_existing";
     public static final boolean DEFAULT_SKIP_EXISTING = false;
+    public static final String BATCH_SIZE_BYTES_FIELD = "batch_size_bytes";
+    public static final int DEFAULT_BATCH_SIZE_BYTES = -1;
+    /**
+     * Maximum allowed value for batch_size_bytes. Set to 100MB to match OpenSearch's default
+     * http.max_content_length, beyond which the request would be rejected by the HTTP layer anyway.
+     */
+    public static final int MAX_BATCH_SIZE_BYTES = 100 * 1024 * 1024; // 100MB
+    /**
+     * When batch_size_bytes is configured but batch_size is not explicitly set by the user,
+     * we auto-elevate batch_size to this value so that the byte-based limit becomes the primary
+     * effective batching constraint. 1000 is the maximum batch size supported by OpenSearch's
+     * ingest pipeline batching framework (AbstractBatchingProcessor), so this effectively makes
+     * batch_size_bytes the sole constraint for typical workloads.
+     *
+     * <p>For models that enforce both a payload size limit AND a per-request document-count limit
+     * (e.g. Cohere Embed supports at most 96 texts per request), users should set batch_size
+     * explicitly alongside batch_size_bytes. The processor will then respect whichever limit is
+     * hit first.
+     */
+    public static final int AUTO_BATCH_SIZE_FOR_BYTE_BATCHING = 1000;
     private static final BiFunction<Object, Object, Object> REMAPPING_FUNCTION = (v1, v2) -> {
         if (v1 instanceof Collection && v2 instanceof Collection) {
             ((Collection) v1).addAll((Collection) v2);
@@ -92,11 +114,46 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
 
     private final Environment environment;
     private final ClusterService clusterService;
+    private final int batchSizeBytes;
+
+    /** Returns the effective batch_size configured for this processor. Exposed for testing. */
+    @VisibleForTesting
+    public int getBatchSize() {
+        return batchSize;
+    }
 
     public InferenceProcessor(
         String tag,
         String description,
         int batchSize,
+        String type,
+        String listTypeNestedMapKey,
+        String modelId,
+        Map<String, Object> fieldMap,
+        MLCommonsClientAccessor clientAccessor,
+        Environment environment,
+        ClusterService clusterService
+    ) {
+        this(
+            tag,
+            description,
+            batchSize,
+            DEFAULT_BATCH_SIZE_BYTES,
+            type,
+            listTypeNestedMapKey,
+            modelId,
+            fieldMap,
+            clientAccessor,
+            environment,
+            clusterService
+        );
+    }
+
+    public InferenceProcessor(
+        String tag,
+        String description,
+        int batchSize,
+        int batchSizeBytes,
         String type,
         String listTypeNestedMapKey,
         String modelId,
@@ -115,6 +172,84 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         this.mlCommonsClientAccessor = clientAccessor;
         this.environment = environment;
         this.clusterService = clusterService;
+        this.batchSizeBytes = batchSizeBytes;
+    }
+
+    /**
+     * Validates the batch_size_bytes configuration value and resolves the effective batch_size
+     * to use when constructing a processor. This shared helper is intended to be called from
+     * processor factory implementations to avoid duplicating validation logic.
+     *
+     * <p>Validation rules:
+     * <ul>
+     *   <li>If batch_size_bytes is the sentinel value ({@link #DEFAULT_BATCH_SIZE_BYTES}), it is
+     *       disabled and no validation is performed.</li>
+     *   <li>If batch_size_bytes is set, it must be a positive integer.</li>
+     *   <li>If batch_size_bytes is set, it must not exceed {@link #MAX_BATCH_SIZE_BYTES} (100MB).</li>
+     * </ul>
+     *
+     * <p><b>Batch size resolution:</b>
+     * <ul>
+     *   <li>If the user did not explicitly set batch_size ({@code userSetBatchSize} is false),
+     *       batch_size is auto-elevated to {@link #AUTO_BATCH_SIZE_FOR_BYTE_BATCHING}
+     *       ({@code Integer.MAX_VALUE}), making the byte limit the sole effective constraint.
+     *       This is the correct behavior for models with only a payload size limit (e.g. Amazon
+     *       Bedrock, Claude, most OpenAI-compatible endpoints).</li>
+     *   <li>If the user explicitly set batch_size, it is preserved as-is. The processor will
+     *       then dispatch a batch when either the document-count limit or the byte limit is
+     *       reached first. This is the correct configuration for models that enforce both limits
+     *       (e.g. Cohere Embed: max 96 texts per request and a payload size limit).</li>
+     * </ul>
+     *
+     * <p><b>Why {@code userSetBatchSize} is needed:</b>
+     * {@code AbstractBatchingProcessor.Factory.create()} removes {@code batch_size} from the
+     * config map via {@code ConfigurationUtils.readIntProperty} before calling
+     * {@code newProcessor()}, so it is impossible to detect user intent inside
+     * {@code newProcessor()} directly. Factories must override {@code create()} to peek at the
+     * config map before calling {@code super.create()} and pass the result here.
+     *
+     * @param processorType    the processor type string, used in error messages
+     * @param tag              the processor tag, used in error messages
+     * @param batchSizeBytes   the raw batch_size_bytes value read from config
+     * @param batchSize        the batch_size value resolved by AbstractBatchingProcessor
+     * @param userSetBatchSize true if the user explicitly included batch_size in the pipeline config
+     * @return the effective batch_size to pass to the processor constructor
+     * @throws IllegalArgumentException if batch_size_bytes is invalid
+     */
+    public static int validateBatchSizeBytesAndResolveEffectiveBatchSize(
+        String processorType,
+        String tag,
+        int batchSizeBytes,
+        int batchSize,
+        boolean userSetBatchSize
+    ) {
+        if (batchSizeBytes == DEFAULT_BATCH_SIZE_BYTES) {
+            return batchSize;
+        }
+        if (batchSizeBytes <= 0) {
+            throw new IllegalArgumentException(
+                "[" + processorType + "] [" + tag + "] [" + BATCH_SIZE_BYTES_FIELD + "] must be a positive integer when specified"
+            );
+        }
+        if (batchSizeBytes > MAX_BATCH_SIZE_BYTES) {
+            throw new IllegalArgumentException(
+                "["
+                    + processorType
+                    + "] ["
+                    + tag
+                    + "] ["
+                    + BATCH_SIZE_BYTES_FIELD
+                    + "] must not exceed "
+                    + MAX_BATCH_SIZE_BYTES
+                    + " bytes (100MB)"
+            );
+        }
+        // batch_size_bytes is enabled. If the user did not explicitly set batch_size, auto-elevate
+        // it so the byte limit is the sole effective constraint.
+        if (!userSetBatchSize) {
+            return AUTO_BATCH_SIZE_FOR_BYTE_BATCHING;
+        }
+        return batchSize;
     }
 
     private void validateEmbeddingConfiguration(Map<String, Object> fieldMap) {
@@ -208,9 +343,23 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
 
     /**
      * This is a helper function for subBatchExecute, which invokes doBatchExecute for given inference list.
+     * When batch_size_bytes is configured, the inference list is further split into sub-batches based on
+     * cumulative byte size of the texts. Each sub-batch is sent to doBatchExecute independently and results
+     * are stitched back together before being passed to batchExecuteHandler.
+     *
+     * <p><b>Failure semantics:</b> When batch_size_bytes is enabled, multiple sub-batches are dispatched
+     * in parallel. If any sub-batch fails, the entire set of ingestDocumentWrappers is failed via
+     * {@code updateWithExceptions}. This is consistent with the existing behavior when batch_size_bytes
+     * is disabled (a single doBatchExecute failure fails all documents in the batch). However, users
+     * should be aware that with auto-elevated batch_size (when only batch_size_bytes is set and
+     * batch_size is not explicitly configured), a larger number of documents may be grouped into a
+     * single internal batch, so a single inference failure will affect more documents than it would
+     * with a small explicit batch_size.
+     *
      * @param ingestDocumentWrappers a list of IngestDocuments in a batch.
      * @param inferenceList a list of String for inference.
      * @param dataForInferences a list of data for inference, which includes ingestDocumentWrapper, processMap, inferenceList.
+     * @param handler a callback handler to handle inference results.
      */
     protected void doSubBatchExecute(
         List<IngestDocumentWrapper> ingestDocumentWrappers,
@@ -221,10 +370,132 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
         Tuple<List<String>, Map<Integer, Integer>> sortedResult = sortByLengthAndReturnOriginalOrder(inferenceList);
         inferenceList = sortedResult.v1();
         Map<Integer, Integer> originalOrder = sortedResult.v2();
-        doBatchExecute(inferenceList, results -> {
-            batchExecuteHandler(results, dataForInferences, originalOrder);
-            handler.accept(ingestDocumentWrappers);
-        }, exception -> { updateWithExceptions(ingestDocumentWrappers, handler, exception); });
+
+        if (batchSizeBytes <= 0) {
+            // No byte-based batching — send the entire inference list in one call (existing behavior)
+            doBatchExecute(inferenceList, results -> {
+                batchExecuteHandler(results, dataForInferences, originalOrder);
+                handler.accept(ingestDocumentWrappers);
+            }, exception -> { updateWithExceptions(ingestDocumentWrappers, handler, exception); });
+            return;
+        }
+
+        // Split inference list into sub-batches based on cumulative byte size
+        List<List<String>> subBatches = splitInferenceListByBytes(inferenceList, batchSizeBytes);
+
+        if (subBatches.size() == 1) {
+            // Only one sub-batch, no need for stitching logic
+            doBatchExecute(subBatches.get(0), results -> {
+                batchExecuteHandler(results, dataForInferences, originalOrder);
+                handler.accept(ingestDocumentWrappers);
+            }, exception -> { updateWithExceptions(ingestDocumentWrappers, handler, exception); });
+            return;
+        }
+
+        // Multiple sub-batches: execute in parallel and stitch results in order
+        int numBatches = subBatches.size();
+        List<?>[] orderedResults = new List<?>[numBatches];
+        AtomicInteger completedCount = new AtomicInteger(0);
+        AtomicReference<Exception> firstException = new AtomicReference<>();
+
+        for (int i = 0; i < numBatches; i++) {
+            final int batchIdx = i;
+            doBatchExecute(subBatches.get(batchIdx), results -> {
+                orderedResults[batchIdx] = results;
+                if (completedCount.incrementAndGet() == numBatches) {
+                    // All sub-batches done — stitch results in original order
+                    List<Object> allResults = new ArrayList<>();
+                    for (List<?> batchResult : orderedResults) {
+                        allResults.addAll(batchResult);
+                    }
+                    batchExecuteHandler(allResults, dataForInferences, originalOrder);
+                    handler.accept(ingestDocumentWrappers);
+                }
+            }, exception -> {
+                if (firstException.compareAndSet(null, exception)) {
+                    updateWithExceptions(ingestDocumentWrappers, handler, exception);
+                }
+            });
+        }
+    }
+
+    /**
+     * Splits an inference list into sub-batches where each sub-batch's cumulative UTF-8 byte size
+     * does not exceed maxBytes. A single text that exceeds maxBytes is always placed in its own
+     * sub-batch (floor of 1 item per batch) — it is never rejected. This means the actual payload
+     * sent to ML Commons for a single oversized text may exceed the configured batch_size_bytes
+     * limit. Users whose models enforce strict payload size limits should pre-chunk their text
+     * fields (e.g. using the chunking ingest processor) to ensure no single text exceeds the limit.
+     *
+     * <p>UTF-8 byte length is computed without allocating a byte array, by iterating the string's
+     * characters directly. This avoids the GC pressure of {@code String.getBytes(UTF_8)} when
+     * called for every text in a large inference list.
+     *
+     * @param inferenceList the list of inference texts to split
+     * @param maxBytes the maximum cumulative byte size per sub-batch
+     * @return a list of sub-batches
+     */
+    @VisibleForTesting
+    static List<List<String>> splitInferenceListByBytes(List<String> inferenceList, int maxBytes) {
+        List<List<String>> subBatches = new ArrayList<>();
+        List<String> currentBatch = new ArrayList<>();
+        long currentBatchBytes = 0;
+
+        for (String text : inferenceList) {
+            long textBytes = utf8ByteLength(text);
+
+            if (!currentBatch.isEmpty() && currentBatchBytes + textBytes > maxBytes) {
+                // Adding this text would exceed the limit — flush current batch
+                subBatches.add(currentBatch);
+                currentBatch = new ArrayList<>();
+                currentBatchBytes = 0;
+            }
+
+            currentBatch.add(text);
+            currentBatchBytes += textBytes;
+        }
+
+        if (!currentBatch.isEmpty()) {
+            subBatches.add(currentBatch);
+        }
+
+        return subBatches;
+    }
+
+    /**
+     * Computes the UTF-8 encoded byte length of a string without allocating a byte array.
+     * This is equivalent to {@code text.getBytes(StandardCharsets.UTF_8).length} but avoids
+     * the allocation and copy overhead, which matters when called for every text in a large
+     * inference list.
+     *
+     * <p>UTF-8 encoding rules by codepoint range:
+     * <ul>
+     *   <li>U+0000–U+007F (ASCII): 1 byte</li>
+     *   <li>U+0080–U+07FF: 2 bytes</li>
+     *   <li>U+0800–U+FFFF (BMP, excluding surrogates): 3 bytes</li>
+     *   <li>U+10000–U+10FFFF (supplementary, encoded as surrogate pairs in Java): 4 bytes</li>
+     * </ul>
+     *
+     * @param text the string to measure
+     * @return the number of bytes required to encode the string in UTF-8
+     */
+    @VisibleForTesting
+    static long utf8ByteLength(String text) {
+        long bytes = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c <= 0x7F) {
+                bytes++;
+            } else if (c <= 0x7FF) {
+                bytes += 2;
+            } else if (Character.isHighSurrogate(c)) {
+                bytes += 4; // supplementary character encoded as surrogate pair = 4 UTF-8 bytes
+                i++;        // skip the paired low surrogate
+            } else {
+                bytes += 3;
+            }
+        }
+        return bytes;
     }
 
     protected void batchExecuteHandler(List<?> results, List<DataForInference> dataForInferences, Map<Integer, Integer> originalOrder) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessor.java
@@ -84,7 +84,53 @@ public final class SparseEncodingProcessor extends InferenceProcessor {
         Environment environment,
         ClusterService clusterService
     ) {
-        super(tag, description, batchSize, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
+        this(
+            tag,
+            description,
+            batchSize,
+            DEFAULT_BATCH_SIZE_BYTES,
+            modelId,
+            fieldMap,
+            skipExisting,
+            textEmbeddingInferenceFilter,
+            pruneType,
+            pruneRatio,
+            openSearchClient,
+            clientAccessor,
+            environment,
+            clusterService
+        );
+    }
+
+    public SparseEncodingProcessor(
+        String tag,
+        String description,
+        int batchSize,
+        int batchSizeBytes,
+        String modelId,
+        Map<String, Object> fieldMap,
+        boolean skipExisting,
+        TextEmbeddingInferenceFilter textEmbeddingInferenceFilter,
+        PruneType pruneType,
+        float pruneRatio,
+        OpenSearchClient openSearchClient,
+        MLCommonsClientAccessor clientAccessor,
+        Environment environment,
+        ClusterService clusterService
+    ) {
+        super(
+            tag,
+            description,
+            batchSize,
+            batchSizeBytes,
+            TYPE,
+            LIST_TYPE_NESTED_MAP_KEY,
+            modelId,
+            fieldMap,
+            clientAccessor,
+            environment,
+            clusterService
+        );
         this.pruneType = pruneType;
         this.pruneRatio = pruneRatio;
         this.skipExisting = skipExisting;

--- a/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessor.java
@@ -56,7 +56,49 @@ public final class TextEmbeddingProcessor extends InferenceProcessor {
         Environment environment,
         ClusterService clusterService
     ) {
-        super(tag, description, batchSize, TYPE, LIST_TYPE_NESTED_MAP_KEY, modelId, fieldMap, clientAccessor, environment, clusterService);
+        this(
+            tag,
+            description,
+            batchSize,
+            DEFAULT_BATCH_SIZE_BYTES,
+            modelId,
+            fieldMap,
+            skipExisting,
+            textEmbeddingInferenceFilter,
+            openSearchClient,
+            clientAccessor,
+            environment,
+            clusterService
+        );
+    }
+
+    public TextEmbeddingProcessor(
+        String tag,
+        String description,
+        int batchSize,
+        int batchSizeBytes,
+        String modelId,
+        Map<String, Object> fieldMap,
+        boolean skipExisting,
+        TextEmbeddingInferenceFilter textEmbeddingInferenceFilter,
+        OpenSearchClient openSearchClient,
+        MLCommonsClientAccessor clientAccessor,
+        Environment environment,
+        ClusterService clusterService
+    ) {
+        super(
+            tag,
+            description,
+            batchSize,
+            batchSizeBytes,
+            TYPE,
+            LIST_TYPE_NESTED_MAP_KEY,
+            modelId,
+            fieldMap,
+            clientAccessor,
+            environment,
+            clusterService
+        );
         this.skipExisting = skipExisting;
         this.textEmbeddingInferenceFilter = textEmbeddingInferenceFilter;
         this.openSearchClient = openSearchClient;

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/SparseEncodingProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/SparseEncodingProcessorFactory.java
@@ -8,7 +8,10 @@ import lombok.extern.log4j.Log4j2;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.AbstractBatchingProcessor;
+import org.opensearch.ingest.ConfigurationUtils;
+import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.processor.InferenceProcessor;
 import org.opensearch.neuralsearch.processor.SparseEncodingProcessor;
 import org.opensearch.neuralsearch.processor.optimization.TextEmbeddingInferenceFilter;
 import org.opensearch.neuralsearch.util.prune.PruneType;
@@ -23,6 +26,8 @@ import static org.opensearch.ingest.ConfigurationUtils.readDoubleProperty;
 import static org.opensearch.ingest.ConfigurationUtils.readMap;
 import static org.opensearch.ingest.ConfigurationUtils.readOptionalStringProperty;
 import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
+import static org.opensearch.neuralsearch.processor.InferenceProcessor.BATCH_SIZE_BYTES_FIELD;
+import static org.opensearch.neuralsearch.processor.InferenceProcessor.DEFAULT_BATCH_SIZE_BYTES;
 import static org.opensearch.neuralsearch.processor.SparseEncodingProcessor.DEFAULT_SKIP_EXISTING;
 import static org.opensearch.neuralsearch.processor.SparseEncodingProcessor.SKIP_EXISTING;
 import static org.opensearch.neuralsearch.processor.SparseEncodingProcessor.TYPE;
@@ -39,6 +44,16 @@ public class SparseEncodingProcessorFactory extends AbstractBatchingProcessor.Fa
     private final Environment environment;
     private final ClusterService clusterService;
 
+    /**
+     * Holds whether the user explicitly set batch_size in the pipeline config for the current
+     * create() call. This is needed because AbstractBatchingProcessor.Factory.create() removes
+     * batch_size from the config map (via ConfigurationUtils.readIntProperty) before calling
+     * newProcessor(), making it impossible to detect user intent inside newProcessor() directly.
+     * ThreadLocal ensures thread safety since factory instances are shared across concurrent
+     * pipeline creation calls.
+     */
+    private final ThreadLocal<Boolean> userSetBatchSize = new ThreadLocal<>();
+
     public SparseEncodingProcessorFactory(
         OpenSearchClient openSearchClient,
         MLCommonsClientAccessor clientAccessor,
@@ -53,10 +68,34 @@ public class SparseEncodingProcessorFactory extends AbstractBatchingProcessor.Fa
     }
 
     @Override
+    public AbstractBatchingProcessor create(
+        Map<String, Processor.Factory> processorFactories,
+        String tag,
+        String description,
+        Map<String, Object> config
+    ) throws Exception {
+        // Peek before super.create() removes batch_size from the config map
+        userSetBatchSize.set(config.containsKey(AbstractBatchingProcessor.BATCH_SIZE_FIELD));
+        try {
+            return super.create(processorFactories, tag, description, config);
+        } finally {
+            userSetBatchSize.remove();
+        }
+    }
+
+    @Override
     protected AbstractBatchingProcessor newProcessor(String tag, String description, int batchSize, Map<String, Object> config) {
         String modelId = readStringProperty(TYPE, tag, config, MODEL_ID_FIELD);
         Map<String, Object> fieldMap = readMap(TYPE, tag, config, FIELD_MAP_FIELD);
         boolean skipExisting = readBooleanProperty(TYPE, tag, config, SKIP_EXISTING, DEFAULT_SKIP_EXISTING);
+        int batchSizeBytes = ConfigurationUtils.readIntProperty(TYPE, tag, config, BATCH_SIZE_BYTES_FIELD, DEFAULT_BATCH_SIZE_BYTES);
+        batchSize = InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize(
+            TYPE,
+            tag,
+            batchSizeBytes,
+            batchSize,
+            Boolean.TRUE.equals(userSetBatchSize.get())
+        );
         // if the field is miss, will return PruneType.None
         PruneType pruneType = PruneType.fromString(readOptionalStringProperty(TYPE, tag, config, PruneUtils.PRUNE_TYPE_FIELD));
         float pruneRatio = 0;
@@ -84,6 +123,7 @@ public class SparseEncodingProcessorFactory extends AbstractBatchingProcessor.Fa
             tag,
             description,
             batchSize,
+            batchSizeBytes,
             modelId,
             fieldMap,
             skipExisting,

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/TextEmbeddingProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/TextEmbeddingProcessorFactory.java
@@ -7,6 +7,8 @@ package org.opensearch.neuralsearch.processor.factory;
 import static org.opensearch.ingest.ConfigurationUtils.readBooleanProperty;
 import static org.opensearch.ingest.ConfigurationUtils.readMap;
 import static org.opensearch.ingest.ConfigurationUtils.readStringProperty;
+import static org.opensearch.neuralsearch.processor.InferenceProcessor.BATCH_SIZE_BYTES_FIELD;
+import static org.opensearch.neuralsearch.processor.InferenceProcessor.DEFAULT_BATCH_SIZE_BYTES;
 import static org.opensearch.neuralsearch.processor.TextEmbeddingProcessor.SKIP_EXISTING;
 import static org.opensearch.neuralsearch.processor.TextEmbeddingProcessor.DEFAULT_SKIP_EXISTING;
 import static org.opensearch.neuralsearch.processor.TextEmbeddingProcessor.TYPE;
@@ -18,7 +20,10 @@ import java.util.Map;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.env.Environment;
 import org.opensearch.ingest.AbstractBatchingProcessor;
+import org.opensearch.ingest.ConfigurationUtils;
+import org.opensearch.ingest.Processor;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.processor.InferenceProcessor;
 import org.opensearch.neuralsearch.processor.TextEmbeddingProcessor;
 import org.opensearch.neuralsearch.processor.optimization.TextEmbeddingInferenceFilter;
 import org.opensearch.transport.client.OpenSearchClient;
@@ -36,6 +41,16 @@ public final class TextEmbeddingProcessorFactory extends AbstractBatchingProcess
 
     private final ClusterService clusterService;
 
+    /**
+     * Holds whether the user explicitly set batch_size in the pipeline config for the current
+     * create() call. This is needed because AbstractBatchingProcessor.Factory.create() removes
+     * batch_size from the config map (via ConfigurationUtils.readIntProperty) before calling
+     * newProcessor(), making it impossible to detect user intent inside newProcessor() directly.
+     * ThreadLocal ensures thread safety since factory instances are shared across concurrent
+     * pipeline creation calls.
+     */
+    private final ThreadLocal<Boolean> userSetBatchSize = new ThreadLocal<>();
+
     public TextEmbeddingProcessorFactory(
         final OpenSearchClient openSearchClient,
         final MLCommonsClientAccessor clientAccessor,
@@ -50,14 +65,39 @@ public final class TextEmbeddingProcessorFactory extends AbstractBatchingProcess
     }
 
     @Override
+    public AbstractBatchingProcessor create(
+        Map<String, Processor.Factory> processorFactories,
+        String tag,
+        String description,
+        Map<String, Object> config
+    ) throws Exception {
+        // Peek before super.create() removes batch_size from the config map
+        userSetBatchSize.set(config.containsKey(AbstractBatchingProcessor.BATCH_SIZE_FIELD));
+        try {
+            return super.create(processorFactories, tag, description, config);
+        } finally {
+            userSetBatchSize.remove();
+        }
+    }
+
+    @Override
     protected AbstractBatchingProcessor newProcessor(String tag, String description, int batchSize, Map<String, Object> config) {
         String modelId = readStringProperty(TYPE, tag, config, MODEL_ID_FIELD);
         Map<String, Object> fieldMap = readMap(TYPE, tag, config, FIELD_MAP_FIELD);
         boolean skipExisting = readBooleanProperty(TYPE, tag, config, SKIP_EXISTING, DEFAULT_SKIP_EXISTING);
+        int batchSizeBytes = ConfigurationUtils.readIntProperty(TYPE, tag, config, BATCH_SIZE_BYTES_FIELD, DEFAULT_BATCH_SIZE_BYTES);
+        batchSize = InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize(
+            TYPE,
+            tag,
+            batchSizeBytes,
+            batchSize,
+            Boolean.TRUE.equals(userSetBatchSize.get())
+        );
         return new TextEmbeddingProcessor(
             tag,
             description,
             batchSize,
+            batchSizeBytes,
             modelId,
             fieldMap,
             skipExisting,

--- a/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/InferenceProcessorTests.java
@@ -193,6 +193,185 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
         assertEquals(List.of("value4"), processor.getAllInferenceInputs().get(2));
     }
 
+    public void test_validateBatchSizeBytesAndResolveEffectiveBatchSize_disabled_returnsOriginalBatchSize() {
+        // DEFAULT_BATCH_SIZE_BYTES (-1) means disabled — batchSize unchanged regardless of userSetBatchSize
+        assertEquals(5, InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize("type", "tag", -1, 5, false));
+        assertEquals(5, InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize("type", "tag", -1, 5, true));
+    }
+
+    public void test_validateBatchSizeBytesAndResolveEffectiveBatchSize_userDidNotSetBatchSize_autoElevates() {
+        // batch_size_bytes enabled, user did NOT set batch_size → auto-elevate to AUTO_BATCH_SIZE_FOR_BYTE_BATCHING
+        int result = InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize("type", "tag", 102400, 1, false);
+        assertEquals(InferenceProcessor.AUTO_BATCH_SIZE_FOR_BYTE_BATCHING, result);
+    }
+
+    public void test_validateBatchSizeBytesAndResolveEffectiveBatchSize_userSetBatchSize_preservesIt() {
+        // batch_size_bytes enabled, user explicitly set batch_size=50 → preserve 50, do NOT auto-elevate
+        int result = InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize("type", "tag", 102400, 50, true);
+        assertEquals(50, result);
+    }
+
+    public void test_validateBatchSizeBytesAndResolveEffectiveBatchSize_userSetBatchSizeToOne_preservesIt() {
+        // Edge case: user explicitly set batch_size=1 (intentional safety limit) — must be preserved
+        int result = InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize("type", "tag", 102400, 1, true);
+        assertEquals(1, result);
+    }
+
+    public void test_validateBatchSizeBytesAndResolveEffectiveBatchSize_invalidValue_throwsException() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize("type", "tag", 0, 1, false)
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize("type", "tag", -5, 1, false)
+        );
+    }
+
+    public void test_validateBatchSizeBytesAndResolveEffectiveBatchSize_exceedsMax_throwsException() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> InferenceProcessor.validateBatchSizeBytesAndResolveEffectiveBatchSize(
+                "type",
+                "tag",
+                InferenceProcessor.MAX_BATCH_SIZE_BYTES + 1,
+                1,
+                false
+            )
+        );
+    }
+
+    public void test_splitInferenceListByBytes_singleBatch() {
+        List<String> inferenceList = List.of("hello", "world");
+        // 10 bytes total for ASCII, set limit high enough for one batch
+        List<List<String>> result = InferenceProcessor.splitInferenceListByBytes(inferenceList, 1000);
+        assertEquals(1, result.size());
+        assertEquals(List.of("hello", "world"), result.get(0));
+    }
+
+    public void test_splitInferenceListByBytes_multipleBatches() {
+        // "aaa" = 3 bytes, "bbb" = 3 bytes, "ccc" = 3 bytes, "ddd" = 3 bytes
+        List<String> inferenceList = List.of("aaa", "bbb", "ccc", "ddd");
+        // Set limit to 6 bytes: should produce batches of [aaa, bbb], [ccc, ddd]
+        List<List<String>> result = InferenceProcessor.splitInferenceListByBytes(inferenceList, 6);
+        assertEquals(2, result.size());
+        assertEquals(List.of("aaa", "bbb"), result.get(0));
+        assertEquals(List.of("ccc", "ddd"), result.get(1));
+    }
+
+    public void test_splitInferenceListByBytes_singleItemExceedsLimit() {
+        // A single text that exceeds the byte limit should still be in its own batch (floor of 1)
+        List<String> inferenceList = List.of("this_is_a_long_text", "short");
+        List<List<String>> result = InferenceProcessor.splitInferenceListByBytes(inferenceList, 5);
+        assertEquals(2, result.size());
+        assertEquals(List.of("this_is_a_long_text"), result.get(0));
+        assertEquals(List.of("short"), result.get(1));
+    }
+
+    public void test_splitInferenceListByBytes_exactBoundary() {
+        // "abc" = 3 bytes each. Limit of 3 means each item gets its own batch
+        List<String> inferenceList = List.of("abc", "def", "ghi");
+        List<List<String>> result = InferenceProcessor.splitInferenceListByBytes(inferenceList, 3);
+        assertEquals(3, result.size());
+        assertEquals(List.of("abc"), result.get(0));
+        assertEquals(List.of("def"), result.get(1));
+        assertEquals(List.of("ghi"), result.get(2));
+    }
+
+    public void test_splitInferenceListByBytes_emptyList() {
+        List<String> inferenceList = Collections.emptyList();
+        List<List<String>> result = InferenceProcessor.splitInferenceListByBytes(inferenceList, 100);
+        assertTrue(result.isEmpty());
+    }
+
+    public void test_splitInferenceListByBytes_utf8MultiByte() {
+        // Unicode characters: "日本" = 6 bytes in UTF-8 (3 bytes per CJK character)
+        List<String> inferenceList = List.of("日本", "語");
+        // "日本" = 6 bytes, "語" = 3 bytes. Limit of 6 means first item fills a batch, second goes to next
+        List<List<String>> result = InferenceProcessor.splitInferenceListByBytes(inferenceList, 6);
+        assertEquals(2, result.size());
+        assertEquals(List.of("日本"), result.get(0));
+        assertEquals(List.of("語"), result.get(1));
+    }
+
+    public void test_utf8ByteLength_ascii() {
+        assertEquals(5, InferenceProcessor.utf8ByteLength("hello"));
+        assertEquals(0, InferenceProcessor.utf8ByteLength(""));
+    }
+
+    public void test_utf8ByteLength_multiByteChars() {
+        // CJK characters: 3 bytes each in UTF-8
+        assertEquals(6, InferenceProcessor.utf8ByteLength("日本"));
+        // 2-byte UTF-8 range (U+0080–U+07FF)
+        assertEquals(2, InferenceProcessor.utf8ByteLength("\u00e9")); // é
+        // Supplementary character (surrogate pair in Java, 4 bytes in UTF-8)
+        assertEquals(4, InferenceProcessor.utf8ByteLength("\uD83D\uDE00")); // 😀
+    }
+
+    public void test_utf8ByteLength_matchesGetBytes() {
+        // Verify our zero-allocation implementation matches the reference implementation
+        String[] samples = { "hello", "日本語", "café", "\uD83D\uDE00 emoji", "", "ASCII only 123" };
+        for (String s : samples) {
+            long expected = s.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            assertEquals("Mismatch for: " + s, expected, InferenceProcessor.utf8ByteLength(s));
+        }
+    }
+
+    public void test_batchExecute_byteSizeSubBatches() {
+        final int docCount = 3;
+        List<List<Float>> inferenceResults = createMockVectorWithLength(6);
+        // batchSize=100 (high, won't limit), batchSizeBytes=10 (will split)
+        TestInferenceProcessor processor = new TestInferenceProcessor(inferenceResults, 100, 10, null);
+        List<IngestDocumentWrapper> wrapperList = createIngestDocumentWrappers(docCount);
+        // Each "valueX" is 6 bytes. With batchSizeBytes=10, we can fit 1 per batch (6 > 10/2 but 6+6=12 > 10)
+        wrapperList.get(0).getIngestDocument().setFieldValue("key1", "value0");
+        wrapperList.get(1).getIngestDocument().setFieldValue("key1", "value1");
+        wrapperList.get(2).getIngestDocument().setFieldValue("key1", "value2");
+        List<IngestDocumentWrapper> allResults = new ArrayList<>();
+        processor.batchExecute(wrapperList, allResults::addAll);
+        // "value0"=6 bytes, "value1"=6 bytes, "value2"=6 bytes
+        // With limit 10: batch1=[value0] (6 bytes), then value1 would make 12 > 10, so flush
+        // After sort by length (all same length), batches should be:
+        // [value0, value1] would be 12 > 10, so: [value0](6), [value1](6), [value2](6)
+        // Actually: first item "value0" (6 bytes) fits. Second "value1" (6+6=12 > 10) triggers flush.
+        // So: [value0], [value1], [value2] = 3 sub-batches
+        assertEquals(3, processor.getAllInferenceInputs().size());
+        for (int i = 0; i < docCount; ++i) {
+            assertEquals(wrapperList.get(i).getIngestDocument(), allResults.get(i).getIngestDocument());
+        }
+    }
+
+    public void test_batchExecute_byteSizeDisabled() {
+        final int docCount = 2;
+        List<List<Float>> inferenceResults = createMockVectorWithLength(6);
+        // batchSizeBytes=-1 means disabled, should behave like normal batch
+        TestInferenceProcessor processor = new TestInferenceProcessor(inferenceResults, 100, -1, null);
+        List<IngestDocumentWrapper> wrapperList = createIngestDocumentWrappers(docCount);
+        wrapperList.get(0).getIngestDocument().setFieldValue("key1", "value0");
+        wrapperList.get(1).getIngestDocument().setFieldValue("key1", "value1");
+        List<IngestDocumentWrapper> allResults = new ArrayList<>();
+        processor.batchExecute(wrapperList, allResults::addAll);
+        // All in one batch since batchSizeBytes is disabled
+        assertEquals(1, processor.getAllInferenceInputs().size());
+        assertEquals(2, processor.getAllInferenceInputs().get(0).size());
+    }
+
+    public void test_batchExecute_byteSizeLargeEnough() {
+        final int docCount = 3;
+        List<List<Float>> inferenceResults = createMockVectorWithLength(6);
+        // batchSizeBytes large enough to fit all texts in one batch
+        TestInferenceProcessor processor = new TestInferenceProcessor(inferenceResults, 100, 100000, null);
+        List<IngestDocumentWrapper> wrapperList = createIngestDocumentWrappers(docCount);
+        wrapperList.get(0).getIngestDocument().setFieldValue("key1", "value0");
+        wrapperList.get(1).getIngestDocument().setFieldValue("key1", "value1");
+        wrapperList.get(2).getIngestDocument().setFieldValue("key1", "value2");
+        List<IngestDocumentWrapper> allResults = new ArrayList<>();
+        processor.batchExecute(wrapperList, allResults::addAll);
+        // All in one batch
+        assertEquals(1, processor.getAllInferenceInputs().size());
+        assertEquals(3, processor.getAllInferenceInputs().get(0).size());
+    }
+
     private class TestInferenceProcessor extends InferenceProcessor {
         List<?> vectors;
         Exception exception;
@@ -202,6 +381,24 @@ public class InferenceProcessorTests extends InferenceProcessorTestCase {
 
         public TestInferenceProcessor(List<?> vectors, int batchSize, Exception exception) {
             super(TAG, DESCRIPTION, batchSize, TYPE, MAP_KEY, MODEL_ID, FIELD_MAP, clientAccessor, environment, mockClusterService);
+            this.vectors = vectors;
+            this.exception = exception;
+        }
+
+        public TestInferenceProcessor(List<?> vectors, int batchSize, int batchSizeBytes, Exception exception) {
+            super(
+                TAG,
+                DESCRIPTION,
+                batchSize,
+                batchSizeBytes,
+                TYPE,
+                MAP_KEY,
+                MODEL_ID,
+                FIELD_MAP,
+                clientAccessor,
+                environment,
+                mockClusterService
+            );
             this.vectors = vectors;
             this.exception = exception;
         }

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -2689,4 +2689,154 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         verify(resultHandler).accept(resultCaptor.capture());
         assertEquals(docCount, resultCaptor.getValue().size());
     }
+
+    @SneakyThrows
+    public void testFactory_withBatchSizeBytes_successful() {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1_knn"));
+        config.put(AbstractBatchingProcessor.BATCH_SIZE_FIELD, 10);
+        config.put(InferenceProcessor.BATCH_SIZE_BYTES_FIELD, 102400);
+        TextEmbeddingProcessor processor = (TextEmbeddingProcessor) textEmbeddingProcessorFactory.create(
+            registry,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            config
+        );
+        assertNotNull(processor);
+    }
+
+    /**
+     * Verifies that when batch_size_bytes is set and batch_size is NOT explicitly set by the user,
+     * the factory auto-elevates batch_size to Integer.MAX_VALUE so the byte limit is the sole
+     * effective constraint. Also confirms that batch_size IS removed from config before
+     * newProcessor() is called (proving the ThreadLocal approach is necessary).
+     */
+    @SneakyThrows
+    public void testFactory_batchSizeRemovedFromConfigBeforeNewProcessor() {
+        final boolean[] batchSizePresentInNewProcessor = { false };
+
+        // Use an anonymous subclass of AbstractBatchingProcessor.Factory to intercept newProcessor()
+        // and inspect the config map state at that point (TextEmbeddingProcessorFactory is final).
+        AbstractBatchingProcessor.Factory probeFactory = new AbstractBatchingProcessor.Factory("text_embedding") {
+            @Override
+            protected AbstractBatchingProcessor newProcessor(String tag, String description, int batchSize, Map<String, Object> config) {
+                batchSizePresentInNewProcessor[0] = config.containsKey(AbstractBatchingProcessor.BATCH_SIZE_FIELD);
+                return mock(AbstractBatchingProcessor.class);
+            }
+        };
+
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(AbstractBatchingProcessor.BATCH_SIZE_FIELD, 10);
+
+        probeFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config);
+
+        // Confirms batch_size is removed before newProcessor() — the ThreadLocal approach is necessary
+        assertFalse(
+            "batch_size is removed from config by AbstractBatchingProcessor.Factory.create() before "
+                + "newProcessor() is called — config.containsKey(BATCH_SIZE_FIELD) is not viable inside newProcessor()",
+            batchSizePresentInNewProcessor[0]
+        );
+    }
+
+    /**
+     * When batch_size_bytes is set but batch_size is NOT explicitly configured, batch_size should
+     * be auto-elevated to Integer.MAX_VALUE so the byte limit is the sole effective constraint.
+     */
+    @SneakyThrows
+    public void testFactory_withBatchSizeBytesOnly_autoElevatesBatchSize() {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1_knn"));
+        // batch_size_bytes set, batch_size NOT set
+        config.put(InferenceProcessor.BATCH_SIZE_BYTES_FIELD, 102400);
+        TextEmbeddingProcessor processor = (TextEmbeddingProcessor) textEmbeddingProcessorFactory.create(
+            registry,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            config
+        );
+        assertNotNull(processor);
+        assertEquals(InferenceProcessor.AUTO_BATCH_SIZE_FOR_BYTE_BATCHING, processor.getBatchSize());
+    }
+
+    /**
+     * When both batch_size and batch_size_bytes are set, the user's explicit batch_size must be
+     * preserved — it should NOT be overridden by auto-elevation.
+     */
+    @SneakyThrows
+    public void testFactory_withBatchSizeAndBatchSizeBytes_respectsExplicitBatchSize() {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1_knn"));
+        config.put(AbstractBatchingProcessor.BATCH_SIZE_FIELD, 50);
+        config.put(InferenceProcessor.BATCH_SIZE_BYTES_FIELD, 102400);
+        TextEmbeddingProcessor processor = (TextEmbeddingProcessor) textEmbeddingProcessorFactory.create(
+            registry,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            config
+        );
+        assertNotNull(processor);
+        assertEquals(50, processor.getBatchSize());
+    }
+
+    @SneakyThrows
+    public void testFactory_withoutBatchSizeBytes_successful() {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1_knn"));
+        // No batch_size_bytes — should use default (-1, disabled)
+        TextEmbeddingProcessor processor = (TextEmbeddingProcessor) textEmbeddingProcessorFactory.create(
+            registry,
+            PROCESSOR_TAG,
+            DESCRIPTION,
+            config
+        );
+        assertNotNull(processor);
+    }
+
+    public void testFactory_withInvalidBatchSizeBytes_throwsException() {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1_knn"));
+        config.put(InferenceProcessor.BATCH_SIZE_BYTES_FIELD, 0);
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config)
+        );
+        assertTrue(exception.getMessage().contains("must be a positive integer"));
+    }
+
+    public void testFactory_withNegativeBatchSizeBytes_throwsException() {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1_knn"));
+        config.put(InferenceProcessor.BATCH_SIZE_BYTES_FIELD, -5);
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config)
+        );
+        assertTrue(exception.getMessage().contains("must be a positive integer"));
+    }
+
+    public void testFactory_withBatchSizeBytesExceedingMax_throwsException() {
+        Map<String, Processor.Factory> registry = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(TextEmbeddingProcessor.MODEL_ID_FIELD, "mockModelId");
+        config.put(TextEmbeddingProcessor.FIELD_MAP_FIELD, ImmutableMap.of("key1", "key1_knn"));
+        config.put(InferenceProcessor.BATCH_SIZE_BYTES_FIELD, InferenceProcessor.MAX_BATCH_SIZE_BYTES + 1);
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> textEmbeddingProcessorFactory.create(registry, PROCESSOR_TAG, DESCRIPTION, config)
+        );
+        assertTrue(exception.getMessage().contains("must not exceed"));
+    }
 }

--- a/src/test/resources/processor/PipelineConfigurationWithBatchSizeBytes.json
+++ b/src/test/resources/processor/PipelineConfigurationWithBatchSizeBytes.json
@@ -1,0 +1,23 @@
+{
+  "description": "text embedding pipeline with batch_size_bytes",
+  "processors": [
+    {
+      "text_embedding": {
+        "model_id": "%s",
+        "batch_size": 100,
+        "batch_size_bytes": %d,
+        "field_map": {
+          "title": "title_knn",
+          "favor_list": "favor_list_knn",
+          "favorites": {
+            "game": "game_knn",
+            "movie": "movie_knn"
+          },
+          "nested_passages": {
+            "text": "embedding"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Add size-based (byte-aware) batching for neural search ingest processors

https://github.com/opensearch-project/neural-search/issues/1761

### Related Issues
Resolves [#[Issue number to be closed when this PR is merged]](https://github.com/opensearch-project/neural-search/issues/1761)


### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
