### PR TITLE
Bump assertj-core from 3.24.2 to 3.27.7 to fix CVE-2026-24400

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,7 @@ dependencies {
     testFixturesImplementation fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
     testImplementation fileTree(dir: knnJarDirectory, include: ["opensearch-knn-${opensearch_build}.jar", "remote-index-build-client-${opensearch_build}.jar"])
     testImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: "${versions.bytebuddy}"
     testImplementation group: 'org.objenesis', name: 'objenesis', version: "${versions.objenesis}"
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${versions.bytebuddy}"


### PR DESCRIPTION
### Description

Upgrades org.assertj:assertj-core from 3.24.2 to 3.27.7 to remediate [CVE-2026-24400](https://github.com/advisories)
Affected scope: org.assertj:assertj-core >= 1.4.0, < 3.27.7
Fix: bumping to 3.27.7, the minimum patched version

This dependency is used in testImplementation only, so there is no impact on production runtime behavior. No API or functional changes are introduced.

Existing test suite should continue to pass without modification as 3.27.7 is backwards compatible.

### Related Issues

See https://github.com/assertj/assertj/releases/tag/assertj-build-3.27.7

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
