### PR TITLE
Skip adding to BWC version arrays for patch version bumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -582,6 +582,25 @@ task updateVersion {
         println "New OpenSearch version: ${newVersionWithoutSnapshot}"
         println "Previous OpenSearch version: ${currentVersionWithoutSnapshot}"
 
+        // Check version bump type
+        def currentVersionParts = currentVersionWithoutSnapshot.tokenize('.')
+        def newVersionParts = newVersionWithoutSnapshot.tokenize('.')
+        def currentMajor = currentVersionParts[0] as Integer
+        def currentMinor = currentVersionParts[1] as Integer
+        def newMajor = newVersionParts[0] as Integer
+        def newMinor = newVersionParts[1] as Integer
+        def isPatchVersionBump = (currentMajor == newMajor && currentMinor == newMinor)
+        def isMinorVersionBump = (currentMajor == newMajor && currentMinor != newMinor)
+        def isMajorVersionBump = (currentMajor != newMajor)
+
+        if (isPatchVersionBump) {
+            println "Detected patch version bump (${currentVersionWithoutSnapshot} -> ${newVersionWithoutSnapshot}), will skip adding to BWC version arrays"
+        } else if (isMinorVersionBump) {
+            println "Detected minor version bump (${currentVersionWithoutSnapshot} -> ${newVersionWithoutSnapshot}), will skip updating bwc.bundle.version"
+        } else if (isMajorVersionBump) {
+            println "Detected major version bump (${currentVersionWithoutSnapshot} -> ${newVersionWithoutSnapshot})"
+        }
+
         // Step 3: Update gradle.properties - systemProp.bwc.version
         ant.replaceregexp(
             file: 'gradle.properties',
@@ -592,13 +611,19 @@ task updateVersion {
         )
 
         // Step 4: Update gradle.properties - systemProp.bwc.bundle.version
-        ant.replaceregexp(
-            file: 'gradle.properties',
-            match: "systemProp.bwc.bundle.version=${currentBwcBundleVersion}",
-            replace: "systemProp.bwc.bundle.version=${currentVersionWithoutSnapshot}",
-            flags: 'g',
-            byline: true
-        )
+        // Only update for major version bumps
+        if (isMajorVersionBump) {
+            ant.replaceregexp(
+                file: 'gradle.properties',
+                match: "systemProp.bwc.bundle.version=${currentBwcBundleVersion}",
+                replace: "systemProp.bwc.bundle.version=${currentVersionWithoutSnapshot}",
+                flags: 'g',
+                byline: true
+            )
+            println "Updated systemProp.bwc.bundle.version to ${currentVersionWithoutSnapshot}"
+        } else {
+            println "Skipped updating systemProp.bwc.bundle.version (only updated for major version bumps)"
+        }
 
         // Step 5: Update backwards_compatibility_tests_workflow.yml - opensearch_version
         ant.replaceregexp(
@@ -611,10 +636,11 @@ task updateVersion {
 
         // Step 6: Update backwards_compatibility_tests_workflow.yml - bwc_version arrays
         // Add the current version to the BWC version list if not already present
+        // Skip this step for patch version bumps (e.g., 3.7.0 -> 3.7.1)
         def workflowFile = file('.github/workflows/backwards_compatibility_tests_workflow.yml')
         def workflowContent = workflowFile.text
 
-        if (!workflowContent.contains("\"${currentVersionWithoutSnapshot}\"")) {
+        if (!isPatchVersionBump && !workflowContent.contains("\"${currentVersionWithoutSnapshot}\"")) {
             // Read the workflow file and update it manually for more precise control
             def updatedContent = workflowContent
 
@@ -625,14 +651,14 @@ task updateVersion {
                 def lastMinor = lastVersionParts[1] as Integer
                 def lastPatch = lastVersionParts.size() > 2 ? lastVersionParts[2] as Integer : 0
 
-                def currentVersionParts = currentVersionWithoutSnapshot.tokenize('.')
-                def currentMajor = currentVersionParts[0] as Integer
-                def currentMinor = currentVersionParts[1] as Integer
-                def currentPatch = currentVersionParts.size() > 2 ? currentVersionParts[2] as Integer : 0
+                def currVersionParts = currentVersionWithoutSnapshot.tokenize('.')
+                def currMajor = currVersionParts[0] as Integer
+                def currMinor = currVersionParts[1] as Integer
+                def currPatch = currVersionParts.size() > 2 ? currVersionParts[2] as Integer : 0
 
-                return (currentMajor > lastMajor) ||
-                       (currentMajor == lastMajor && currentMinor > lastMinor) ||
-                       (currentMajor == lastMajor && currentMinor == lastMinor && currentPatch > lastPatch)
+                return (currMajor > lastMajor) ||
+                       (currMajor == lastMajor && currMinor > lastMinor) ||
+                       (currMajor == lastMajor && currMinor == lastMinor && currPatch > lastPatch)
             }
 
             // Helper closure to extract versions from bwc_version array
@@ -678,6 +704,8 @@ task updateVersion {
             }
 
             workflowFile.text = updatedContent
+        } else if (isPatchVersionBump) {
+            println "Skipped adding ${currentVersionWithoutSnapshot} to BWC version list (patch version bump)"
         } else {
             println "Version ${currentVersionWithoutSnapshot} already exists in BWC version list"
         }


### PR DESCRIPTION
### Description
Modified updateVersion task to detect patch version bumps (e.g., 3.7.0 to 3.7.1) and skip adding the old version to the bwc_version arrays in the backwards compatibility test workflow. Major and minor version bumps will continue to add versions to the BWC test matrices as before.

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Test
```
./gradlew updateVersion -DnewVersion=3.7.1
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 9.2.0
  OS Info               : Linux 6.12.80-105.147.amzn2023.x86_64 (amd64)
  JDK Version           : 21 (Amazon Corretto JDK 21 (21.0.11+10-LTS))
  JAVA_HOME             : /usr/lib/jvm/java-21-amazon-corretto.x86_64
  Random Testing Seed   : A70DFC2F71866EE3
  Crypto Standard       : any-supported
=======================================

> Task :updateVersion
Setting version to 3.7.1.
Current BWC version: 3.7.0
Current BWC bundle version: 3.6.0
New OpenSearch version: 3.7.1
Previous OpenSearch version: 3.7.0
Detected patch version bump (3.7.0 -> 3.7.1), will skip adding to BWC version arrays
Skipped updating systemProp.bwc.bundle.version (only updated for major version bumps)
Skipped adding 3.7.0 to BWC version list (patch version bump)
```
Diff
```
diff --git a/.github/workflows/backwards_compatibility_tests_workflow.yml b/.github/workflows/backwards_compatibility_tests_workflow.yml
index b14c33c2..f7300485 100644
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -26,7 +26,7 @@ jobs:
         java: [21, 25]
         os: [ubuntu-latest]
         bwc_version : ["2.9.0","2.10.0","2.11.0","2.12.0","2.13.0","2.14.0","2.15.0","2.16.0","2.17.0","2.18.0","2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0", "3.4.0", "3.5.0", "3.6.0"]
-        opensearch_version : ["3.7.0-SNAPSHOT"]
+        opensearch_version : ["3.7.1-SNAPSHOT"]

     name: NeuralSearch Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -68,7 +68,7 @@ jobs:
         java: [21, 25]
         os: [ubuntu-latest]
         bwc_version: ["2.19.1","3.0.0", "3.1.0", "3.2.0", "3.3.0","3.4.0", "3.5.0", "3.6.0"]
-        opensearch_version: ["3.7.0-SNAPSHOT"]
+        opensearch_version : ["3.7.1-SNAPSHOT"]

     name: NeuralSearch Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
diff --git a/build.gradle b/build.gradle
index 5ec8740a..51e22a8e 100644
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ import java.util.concurrent.Callable

 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.7.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.7.1-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         version_tokens = opensearch_version.tokenize('-')
diff --git a/gradle.properties b/gradle.properties
index 4df27afd..8f1a9af9 100644
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=3.7.0-SNAPSHOT
+systemProp.bwc.version=3.7.1-SNAPSHOT
 systemProp.bwc.bundle.version=3.6.0
```