### PR TITLE
Unwrap LeafReader to fix core PR 21318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Fix semantic highlighter crash on documents with missing highlighted fields ([#1810](https://github.com/opensearch-project/neural-search/pull/1810))
 * [Text Chunking] Fix text chunking processor ignoring index max_token_count setting when ingesting via alias ([#1803](https://github.com/opensearch-project/neural-search/pull/1803))
+* Fix sparse ANN search failure due to a core change ([#1855](https://github.com/opensearch-project/neural-search/pull/1855)) 
 
 ### Infrastructure
 * Fix flaky integration test failure caused by ML memory circuit breaker during model deployment in distribution pipeline ([#1824](https://github.com/opensearch-project/neural-search/pull/1824))

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/SeismicBaseScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/SeismicBaseScorer.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
@@ -72,7 +73,11 @@ public abstract class SeismicBaseScorer extends Scorer {
     }
 
     protected void initialize(LeafReader leafReader) throws IOException {
-        Terms terms = Terms.getTerms(leafReader, fieldName);
+        // Unwrap FilterLeafReader (e.g. ExitableFilterAtomicReader) to get direct access to
+        // SparsePostingsEnum without ExitablePostingsEnum wrapping. This is safe because
+        // SEISMIC uses cluster-based iteration via clusterIterator(), not PostingsEnum.nextDoc().
+        LeafReader unwrapped = FilterLeafReader.unwrap(leafReader);
+        Terms terms = Terms.getTerms(unwrapped, fieldName);
         for (String token : sparseQueryContext.getTokens()) {
             TermsEnum termsEnum = terms.iterator();
             BytesRef term = new BytesRef(token);


### PR DESCRIPTION
### Description
Core PR #21318 made a change which wraps SparsePostingsEnum into ExitablePostingsEnum which breaks our search logic.

### Related Issues
Resolves #1854
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
