### PR TITLE
[Backport 2.19]Removed mirror for jdt failures

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -7,7 +7,7 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/neural-search/pull/1543

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
