### PR TITLE
Fix HybridQueryDocIdStream by adding intoArray overridden method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Neural] Fix issue where remote symmetric models are not supported ([#1767](https://github.com/opensearch-project/neural-search/pull/1767))
 - [HYBRID]: Fix profiler support for hybrid query by unwrapping ProfileScorer to access HybridSubQueryScorer ([#1754](https://github.com/opensearch-project/neural-search/pull/1754))
 - [HYBRID]: Fix missing results and ranking issue in hybrid query collapse([#1763](https://github.com/opensearch-project/neural-search/pull/1763))
+- [HYBRID]: Fix HybridQueryDocIdStream by adding intoArray overridden method from upstream
 
 
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
@@ -42,6 +42,21 @@ public class HybridQueryDocIdStream extends DocIdStream {
         return false;
     }
 
+    @Override
+    public int intoArray(int upTo, int[] docIds) {
+        final int[] index = { 0 };
+        try {
+            forEach(upTo, docId -> {
+                if (index[0] < docIds.length) {
+                    docIds[index[0]++] = docId;
+                }
+            });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return index[0];
+    }
+
     // This class does not respect the upTo value; it consumes all matching documents.
     @Override
     public void forEach(int upTo, CheckedIntConsumer<IOException> consumer) throws IOException {
@@ -70,13 +85,5 @@ public class HybridQueryDocIdStream extends DocIdStream {
                 bits ^= 1L << numberOfTrailingZeros;
             }
         }
-    }
-
-    // This lazy loading is necessary because the matching bit isn't available at the time this class is constructed.
-    private FixedBitSet getLocalMatchingBitSet() {
-        if (localMatchingBitSet == null) {
-            localMatchingBitSet = hybridBulkScorer.getMatching().clone();
-        }
-        return localMatchingBitSet;
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStreamTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStreamTests.java
@@ -122,6 +122,49 @@ public class HybridQueryDocIdStreamTests extends OpenSearchTestCase {
     }
 
     @SneakyThrows
+    public void testIntoArray_whenMultipleMatchingDocs_thenArrayFilled() {
+        // setup
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        matchingDocs.set(DOC_ID_1);
+        matchingDocs.set(DOC_ID_2);
+        matchingDocs.set(DOC_ID_3);
+
+        HybridBulkScorer mockScorer = createMockScorerWithDocs(matchingDocs);
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        int[] docIds = new int[5];
+
+        // execute
+        int count = stream.intoArray(Integer.MAX_VALUE, docIds);
+
+        // verify
+        assertEquals(3, count);
+        assertEquals(DOC_ID_1, docIds[0]);
+        assertEquals(DOC_ID_2, docIds[1]);
+        assertEquals(DOC_ID_3, docIds[2]);
+    }
+
+    @SneakyThrows
+    public void testIntoArray_whenArraySmallerThanMatches_thenPartialFill() {
+        // setup
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        matchingDocs.set(DOC_ID_1);
+        matchingDocs.set(DOC_ID_2);
+        matchingDocs.set(DOC_ID_3);
+
+        HybridBulkScorer mockScorer = createMockScorerWithDocs(matchingDocs);
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        int[] docIds = new int[2];
+
+        // execute
+        int count = stream.intoArray(Integer.MAX_VALUE, docIds);
+
+        // verify
+        assertEquals(2, count);
+        assertEquals(DOC_ID_1, docIds[0]);
+        assertEquals(DOC_ID_2, docIds[1]);
+    }
+
+    @SneakyThrows
     public void testForEach_whenSubsequentCalls_thenUpToParameterIgnored() {
         // setup
         FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);


### PR DESCRIPTION
### Description
Fixed HybridQueryDocIdStream by adding intoArray overridden method coming from upstream https://github.com/apache/lucene/pull/15173

```
 /__w/neural-search/neural-search/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java:20: error: HybridQueryDocIdStream is not abstract and does not override abstract method intoArray(int,int[]) in DocIdStream
  public class HybridQueryDocIdStream extends DocIdStream {
         ^
  Note: Recompile with -Xlint:unchecked for details.
  Note: Some input files use or override a deprecated API.
  /__w/neural-search/neural-search/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java:64: warning: [removal] <Request,Response>apply(Task,String,Request,ActionListener<Response>,ActionFilterChain<Request,Response>) in ActionFilter has been deprecated and marked for removal
      public <Request extends org.opensearch.action.ActionRequest, Response extends ActionResponse> void apply(
                                                                                                         ^
    where Request,Response are type-variables:
      Request extends ActionRequest declared in method <Request,Response>apply(Task,String,Request,ActionListener<Response>,ActionFilterChain<Request,Response>)
      Response extends ActionResponse declared in method <Request,Response>apply(Task,String,Request,ActionListener<Response>,ActionFilterChain<Request,Response>)
  Note: Some input files use unchecked or unsafe operations.
  1 error

```

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/1781
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
