### PR TITLE
[Agentic Search] Forward OpenSearchStatusException from agent execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Fix semantic highlighter crash on documents with missing highlighted fields ([#1810](https://github.com/opensearch-project/neural-search/pull/1810))
 * [Text Chunking] Fix text chunking processor ignoring index max_token_count setting when ingesting via alias ([#1803](https://github.com/opensearch-project/neural-search/pull/1803))
+* Forward OpenSearchStatusException from agent execution to preserve error codes ([#1851](https://github.com/opensearch-project/neural-search/pull/1851))
 
 ### Infrastructure
 * Fix flaky integration test failure caused by ML memory circuit breaker during model deployment in distribution pipeline ([#1824](https://github.com/opensearch-project/neural-search/pull/1824))

--- a/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessor.java
@@ -24,6 +24,7 @@ import org.opensearch.search.pipeline.AbstractProcessor;
 import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.core.action.ActionListener;
 
 import java.io.IOException;
@@ -225,7 +226,11 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
                         e.getMessage()
                     );
                     agenticQuery.setAgentFailureReason(errorMessage);
-                    requestListener.onFailure(new IllegalArgumentException("Agentic search failed - " + errorMessage, e));
+                    if (e instanceof OpenSearchStatusException) {
+                        requestListener.onFailure(e);
+                    } else {
+                        requestListener.onFailure(new IllegalArgumentException("Agentic search failed - " + errorMessage, e));
+                    }
                 })
             );
         }, e -> {
@@ -236,7 +241,11 @@ public class AgenticQueryTranslatorProcessor extends AbstractProcessor implement
                 e.getMessage()
             );
             agenticQuery.setAgentFailureReason(errorMessage);
-            requestListener.onFailure(new IllegalArgumentException("Agentic search failed - " + errorMessage, e));
+            if (e instanceof OpenSearchStatusException) {
+                requestListener.onFailure(e);
+            } else {
+                requestListener.onFailure(new IllegalArgumentException("Agentic search failed - " + errorMessage, e));
+            }
         }));
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/AgenticQueryTranslatorProcessorTests.java
@@ -5,8 +5,10 @@
 package org.opensearch.neuralsearch.processor;
 
 import org.opensearch.OpenSearchParseException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.core.ParseField;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
@@ -226,6 +228,43 @@ public class AgenticQueryTranslatorProcessorTests extends OpenSearchTestCase {
         ArgumentCaptor<IllegalArgumentException> exceptionCaptor = ArgumentCaptor.forClass(IllegalArgumentException.class);
         verify(listener).onFailure(exceptionCaptor.capture());
         assertTrue(exceptionCaptor.getValue().getMessage().contains("Agentic search failed - Agent execution error"));
+    }
+
+    public void testProcessRequestAsync_withAgenticQuery_agentThrottled_forwardsStatus() throws IOException {
+        AgenticSearchQueryBuilder agenticQuery = new AgenticSearchQueryBuilder().queryText(QUERY_TEXT);
+        SearchRequest request = new SearchRequest("test-index");
+        request.source(new SearchSourceBuilder().query(agenticQuery));
+
+        ActionListener<SearchRequest> listener = mock(ActionListener.class);
+
+        AgentInfoDTO agentInfo = new AgentInfoDTO("conversational", false, false, "bedrock/converse/claude");
+        doAnswer(invocation -> {
+            ActionListener<AgentInfoDTO> agentInfoListener = invocation.getArgument(1);
+            agentInfoListener.onResponse(agentInfo);
+            return null;
+        }).when(mockMLClient).getAgentDetails(eq(AGENT_ID), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<AgentExecutionDTO> agentListener = invocation.getArgument(6);
+            agentListener.onFailure(new OpenSearchStatusException("Too many requests", RestStatus.TOO_MANY_REQUESTS));
+            return null;
+        }).when(mockMLClient)
+            .executeAgent(
+                any(SearchRequest.class),
+                any(AgenticSearchQueryBuilder.class),
+                eq(AGENT_ID),
+                eq(agentInfo),
+                eq((String) null),
+                eq(mockXContentRegistry),
+                any(ActionListener.class)
+            );
+
+        processor.processRequestAsync(request, mockContext, listener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.TOO_MANY_REQUESTS, ((OpenSearchStatusException) captor.getValue()).status());
     }
 
     public void testProcessRequestAsync_withAgenticQuery_parseFailure() throws IOException {


### PR DESCRIPTION


### Description
Forward OpenSearchStatusException from agent execution to preserve error codes

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
