### PR TITLE
fix: zscore returns 0.0 when sd is zero, arithmetic mean excludes zero scores

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ArithmeticMeanScoreCombinationTechnique.java
@@ -46,7 +46,7 @@ public class ArithmeticMeanScoreCombinationTechnique implements ScoreCombination
         float sumOfWeights = 0;
         for (int indexOfSubQuery = 0; indexOfSubQuery < scores.length; indexOfSubQuery++) {
             float score = scores[indexOfSubQuery];
-            if (score >= 0.0) {
+            if (score > 0.0) {
                 float weight = scoreCombinationUtil.getWeightForSubQuery(weights, indexOfSubQuery);
                 score = score * weight;
                 combinedScore += score;

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechnique.java
@@ -216,7 +216,7 @@ public class ZScoreNormalizationTechnique implements ScoreNormalizationTechnique
         }
         // Case when sd is 0
         if (Floats.compare(standardDeviation, 0.0f) == 0) {
-            return minScore;
+            return 0.0f;
         }
         float normalizedScore = (score - mean) / standardDeviation;
 


### PR DESCRIPTION
Found two small bugs while going through the normalization and combination code.

`ZScoreNormalizationTechnique.normalizeSingleScore` returns `minScore` when standard deviation is 0, but the test helper at line 371 and the inline comment on line 286 both document the expected value as `0.0f` for that edge case.

`ArithmeticMeanScoreCombinationTechnique` uses `score >= 0.0` to include scores in the weighted mean, but the class javadoc explicitly says zero scores are excluded from N. The condition should be `score > 0.0` so a document matched by only some subqueries does not get its score diluted by the zeros from the others.

Happy to close if either of these is intentional, you know the codebase far better than I do.