### PR TITLE
Fix rerank processor to extract text from nested and dot-notation fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+- Fix rerank processor unable to extract text from nested and dot-notation fields in document_fields ([#1805](https://github.com/opensearch-project/neural-search/pull/1805))
 - [HYBRID]: Fix relevancy bugs in hybrid query collapse ([#1753](https://github.com/opensearch-project/neural-search/pull/1753))
 - [Neural] Fix issue where remote symmetric models are not supported ([#1767](https://github.com/opensearch-project/neural-search/pull/1767))
 - [HYBRID]: Fix profiler support for hybrid query by unwrapping ProfileScorer to access HybridSubQueryScorer ([#1754](https://github.com/opensearch-project/neural-search/pull/1754))

--- a/src/main/java/org/opensearch/neuralsearch/processor/rerank/context/DocumentContextSourceFetcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/rerank/context/DocumentContextSourceFetcher.java
@@ -9,16 +9,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.xcontent.ObjectPath;
 import org.opensearch.search.SearchHit;
 
 import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.RERANKER_MAX_DOC_FIELDS;
+
+import org.opensearch.neuralsearch.processor.util.ProcessorUtils;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -64,20 +66,26 @@ public class DocumentContextSourceFetcher implements ContextSourceFetcher {
         if (hit.getFields().containsKey(field)) {
             Object fieldValue = hit.field(field).getValue();
             return String.valueOf(fieldValue);
-        } else if (hit.hasSource() && hit.getSourceAsMap().containsKey(field)) {
-            Object sourceValue = ObjectPath.eval(field, hit.getSourceAsMap());
-            return String.valueOf(sourceValue);
-        } else {
-            log.warn(
-                String.format(
-                    Locale.ROOT,
-                    "Could not find field %s in document %s for reranking! Using the empty string instead.",
-                    field,
-                    hit.getId()
-                )
-            );
-            return "";
         }
+        if (hit.hasSource()) {
+            Optional<Object> value = ProcessorUtils.getValueFromSource(hit.getSourceAsMap(), field);
+            if (value.isPresent()) {
+                Object val = value.get();
+                if (val instanceof List) {
+                    return ((List<?>) val).stream().map(String::valueOf).collect(Collectors.joining(" "));
+                }
+                return String.valueOf(val);
+            }
+        }
+        log.warn(
+            String.format(
+                Locale.ROOT,
+                "Could not find field %s in document %s for reranking! Using the empty string instead.",
+                field,
+                hit.getId()
+            )
+        );
+        return "";
     }
 
     @Override

--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/context/DocumentContextSourceFetcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/context/DocumentContextSourceFetcherTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.rerank.context;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.test.OpenSearchTestCase;
+
+import lombok.SneakyThrows;
+
+public class DocumentContextSourceFetcherTests extends OpenSearchTestCase {
+
+    @SneakyThrows
+    public void testContextFromSearchHit_whenFlatField_thenExtractsValue() {
+        DocumentContextSourceFetcher fetcher = new DocumentContextSourceFetcher(List.of("title"));
+        SearchResponse response = createSearchResponse(createHit("{\"title\": \"good morning\"}", "1"));
+
+        fetchAndAssert(fetcher, response, contexts -> {
+            assertEquals(1, contexts.size());
+            assertEquals("good morning", contexts.get(0));
+        });
+    }
+
+    @SneakyThrows
+    public void testContextFromSearchHit_whenDotNotationField_thenExtractsValue() {
+        DocumentContextSourceFetcher fetcher = new DocumentContextSourceFetcher(List.of("metadata.author"));
+        SearchResponse response = createSearchResponse(createHit("{\"metadata\": {\"author\": \"John\"}}", "1"));
+
+        fetchAndAssert(fetcher, response, contexts -> {
+            assertEquals(1, contexts.size());
+            assertEquals("John", contexts.get(0));
+        });
+    }
+
+    @SneakyThrows
+    public void testContextFromSearchHit_whenNestedArrayField_thenExtractsConcatenatedValues() {
+        DocumentContextSourceFetcher fetcher = new DocumentContextSourceFetcher(List.of("content.text"));
+        SearchResponse response = createSearchResponse(
+            createHit("{\"content\": [{\"text\": \"good morning\", \"page\": 1}, {\"text\": \"good evening\", \"page\": 2}]}", "1")
+        );
+
+        fetchAndAssert(fetcher, response, contexts -> {
+            assertEquals(1, contexts.size());
+            assertTrue("Should contain 'good morning', got: " + contexts.get(0), contexts.get(0).contains("good morning"));
+            assertTrue("Should contain 'good evening', got: " + contexts.get(0), contexts.get(0).contains("good evening"));
+        });
+    }
+
+    @SneakyThrows
+    public void testContextFromSearchHit_whenMissingField_thenReturnsEmpty() {
+        DocumentContextSourceFetcher fetcher = new DocumentContextSourceFetcher(List.of("nonexistent"));
+        SearchResponse response = createSearchResponse(createHit("{\"title\": \"hello\"}", "1"));
+
+        fetchAndAssert(fetcher, response, contexts -> {
+            assertEquals(1, contexts.size());
+            assertEquals("", contexts.get(0));
+        });
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    private void fetchAndAssert(DocumentContextSourceFetcher fetcher, SearchResponse response, ContextAssertion assertion) {
+        fetcher.fetchContext(new SearchRequest(), response, ActionListener.wrap(result -> {
+            List<String> contexts = (List<String>) result.get(DocumentContextSourceFetcher.DOCUMENT_CONTEXT_LIST_FIELD);
+            assertion.assertContexts(contexts);
+        }, e -> fail("Should not fail: " + e.getMessage())));
+    }
+
+    private interface ContextAssertion {
+        void assertContexts(List<String> contexts);
+    }
+
+    private SearchHit createHit(String jsonSource, String id) {
+        SearchHit hit = new SearchHit(Integer.parseInt(id), id, Collections.emptyMap(), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(jsonSource));
+        hit.score(1.0f);
+        return hit;
+    }
+
+    private SearchResponse createSearchResponse(SearchHit... hits) {
+        TotalHits totalHits = new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO);
+        SearchHits searchHits = new SearchHits(hits, totalHits, 1.0f);
+        SearchResponseSections internal = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
+        return new SearchResponse(internal, null, 1, 1, 0, 1, new ShardSearchFailure[0], new SearchResponse.Clusters(1, 1, 0), null);
+    }
+}


### PR DESCRIPTION
### Description
DocumentContextSourceFetcher.contextFromSearchHit() method used hit.getSourceAsMap().containsKey(field) as a guard before calling ObjectPath.eval(). For dot-notation paths like "content.text", containsKey() checks for the literal key in the top-level map and returns false, field value is never extracted and the reranker receives empty strings, making reranking have no effect.

Additionally, for nested type fields where `_source` contains an array of objects, previous code did not handle list traversal.

Fix: Replace the broken field extraction with ProcessorUtils.getValueFromSource() which already exists in the codebase, correctly handles dot-notation traversal through nested maps and arrays, and is already used by ByFieldRerankProcessor.

### Related Issues
https://github.com/opensearch-project/neural-search/issues/657

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
