### PR TITLE
Disable search timeout for sparse neural search tests

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseBaseIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseBaseIT.java
@@ -42,6 +42,17 @@ public abstract class SparseBaseIT extends BaseNeuralSearchIT {
         super.setUp();
     }
 
+    /**
+     * Disable timeout for sparse neural search queries. When timeout is enabled, OpenSearch wraps
+     * PostingsEnum in ExitablePostingsEnum for cancellation support. However, SparsePostingsEnum
+     * has custom methods (e.g., clusterIterator()) that are not accessible through the wrapper,
+     * causing IllegalStateException during query execution.
+     */
+    @Override
+    protected String getSearchTimeout() {
+        return "";  // No timeout for sparse searches to avoid ExitablePostingsEnum wrapping
+    }
+
     protected void createSparseIndex(
         String indexName,
         String fieldName,

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -743,6 +743,16 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
     }
 
     /**
+     * Returns the search timeout query parameter. Override this method in subclasses to disable timeout
+     * for queries that are incompatible with ExitablePostingsEnum wrapping (e.g., sparse neural search).
+     *
+     * @return timeout query parameter string (e.g., "?timeout=1000s") or empty string to disable timeout
+     */
+    protected String getSearchTimeout() {
+        return "?timeout=1000s";
+    }
+
+    /**
      * Execute a search request initialized from a neural query builder
      *
      * @param index Index to search against
@@ -1033,7 +1043,10 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
         builder.endObject();
 
-        Request request = new Request("GET", "/" + index + "/_search?timeout=1000s");
+        // Note: timeout parameter may cause issues with custom PostingsEnum implementations (e.g., SparsePostingsEnum)
+        // that require access to custom methods. When timeout is set, OpenSearch wraps PostingsEnum in ExitablePostingsEnum
+        // which prevents access to those custom methods. Override this in subclasses if needed.
+        Request request = new Request("GET", "/" + index + "/_search" + getSearchTimeout());
         request.addParameter("allow_partial_search_results", "false");
         request.addParameter("size", Integer.toString(resultSize));
         if (preferenceShards != null && !preferenceShards.isEmpty()) {


### PR DESCRIPTION


### Description
When search timeout is enabled, OpenSearch wraps PostingsEnum in ExitablePostingsEnum to support query cancellation. However, this causes issues for sparse neural search because SparsePostingsEnum has custom methods (e.g., clusterIterator()) that are not accessible through the wrapper, resulting in IllegalStateException during query execution.

This issue manifested consistently in CI after Gradle 9.4.1 upgrade due to parallel test execution and resource contention, which triggered the timeout wrapping mechanism more reliably than in local environments.

Solution:
- Added getSearchTimeout() method in BaseNeuralSearchIT that returns timeout parameter by default
- Overrode it in SparseBaseIT to return empty string, disabling timeout for all sparse search tests
- Added documentation explaining the architectural incompatibility

This approach avoids the security risks of using reflection with setAccessible() to unwrap PostingsEnum, and clearly documents the limitation that sparse neural search queries with timeout parameters are not currently supported.

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
