### PR TITLE
Improve error messages for unexpected model response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 
 ### Enhancements
+* Improve error messages for misconfigured remote model connectors to provide actionable guidance on post_process_function configuration ([#1825](https://github.com/opensearch-project/neural-search/pull/1825))
 
 ### Bug Fixes
 * Fix semantic highlighter crash on documents with missing highlighted fields ([#1810](https://github.com/opensearch-project/neural-search/pull/1810))

--- a/src/main/java/org/opensearch/neuralsearch/highlight/utils/HighlightExtractorUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/highlight/utils/HighlightExtractorUtils.java
@@ -49,7 +49,11 @@ public class HighlightExtractorUtils {
             return null;
         }
         if (fieldTextObject instanceof String == false) {
-            log.debug("Field {} must be a string for highlighting, but was {}", fieldContext.fieldName, fieldTextObject.getClass().getSimpleName());
+            log.debug(
+                "Field {} must be a string for highlighting, but was {}",
+                fieldContext.fieldName,
+                fieldTextObject.getClass().getSimpleName()
+            );
             return null;
         }
         String fieldTextString = (String) fieldTextObject;

--- a/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessor.java
@@ -225,7 +225,7 @@ public class MLCommonsClientAccessor {
         for (final ModelTensors tensors : tensorOutputList) {
             final List<ModelTensor> tensorsList = tensors.getMlModelTensors();
             for (final ModelTensor tensor : tensorsList) {
-                // Check if we have standard tensor data first
+                // Check if we have standard tensor data first (local models)
                 if (tensor.getData() != null) {
                     if (tensor.getData().length > 0) {
                         vector.add(Arrays.stream(tensor.getData()).map(value -> (T) value).collect(Collectors.toList()));
@@ -234,34 +234,76 @@ public class MLCommonsClientAccessor {
                         vector.add(new ArrayList<>());
                     }
                 } else {
-                    // Try to extract from asymmetric remote embedding model response
-                    List<List<T>> remoteVectors = extractVectorsFromAsymmetricRemoteEmbeddingResponse(tensor);
+                    // Remote model: extract from dataAsMap with "response" key
+                    List<List<T>> remoteVectors = extractVectorsFromRemoteEmbeddingResponse(tensor);
                     vector.addAll(remoteVectors);
                 }
             }
         }
+
         return vector;
     }
 
     /**
-     * Extracts vectors from asymmetric remote embedding model response format.
-     * Handles the simplified format used by asymmetric E5 remote embedding models: [[emb1], [emb2], [emb3]]
+     * Extracts embedding vectors from a remote model response tensor.
+     * Remote models (both symmetric and asymmetric) return embeddings via dataAsMap
+     * with a "response" key containing a list of float arrays: [[emb1], [emb2], ...]
+     * <p>
+     * If the response format is invalid, throws an {@link IllegalStateException} with
+     * an actionable message guiding the user to fix their connector's post_process_function.
      */
-    private <T extends Number> List<List<T>> extractVectorsFromAsymmetricRemoteEmbeddingResponse(ModelTensor tensor) {
-        final List<List<T>> vectors = new ArrayList<>();
+    private <T extends Number> List<List<T>> extractVectorsFromRemoteEmbeddingResponse(ModelTensor tensor) {
         Map<String, ?> dataMap = tensor.getDataAsMap();
 
-        if (dataMap != null && !dataMap.isEmpty()) {
-            Object responseData = dataMap.get(RESPONSE_FIELD);
-            if (responseData instanceof List) {
-                List<?> responseList = (List<?>) responseData;
-                // Handle simplified format from asymmetric E5 remote embedding models: [[emb1], [emb2], [emb3]]
-                for (Object embedding : responseList) {
-                    if (embedding instanceof List) {
-                        vectors.add(((List<?>) embedding).stream().map(v -> (T) v).collect(Collectors.toList()));
-                    }
-                }
+        if (dataMap == null) {
+            throw new IllegalStateException(
+                "The remote model returned no data. "
+                    + "Ensure the connector's post_process_function is configured to return: "
+                    + "{\"response\": [[float, float, ...], ...]}"
+            );
+        }
+
+        if (!dataMap.containsKey(RESPONSE_FIELD)) {
+            throw new IllegalStateException(
+                "The remote model response is missing the required 'response' key. "
+                    + "Ensure the connector's post_process_function returns: "
+                    + "{\"response\": [[float, float, ...], ...]}"
+            );
+        }
+
+        Object responseData = dataMap.get(RESPONSE_FIELD);
+
+        if (!(responseData instanceof List)) {
+            throw new IllegalStateException(
+                "The remote model 'response' field must be a list of float arrays, but got: "
+                    + (responseData == null ? "null" : responseData.getClass().getSimpleName())
+                    + ". Ensure the connector's post_process_function returns: "
+                    + "{\"response\": [[float, float, ...], ...]}"
+            );
+        }
+
+        final List<List<T>> vectors = new ArrayList<>();
+        for (Object embedding : (List<?>) responseData) {
+            if (!(embedding instanceof List)) {
+                throw new IllegalStateException(
+                    "Each element in the remote model 'response' must be a list of floats, but got: "
+                        + (embedding == null ? "null" : embedding.getClass().getSimpleName())
+                        + ". Ensure the connector's post_process_function returns: "
+                        + "{\"response\": [[float, float, ...], ...]}"
+                );
             }
+            List<?> embeddingList = (List<?>) embedding;
+            // Validate the first element only (O(1) per embedding) to avoid per-element overhead
+            // on the hot path while still catching misconfigured post_process_function responses.
+            if (!embeddingList.isEmpty() && !(embeddingList.get(0) instanceof Number)) {
+                throw new IllegalStateException(
+                    "Each value in a remote model embedding must be a number (float), but got: "
+                        + embeddingList.get(0).getClass().getSimpleName()
+                        + ". Ensure the connector's post_process_function returns: "
+                        + "{\"response\": [[float, float, ...], ...]}"
+                );
+            }
+            vectors.add(embeddingList.stream().map(v -> (T) v).collect(Collectors.toList()));
         }
         return vectors;
     }

--- a/src/main/java/org/opensearch/neuralsearch/util/TokenWeightUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/TokenWeightUtil.java
@@ -51,10 +51,19 @@ public class TokenWeightUtil {
         List<Object> results = new ArrayList<>();
         for (Map<String, ?> map : mapResultList) {
             if (!map.containsKey(RESPONSE_KEY)) {
-                throw new IllegalArgumentException("The inference result should be associated with the field [" + RESPONSE_KEY + "].");
+                throw new IllegalArgumentException(
+                    "The model response is missing the required 'response' key. "
+                        + "Ensure the model returns: {\"response\": [{\"token\": weight, ...}, ...]}. "
+                        + "For remote models, check the connector's post_process_function."
+                );
             }
             if (!List.class.isAssignableFrom(map.get(RESPONSE_KEY).getClass())) {
-                throw new IllegalArgumentException("The data object associated with field [" + RESPONSE_KEY + "] should be a list.");
+                throw new IllegalArgumentException(
+                    "The model 'response' field must be a list of token-weight maps, but got: "
+                        + map.get(RESPONSE_KEY).getClass().getSimpleName()
+                        + ". Ensure the model returns: {\"response\": [{\"token\": weight, ...}, ...]}. "
+                        + "For remote models, check the connector's post_process_function."
+                );
             }
             results.addAll((List<?>) map.get("response"));
         }
@@ -63,12 +72,21 @@ public class TokenWeightUtil {
 
     private static Map<String, Float> buildTokenWeightMap(Object uncastedMap) {
         if (!Map.class.isAssignableFrom(uncastedMap.getClass())) {
-            throw new IllegalArgumentException("The expected inference result is a Map with String keys and Float values.");
+            throw new IllegalArgumentException(
+                "Each element in the model 'response' must be a token-weight map, but got: "
+                    + uncastedMap.getClass().getSimpleName()
+                    + ". Ensure the model returns: {\"response\": [{\"token\": weight, ...}, ...]}. "
+                    + "For remote models, check the connector's post_process_function."
+            );
         }
         Map<String, Float> result = new HashMap<>();
         for (Map.Entry<?, ?> entry : ((Map<?, ?>) uncastedMap).entrySet()) {
             if (!String.class.isAssignableFrom(entry.getKey().getClass()) || !Number.class.isAssignableFrom(entry.getValue().getClass())) {
-                throw new IllegalArgumentException("The expected inference result is a Map with String keys and Float values.");
+                throw new IllegalArgumentException(
+                    "The model token-weight map must have String keys and numeric values. "
+                        + "Ensure the model returns: {\"response\": [{\"token\": weight, ...}, ...]}. "
+                        + "For remote models, check the connector's post_process_function."
+                );
             }
             result.put((String) entry.getKey(), ((Number) entry.getValue()).floatValue());
         }

--- a/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/MLCommonsClientAccessorTests.java
@@ -2320,6 +2320,358 @@ public class MLCommonsClientAccessorTests extends OpenSearchTestCase {
         Mockito.verifyNoMoreInteractions(listener);
     }
 
+    // -----------------------------------------------------------------------
+    // Tests for extractVectorsFromRemoteEmbeddingResponse and
+    // buildVectorFromResponse — happy paths and edge cases
+    // -----------------------------------------------------------------------
+
+    /**
+     * Remote model returns a valid response with multiple embeddings.
+     * Verifies that all embeddings are correctly extracted and returned in order.
+     */
+    public void testInferenceSentences_whenRemoteResponseIsValidWithMultipleEmbeddings_thenSuccess() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // Two embeddings: [0.1, 0.2, 0.3] and [0.4, 0.5, 0.6]
+        final Map<String, Object> dataAsMap = new HashMap<>();
+        dataAsMap.put("response", List.of(List.of(0.1, 0.2, 0.3), List.of(0.4, 0.5, 0.6)));
+        final ModelTensor tensor = new ModelTensor("response", null, null, null, null, null, dataAsMap);
+        final ModelTensors modelTensors = new ModelTensors(List.of(tensor));
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(List.of(modelTensors));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<List<List<Number>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(resultListener).onResponse(captor.capture());
+        List<List<Number>> result = captor.getValue();
+        assertEquals("Should return 2 embeddings", 2, result.size());
+        assertEquals("First embedding should have 3 values", 3, result.get(0).size());
+        assertEquals("Second embedding should have 3 values", 3, result.get(1).size());
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    /**
+     * Remote model returns a valid response with an empty "response" list.
+     * This is a legitimate case (e.g., all inputs were filtered) — no exception should be thrown.
+     */
+    public void testInferenceSentences_whenRemoteResponseHasEmptyResponseList_thenReturnsEmptyVector() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // "response": [] — valid but empty
+        final Map<String, Object> dataAsMap = new HashMap<>();
+        dataAsMap.put("response", Collections.emptyList());
+        final ModelTensor tensor = new ModelTensor("response", null, null, null, null, null, dataAsMap);
+        final ModelTensors modelTensors = new ModelTensors(List.of(tensor));
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(List.of(modelTensors));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<List<List<Number>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(resultListener).onResponse(captor.capture());
+        assertTrue("Should return empty vector list for empty response", captor.getValue().isEmpty());
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    /**
+     * Remote model returns a valid response with one embedding that has zero dimensions.
+     * Verifies that an empty inner list is returned without error.
+     */
+    public void testInferenceSentences_whenRemoteResponseHasEmptyInnerList_thenReturnsEmptyEmbedding() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // "response": [[]] — one embedding with zero dimensions
+        final Map<String, Object> dataAsMap = new HashMap<>();
+        dataAsMap.put("response", List.of(Collections.emptyList()));
+        final ModelTensor tensor = new ModelTensor("response", null, null, null, null, null, dataAsMap);
+        final ModelTensors modelTensors = new ModelTensors(List.of(tensor));
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(List.of(modelTensors));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<List<List<Number>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(resultListener).onResponse(captor.capture());
+        List<List<Number>> result = captor.getValue();
+        assertEquals("Should return 1 embedding", 1, result.size());
+        assertTrue("The single embedding should be empty", result.get(0).isEmpty());
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    /**
+     * buildVectorFromResponse: when the tensor output list is empty, returns an empty vector list.
+     */
+    public void testInferenceSentences_whenEmptyTensorOutputList_thenReturnsEmptyVector() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // Empty tensor output list
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(Collections.emptyList());
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<List<List<Number>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(resultListener).onResponse(captor.capture());
+        assertTrue("Should return empty vector list when tensor output list is empty", captor.getValue().isEmpty());
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    /**
+     * buildVectorFromResponse: local model tensor with getData() returning an empty array (length == 0).
+     * Verifies the empty-array branch adds an empty list to the result.
+     */
+    public void testInferenceSentences_whenLocalModelTensorHasEmptyDataArray_thenReturnsEmptyEmbedding() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // Local model tensor with empty data array (getData().length == 0)
+        final ModelTensorOutput modelTensorOutput = createModelTensorOutput(new Float[] {});
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<List<List<Number>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(resultListener).onResponse(captor.capture());
+        List<List<Number>> result = captor.getValue();
+        assertEquals("Should return 1 embedding entry for empty data array", 1, result.size());
+        assertTrue("The single embedding should be empty", result.get(0).isEmpty());
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for remote model response validation in buildVectorFromResponse /
+    // extractVectorsFromRemoteEmbeddingResponse
+    // -----------------------------------------------------------------------
+
+    /**
+     * Remote model returns a tensor where getData() == null and getDataAsMap() == null.
+     * Expects IllegalStateException with a message about null data and post_process_function.
+     */
+    public void testInferenceSentences_whenRemoteTensorHasNullDataAndNullDataAsMap_thenIllegalStateException() {
+        // Mock getModel to return a symmetric (remote) model
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // Build a tensor with getData() == null and getDataAsMap() == null
+        final ModelTensor tensor = new ModelTensor("response", null, null, null, null, null, null);
+        final ModelTensors modelTensors = new ModelTensors(List.of(tensor));
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(List.of(modelTensors));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(resultListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalStateException);
+        assertTrue("Error message should mention null data", captor.getValue().getMessage().contains("The remote model returned no data"));
+        assertTrue("Error message should mention post_process_function", captor.getValue().getMessage().contains("post_process_function"));
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    /**
+     * Remote model returns a tensor where getData() == null and getDataAsMap() is non-null
+     * but missing the "response" key.
+     * Expects IllegalStateException with a message about the missing "response" key.
+     */
+    public void testInferenceSentences_whenRemoteTensorMissingResponseKey_thenIllegalStateException() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // dataAsMap has a key, but not "response"
+        final ModelTensor tensor = new ModelTensor("response", null, null, null, null, null, Map.of("wrong_key", "some_value"));
+        final ModelTensors modelTensors = new ModelTensors(List.of(tensor));
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(List.of(modelTensors));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(resultListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalStateException);
+        assertTrue(
+            "Error message should mention missing 'response' key",
+            captor.getValue().getMessage().contains("missing the required 'response' key")
+        );
+        assertTrue("Error message should mention post_process_function", captor.getValue().getMessage().contains("post_process_function"));
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    /**
+     * Remote model returns a tensor where getData() == null and getDataAsMap()["response"]
+     * is a String (not a List).
+     * Expects IllegalStateException with a message about the wrong type for "response".
+     */
+    public void testInferenceSentences_whenRemoteResponseIsNotList_thenIllegalStateException() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // "response" is a String, not a List
+        final ModelTensor tensor = new ModelTensor("response", null, null, null, null, null, Map.of("response", "not_a_list"));
+        final ModelTensors modelTensors = new ModelTensors(List.of(tensor));
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(List.of(modelTensors));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(resultListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalStateException);
+        assertTrue(
+            "Error message should mention 'response' must be a list",
+            captor.getValue().getMessage().contains("'response' field must be a list of float arrays")
+        );
+        assertTrue("Error message should mention the actual type", captor.getValue().getMessage().contains("String"));
+        assertTrue("Error message should mention post_process_function", captor.getValue().getMessage().contains("post_process_function"));
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    /**
+     * Remote model returns a tensor where getData() == null and getDataAsMap()["response"]
+     * is a List but its elements are Strings (not Lists of floats).
+     * Expects IllegalStateException with a message about elements not being lists.
+     */
+    public void testInferenceSentences_whenRemoteResponseElementsAreNotLists_thenIllegalStateException() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // "response" is a List, but elements are Strings instead of Lists of floats
+        final Map<String, Object> dataAsMap = new HashMap<>();
+        dataAsMap.put("response", List.of("embedding1", "embedding2"));
+        final ModelTensor tensor = new ModelTensor("response", null, null, null, null, null, dataAsMap);
+        final ModelTensors modelTensors = new ModelTensors(List.of(tensor));
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(List.of(modelTensors));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(resultListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalStateException);
+        assertTrue(
+            "Error message should mention each element must be a list of floats",
+            captor.getValue().getMessage().contains("must be a list of floats")
+        );
+        assertTrue("Error message should mention the actual type", captor.getValue().getMessage().contains("String"));
+        assertTrue("Error message should mention post_process_function", captor.getValue().getMessage().contains("post_process_function"));
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
+    /**
+     * Remote model returns a tensor where getData() == null and getDataAsMap()["response"]
+     * is a List of Lists, but the inner list elements are Strings (not Numbers).
+     * Expects IllegalStateException with a message about values not being numbers.
+     */
+    public void testInferenceSentences_whenRemoteEmbeddingValuesAreNotNumbers_thenIllegalStateException() {
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLModel> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(createSymmetricModel());
+            return null;
+        }).when(client).getModel(eq(TestCommonConstants.MODEL_ID), eq(null), Mockito.isA(ActionListener.class));
+
+        // "response" is a List of Lists, but inner values are Strings instead of Numbers
+        final Map<String, Object> dataAsMap = new HashMap<>();
+        dataAsMap.put("response", List.of(List.of("not_a_float", "also_not_a_float")));
+        final ModelTensor tensor = new ModelTensor("response", null, null, null, null, null, dataAsMap);
+        final ModelTensors modelTensors = new ModelTensors(List.of(tensor));
+        final ModelTensorOutput modelTensorOutput = new ModelTensorOutput(List.of(modelTensors));
+
+        Mockito.doAnswer(invocation -> {
+            final ActionListener<MLOutput> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(modelTensorOutput);
+            return null;
+        }).when(client).predict(eq(TestCommonConstants.MODEL_ID), Mockito.isA(MLInput.class), Mockito.isA(ActionListener.class));
+
+        accessor.inferenceSentences(TestCommonConstants.TEXT_INFERENCE_REQUEST, resultListener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(resultListener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof IllegalStateException);
+        assertTrue(
+            "Error message should mention values must be numbers",
+            captor.getValue().getMessage().contains("must be a number (float)")
+        );
+        assertTrue("Error message should mention the actual type", captor.getValue().getMessage().contains("String"));
+        assertTrue("Error message should mention post_process_function", captor.getValue().getMessage().contains("post_process_function"));
+        Mockito.verifyNoMoreInteractions(resultListener);
+    }
+
     public void testExtractClaudeAgentSteps_WithIndexName() throws Exception {
         final String agentId = "test-agent-id";
         final ActionListener<AgentExecutionDTO> listener = mock(ActionListener.class);

--- a/src/test/java/org/opensearch/neuralsearch/util/TokenWeightUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/TokenWeightUtilTests.java
@@ -60,7 +60,19 @@ public class TokenWeightUtilTests extends OpenSearchTestCase {
           }]
         */
         List<Map<String, ?>> inputData = List.of(Map.of("response", MOCK_DATA));
-        expectThrows(IllegalArgumentException.class, () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData));
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData)
+        );
+        assertTrue(
+            "Error message should mention 'response' must be a list",
+            ex.getMessage().contains("'response' field must be a list of token-weight maps")
+        );
+        assertTrue("Error message should mention post_process_function", ex.getMessage().contains("post_process_function"));
+        assertTrue(
+            "Error message should include the actual type",
+            ex.getMessage().contains("HashMap") || ex.getMessage().contains("Map") || ex.getMessage().contains("ImmutableMap")
+        );
     }
 
     public void testFetchListOfTokenWeightMap_whenNotUseResponseKey_thenFail() {
@@ -70,7 +82,12 @@ public class TokenWeightUtilTests extends OpenSearchTestCase {
           }]
         */
         List<Map<String, ?>> inputData = List.of(Map.of("some_key", List.of(MOCK_DATA)));
-        expectThrows(IllegalArgumentException.class, () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData));
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData)
+        );
+        assertTrue("Error message should mention missing 'response' key", ex.getMessage().contains("missing the required 'response' key"));
+        assertTrue("Error message should mention post_process_function", ex.getMessage().contains("post_process_function"));
     }
 
     public void testFetchListOfTokenWeightMap_whenInputObjectIsNotMap_thenFail() {
@@ -80,7 +97,15 @@ public class TokenWeightUtilTests extends OpenSearchTestCase {
           }]
         */
         List<Map<String, ?>> inputData = List.of(Map.of("response", List.of(List.of(MOCK_DATA))));
-        expectThrows(IllegalArgumentException.class, () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData));
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData)
+        );
+        assertTrue(
+            "Error message should mention each element must be a token-weight map",
+            ex.getMessage().contains("must be a token-weight map")
+        );
+        assertTrue("Error message should mention post_process_function", ex.getMessage().contains("post_process_function"));
     }
 
     public void testFetchListOfTokenWeightMap_whenInputTokenMapWithNonStringKeys_thenFail() {
@@ -91,7 +116,15 @@ public class TokenWeightUtilTests extends OpenSearchTestCase {
         */
         Map<?, Float> mockData = Map.of("hello", 1.f, 2.3f, 2.f);
         List<Map<String, ?>> inputData = List.of(Map.of("response", List.of(mockData)));
-        expectThrows(IllegalArgumentException.class, () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData));
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData)
+        );
+        assertTrue(
+            "Error message should mention String keys and numeric values",
+            ex.getMessage().contains("String keys and numeric values")
+        );
+        assertTrue("Error message should mention post_process_function", ex.getMessage().contains("post_process_function"));
     }
 
     public void testFetchListOfTokenWeightMap_whenInputTokenMapWithNonFloatValues_thenFail() {
@@ -102,6 +135,14 @@ public class TokenWeightUtilTests extends OpenSearchTestCase {
         */
         Map<String, ?> mockData = Map.of("hello", 1.f, "world", "world");
         List<Map<String, ?>> inputData = List.of(Map.of("response", List.of(mockData)));
-        expectThrows(IllegalArgumentException.class, () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData));
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> TokenWeightUtil.fetchListOfTokenWeightMap(inputData)
+        );
+        assertTrue(
+            "Error message should mention String keys and numeric values",
+            ex.getMessage().contains("String keys and numeric values")
+        );
+        assertTrue("Error message should mention post_process_function", ex.getMessage().contains("post_process_function"));
     }
 }


### PR DESCRIPTION
### Description
**Problem**

When a remote dense or sparse embedding model's ML Commons connector lacks a properly configured `post_process_function`, the plugin threw confusing internal errors (`IndexOutOfBoundsException`, `NoSuchElementException`, `ClassCastException`) with no indication of the root cause or how to fix it.

**Root Cause**

- **Dense models** (`MLCommonsClientAccessor.buildVectorFromResponse`): when `tensor.getData()` is null (remote models only), the code silently returned an empty vector list, causing downstream index-out-of-bounds errors.
- **Sparse models** (`TokenWeightUtil.fetchListOfTokenWeightMap`): existing validation errors described the data problem but gave no guidance on what to fix.

**Changes**

- `MLCommonsClientAccessor`: renamed `extractVectorsFromAsymmetricRemoteEmbeddingResponse` → `extractVectorsFromRemoteEmbeddingResponse` (applies to all remote dense models, not just asymmetric) and added explicit validation for each failure mode — null `dataAsMap`, missing `"response"` key, non-list response, non-list elements, and non-numeric values (O(1) first-element check to avoid hot-path overhead). Each error message names the exact problem, shows the expected format `{"response": [[float, float, ...], ...]}`, and directs the user to fix their connector's `post_process_function`.
- `TokenWeightUtil`: updated 4 error messages to be model-type-agnostic — they describe the problem, show the expected sparse format `{"response": [{"token": weight, ...}, ...]}`, and mention `post_process_function` as a hint for remote model users without misleading local model users.
- Added 5 unit tests in `MLCommonsClientAccessorTests` and updated 5 existing tests in `TokenWeightUtilTests` to assert the new actionable message content.

**Testing**

All existing and new unit tests pass.

### Related Issues
Resolves #1549 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
