### PR TITLE
Return unmodifiable list from HybridQueryBuilder queries() accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 
 ### Refactoring
+- [HYBRID] Return unmodifiable list from HybridQueryBuilder queries() accessor to prevent external state mutation ([#1764](https://github.com/opensearch-project/neural-search/pull/1764))

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -7,6 +7,7 @@ package org.opensearch.neuralsearch.query;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -34,6 +35,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
 import org.opensearch.index.query.QueryBuilderVisitor;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -60,9 +62,19 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     private static final ParseField FILTER_FIELD = new ParseField("filter");
     private static final ParseField PAGINATION_DEPTH_FIELD = new ParseField("pagination_depth");
 
+    @Getter(AccessLevel.NONE)
     private final List<QueryBuilder> queries = new ArrayList<>();
 
     private Integer paginationDepth;
+
+    /**
+     * Returns an unmodifiable view of the sub-queries in this hybrid query.
+     * Clients cannot modify the returned list, ensuring the internal state of this builder is protected.
+     * @return unmodifiable list of query builders
+     */
+    public List<QueryBuilder> queries() {
+        return Collections.unmodifiableList(queries);
+    }
 
     public static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
     private static final int LOWER_BOUND_OF_PAGINATION_DEPTH = 0;

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -1131,6 +1131,31 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertEquals(1, innerHitsMap.size());
     }
 
+    public void testQueries_whenAccessedViaPublicMethod_thenReturnUnmodifiableList() {
+        setUpClusterService();
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        TermQueryBuilder termQuery = QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT);
+        hybridQueryBuilder.add(termQuery);
+
+        List<QueryBuilder> returnedQueries = hybridQueryBuilder.queries();
+
+        // verify the returned list reflects internal state
+        assertEquals(1, returnedQueries.size());
+        assertSame(termQuery, returnedQueries.get(0));
+
+        // verify add throws UnsupportedOperationException
+        expectThrows(UnsupportedOperationException.class, () -> returnedQueries.add(QueryBuilders.termQuery("field", "value")));
+
+        // verify remove throws UnsupportedOperationException
+        expectThrows(UnsupportedOperationException.class, () -> returnedQueries.remove(0));
+
+        // verify clear throws UnsupportedOperationException
+        expectThrows(UnsupportedOperationException.class, () -> returnedQueries.clear());
+
+        // verify internal state is not affected by failed mutation attempts
+        assertEquals(1, hybridQueryBuilder.queries().size());
+    }
+
     public void testExtractInnerHitsBuilders_whenMultipleInnerHitsOnSamePath_thenFail() {
         InnerHitBuilder innerHitBuilder = new InnerHitBuilder();
         NestedQueryBuilder nestedQueryBuilder1 = new NestedQueryBuilder(


### PR DESCRIPTION
### Description
Refactored `HybridQueryBuilder` to return an unmodifiable view of the internal `queries` list from the public `queries()` method.

Previously, the Lombok-generated getter returned a direct reference to the mutable `ArrayList`, allowing external callers to inadvertently mutate the builder's internal state (e.g., via `add()`, `remove()`, `clear()`).

**Changes:**
- Suppressed Lombok getter for `queries` field using `@Getter(AccessLevel.NONE)`
- Added manual `queries()` method returning `Collections.unmodifiableList(queries)` — a zero-copy wrapper that permits reads but throws `UnsupportedOperationException` on any mutation attempt
- All internal methods continue to access the `queries` field directly — zero behavior change
- Added unit test verifying immutability guarantees (add/remove/clear throw `UnsupportedOperationException`)

### Related Issues
N/A — minor defensive refactoring, no issue filed

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).