### PR TITLE
Refactor updateVersion task to be more complete

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -23,10 +23,10 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [ 21, 25 ]
+        java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version : [ "2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0", "3.4.0", "3.5.0", "3.6.0" ]
-        opensearch_version : [ "3.7.0-SNAPSHOT" ]
+        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0", "3.4.0", "3.5.0", "3.6.0"]
+        opensearch_version : ["3.7.0-SNAPSHOT"]
 
     name: NeuralSearch Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -67,8 +67,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: [ "2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0", "3.5.0", "3.6.0"" ]
-        opensearch_version: [ "3.7.0-SNAPSHOT" ]
+        bwc_version: ["2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0", "3.5.0", "3.6.0"]
+        opensearch_version: ["3.7.0-SNAPSHOT"]
 
     name: NeuralSearch Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}

--- a/build.gradle
+++ b/build.gradle
@@ -545,8 +545,142 @@ task updateVersion {
     doLast {
         ext.newVersion = System.getProperty('newVersion')
         println "Setting version to ${newVersion}."
-        // String tokenization to support -SNAPSHOT
-        ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
+
+        // Parse version strings
+        ext.newVersionWithoutSnapshot = newVersion.tokenize('-')[0]
+        ext.currentVersionWithoutSnapshot = opensearch_version.tokenize('-')[0]
+
+        // Step 1: Update build.gradle with new OpenSearch version
+        ant.replaceregexp(
+            file: 'build.gradle',
+            match: '"opensearch.version", "\\d.*"',
+            replace: "\"opensearch.version\", \"${newVersionWithoutSnapshot}-SNAPSHOT\"",
+            flags: 'g',
+            byline: true
+        )
+
+        // Step 2: Read current BWC versions from gradle.properties to determine what to update
+        def gradlePropsFile = file('gradle.properties')
+        def currentBwcVersion = null
+        def currentBwcBundleVersion = null
+
+        gradlePropsFile.eachLine { line ->
+            if (line.startsWith('systemProp.bwc.version=')) {
+                currentBwcVersion = line.split('=')[1].trim().tokenize('-')[0]
+            }
+            if (line.startsWith('systemProp.bwc.bundle.version=')) {
+                currentBwcBundleVersion = line.split('=')[1].trim()
+            }
+        }
+
+        if (currentBwcVersion == null || currentBwcBundleVersion == null) {
+            throw new GradleException("Could not read BWC versions from gradle.properties")
+        }
+
+        println "Current BWC version: ${currentBwcVersion}"
+        println "Current BWC bundle version: ${currentBwcBundleVersion}"
+        println "New OpenSearch version: ${newVersionWithoutSnapshot}"
+        println "Previous OpenSearch version: ${currentVersionWithoutSnapshot}"
+
+        // Step 3: Update gradle.properties - systemProp.bwc.version
+        ant.replaceregexp(
+            file: 'gradle.properties',
+            match: "systemProp.bwc.version=${currentBwcVersion}(-SNAPSHOT)?",
+            replace: "systemProp.bwc.version=${newVersionWithoutSnapshot}-SNAPSHOT",
+            flags: 'g',
+            byline: true
+        )
+
+        // Step 4: Update gradle.properties - systemProp.bwc.bundle.version
+        ant.replaceregexp(
+            file: 'gradle.properties',
+            match: "systemProp.bwc.bundle.version=${currentBwcBundleVersion}",
+            replace: "systemProp.bwc.bundle.version=${currentVersionWithoutSnapshot}",
+            flags: 'g',
+            byline: true
+        )
+
+        // Step 5: Update backwards_compatibility_tests_workflow.yml - opensearch_version
+        ant.replaceregexp(
+            file: '.github/workflows/backwards_compatibility_tests_workflow.yml',
+            match: "opensearch_version\\s*:\\s*\\[\\s*\"${currentVersionWithoutSnapshot}-SNAPSHOT\"\\s*\\]",
+            replace: "opensearch_version : [\"${newVersionWithoutSnapshot}-SNAPSHOT\"]",
+            flags: 'g',
+            byline: true
+        )
+
+        // Step 6: Update backwards_compatibility_tests_workflow.yml - bwc_version arrays
+        // Add the current version to the BWC version list if not already present
+        def workflowFile = file('.github/workflows/backwards_compatibility_tests_workflow.yml')
+        def workflowContent = workflowFile.text
+
+        if (!workflowContent.contains("\"${currentVersionWithoutSnapshot}\"")) {
+            // Read the workflow file and update it manually for more precise control
+            def updatedContent = workflowContent
+
+            // Helper closure to check if current version is later than the last version in a list
+            def isCurrentVersionNewer = { String lastVersion ->
+                def lastVersionParts = lastVersion.tokenize('.')
+                def lastMajor = lastVersionParts[0] as Integer
+                def lastMinor = lastVersionParts[1] as Integer
+                def lastPatch = lastVersionParts.size() > 2 ? lastVersionParts[2] as Integer : 0
+
+                def currentVersionParts = currentVersionWithoutSnapshot.tokenize('.')
+                def currentMajor = currentVersionParts[0] as Integer
+                def currentMinor = currentVersionParts[1] as Integer
+                def currentPatch = currentVersionParts.size() > 2 ? currentVersionParts[2] as Integer : 0
+
+                return (currentMajor > lastMajor) ||
+                       (currentMajor == lastMajor && currentMinor > lastMinor) ||
+                       (currentMajor == lastMajor && currentMinor == lastMinor && currentPatch > lastPatch)
+            }
+
+            // Helper closure to extract versions from bwc_version array
+            def extractVersions = { String content ->
+                def matcher = content =~ /bwc_version\s*:\s*\[([^\]]+)\]/
+                if (matcher.find()) {
+                    def versionListStr = matcher.group(1)
+                    return versionListStr.findAll(/"([^"]+)"/).collect { it.replaceAll('"', '').trim() }
+                }
+                return []
+            }
+
+            // For Restart-Upgrade-BWCTests-NeuralSearch job
+            def restartStart = updatedContent.indexOf('Restart-Upgrade-BWCTests-NeuralSearch:')
+            def rollingStart = updatedContent.indexOf('Rolling-Upgrade-BWCTests-NeuralSearch:')
+
+            if (restartStart != -1 && rollingStart != -1) {
+                // Extract and update Restart-Upgrade section
+                def restartSection = updatedContent.substring(restartStart, rollingStart)
+                def restartVersions = extractVersions(restartSection)
+                if (!restartVersions.isEmpty() && isCurrentVersionNewer(restartVersions.last())) {
+                    def updatedRestartSection = restartSection.replaceFirst(
+                        /(?m)(^\s*bwc_version\s*:\s*\[([^\]]+))\]/,
+                        "\$1, \"${currentVersionWithoutSnapshot}\"]"
+                    )
+                    updatedContent = updatedContent.substring(0, restartStart) + updatedRestartSection + updatedContent.substring(rollingStart)
+                    println "Added ${currentVersionWithoutSnapshot} to Restart-Upgrade BWC version list"
+                }
+
+                // Extract and update Rolling-Upgrade section
+                def rollingSection = updatedContent.substring(rollingStart)
+                def rollingVersions = extractVersions(rollingSection)
+                if (!rollingVersions.isEmpty() && isCurrentVersionNewer(rollingVersions.last())) {
+                    def updatedRollingSection = rollingSection.replaceFirst(
+                        /(?m)(^\s*bwc_version:\s*\[([^\]]+))\]/,
+                        "\$1, \"${currentVersionWithoutSnapshot}\"]"
+                    )
+                    // Need to recalculate rollingStart in case the restart section changed
+                    def newRollingStart = updatedContent.indexOf('Rolling-Upgrade-BWCTests-NeuralSearch:')
+                    updatedContent = updatedContent.substring(0, newRollingStart) + updatedRollingSection
+                    println "Added ${currentVersionWithoutSnapshot} to Rolling-Upgrade BWC version list"
+                }
+            }
+
+            workflowFile.text = updatedContent
+        } else {
+            println "Version ${currentVersionWithoutSnapshot} already exists in BWC version list"
+        }
     }
 }
 


### PR DESCRIPTION


### Description
This fixes the issue where major version upgrades does not update all relevant files. The task now:
- Reads existing BWC versions from gradle.properties
- Updates build.gradle, gradle.properties, and bwc test workflow file
- Automatically appends the current version to BWC test matrices

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### Test
`./gradlew updateVersion -DnewVersion=3.7.0`
```
diff --git a/.github/workflows/backwards_compatibility_tests_workflow.yml b/.github/workflows/backwards_compatibility_tests_workflow.yml
index b14c33c2..2de0f3db 100644
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -25,8 +25,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3
.0", "3.4.0", "3.5.0", "3.6.0"]
-        opensearch_version : ["3.7.0-SNAPSHOT"]
+        bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3
.0", "3.4.0", "3.5.0", "3.6.0", "3.7.0"]
+        opensearch_version : ["3.8.0-SNAPSHOT"]

     name: NeuralSearch Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -61,14 +61,16 @@ jobs:
           echo "Running restart-upgrade backwards compatibility tests ..."
           su `id -un 1000` -c "./gradlew :qa:restart-upgrade:testAgainstNewCluster --parallel -D'tests.bwc.version=${{ matrix.bwc_version }}'"

+   }}'"
+
   Rolling-Upgrade-BWCTests-NeuralSearch:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: ["2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0", "3.5.0", "3.6.0"]
-        opensearch_version: ["3.7.0-SNAPSHOT"]
+        bwc_version: ["2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0", "3.5.0", "3.6.0", "3.7.0"]
+        opensearch_version : ["3.8.0-SNAPSHOT"]

     name: NeuralSearch Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
diff --git a/build.gradle b/build.gradle
index c0cb2edb..642f309b 100644
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ import java.util.concurrent.Callable

 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.7.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.8.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         version_tokens = opensearch_version.tokenize('-')
diff --git a/gradle.properties b/gradle.properties
index 4df27afd..3f0ebad9 100644
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=3.7.0-SNAPSHOT
-systemProp.bwc.bundle.version=3.6.0
+systemProp.bwc.version=3.8.0-SNAPSHOT
+systemProp.bwc.bundle.version=3.7.0

 # For fixing Spotless check with Java 17
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
```