### PR TITLE
Propagate setMinCompetitiveScore to sub-query scorers in HybridBulkScorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 * Improve error messages for misconfigured remote model connectors to provide actionable guidance on post_process_function configuration ([#1825](https://github.com/opensearch-project/neural-search/pull/1825))
+* [Hybrid Query] Propagate setMinCompetitiveScore to sub-query scorers in HybridBulkScorer to enable WAND block-level skipping ([#1831](https://github.com/opensearch-project/neural-search/pull/1831))
 
 ### Bug Fixes
 * Fix semantic highlighter crash on documents with missing highlighted fields ([#1810](https://github.com/opensearch-project/neural-search/pull/1810))

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridBulkScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridBulkScorer.java
@@ -125,6 +125,13 @@ public class HybridBulkScorer extends BulkScorer {
             if (Objects.isNull(scorers[subQueryIndex]) || docIds[subQueryIndex] >= max) {
                 continue;
             }
+            // Propagate competitive score threshold to sub-query scorer so that its ImpactsDISI
+            // can skip posting list blocks where maxScore < threshold (WAND/block-max optimization).
+            // minScores[] is updated by the collector's priority queue overflow feedback loop.
+            float minScore = hybridSubQueryScorer.getMinScores()[subQueryIndex];
+            if (minScore > 0) {
+                scorers[subQueryIndex].setMinCompetitiveScore(minScore);
+            }
             DocIdSetIterator it = scorers[subQueryIndex].iterator();
             int doc = docIds[subQueryIndex];
             if (doc < windowMin) {

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridScorerSupplier.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridScorerSupplier.java
@@ -11,7 +11,6 @@ import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
-import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,9 +71,12 @@ public class HybridScorerSupplier extends ScorerSupplier {
     @Override
     public BulkScorer bulkScorer() throws IOException {
         List<Scorer> scorers = new ArrayList<>();
-        for (Weight weight : weight.getWeights()) {
-            Scorer scorer = weight.scorer(context);
-            scorers.add(scorer);
+        for (ScorerSupplier ss : scorerSuppliers) {
+            if (Objects.nonNull(ss)) {
+                scorers.add(ss.get(Long.MAX_VALUE));
+            } else {
+                scorers.add(null);
+            }
         }
         return new HybridBulkScorer(scorers, scoreMode.needsScores(), context.reader().maxDoc());
     }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridBulkScorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridBulkScorerTests.java
@@ -16,7 +16,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HybridBulkScorerTests extends OpenSearchTestCase {
@@ -208,6 +211,100 @@ public class HybridBulkScorerTests extends OpenSearchTestCase {
 
         // Should return NO_MORE_DOCS when all scorers are exhausted
         assertEquals("Should return NO_MORE_DOCS when all scorers exhausted", DocIdSetIterator.NO_MORE_DOCS, result);
+    }
+
+    /**
+     * Test that setMinCompetitiveScore is propagated to sub-query scorers when minScores > 0.
+     * This enables Lucene's ImpactsDISI to skip posting list blocks where maxScore < threshold.
+     */
+    public void testSetMinCompetitiveScorePropagatedToSubScorers() throws IOException {
+        List<Scorer> scorers = Arrays.asList(mockScorer1, mockScorer2);
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        // Set competitive threshold via hybridSubQueryScorer's minScores array
+        bulkScorer.getHybridSubQueryScorer().getMinScores()[0] = 0.5f;
+        bulkScorer.getHybridSubQueryScorer().getMinScores()[1] = 0.3f;
+
+        LeafCollector mockLeafCollector = mock(LeafCollector.class);
+
+        // Setup iterators: each has one doc, then exhausted
+        when(mockIterator1.docID()).thenReturn(-1);
+        when(mockIterator1.advance(0)).thenReturn(10);
+        when(mockIterator1.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+
+        when(mockIterator2.docID()).thenReturn(-1);
+        when(mockIterator2.advance(0)).thenReturn(20);
+        when(mockIterator2.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+
+        when(mockScorer1.score()).thenReturn(1.0f);
+        when(mockScorer2.score()).thenReturn(0.8f);
+
+        bulkScorer.score(mockLeafCollector, null, 0, MAX_DOC);
+
+        // Verify setMinCompetitiveScore was called on each sub-scorer
+        verify(mockScorer1).setMinCompetitiveScore(0.5f);
+        verify(mockScorer2).setMinCompetitiveScore(0.3f);
+    }
+
+    /**
+     * Test that setMinCompetitiveScore is propagated per sub-query: only sub-scorers whose
+     * minScores[i] > 0 receive the call. Locks in the targeted (not global) propagation semantics.
+     */
+    public void testSetMinCompetitiveScore_onlyPropagatedToSubScorerWithPositiveThreshold() throws IOException {
+        List<Scorer> scorers = Arrays.asList(mockScorer1, mockScorer2);
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        // Only sub-query 0 has a competitive threshold; sub-query 1 stays at 0 (cold-start)
+        bulkScorer.getHybridSubQueryScorer().getMinScores()[0] = 0.5f;
+
+        LeafCollector mockLeafCollector = mock(LeafCollector.class);
+
+        when(mockIterator1.docID()).thenReturn(-1);
+        when(mockIterator1.advance(0)).thenReturn(10);
+        when(mockIterator1.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+
+        when(mockIterator2.docID()).thenReturn(-1);
+        when(mockIterator2.advance(0)).thenReturn(20);
+        when(mockIterator2.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+
+        when(mockScorer1.score()).thenReturn(1.0f);
+        when(mockScorer2.score()).thenReturn(0.8f);
+
+        bulkScorer.score(mockLeafCollector, null, 0, MAX_DOC);
+
+        // scorer1 receives its own threshold; scorer2 receives nothing
+        verify(mockScorer1).setMinCompetitiveScore(0.5f);
+        verify(mockScorer2, never()).setMinCompetitiveScore(anyFloat());
+    }
+
+    /**
+     * Test that setMinCompetitiveScore is NOT propagated when minScores = 0 (default).
+     * Before the priority queue overflows, minScores stays at 0 and propagation should be skipped.
+     */
+    public void testSetMinCompetitiveScoreNotPropagatedWhenZero() throws IOException {
+        List<Scorer> scorers = Arrays.asList(mockScorer1, mockScorer2);
+        HybridBulkScorer bulkScorer = new HybridBulkScorer(scorers, true, MAX_DOC);
+
+        // minScores defaults to 0 — don't set anything
+
+        LeafCollector mockLeafCollector = mock(LeafCollector.class);
+
+        when(mockIterator1.docID()).thenReturn(-1);
+        when(mockIterator1.advance(0)).thenReturn(10);
+        when(mockIterator1.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+
+        when(mockIterator2.docID()).thenReturn(-1);
+        when(mockIterator2.advance(0)).thenReturn(20);
+        when(mockIterator2.nextDoc()).thenReturn(DocIdSetIterator.NO_MORE_DOCS);
+
+        when(mockScorer1.score()).thenReturn(1.0f);
+        when(mockScorer2.score()).thenReturn(0.8f);
+
+        bulkScorer.score(mockLeafCollector, null, 0, MAX_DOC);
+
+        // Verify setMinCompetitiveScore was never called
+        verify(mockScorer1, never()).setMinCompetitiveScore(anyFloat());
+        verify(mockScorer2, never()).setMinCompetitiveScore(anyFloat());
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -1209,6 +1209,71 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     }
 
     /**
+     * Tests that hybrid query with a mix of text and kNN sub-queries executes correctly with
+     * profiler enabled. Exercises the BulkScorer path where setMinCompetitiveScore is propagated
+     * to sub-query scorers. Asserts ranking is stable across invocations and profile data is
+     * well-formed (no regression from the WAND propagation fix in #1831).
+     */
+    @SneakyThrows
+    public void testProfile_whenHybridQueryWithTextAndKnnSubQueries_thenConsistentRanking() {
+        initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
+        createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
+
+        String query = "{\n"
+            + "  \"query\": {\n"
+            + "    \"hybrid\": {\n"
+            + "      \"queries\": [\n"
+            + "        { \"term\": { \""
+            + TEST_TEXT_FIELD_NAME_1
+            + "\": \""
+            + TEST_QUERY_TEXT3
+            + "\" } },\n"
+            + "        { \"knn\": { \""
+            + TEST_KNN_VECTOR_FIELD_NAME_1
+            + "\": { \"vector\": [1.0, 1.0, 1.0, 1.0], \"k\": 5 } } }\n"
+            + "      ]\n"
+            + "    }\n"
+            + "  },\n"
+            + "  \"profile\": true\n"
+            + "}";
+
+        // Run twice and verify identical ranking — catches any non-determinism introduced by WAND
+        Map<String, Object> first = searchWithRawQuery(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, query, 10, SEARCH_PIPELINE);
+        Map<String, Object> second = searchWithRawQuery(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, query, 10, SEARCH_PIPELINE);
+
+        int firstHits = getHitCount(first);
+        assertEquals("hit count must be stable across invocations", firstHits, getHitCount(second));
+        assertTrue("expected at least one hit", firstHits >= 1);
+
+        List<Map<String, Object>> hits1 = getNestedHits(first);
+        List<Map<String, Object>> hits2 = getNestedHits(second);
+        for (int i = 0; i < hits1.size(); i++) {
+            assertEquals("doc id order must match", hits1.get(i).get("_id"), hits2.get(i).get("_id"));
+            double score = (double) hits1.get(i).get("_score");
+            assertFalse("score must not be NaN", Double.isNaN(score));
+            assertTrue("score must be positive", score > 0);
+        }
+
+        // Profile structure sanity — breakdown must include the set_min_competitive_score_count key
+        assertNotNull("profile data must be present", first.get("profile"));
+        Map<String, Object> profile = (Map<String, Object>) first.get("profile");
+        List<Map<String, Object>> shards = (List<Map<String, Object>>) profile.get("shards");
+        assertFalse("profile shards must not be empty", shards.isEmpty());
+        boolean foundBreakdownKey = false;
+        for (Map<String, Object> shard : shards) {
+            for (Map<String, Object> searchProfile : (List<Map<String, Object>>) shard.get("searches")) {
+                for (Map<String, Object> queryProfile : (List<Map<String, Object>>) searchProfile.get("query")) {
+                    Map<String, Object> breakdown = (Map<String, Object>) queryProfile.get("breakdown");
+                    if (breakdown != null && breakdown.containsKey("set_min_competitive_score_count")) {
+                        foundBreakdownKey = true;
+                    }
+                }
+            }
+        }
+        assertTrue("profile breakdown must expose set_min_competitive_score_count key", foundBreakdownKey);
+    }
+
+    /**
      * Tests that hybrid query with multiple shards works with profiler enabled.
      * This tests the distributed profiling scenario.
      */

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -1209,17 +1209,29 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
     }
 
     /**
-     * Tests that hybrid query with a mix of text and kNN sub-queries executes correctly with
-     * profiler enabled. Exercises the BulkScorer path where setMinCompetitiveScore is propagated
-     * to sub-query scorers. Asserts ranking is stable across invocations and profile data is
-     * well-formed (no regression from the WAND propagation fix in #1831).
+     * Tests that the BulkScorer path (where PR #1831 propagates setMinCompetitiveScore for WAND
+     * pruning) produces results consistent with the Scorer path. Since HybridBulkScorer and
+     * HybridQueryScorer are independently implemented, matching output across the two paths is a
+     * direct correctness regression guard for the WAND optimization introduced in #1831: if WAND
+     * ever drops a document that the Scorer path kept, this test fails.
+     *
+     * Path selection:
+     *  - profile=false → QueryPhase uses Weight.bulkScorer(ctx) → HybridScorerSupplier.bulkScorer()
+     *    → HybridBulkScorer (the path PR #1831 modifies).
+     *  - profile=true  → ProfileWeight.bulkScorer() falls back to the default Scorer-wrapped
+     *    BulkScorer (ProfileWeight.java intentionally avoids specialized BulkScorers so per-op
+     *    timings can be measured), so this path goes through HybridQueryScorer and is unaffected
+     *    by the PR. This is why the profiler's set_min_competitive_score_count cannot be used to
+     *    directly prove WAND fires — the profile path bypasses HybridBulkScorer entirely. The
+     *    BulkScorer-level verification for the PR is covered by unit tests in
+     *    HybridBulkScorerTests and HybridScorerSupplierTests.
      */
     @SneakyThrows
-    public void testProfile_whenHybridQueryWithTextAndKnnSubQueries_thenConsistentRanking() {
+    public void testHybridQueryWithTextAndKnn_whenBulkScorerAndScorerPaths_thenProduceConsistentResults() {
         initializeIndexIfNotExist(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME);
         createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
 
-        String query = "{\n"
+        String baseQuery = "{\n"
             + "  \"query\": {\n"
             + "    \"hybrid\": {\n"
             + "      \"queries\": [\n"
@@ -1235,30 +1247,57 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             + ", \"k\": 5 } } }\n"
             + "      ]\n"
             + "    }\n"
-            + "  },\n"
-            + "  \"profile\": true\n"
-            + "}";
+            + "  }";
+        String bulkScorerQuery = baseQuery + "\n}";
+        String profiledQuery = baseQuery + ",\n  \"profile\": true\n}";
 
-        // Run twice and verify identical ranking — catches any non-determinism introduced by WAND
-        Map<String, Object> first = searchWithRawQuery(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, query, 10, SEARCH_PIPELINE);
-        Map<String, Object> second = searchWithRawQuery(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, query, 10, SEARCH_PIPELINE);
+        // Path that the PR actually modifies (WAND propagation active)
+        Map<String, Object> bulkResponse = searchWithRawQuery(TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME, bulkScorerQuery, 10, SEARCH_PIPELINE);
+        // Reference path (HybridQueryScorer, not modified by PR)
+        Map<String, Object> profiledResponse = searchWithRawQuery(
+            TEST_BASIC_VECTOR_DOC_FIELD_INDEX_NAME,
+            profiledQuery,
+            10,
+            SEARCH_PIPELINE
+        );
 
-        int firstHits = getHitCount(first);
-        assertEquals("hit count must be stable across invocations", firstHits, getHitCount(second));
-        assertTrue("expected at least one hit", firstHits >= 1);
+        int bulkHits = getHitCount(bulkResponse);
+        int profiledHits = getHitCount(profiledResponse);
+        assertTrue("expected at least one hit", bulkHits >= 1);
+        assertEquals("BulkScorer path (with WAND) and Scorer path (reference) must return the same number of hits", profiledHits, bulkHits);
 
-        List<Map<String, Object>> hits1 = getNestedHits(first);
-        List<Map<String, Object>> hits2 = getNestedHits(second);
-        for (int i = 0; i < hits1.size(); i++) {
-            assertEquals("doc id order must match", hits1.get(i).get("_id"), hits2.get(i).get("_id"));
-            double score = (double) hits1.get(i).get("_score");
-            assertFalse("score must not be NaN", Double.isNaN(score));
-            assertTrue("score must be positive", score > 0);
+        // Strongest correctness guard: WAND pruning on the BulkScorer path must not drop any
+        // document that the Scorer path returns. Hit IDs and rank order must match exactly; scores
+        // must be finite and positive on both sides. Floating-point score deltas are bounded by the
+        // standard Lucene intra-run variance threshold (0.002) used elsewhere in this codebase.
+        List<Map<String, Object>> bulkHitsList = getNestedHits(bulkResponse);
+        List<Map<String, Object>> profiledHitsList = getNestedHits(profiledResponse);
+        assertEquals("hit list sizes must match", profiledHitsList.size(), bulkHitsList.size());
+        for (int i = 0; i < bulkHitsList.size(); i++) {
+            assertEquals(
+                "doc id at rank " + i + " must match across BulkScorer and Scorer paths",
+                profiledHitsList.get(i).get("_id"),
+                bulkHitsList.get(i).get("_id")
+            );
+            double bulkScore = ((Number) bulkHitsList.get(i).get("_score")).doubleValue();
+            double profiledScore = ((Number) profiledHitsList.get(i).get("_score")).doubleValue();
+            assertFalse("BulkScorer score must not be NaN", Double.isNaN(bulkScore));
+            assertFalse("Scorer path score must not be NaN", Double.isNaN(profiledScore));
+            assertTrue("BulkScorer score must be positive", bulkScore > 0);
+            assertTrue("Scorer path score must be positive", profiledScore > 0);
+            assertEquals(
+                "scores at rank " + i + " must match across paths within Lucene floating-point tolerance",
+                profiledScore,
+                bulkScore,
+                0.002
+            );
         }
 
-        // Profile structure sanity — breakdown must include the set_min_competitive_score_count key
-        assertNotNull("profile data must be present", first.get("profile"));
-        Map<String, Object> profile = (Map<String, Object>) first.get("profile");
+        // Secondary: profile output structure is not regressed (query remained executable with
+        // profile: true and produced a breakdown with the WAND-related counter key). Non-blocking
+        // — the fix itself is verified by the cross-path comparison above.
+        assertNotNull("profile data must be present", profiledResponse.get("profile"));
+        Map<String, Object> profile = (Map<String, Object>) profiledResponse.get("profile");
         List<Map<String, Object>> shards = (List<Map<String, Object>>) profile.get("shards");
         assertFalse("profile shards must not be empty", shards.isEmpty());
         boolean foundBreakdownKey = false;

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryIT.java
@@ -1230,7 +1230,9 @@ public class HybridQueryIT extends BaseNeuralSearchIT {
             + "\" } },\n"
             + "        { \"knn\": { \""
             + TEST_KNN_VECTOR_FIELD_NAME_1
-            + "\": { \"vector\": [1.0, 1.0, 1.0, 1.0], \"k\": 5 } } }\n"
+            + "\": { \"vector\": "
+            + Floats.asList(testVector1).toString()
+            + ", \"k\": 5 } } }\n"
             + "      ]\n"
             + "    }\n"
             + "  },\n"

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridScorerSupplierTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridScorerSupplierTests.java
@@ -26,9 +26,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.lucene.search.BulkScorer;
+
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.neuralsearch.query.HybridQueryBuilderTests.TEXT_FIELD_NAME;
 
@@ -125,6 +128,35 @@ public class HybridScorerSupplierTests extends OpenSearchQueryTestCase {
         HybridScorerSupplier hybridScorerSupplier = new HybridScorerSupplier(scorerSuppliers, weight, scoreMode, context);
 
         assertEquals(100L, hybridScorerSupplier.cost());
+    }
+
+    public void testBulkScorerUsesExistingScorerSuppliers() throws IOException {
+        ScorerSupplier ss1 = createMockScorerSupplier(100L);
+        ScorerSupplier ss2 = createMockScorerSupplier(200L);
+        List<ScorerSupplier> scorerSuppliers = Arrays.asList(ss1, ss2);
+
+        HybridScorerSupplier hybridScorerSupplier = new HybridScorerSupplier(scorerSuppliers, weight, scoreMode, context);
+
+        BulkScorer bulkScorer = hybridScorerSupplier.bulkScorer();
+
+        assertNotNull(bulkScorer);
+        assertTrue(bulkScorer instanceof HybridBulkScorer);
+        // Verify get() was called on each ScorerSupplier with Long.MAX_VALUE
+        verify(ss1).get(eq(Long.MAX_VALUE));
+        verify(ss2).get(eq(Long.MAX_VALUE));
+    }
+
+    public void testBulkScorerHandlesNullScorerSupplier() throws IOException {
+        ScorerSupplier ss1 = createMockScorerSupplier(100L);
+        List<ScorerSupplier> scorerSuppliers = Arrays.asList(null, ss1);
+
+        HybridScorerSupplier hybridScorerSupplier = new HybridScorerSupplier(scorerSuppliers, weight, scoreMode, context);
+
+        BulkScorer bulkScorer = hybridScorerSupplier.bulkScorer();
+
+        assertNotNull(bulkScorer);
+        assertTrue(bulkScorer instanceof HybridBulkScorer);
+        verify(ss1).get(eq(Long.MAX_VALUE));
     }
 
     private ScorerSupplier createMockScorerSupplier() throws IOException {


### PR DESCRIPTION
 ### Description
Set the min competitive score to the sub-query scorer, this way sub scorers can cut off non-competitive hits. Overall this allows to collect less documents in edge case scenarios and decrease response time + lower CPU utilization. 

**Benchmark data** 

Measured response times before the fix (baseline) and with this PR on a local test cluster for 1.6M synchetic documents 

```
  ┌──────┬──────┬──────────┬─────────┬────────────┬────────┬────────┐
  │ size │ conc │ base p50 │ fix p50 │ Δ p50      │ Δ p90  │ Δ p99  │
  ├──────┼──────┼──────────┼─────────┼────────────┼────────┼────────┤
  │ 24   │ 8    │ 22.0     │ 14.0    │ −36.4%     │ −34.7% │ −21.8% │
  │ 24   │ 13   │ 24.5     │ 17.5    │ −28.6%     │ −25.0% │ −28.1% │
  │ 24   │ 25   │ 40.5     │ 27.5    │ −32.1%     │ −29.8% │ −22.8% │
  │ 100  │ 8    │ 26.0     │ 23.0    │ −11.5%     │ −13.3% │ −13.8% │
  │ 100  │ 13   │ 30.5     │ 27.5    │ −9.8%      │ −8.7%  │ −5.3%  │
  │ 100  │ 25   │ 51.0     │ 46.5    │ −8.8%      │ −7.8%  │ −2.0%  │
  └──────┴──────┴──────────┴─────────┴────────────┴────────┴────────┘
```


### Related Issues
https://github.com/opensearch-project/neural-search/issues/1829

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
