### PR TITLE
Fix Competitive doc Id check with score in HybridTopScoreDocCollector and HybridCollapsingTopDocCollector

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollector.java
@@ -265,7 +265,7 @@ public class HybridCollapsingTopDocsCollector<T> implements HybridSearchCollecto
                     }
 
                     // Skip non-competitive docs when sorting by score
-                    if (isSortByScore && score <= 0 && score < minScoreThresholds[subQuery]) {
+                    if (isSortByScore && (score <= 0 || score < minScoreThresholds[subQuery])) {
                         continue;
                     }
 

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridTopScoreDocCollector.java
@@ -173,7 +173,7 @@ public class HybridTopScoreDocCollector implements HybridSearchCollector {
         }
 
         private boolean isNonCompetitiveScore(float score, int subQueryIndex) {
-            return score <= 0 && score < minScoreThresholds[subQueryIndex];
+            return score <= 0 || score < minScoreThresholds[subQueryIndex];
         }
 
         /**

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
@@ -91,7 +91,7 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
 
         for (CollapseTopFieldDocs collapseTopFieldDocs : topDocs) {
             // With flat queue, totalHits counts all docs with score > 0 per sub-query
-            // random().nextFloat() returns [0.0, 1.0), so nearly all 1000 docs have score > 0
+            // random().nextFloat() returns [0.0, 1.0). CollapseTopFieldDocs will have totalHits as per minScoreThresholds.
             assertEquals(getExpectedCount(scores, numHits), collapseTopFieldDocs.totalHits.value(), 0.001);
             assertEquals(numHits, collapseTopFieldDocs.scoreDocs.length);
         }

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
@@ -201,7 +201,7 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
 
         for (CollapseTopFieldDocs collapseTopFieldDocs : topDocs) {
             // With flat queue, totalHits counts all docs with score > 0 per sub-query
-            assertTrue(collapseTopFieldDocs.totalHits.value() > 0);
+            assertEquals(getExpectedCount(scores, numHits), collapseTopFieldDocs.totalHits.value(), 0.001);
             assertEquals(numHits, collapseTopFieldDocs.scoreDocs.length);
         }
 

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
@@ -31,6 +31,7 @@ import org.opensearch.neuralsearch.search.HitsThresholdChecker;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -91,7 +92,7 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
         for (CollapseTopFieldDocs collapseTopFieldDocs : topDocs) {
             // With flat queue, totalHits counts all docs with score > 0 per sub-query
             // random().nextFloat() returns [0.0, 1.0), so nearly all 1000 docs have score > 0
-            assertTrue(collapseTopFieldDocs.totalHits.value() >= 999);
+            assertEquals(getExpectedCount(scores, numHits), collapseTopFieldDocs.totalHits.value(), 0.001);
             assertEquals(numHits, collapseTopFieldDocs.scoreDocs.length);
         }
 
@@ -200,7 +201,7 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
 
         for (CollapseTopFieldDocs collapseTopFieldDocs : topDocs) {
             // With flat queue, totalHits counts all docs with score > 0 per sub-query
-            assertTrue(collapseTopFieldDocs.totalHits.value() >= 999);
+            assertTrue(collapseTopFieldDocs.totalHits.value() > 0);
             assertEquals(numHits, collapseTopFieldDocs.scoreDocs.length);
         }
 
@@ -266,7 +267,7 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
 
         for (CollapseTopFieldDocs collapseTopFieldDocs : topDocs) {
             // With flat queue, totalHits counts all docs with score > 0 per sub-query
-            assertEquals(100, collapseTopFieldDocs.totalHits.value());
+            assertEquals(getExpectedCount(scores, topNGroups), collapseTopFieldDocs.totalHits.value());
 
             // Flat queue of size topNGroups=10, so at most 10 results
             assertTrue("Should have some results", collapseTopFieldDocs.scoreDocs.length > 0);
@@ -305,7 +306,7 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
             COLLAPSE_FIELD_NAME,
             fieldType,
             sort,
-            5,  // topNGroups
+            numHits,  // topNGroups
             new HitsThresholdChecker(TOTAL_HITS_UP_TO)
         );
 
@@ -331,7 +332,7 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
 
         for (CollapseTopFieldDocs collapseTopFieldDocs : topDocs) {
             // With flat queue, totalHits counts all docs with score > 0 per sub-query
-            assertEquals(20, collapseTopFieldDocs.totalHits.value());
+            assertEquals(getExpectedCount(scores, numHits), collapseTopFieldDocs.totalHits.value());
 
             // Flat queue of size 5, all 20 docs are in same group "samegroup"
             // Queue holds top 5 docs globally
@@ -1148,4 +1149,24 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
         writer.addDocument(doc);
     }
 
+    private int getExpectedCount(List<Float> scores, int topK) {
+        PriorityQueue<Float> minHeap = new PriorityQueue<>(topK);
+        float minScoreThreshold = Float.MIN_VALUE;
+        int count = 0;
+
+        for (float score : scores) {
+            if (score <= 0 || score < minScoreThreshold) continue;
+
+            count++;  // matches collectedHitsPerSubQuery increment position
+
+            if (minHeap.size() < topK) {
+                minHeap.add(score);
+            } else if (score > minHeap.peek()) {
+                float evicted = minHeap.poll();
+                minHeap.add(score);
+                minScoreThreshold = Math.max(minScoreThreshold, evicted);
+            }
+        }
+        return count;
+    }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
@@ -1157,7 +1157,7 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
         for (float score : scores) {
             if (score <= 0 || score < minScoreThreshold) continue;
 
-            count++;  // matches collectedHitsPerSubQuery increment position
+            count++;
 
             if (minHeap.size() < topK) {
                 minHeap.add(score);

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollectorTests.java
@@ -379,6 +379,7 @@ public class HybridLeafCollectorTests extends HybridCollectorTestCase {
         // Set profiler-mode fields
         hybridLeafCollector.hybridQueryScorer = mockHybridScorer;
         hybridLeafCollector.compoundQueryScorer = new HybridSubQueryScorer(1);
+        hybridLeafCollector.minScoreThresholds = new float[] { Float.MIN_VALUE };
 
         // Call collect() which should internally call populateScoresFromHybridQueryScorer()
         leafCollector.collect(0);


### PR DESCRIPTION
### Description
This Pr fixes the dead competitiveDoc check in both HybridCollapsingTopScoreDocCollector and HybridCollapsingTopDocCollector by switch condition from && to ||.

Earlier all the positive scores used to participate in collectedHits but now only ones that are greater than minScoreThreshold will participate.

### Related Issues
[1795](https://github.com/opensearch-project/neural-search/issues/1795)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
