### PR TITLE
Rename createLocalInput to createMLInput for clarity

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/ml/NeuralSearchMLInputBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/NeuralSearchMLInputBuilder.java
@@ -84,9 +84,9 @@ public class NeuralSearchMLInputBuilder {
     }
 
     /**
-     * Creates MLInput for local models with flexible dataset and function types.
+     * Creates MLInput with flexible dataset and function types.
      */
-    private static MLInput createLocalInput(FunctionName functionName, MLInputDataset inputDataset, MLAlgoParams mlAlgoParams) {
+    private static MLInput createMLInput(FunctionName functionName, MLInputDataset inputDataset, MLAlgoParams mlAlgoParams) {
         return new MLInput(functionName, mlAlgoParams, inputDataset);
     }
 
@@ -119,7 +119,7 @@ public class NeuralSearchMLInputBuilder {
      */
     public static MLInput createTextSimilarityInput(String query, List<String> inputText) {
         MLInputDataset inputDataset = new TextSimilarityInputDataSet(query, inputText);
-        return createLocalInput(FunctionName.TEXT_SIMILARITY, inputDataset, null);
+        return createMLInput(FunctionName.TEXT_SIMILARITY, inputDataset, null);
     }
 
     /**
@@ -127,7 +127,7 @@ public class NeuralSearchMLInputBuilder {
      */
     public static MLInput createQuestionAnsweringInput(String question, String context) {
         MLInputDataset inputDataset = new QuestionAnsweringInputDataSet(question, context);
-        return createLocalInput(FunctionName.QUESTION_ANSWERING, inputDataset, null);
+        return createMLInput(FunctionName.QUESTION_ANSWERING, inputDataset, null);
     }
 
     /**


### PR DESCRIPTION
### Description
The method createLocalInput was misleadingly named as it handles MLInput creation for both local and remote models, not just local models. Renamed to createMLInput to better reflect its general-purpose nature.

### Related Issues
Fixes #1719
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
