### PR TITLE
Fix flaky integration test failure caused by ML memory circuit breaker during model deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Text Chunking] Fix text chunking processor ignoring index max_token_count setting when ingesting via alias ([#1803](https://github.com/opensearch-project/neural-search/pull/1803))
 
 ### Infrastructure
+* Fix flaky integration test failure caused by ML memory circuit breaker during model deployment in distribution pipeline ([#1824](https://github.com/opensearch-project/neural-search/pull/1824))
 
 ### Documentation
 

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -153,6 +153,7 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     private static final Set<String> DEPLOYED_MODEL_IDS = ConcurrentHashMap.newKeySet();
     private static final int MAX_ATTEMPTS = 30;
     private static final int WAIT_TIME_IN_SECONDS = 2;
+    private static final int MAX_DEPLOY_RETRIES = 3;
     private static final long TIMEOUT = 10000;
     protected String numOfNodes;
 
@@ -365,12 +366,24 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     }
 
     protected void waitForModelToBeReady(String modelId) throws Exception {
+        int deployRetries = 0;
         for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-            if (isModelReadyForInference(modelId)) {
+            MLModelState state = getModelState(modelId);
+            if (MLModelState.LOADED.equals(state) || MLModelState.DEPLOYED.equals(state)) {
                 logger.info("Model {} is ready for inference after {} attempts", modelId, attempt + 1);
                 return;
             }
-            logger.info("Waiting for model {} to be ready. Attempt {}/{}", modelId, attempt + 1, MAX_ATTEMPTS);
+            if (MLModelState.DEPLOY_FAILED.equals(state) && deployRetries < MAX_DEPLOY_RETRIES) {
+                deployRetries++;
+                logger.info(
+                    "Model {} deploy failed (likely circuit breaker), retrying deploy {}/{}",
+                    modelId,
+                    deployRetries,
+                    MAX_DEPLOY_RETRIES
+                );
+                loadModel(modelId);
+            }
+            logger.info("Waiting for model {} to be ready. Attempt {}/{}, state: {}", modelId, attempt + 1, MAX_ATTEMPTS, state);
             Thread.sleep(WAIT_TIME_IN_SECONDS * 1000);
         }
         throw new RuntimeException("Model " + modelId + " failed to be ready for inference after " + MAX_ATTEMPTS + " attempts");

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -381,7 +381,11 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
                     deployRetries,
                     MAX_DEPLOY_RETRIES
                 );
-                loadModel(modelId);
+                try {
+                    loadModel(modelId);
+                } catch (Exception e) {
+                    logger.warn("Model {} deploy retry {} failed: {}", modelId, deployRetries, e.getMessage());
+                }
             }
             logger.info("Waiting for model {} to be ready. Attempt {}/{}, state: {}", modelId, attempt + 1, MAX_ATTEMPTS, state);
             Thread.sleep(WAIT_TIME_IN_SECONDS * 1000);


### PR DESCRIPTION
### Description
Fix flaky integration test failure in distribution pipeline caused by ML memory circuit breaker tripping during model deployment.

When the circuit breaker trips (due to accumulated heap pressure from running many model load/undeploy cycles in a single JVM with limited heap), the model enters `DEPLOY_FAILED` state. Previously, `waitForModelToBeReady()` would only poll the model state without retrying the deploy, causing the test to time out after 30 polling attempts even though the circuit breaker may have already cleared (GC logs show memory recovering immediately after the failure).

This change adds retry logic: when `DEPLOY_FAILED` state is detected, the deploy operation is retried up to 3 times.

### Related Issues
Resolves #1823

This is a recurring issue pattern:
- #596 (Jun 2024) — same CB failure in distribution pipeline
- #1093 (Jan 2025) — same pattern

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

### Changes
- `BaseNeuralSearchIT.waitForModelToBeReady()`: detect `DEPLOY_FAILED` state and retry deploy (up to 3 times)
- Added `MAX_DEPLOY_RETRIES = 3` constant
- Improved logging to include current model state