### PR TITLE
Add integration tests for text embedding processor/semantic field with remote model

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/ml/SymmetricRemoteModelIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/SymmetricRemoteModelIT.java
@@ -1,0 +1,740 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.ml;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+import org.opensearch.neuralsearch.util.RemoteModelTestUtils;
+
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_USER_AGENT;
+
+/**
+ * Integration tests for Symmetric Text Embedding using remote models via TorchServe.
+ * Tests symmetric text embedding functionality with the symmetric_text_embedding handler.
+ */
+@Log4j2
+public class SymmetricRemoteModelIT extends BaseNeuralSearchIT {
+
+    private static final String INDEX_NAME = "symmetric_remote_index";
+    private static final String PIPELINE_NAME = "symmetric_remote_pipeline";
+
+    // Test document fields
+    protected static final String QUERY_TEXT = "hello";
+    protected static final String TEXT_FIELD_NAME = "passage_text";
+    protected static final String EMBEDDING_FIELD_NAME = "passage_embedding";
+    protected static final String NESTED_FIELD_NAME = "nested_passages";
+    protected static final String LEVEL_2_FIELD = "level_2";
+    protected static final String LEVEL_3_FIELD_TEXT = "level_3_text";
+    protected static final String LEVEL_3_FIELD_CONTAINER = "level_3_container";
+    protected static final String LEVEL_3_FIELD_EMBEDDING = "level_3_embedding";
+
+    // Load test documents
+    private final String INGEST_DOC1 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc1.json").toURI()));
+    private final String INGEST_DOC2 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc2.json").toURI()));
+    private final String INGEST_DOC3 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc3.json").toURI()));
+    private final String INGEST_DOC4 = Files.readString(Path.of(classLoader.getResource("processor/ingest_doc4.json").toURI()));
+    private final String UPDATE_DOC1 = Files.readString(Path.of(classLoader.getResource("processor/update_doc1.json").toURI()));
+    private final String UPDATE_DOC2 = Files.readString(Path.of(classLoader.getResource("processor/update_doc2.json").toURI()));
+    private final String BULK_ITEM_TEMPLATE = Files.readString(
+        Path.of(classLoader.getResource("processor/bulk_item_template.json").toURI())
+    );
+
+    private String remoteModelId;
+    private String connectorId;
+    private boolean isTorchServeAvailable = false;
+    private static final int EMBEDDING_DIMENSION = 128; // Using tiny model with 128 dimensions
+
+    public SymmetricRemoteModelIT() throws IOException, URISyntaxException {}
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        updateClusterSettings();
+
+        // Configure ML Commons to trust localhost endpoints for remote models
+        updateClusterSettings("plugins.ml_commons.only_run_on_ml_node", false);
+        updateClusterSettings("plugins.ml_commons.connector.private_ip_enabled", true);
+        updateClusterSettings("plugins.ml_commons.allow_registering_model_via_url", true);
+        updateClusterSettings(
+            "plugins.ml_commons.trusted_connector_endpoints_regex",
+            List.of(
+                "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                "^http://localhost:.*",
+                "^http://127\\.0\\.0\\.1:.*",
+                "^http://torchserve:.*"
+            )
+        );
+
+        // Check for TorchServe endpoint availability
+        String torchServeEndpoint = System.getenv("TORCHSERVE_ENDPOINT");
+        if (torchServeEndpoint == null) {
+            torchServeEndpoint = System.getProperty("tests.torchserve.endpoint");
+        }
+
+        if (torchServeEndpoint != null && !torchServeEndpoint.isEmpty()) {
+            // Check if TorchServe is available
+            isTorchServeAvailable = RemoteModelTestUtils.isRemoteEndpointAvailable(torchServeEndpoint);
+            if (isTorchServeAvailable) {
+                log.info("TorchServe endpoint available at: {}", torchServeEndpoint);
+
+                try {
+                    // Create remote connector
+                    connectorId = createRemoteModelConnector(torchServeEndpoint);
+                    log.info("Created connector with ID: {}", connectorId);
+
+                    // Deploy the symmetric text embedding model
+                    remoteModelId = deployRemoteModel(connectorId, "symmetric-text-embedding-remote");
+                    log.info("Deployed remote text embedding model with ID: {}", remoteModelId);
+
+                } catch (Exception e) {
+                    log.error("Failed to set up remote model: ", e);
+                    isTorchServeAvailable = false;
+                }
+            } else {
+                log.info("TorchServe not available at {}, tests will be skipped", torchServeEndpoint);
+            }
+        } else {
+            log.info("TorchServe endpoint not configured, tests will be skipped");
+        }
+    }
+
+    @After
+    @SneakyThrows
+    public void tearDown() {
+        super.tearDown();
+
+        // Clean up indexes
+        try {
+            deleteIndex(INDEX_NAME);
+        } catch (Exception e) {
+            log.debug("Index cleanup failed: {}", e.getMessage());
+        }
+
+        // Clean up pipelines
+        try {
+            deleteIngestPipeline(PIPELINE_NAME);
+        } catch (Exception e) {
+            log.debug("Pipeline cleanup failed: {}", e.getMessage());
+        }
+
+        // Clean up remote model resources
+        if (remoteModelId != null || connectorId != null) {
+            cleanupRemoteModelResources(connectorId, remoteModelId);
+        }
+    }
+
+    /**
+     * Test basic document ingestion with remote symmetric model
+     * Verifies that ML Commons connector and model work correctly for single document
+     */
+    @SneakyThrows
+    public void testBasicRemoteModelIngestion() {
+        Assume.assumeTrue("TorchServe is not available, skipping test", isTorchServeAvailable);
+
+        // Create text embedding pipeline with remote model
+        String pipelineConfig = String.format(
+            Locale.ROOT,
+            "{\n"
+                + "  \"description\": \"Text embedding pipeline with remote symmetric model\",\n"
+                + "  \"processors\": [\n"
+                + "    {\n"
+                + "      \"text_embedding\": {\n"
+                + "        \"model_id\": \"%s\",\n"
+                + "        \"field_map\": {\n"
+                + "          \"%s\": \"%s\"\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}",
+            remoteModelId,
+            TEXT_FIELD_NAME,
+            EMBEDDING_FIELD_NAME
+        );
+
+        // Create pipeline using the raw JSON configuration
+        createPipelineProcessor(pipelineConfig, PIPELINE_NAME, remoteModelId, null);
+
+        // Create index with appropriate mapping for 128-dim embeddings
+        String indexMapping = String.format(
+            Locale.ROOT,
+            "{\n"
+                + "  \"settings\": {\n"
+                + "    \"index.knn\": true,\n"
+                + "    \"default_pipeline\": \"%s\"\n"
+                + "  },\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"%s\": {\n"
+                + "        \"type\": \"knn_vector\",\n"
+                + "        \"dimension\": %d,\n"
+                + "        \"method\": {\n"
+                + "          \"name\": \"hnsw\",\n"
+                + "          \"engine\": \"lucene\"\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"%s\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}",
+            PIPELINE_NAME,
+            EMBEDDING_FIELD_NAME,
+            EMBEDDING_DIMENSION,
+            TEXT_FIELD_NAME
+        );
+
+        createIndexWithConfiguration(INDEX_NAME, indexMapping, PIPELINE_NAME);
+
+        // Ingest a document through ML Commons remote model
+        String testDoc = String.format(
+            Locale.ROOT,
+            "{\n" + "  \"%s\": \"OpenSearch is a distributed search and analytics engine\"\n" + "}",
+            TEXT_FIELD_NAME
+        );
+
+        ingestDocument(INDEX_NAME, testDoc, "1");
+        assertEquals(1, getDocCount(INDEX_NAME));
+
+        // Verify the embedding was created by remote model
+        Map<String, Object> doc = getDocById(INDEX_NAME, "1");
+        assertNotNull(doc);
+
+        Map<String, Object> source = (Map<String, Object>) doc.get("_source");
+        assertNotNull(source);
+
+        List<Number> embedding = (List<Number>) source.get(EMBEDDING_FIELD_NAME);
+        assertNotNull("Remote model should create embedding", embedding);
+        assertEquals("Remote model embedding should have correct dimensions", EMBEDDING_DIMENSION, embedding.size());
+
+        // Verify the embedding values are valid (not all zeros)
+        boolean hasNonZeroValues = embedding.stream().anyMatch(value -> value.doubleValue() != 0.0);
+        assertTrue("Embedding should contain non-zero values", hasNonZeroValues);
+
+        log.info("Successfully created embedding with remote model: {} dimensions", embedding.size());
+    }
+
+    /**
+     * Test batch document ingestion with remote model
+     * Verifies ML Commons can handle multiple inference requests efficiently
+     */
+    @SneakyThrows
+    public void testBatchDocumentIngestionWithRemoteModel() {
+        Assume.assumeTrue("TorchServe is not available, skipping test", isTorchServeAvailable);
+
+        // Create pipeline with batch size for efficient ML Commons processing
+        String pipelineConfig = String.format(
+            Locale.ROOT,
+            "{\n"
+                + "  \"description\": \"Batch processing pipeline with remote model\",\n"
+                + "  \"processors\": [\n"
+                + "    {\n"
+                + "      \"text_embedding\": {\n"
+                + "        \"model_id\": \"%s\",\n"
+                + "        \"field_map\": {\n"
+                + "          \"%s\": \"%s\"\n"
+                + "        },\n"
+                + "        \"batch_size\": 3\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}",
+            remoteModelId,
+            TEXT_FIELD_NAME,
+            EMBEDDING_FIELD_NAME
+        );
+
+        // Create pipeline using the raw JSON configuration
+        createPipelineProcessor(pipelineConfig, PIPELINE_NAME, remoteModelId, null);
+
+        // Create index
+        String indexMapping = String.format(
+            Locale.ROOT,
+            "{\n"
+                + "  \"settings\": {\n"
+                + "    \"index.knn\": true,\n"
+                + "    \"default_pipeline\": \"%s\",\n"
+                + "    \"refresh_interval\": \"1s\"\n"
+                + "  },\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"%s\": {\n"
+                + "        \"type\": \"knn_vector\",\n"
+                + "        \"dimension\": %d,\n"
+                + "        \"method\": {\n"
+                + "          \"name\": \"hnsw\",\n"
+                + "          \"engine\": \"lucene\"\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"%s\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"doc_id\": {\n"
+                + "        \"type\": \"keyword\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}",
+            PIPELINE_NAME,
+            EMBEDDING_FIELD_NAME,
+            EMBEDDING_DIMENSION,
+            TEXT_FIELD_NAME
+        );
+
+        createIndexWithConfiguration(INDEX_NAME, indexMapping, PIPELINE_NAME);
+
+        // Use bulk API to test batch processing through ML Commons
+        String bulkRequestBody = "";
+        for (int i = 1; i <= 5; i++) {
+            bulkRequestBody += String.format(Locale.ROOT, "{\"index\": {\"_index\": \"%s\", \"_id\": \"%d\"}}\n", INDEX_NAME, i);
+            bulkRequestBody += String.format(
+                Locale.ROOT,
+                "{\"%s\": \"Document %d: Testing batch inference with ML Commons remote model\", \"doc_id\": \"doc_%d\"}\n",
+                TEXT_FIELD_NAME,
+                i,
+                i
+            );
+        }
+
+        // Execute bulk request using makeRequest
+        Response bulkResponse = makeRequest(
+            client(),
+            "POST",
+            "/_bulk?refresh=true",
+            null,
+            toHttpEntity(bulkRequestBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        assertEquals(200, bulkResponse.getStatusLine().getStatusCode());
+        assertEquals("All documents should be indexed", 5, getDocCount(INDEX_NAME));
+
+        // Verify all embeddings were created by remote model
+        for (int i = 1; i <= 5; i++) {
+            Map<String, Object> doc = getDocById(INDEX_NAME, String.valueOf(i));
+            assertNotNull("Document " + i + " should exist", doc);
+
+            Map<String, Object> source = (Map<String, Object>) doc.get("_source");
+            List<Number> embedding = (List<Number>) source.get(EMBEDDING_FIELD_NAME);
+
+            assertNotNull("Document " + i + " should have embedding from remote model", embedding);
+            assertEquals("Remote model embedding dimensions", EMBEDDING_DIMENSION, embedding.size());
+
+            // Verify doc_id field
+            assertEquals("doc_" + i, source.get("doc_id"));
+        }
+
+        log.info("Successfully processed {} documents in batch with remote model", 5);
+    }
+
+    /**
+     * Test reindexing with remote model
+     * Verifies that documents can be reindexed using ML Commons remote model for embedding generation
+     */
+    @SneakyThrows
+    public void testReindexingWithRemoteModel() {
+        Assume.assumeTrue("TorchServe is not available, skipping test", isTorchServeAvailable);
+
+        // Step 1: Create source index without embeddings
+        String sourceIndex = "source_index";
+        String sourceMapping = String.format(
+            Locale.ROOT,
+            "{\n"
+                + "  \"settings\": {\n"
+                + "    \"number_of_shards\": 1,\n"
+                + "    \"refresh_interval\": \"1s\"\n"
+                + "  },\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"%s\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"title\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"category\": {\n"
+                + "        \"type\": \"keyword\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}",
+            TEXT_FIELD_NAME
+        );
+
+        createIndexWithConfiguration(sourceIndex, sourceMapping, null);
+
+        // Index documents without embeddings
+        String doc1 = String.format(
+            Locale.ROOT,
+            "{\"%s\": \"Machine learning algorithms analyze data patterns\", \"title\": \"ML Basics\", \"category\": \"technology\"}",
+            TEXT_FIELD_NAME
+        );
+        String doc2 = String.format(
+            Locale.ROOT,
+            "{\"%s\": \"Neural networks mimic human brain structure\", \"title\": \"Deep Learning\", \"category\": \"technology\"}",
+            TEXT_FIELD_NAME
+        );
+        String doc3 = String.format(
+            Locale.ROOT,
+            "{\"%s\": \"Search engines help find relevant information\", \"title\": \"Search Technology\", \"category\": \"search\"}",
+            TEXT_FIELD_NAME
+        );
+
+        ingestDocument(sourceIndex, doc1, "1");
+        ingestDocument(sourceIndex, doc2, "2");
+        ingestDocument(sourceIndex, doc3, "3");
+
+        assertEquals(3, getDocCount(sourceIndex));
+
+        // Step 2: Create pipeline with remote model for target index
+        String reindexPipelineName = "reindex_pipeline";
+        String pipelineConfig = String.format(
+            Locale.ROOT,
+            "{\n"
+                + "  \"description\": \"Reindex pipeline with remote model embeddings\",\n"
+                + "  \"processors\": [\n"
+                + "    {\n"
+                + "      \"text_embedding\": {\n"
+                + "        \"model_id\": \"%s\",\n"
+                + "        \"field_map\": {\n"
+                + "          \"%s\": \"%s\"\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}",
+            remoteModelId,
+            TEXT_FIELD_NAME,
+            EMBEDDING_FIELD_NAME
+        );
+
+        createPipelineProcessor(pipelineConfig, reindexPipelineName, remoteModelId, null);
+
+        // Step 3: Create target index with vector field
+        String targetIndex = "target_index_with_embeddings";
+        String targetMapping = String.format(
+            Locale.ROOT,
+            "{\n"
+                + "  \"settings\": {\n"
+                + "    \"index.knn\": true,\n"
+                + "    \"number_of_shards\": 1,\n"
+                + "    \"default_pipeline\": \"%s\"\n"
+                + "  },\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"%s\": {\n"
+                + "        \"type\": \"knn_vector\",\n"
+                + "        \"dimension\": %d,\n"
+                + "        \"method\": {\n"
+                + "          \"name\": \"hnsw\",\n"
+                + "          \"engine\": \"lucene\"\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"%s\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"title\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"category\": {\n"
+                + "        \"type\": \"keyword\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}",
+            reindexPipelineName,
+            EMBEDDING_FIELD_NAME,
+            EMBEDDING_DIMENSION,
+            TEXT_FIELD_NAME
+        );
+
+        createIndexWithConfiguration(targetIndex, targetMapping, reindexPipelineName);
+
+        // Step 4: Perform reindexing - this will use ML Commons remote model to generate embeddings
+        reindex(sourceIndex, targetIndex);
+
+        // Step 5: Verify reindexing with embeddings
+        assertEquals("All documents should be reindexed", 3, getDocCount(targetIndex));
+
+        // Verify each document has embeddings generated by remote model
+        for (int i = 1; i <= 3; i++) {
+            Map<String, Object> doc = getDocById(targetIndex, String.valueOf(i));
+            assertNotNull("Reindexed document " + i + " should exist", doc);
+
+            Map<String, Object> source = (Map<String, Object>) doc.get("_source");
+
+            // Verify original fields are preserved
+            assertNotNull("Text field should be preserved", source.get(TEXT_FIELD_NAME));
+            assertNotNull("Title should be preserved", source.get("title"));
+            assertNotNull("Category should be preserved", source.get("category"));
+
+            // Verify embedding was added by remote model
+            List<Number> embedding = (List<Number>) source.get(EMBEDDING_FIELD_NAME);
+            assertNotNull("Remote model should add embedding during reindex", embedding);
+            assertEquals("Remote model embedding dimensions", EMBEDDING_DIMENSION, embedding.size());
+        }
+
+        // Step 6: Verify neural search works on reindexed documents
+        NeuralQueryBuilder neuralQuery = NeuralQueryBuilder.builder()
+            .fieldName(EMBEDDING_FIELD_NAME)
+            .queryText("artificial intelligence and machine learning")
+            .modelId(remoteModelId)
+            .k(2)
+            .build();
+
+        Map<String, Object> searchResponse = search(targetIndex, neuralQuery, 2);
+        Map<String, Object> hits = (Map<String, Object>) searchResponse.get("hits");
+        List<Map<String, Object>> searchHits = (List<Map<String, Object>>) hits.get("hits");
+
+        assertNotNull("Should find results with neural search", searchHits);
+        assertTrue("Should find at least one document", searchHits.size() > 0);
+
+        log.info("Successfully reindexed {} documents with remote model embeddings", 3);
+
+        // Cleanup
+        deleteIndex(sourceIndex);
+        deleteIndex(targetIndex);
+        deleteIngestPipeline(reindexPipelineName);
+    }
+
+    /**
+     * Test semantic field with remote symmetric model for both ingestion and search
+     * Demonstrates end-to-end semantic search using the semantic field type
+     */
+    @SneakyThrows
+    public void testSemanticFieldWithRemoteModel() {
+        Assume.assumeTrue("TorchServe is not available, skipping test", isTorchServeAvailable);
+
+        String semanticIndex = "semantic_field_test_index";
+
+        try {
+
+            // Step 1: Create index with semantic field mapping
+            String indexMapping = String.format(Locale.ROOT, """
+                {
+                  "settings": {
+                    "index.knn": true
+                  },
+                  "mappings": {
+                    "properties": {
+                      "title": {
+                        "type": "text"
+                      },
+                      "content": {
+                        "type": "semantic",
+                        "model_id": "%s",
+                        "dense_embedding_config": {
+                          "method": {
+                            "engine": "lucene"
+                          }
+                        }
+                      },
+                      "category": {
+                        "type": "keyword"
+                      }
+                    }
+                  }
+                }
+                """, remoteModelId);
+
+            createIndexWithConfiguration(semanticIndex, indexMapping, null);
+
+            // Step 2: Ingest documents with semantic field
+            String doc1 =
+                """
+                    {
+                      "title": "Introduction to Machine Learning",
+                      "content": "Machine learning is a subset of artificial intelligence that enables systems to learn and improve from experience without being explicitly programmed.",
+                      "category": "AI"
+                    }
+                    """;
+
+            String doc2 =
+                """
+                    {
+                      "title": "Deep Learning Fundamentals",
+                      "content": "Deep learning is part of machine learning methods based on artificial neural networks with representation learning.",
+                      "category": "AI"
+                    }
+                    """;
+
+            String doc3 =
+                """
+                    {
+                      "title": "Search Engine Optimization",
+                      "content": "SEO is the process of improving the quality and quantity of website traffic to a website or a web page from search engines.",
+                      "category": "Web"
+                    }
+                    """;
+
+            String doc4 =
+                """
+                    {
+                      "title": "Natural Language Processing",
+                      "content": "NLP is a branch of artificial intelligence that helps computers understand, interpret and manipulate human language.",
+                      "category": "AI"
+                    }
+                    """;
+
+            // Ingest documents
+            try {
+                ingestDocument(semanticIndex, doc1, "1");
+                ingestDocument(semanticIndex, doc2, "2");
+                ingestDocument(semanticIndex, doc3, "3");
+                ingestDocument(semanticIndex, doc4, "4");
+
+                assertEquals(4, getDocCount(semanticIndex));
+            } catch (Exception e) {
+                log.error("Failed to ingest documents: ", e);
+                throw e;
+            }
+
+            // Step 3: Verify semantic field created embeddings
+            Map<String, Object> doc = getDocById(semanticIndex, "1");
+            Map<String, Object> source = (Map<String, Object>) doc.get("_source");
+
+            // Semantic fields store text directly and embeddings in a separate structure
+            String contentText = (String) source.get("content");
+            assertNotNull("Semantic field text should exist", contentText);
+            assertTrue("Original text should contain expected content", contentText.contains("Machine learning"));
+
+            // The embedding is stored in content_semantic_info.embedding
+            Map<String, Object> semanticInfo = (Map<String, Object>) source.get("content_semantic_info");
+            assertNotNull("Semantic info should exist", semanticInfo);
+
+            List<Number> embedding = (List<Number>) semanticInfo.get("embedding");
+            assertNotNull("KNN embedding should exist", embedding);
+            assertEquals("Embedding dimension should match", EMBEDDING_DIMENSION, embedding.size());
+
+            // Verify model info exists
+            Map<String, Object> modelInfo = (Map<String, Object>) semanticInfo.get("model");
+            assertNotNull("Model info should exist", modelInfo);
+
+            // Step 4: Perform neural search on semantic field
+            // For semantic fields, we need to query the embedding field directly
+            NeuralQueryBuilder neuralQuery = NeuralQueryBuilder.builder()
+                .fieldName("content")
+                .queryText("artificial intelligence and machine learning concepts")
+                .k(3)
+                .build();
+
+            Map<String, Object> searchResponse = search(semanticIndex, neuralQuery, 3);
+            Map<String, Object> hits = (Map<String, Object>) searchResponse.get("hits");
+            List<Map<String, Object>> searchHits = (List<Map<String, Object>>) hits.get("hits");
+
+            assertNotNull("Should find results", searchHits);
+            assertEquals("Should find top 3 AI-related documents", 3, searchHits.size());
+
+            // Verify scoring - first result should have highest score
+            double firstScore = (double) searchHits.get(0).get("_score");
+            double secondScore = (double) searchHits.get(1).get("_score");
+            assertTrue("First result should have higher score than second", firstScore >= secondScore);
+
+            log.info("Successfully tested semantic field with remote symmetric model");
+
+        } finally {
+            // Cleanup
+            try {
+                deleteIndex(semanticIndex);
+            } catch (Exception e) {
+                log.debug("Failed to delete index during cleanup: {}", e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Override deployRemoteModel to split registration and deployment
+     * This matches the pattern used in AsymmetricRemoteModelIT which works
+     */
+    @Override
+    protected String deployRemoteModel(String connectorId, String modelName) throws Exception {
+        String requestBody = String.format(Locale.ROOT, """
+            {
+                "name": "%s",
+                "function_name": "remote",
+                "description": "Remote symmetric text embedding model",
+                "connector_id": "%s",
+                "model_config": {
+                    "model_type": "TEXT_EMBEDDING",
+                    "embedding_dimension": 128,
+                    "framework_type": "sentence_transformers",
+                    "additional_config": {
+                        "space_type": "l2"
+                    }
+                }
+            }
+            """, modelName, connectorId);
+
+        // Register the model first
+        Request request = new Request("POST", "/_plugins/_ml/models/_register");
+        request.setJsonEntity(requestBody);
+        Response response = client().performRequest(request);
+        Map<String, Object> responseMap = XContentHelper.convertToMap(
+            XContentType.JSON.xContent(),
+            response.getEntity().getContent(),
+            false
+        );
+
+        String modelId = (String) responseMap.get("model_id");
+
+        // Then deploy it separately
+        Request deployRequest = new Request("POST", "/_plugins/_ml/models/" + modelId + "/_deploy");
+        client().performRequest(deployRequest);
+
+        // Wait for model to be deployed
+        waitForModelToBeReady(modelId);
+
+        return modelId;
+    }
+
+    /**
+     * Create a TorchServe connector for text embedding
+     * Overrides the base method to use proper preprocessing for text embedding
+     */
+    @Override
+    protected String createRemoteModelConnector(String endpoint) throws Exception {
+        String connectorName = "symmetric-connector-" + System.currentTimeMillis();
+        String connectorTemplate = Files.readString(
+            Path.of(Objects.requireNonNull(classLoader.getResource("symmetric/RemoteTorchServeConnector.json")).toURI())
+        );
+        String requestBody = String.format(Locale.ROOT, connectorTemplate, connectorName, endpoint);
+
+        Request request = new Request("POST", "/_plugins/_ml/connectors/_create");
+        request.setJsonEntity(requestBody);
+
+        Response response = client().performRequest(request);
+        Map<String, Object> responseMap = XContentHelper.convertToMap(
+            XContentType.JSON.xContent(),
+            response.getEntity().getContent(),
+            false
+        );
+
+        return (String) responseMap.get("connector_id");
+    }
+
+}

--- a/src/test/resources/remote-models/torchserve/handlers/symmetric_text_embedding_handler.py
+++ b/src/test/resources/remote-models/torchserve/handlers/symmetric_text_embedding_handler.py
@@ -1,0 +1,138 @@
+import json
+import logging
+import torch
+from transformers import AutoTokenizer, AutoModel
+from ts.torch_handler.base_handler import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+class SymmetricTextEmbeddingHandler(BaseHandler):
+    """
+    Simple TorchServe handler for symmetric text embedding
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.model = None
+        self.tokenizer = None
+        self.initialized = False
+
+    def initialize(self, context):
+        """Initialize the model and tokenizer."""
+        try:
+            logger.info("Initializing symmetric text embedding model...")
+
+            # Using Google's tiny BERT - Apache 2.0 licensed, same as OpenSearch!
+            model_name = "google/bert_uncased_L-2_H-128_A-2"  # 4.4MB, 128-dim embeddings, Apache 2.0
+
+            logger.info(f"Loading model: {model_name}")
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+            self.model = AutoModel.from_pretrained(model_name)
+            self.model.eval()
+
+            self.initialized = True
+            logger.info("Model initialized successfully")
+
+        except Exception as e:
+            logger.error(f"Failed to initialize model: {str(e)}")
+            raise
+
+    def preprocess(self, data):
+        """
+        Parse input JSON and return list of texts for embedding generation.
+
+        Expected input formats:
+        1. Direct format: {"texts": ["text1", "text2"]}
+        2. With parameters: {"parameters": {"texts": ["text1", "text2"]}}
+        """
+        texts = []
+
+        for row in data:
+            # Handle different input formats
+            if isinstance(row, dict):
+                if "body" in row:
+                    # HTTP request format - body might be string or dict
+                    body = row["body"]
+                    if isinstance(body, str):
+                        input_data = json.loads(body)
+                    else:
+                        input_data = body
+                else:
+                    # Direct dict format
+                    input_data = row
+            else:
+                # String format
+                input_data = json.loads(row)
+
+            # Handle OpenSearch remote connector format
+            if "parameters" in input_data:
+                params = input_data["parameters"]
+                texts_list = params.get("texts", [])
+            else:
+                texts_list = input_data.get("texts", [])
+
+            texts.extend(texts_list)
+
+        # Ensure we have at least one text
+        if not texts:
+            texts = [""]
+
+        logger.info(f"Processing {len(texts)} text(s)")
+        return texts
+
+    def inference(self, data):
+        """Generate embeddings for the input texts."""
+        try:
+            if not self.initialized:
+                raise RuntimeError("Model not initialized")
+
+            logger.info(f"Running inference on {len(data)} texts")
+
+            # Tokenize
+            inputs = self.tokenizer(
+                data,
+                padding=True,
+                truncation=True,
+                return_tensors="pt",
+                max_length=512
+            )
+
+            # Generate embeddings
+            with torch.no_grad():
+                outputs = self.model(**inputs)
+
+                # Mean pooling
+                token_embeddings = outputs.last_hidden_state
+                attention_mask = inputs['attention_mask']
+                input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+                embeddings = torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+
+                # Normalize
+                embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+
+            result = embeddings.cpu().numpy()
+            logger.info(f"Generated embeddings with shape: {result.shape}")
+
+            return result
+
+        except Exception as e:
+            logger.error(f"Error in inference: {str(e)}")
+            raise
+
+    def postprocess(self, data):
+        """
+        Format prediction output for OpenSearch connector compatibility.
+
+        Expected output format (simple array for OpenSearch to wrap):
+        Single embedding: [0.1, 0.2, 0.3, ...]
+        Batch embeddings: [[0.1, 0.2, ...], [0.3, 0.4, ...]]
+        """
+        # Return simple array format for OpenSearch to wrap properly
+        if len(data.shape) == 2:  # Batch of embeddings
+            # Return array of arrays for batch
+            result = [embedding.tolist() for embedding in data]
+        else:  # Single embedding
+            # Return single array
+            result = data.tolist()
+
+        return [result]

--- a/src/test/resources/remote-models/torchserve/scripts/run.sh
+++ b/src/test/resources/remote-models/torchserve/scripts/run.sh
@@ -178,9 +178,19 @@ except:
 
     # Check if model is already loaded
     local model_status=$(curl -s http://localhost:${MANAGEMENT_PORT}/models 2>/dev/null || echo "[]")
-    if echo "$model_status" | grep -q "${model_name}"; then
+    if echo "$model_status" | grep -q "\"${model_name}\""; then
         log_info "Model '${model_name}' is already loaded"
-        return 0
+
+        # Check if force reload is requested (via environment variable)
+        if [ "${FORCE_RELOAD:-false}" = "true" ]; then
+            log_info "Force reload requested - unloading existing model..."
+            curl -X DELETE http://localhost:${MANAGEMENT_PORT}/models/${model_name} 2>/dev/null
+            sleep 2
+            log_info "Redeploying model with updated handler..."
+        else
+            log_info "To reload with updated handler, use: FORCE_RELOAD=true $0 setup-model ${model_name}"
+            return 0
+        fi
     fi
 
     # Deploy model
@@ -355,47 +365,62 @@ def handle(data, context):
 EOF
     fi
 
-    # Download model files from HuggingFace
-    log_info "Downloading model files from HuggingFace..."
-    local base_url="https://huggingface.co/opensearch-project/opensearch-semantic-highlighter-v1/resolve/main"
+    # Handle model files based on the handler type
+    if [[ "$model_name" == "symmetric_text_embedding" ]] || \
+       [[ "$model_name" == "asymmetric_text_embedding" ]] || \
+       [[ "$model_name" == "agentic_search" ]]; then
+        # These handlers download their own models during initialization
+        log_info "Handler '$model_name' will download its own model during initialization"
+        # Create a placeholder file so the MAR creation doesn't fail
+        touch model_files/placeholder.txt
+    else
+        # Download model files from HuggingFace (for semantic_highlighter and others)
+        log_info "Downloading model files from HuggingFace..."
+        local base_url="https://huggingface.co/opensearch-project/opensearch-semantic-highlighter-v1/resolve/main"
 
-    for file in config.json tokenizer_config.json vocab.txt; do
-        if ! curl -fsSL "$base_url/$file" -o "model_files/$file"; then
-            log_error "Failed to download $file"
+        for file in config.json tokenizer_config.json vocab.txt; do
+            if ! curl -fsSL "$base_url/$file" -o "model_files/$file"; then
+                log_error "Failed to download $file"
+                rm -rf ${work_dir}
+                exit 1
+            fi
+            echo "  ✓ Downloaded $file"
+        done
+
+        # Download model weights
+        log_info "Downloading model weights (this may take a moment)..."
+        if ! curl -L --progress-bar "$base_url/model.safetensors" -o "model_files/model.safetensors"; then
+            log_error "Failed to download model weights"
             rm -rf ${work_dir}
             exit 1
         fi
-        echo "  ✓ Downloaded $file"
-    done
-
-    # Download model weights
-    log_info "Downloading model weights (this may take a moment)..."
-    if ! curl -L --progress-bar "$base_url/model.safetensors" -o "model_files/model.safetensors"; then
-        log_error "Failed to download model weights"
-        rm -rf ${work_dir}
-        exit 1
-    fi
-    log_info "✓ Downloaded model weights"
-
-    # Install torch-model-archiver if needed
-    if ! command -v torch-model-archiver &> /dev/null; then
-        log_info "Installing torch-model-archiver..."
-        pip install -q torch-model-archiver --no-cache-dir
+        log_info "✓ Downloaded model weights"
     fi
 
-    # Create Model Archive
-    log_info "Creating model archive..."
-    torch-model-archiver \
-        --model-name "${model_name}" \
-        --version 1.0 \
-        --handler handler.py \
-        --extra-files model_files/ \
-        --export-path model_store \
-        --force
-
-    # Deploy to container
+    # Get container ID
     local container_id=$(docker ps --format "{{.ID}}" --filter "name=${CONTAINER_NAME}" | head -1)
-    docker cp "model_store/${model_name}.mar" "${container_id}:/home/model-server/model-store/"
+
+    # Copy handler and model files to container
+    docker exec ${container_id} mkdir -p /tmp/model_prep/model_files
+    docker cp handler.py "${container_id}:/tmp/model_prep/"
+    docker cp model_files/. "${container_id}:/tmp/model_prep/model_files/"
+
+    # Install torch-model-archiver in container if needed
+    docker exec ${container_id} bash -c "command -v torch-model-archiver &> /dev/null || pip install -q torch-model-archiver --no-cache-dir"
+
+    # Create Model Archive inside container
+    log_info "Creating model archive..."
+    docker exec ${container_id} bash -c "cd /tmp/model_prep && \
+        torch-model-archiver \
+            --model-name '${model_name}' \
+            --version 1.0 \
+            --handler handler.py \
+            --extra-files model_files/ \
+            --export-path /home/model-server/model-store \
+            --force"
+
+    # Clean up temp files in container
+    docker exec ${container_id} rm -rf /tmp/model_prep
 
     # Try to register model using Management API first (no restart needed)
     log_info "Registering model via Management API..."
@@ -537,29 +562,72 @@ test() {
         return 1
     fi
 
-    # Test semantic_highlighter model specifically
-    local model_name="semantic_highlighter"
+    # Test models based on what's available
+    # Check if symmetric_text_embedding is loaded
+    local loaded_models=$(curl -s http://localhost:${MANAGEMENT_PORT}/models 2>/dev/null || echo "[]")
 
-    # Log memory before inference
-    log_memory_checkpoint "Before single inference"
+    if echo "$loaded_models" | grep -q "symmetric_text_embedding"; then
+        log_info "Testing symmetric_text_embedding model..."
 
-    # Test single inference
-    local response=$(curl -s -X POST http://localhost:${INFERENCE_PORT}/predictions/${model_name} \
-        -H "Content-Type: application/json" \
-        -d '{
-            "question": "What is OpenSearch?",
-            "context": "OpenSearch is a distributed, community-driven, Apache 2.0-licensed, open-source search and analytics suite."
-        }' 2>/dev/null)
+        # Log memory before inference
+        log_memory_checkpoint "Before symmetric embedding inference"
 
-    if echo "$response" | grep -q "highlights"; then
-        log_info "✓ Single inference successful!"
-        echo "  Response: $response"
-        # Log memory after single inference
-        log_memory_checkpoint "After single inference"
-    else
-        log_error "Single inference failed"
-        echo "  Response: $response"
-        exit 1
+        # Test single text embedding
+        local response=$(curl -s -X POST http://localhost:${INFERENCE_PORT}/predictions/symmetric_text_embedding \
+            -H "Content-Type: application/json" \
+            -d '{"texts": ["OpenSearch is a distributed search and analytics engine"]}' 2>/dev/null)
+
+        if echo "$response" | grep -q '\['; then
+            log_info "✓ Symmetric text embedding successful!"
+            # Check if it returns 128-dimensional vectors
+            local vector_length=$(echo "$response" | python3 -c "import json, sys; data=json.load(sys.stdin); print(len(data[0]) if isinstance(data[0], list) else len(data))" 2>/dev/null || echo "0")
+            if [ "$vector_length" = "128" ]; then
+                log_info "  ✓ Correct embedding dimension: 128"
+            else
+                log_warning "  Unexpected embedding dimension: $vector_length"
+            fi
+            log_memory_checkpoint "After symmetric embedding inference"
+        else
+            log_error "Symmetric text embedding failed"
+            echo "  Response: $response"
+        fi
+
+        # Test batch embeddings
+        log_info "Testing batch embeddings..."
+        local batch_response=$(curl -s -X POST http://localhost:${INFERENCE_PORT}/predictions/symmetric_text_embedding \
+            -H "Content-Type: application/json" \
+            -d '{"texts": ["First text", "Second text", "Third text"]}' 2>/dev/null)
+
+        if echo "$batch_response" | grep -q '\[\['; then
+            log_info "✓ Batch embedding successful!"
+        fi
+    fi
+
+    # Test semantic_highlighter if available
+    if echo "$loaded_models" | grep -q "semantic_highlighter"; then
+        log_info "Testing semantic_highlighter model..."
+        local model_name="semantic_highlighter"
+
+        # Log memory before inference
+        log_memory_checkpoint "Before semantic highlighter inference"
+
+        # Test single inference
+        local response=$(curl -s -X POST http://localhost:${INFERENCE_PORT}/predictions/${model_name} \
+            -H "Content-Type: application/json" \
+            -d '{
+                "question": "What is OpenSearch?",
+                "context": "OpenSearch is a distributed, community-driven, Apache 2.0-licensed, open-source search and analytics suite."
+            }' 2>/dev/null)
+
+        if echo "$response" | grep -q "highlights"; then
+            log_info "✓ Semantic highlighting successful!"
+            echo "  Response: $response"
+            # Log memory after single inference
+            log_memory_checkpoint "After semantic highlighter inference"
+        else
+            log_error "Semantic highlighting failed"
+            echo "  Response: $response"
+        fi
     fi
 
     # Test batch inference
@@ -686,6 +754,16 @@ case "${1:-}" in
             exit 1
         fi
         ;;
+    reload-model)
+        if [ -n "$2" ]; then
+            log_info "Reloading model: $2"
+            FORCE_RELOAD=true setup_model "$2"
+        else
+            log_error "Please specify a model name: $0 reload-model <model_name>"
+            list_models
+            exit 1
+        fi
+        ;;
     setup-all-models)
         setup_all_models
         ;;
@@ -708,11 +786,12 @@ case "${1:-}" in
         lifecycle "${2:-}"
         ;;
     *)
-        echo "Usage: $0 {start|setup-model|setup-all-models|list-models|test|stop|remove|status|lifecycle [setup|teardown]}"
+        echo "Usage: $0 {start|setup-model|reload-model|setup-all-models|list-models|test|stop|remove|status|lifecycle [setup|teardown]}"
         echo ""
         echo "Commands:"
         echo "  start            - Start TorchServe container"
         echo "  setup-model      - Deploy specific model to running container"
+        echo "  reload-model     - Force reload model with updated handler"
         echo "  setup-all-models - Deploy all discovered models"
         echo "  list-models      - List all discovered models"
         echo "  test             - Test model inference"

--- a/src/test/resources/symmetric/RemoteTorchServeConnector.json
+++ b/src/test/resources/symmetric/RemoteTorchServeConnector.json
@@ -1,0 +1,21 @@
+{
+    "name": "%s",
+    "description": "TorchServe connector for symmetric text embedding",
+    "version": 1,
+    "protocol": "http",
+    "credential": {
+        "key": "test"
+    },
+    "actions": [
+        {
+            "action_type": "predict",
+            "method": "POST",
+            "url": "%s/predictions/symmetric_text_embedding",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "request_body": "{ \"texts\": ${parameters.texts:-null} }",
+            "pre_process_function": "// Pre-process function for symmetric text embedding\n// Handle both direct API calls and OpenSearch text embedding processor\nif (params.texts != null) {\n  // Direct API call format\n  String textsJson = params.texts.toString();\n  return '{\"parameters\":{\"texts\":' + textsJson + '}}';\n}\nelse if (params.inputText != null) {\n  // OpenSearch text embedding processor format\n  String inputText = params.inputText;\n  return '{\"parameters\":{\"texts\":[\"' + inputText + '\"]}}';  \n}\nelse {\n  // Fallback: try to extract text from any string parameter\n  for (String key : params.keySet()) {\n    Object value = params.get(key);\n    if (value instanceof String && ((String)value).length() > 0) {\n      return '{\"parameters\":{\"texts\":[\"' + value + '\"]}}';\n    }\n  }\n  throw new IllegalArgumentException(\"No text input found in parameters: \" + params.keySet());\n}"
+        }
+    ]
+}


### PR DESCRIPTION
### Description
This commit adds integration tests for k-NN ingestion with ingestion pipelines and semantic field using remote models via TorchServe connectors.




### Related Issues
Resolves #1756


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
