### PR TITLE
Fix HybridQueryDocIdStream.intoArray to avoid unnecessary scorer state mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Neural] Fix issue where remote symmetric models are not supported ([#1767](https://github.com/opensearch-project/neural-search/pull/1767))
 - [HYBRID]: Fix profiler support for hybrid query by unwrapping ProfileScorer to access HybridSubQueryScorer ([#1754](https://github.com/opensearch-project/neural-search/pull/1754))
 - [HYBRID]: Fix missing results and ranking issue in hybrid query collapse([#1763](https://github.com/opensearch-project/neural-search/pull/1763))
-- [HYBRID]: Fix HybridQueryDocIdStream by adding intoArray overridden method from upstream
+- [HYBRID]: Fix HybridQueryDocIdStream by adding intoArray overridden method from upstream ([#1780](https://github.com/opensearch-project/neural-search/pull/1780))
 
 
 ### Infrastructure
@@ -23,5 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 
 ### Maintenance
+- [HYBRID]: Clean up dead code and add missing test coverage for HybridQueryDocIdStream intoArray method ([#1786](https://github.com/opensearch-project/neural-search/pull/1786))
 
 ### Refactoring

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStream.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 public class HybridQueryDocIdStream extends DocIdStream {
     private static final int BLOCK_SHIFT = 6;
     private final HybridBulkScorer hybridBulkScorer;
-    private FixedBitSet localMatchingBitSet;
     @Setter
     private int base;
 
@@ -42,19 +41,37 @@ public class HybridQueryDocIdStream extends DocIdStream {
         return false;
     }
 
+    // This method iterates the matching bitset directly instead of delegating to forEach, enabling early
+    // termination when the docIds array is full. Like forEach, it does not respect the upTo parameter —
+    // it processes matching documents until the array is full or all matches are exhausted.
     @Override
     public int intoArray(int upTo, int[] docIds) {
-        final int[] index = { 0 };
-        try {
-            forEach(upTo, docId -> {
-                if (index[0] < docIds.length) {
-                    docIds[index[0]++] = docId;
+        FixedBitSet matchingBitSet = hybridBulkScorer.getMatching();
+        long[] bitArray = matchingBitSet.getBits();
+        int index = 0;
+
+        for (int idx = 0; idx < bitArray.length && index < docIds.length; idx++) {
+            long bits = bitArray[idx];
+            while (bits != 0L && index < docIds.length) {
+                int numberOfTrailingZeros = Long.numberOfTrailingZeros(bits);
+                final int docIndexInWindow = (idx << BLOCK_SHIFT) | numberOfTrailingZeros;
+                final int docId = base | docIndexInWindow;
+
+                float[][] windowScores = hybridBulkScorer.getWindowScores();
+                for (int subQueryIndex = 0; subQueryIndex < windowScores.length; subQueryIndex++) {
+                    if (Objects.isNull(windowScores[subQueryIndex])) {
+                        continue;
+                    }
+                    float scoreOfDocIdForSubQuery = windowScores[subQueryIndex][docIndexInWindow];
+                    hybridBulkScorer.getHybridSubQueryScorer().getSubQueryScores()[subQueryIndex] = scoreOfDocIdForSubQuery;
                 }
-            });
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+                docIds[index++] = docId;
+                hybridBulkScorer.getHybridSubQueryScorer().resetScores();
+
+                bits ^= 1L << numberOfTrailingZeros;
+            }
         }
-        return index[0];
+        return index;
     }
 
     // This class does not respect the upTo value; it consumes all matching documents.

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStreamTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryDocIdStreamTests.java
@@ -165,6 +165,113 @@ public class HybridQueryDocIdStreamTests extends OpenSearchTestCase {
     }
 
     @SneakyThrows
+    public void testIntoArray_whenNoMatchingDocs_thenZeroReturned() {
+        // setup
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        HybridBulkScorer mockScorer = mock(HybridBulkScorer.class);
+        when(mockScorer.getMatching()).thenReturn(matchingDocs);
+
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        int[] docIds = new int[5];
+
+        // execute
+        int count = stream.intoArray(Integer.MAX_VALUE, docIds);
+
+        // verify
+        assertEquals(0, count);
+    }
+
+    @SneakyThrows
+    public void testIntoArray_whenBaseOffsetProvided_thenDocIdsAdjusted() {
+        // setup
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        matchingDocs.set(DOC_ID_1);
+        matchingDocs.set(DOC_ID_2);
+
+        HybridBulkScorer mockScorer = createMockScorerWithDocs(matchingDocs);
+        int baseOffset = 100;
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        stream.setBase(baseOffset);
+        int[] docIds = new int[5];
+
+        // execute
+        int count = stream.intoArray(Integer.MAX_VALUE, docIds);
+
+        // verify
+        assertEquals(2, count);
+        assertEquals(baseOffset | DOC_ID_1, docIds[0]);
+        assertEquals(baseOffset | DOC_ID_2, docIds[1]);
+    }
+
+    @SneakyThrows
+    public void testIntoArray_whenCrossing64BitBoundary_thenAllDocsInArray() {
+        // setup
+        int numDocs = 128; // Two longs worth of bits
+        FixedBitSet matchingDocs = new FixedBitSet(numDocs);
+        matchingDocs.set(63);  // Last bit in first long
+        matchingDocs.set(64);  // First bit in second long
+
+        HybridBulkScorer mockScorer = createMockScorerWithDocs(matchingDocs, numDocs);
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        int[] docIds = new int[5];
+
+        // execute
+        int count = stream.intoArray(Integer.MAX_VALUE, docIds);
+
+        // verify
+        assertEquals(2, count);
+        assertEquals(63, docIds[0]);
+        assertEquals(64, docIds[1]);
+    }
+
+    @SneakyThrows
+    public void testIntoArray_whenArraySmallerThanMatches_thenScorerStateCleanAfterCall() {
+        // setup - 3 matching docs but array of size 2
+        FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);
+        matchingDocs.set(DOC_ID_1);
+        matchingDocs.set(DOC_ID_2);
+        matchingDocs.set(DOC_ID_3);
+
+        // Use a real sub-query scorer to verify state is clean after partial fill
+        HybridBulkScorer mockScorer = mock(HybridBulkScorer.class);
+        when(mockScorer.getMatching()).thenReturn(matchingDocs);
+        when(mockScorer.getMaxDoc()).thenReturn(200);
+
+        float[][] windowScores = new float[2][NUM_DOCS];
+        for (int i = 0; i < NUM_DOCS; i++) {
+            windowScores[0][i] = 1.0f + i;
+            windowScores[1][i] = 2.0f + i;
+        }
+        when(mockScorer.getWindowScores()).thenReturn(windowScores);
+
+        // Use a real HybridSubQueryScorer (not mocked) to verify resetScores() leaves state clean
+        float[] subQueryScores = new float[2];
+        HybridSubQueryScorer realSubQueryScorer = mock(HybridSubQueryScorer.class);
+        when(realSubQueryScorer.getSubQueryScores()).thenReturn(subQueryScores);
+        // resetScores zeroes the array - simulate this behavior
+        org.mockito.Mockito.doAnswer(invocation -> {
+            java.util.Arrays.fill(subQueryScores, 0.0f);
+            return null;
+        }).when(realSubQueryScorer).resetScores();
+        when(mockScorer.getHybridSubQueryScorer()).thenReturn(realSubQueryScorer);
+
+        HybridQueryDocIdStream stream = new HybridQueryDocIdStream(mockScorer);
+        int[] docIds = new int[2];
+
+        // execute - array is smaller than matches, so forEach continues past array capacity
+        int count = stream.intoArray(Integer.MAX_VALUE, docIds);
+
+        // verify - array has first 2 docs
+        assertEquals(2, count);
+        assertEquals(DOC_ID_1, docIds[0]);
+        assertEquals(DOC_ID_2, docIds[1]);
+
+        // verify - scorer state is clean after intoArray (resetScores was called for all docs including extras)
+        assertEquals(0.0f, subQueryScores[0], 0.0f);
+        assertEquals(0.0f, subQueryScores[1], 0.0f);
+    }
+
+    @SneakyThrows
     public void testForEach_whenSubsequentCalls_thenUpToParameterIgnored() {
         // setup
         FixedBitSet matchingDocs = new FixedBitSet(NUM_DOCS);


### PR DESCRIPTION
### Description
Fixed couple of issue after PR https://github.com/opensearch-project/neural-search/pull/1780:
- optimize logic in HybridQueryDocIdStream.intoArray, when there are more matching docs than `docIds.length` we stop iterating
- minor code review findings - drop unused constant, add method comment, add more unit tests

To increase confidence in this fix I ran test on search relevance before (released 3.5) and after the fix for both score and rank based normalization. They are practically identical with noise level delta due to distribution of docs among shards:

score based normalization, min_max_am:
Metric            Baseline      Local      Delta 
NDCG@1              0.2140     0.2160    +0.0020         
NDCG@10             0.1961     0.1965    +0.0005          
NDCG@100            0.2937     0.2937    +0.0001          
Recall@100          0.4998     0.4996    -0.0002          
MAP                 0.1412     0.1412    +0.0000          

rank based normalization, rrf:
Metric            Baseline      Local      Delta   
NDCG@1              0.2170     0.2170    +0.0000       
NDCG@10             0.1910     0.1904    -0.0006       
NDCG@100            0.2891     0.2890    -0.0000      
Recall@100          0.4905     0.4901    -0.0004      
MAP                 0.1377     0.1378    +0.0001   

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/1784

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
