### PR TITLE
Unify highlight tag application logic and add strict validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Upgrade gradle wrapper to 9.4.1 ([#1849](https://github.com/opensearch-project/neural-search/pull/1849))
 
 ### Refactoring
+* [Semantic Highlighting] Unify highlight tag application logic and add strict validation for model output ([#1862](https://github.com/opensearch-project/neural-search/pull/1862))

--- a/src/main/java/org/opensearch/neuralsearch/highlight/batch/utils/HighlightResultApplier.java
+++ b/src/main/java/org/opensearch/neuralsearch/highlight/batch/utils/HighlightResultApplier.java
@@ -4,7 +4,6 @@
  */
 package org.opensearch.neuralsearch.highlight.batch.utils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,7 +12,7 @@ import lombok.extern.log4j.Log4j2;
 import org.opensearch.core.common.text.Text;
 import org.opensearch.neuralsearch.highlight.SemanticHighlightingConstants;
 import org.opensearch.neuralsearch.highlight.utils.HighlightEncoders;
-import org.opensearch.neuralsearch.processor.util.ProcessorUtils;
+import org.opensearch.neuralsearch.highlight.utils.HighlightTagApplier;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.fetch.subphase.highlight.HighlightField;
 
@@ -111,9 +110,8 @@ public class HighlightResultApplier {
         }
         if (text == null || text.isEmpty()) return;
 
-        boolean hasValidSpans = hasValidSpans(highlights);
-        if (!hasValidSpans) {
-            // No spans returned. Emit a no_match snippet when configured.
+        String highlighted = HighlightTagApplier.applyTags(text, highlights, preTag, postTag);
+        if (highlighted == null) {
             if (noMatchSize > 0) {
                 String snippet = text.length() <= noMatchSize ? text : text.substring(0, noMatchSize);
                 if (SemanticHighlightingConstants.ENCODER_HTML.equalsIgnoreCase(encoder)) {
@@ -124,23 +122,10 @@ public class HighlightResultApplier {
             return;
         }
 
-        String highlighted = applyPositionHighlights(text, highlights, preTag, postTag);
         if (SemanticHighlightingConstants.ENCODER_HTML.equalsIgnoreCase(encoder)) {
             highlighted = HighlightEncoders.htmlEncodePreservingTags(highlighted, preTag, postTag);
         }
         writeHighlightField(hit, fieldName, highlighted);
-    }
-
-    private static boolean hasValidSpans(List<Map<String, Object>> highlights) {
-        if (highlights == null) return false;
-        for (Map<String, Object> highlight : highlights) {
-            Object start = highlight.get(SemanticHighlightingConstants.START_KEY);
-            Object end = highlight.get(SemanticHighlightingConstants.END_KEY);
-            if (ProcessorUtils.isNumeric(start) && ProcessorUtils.isNumeric(end)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static String readString(Map<String, Object> source, String key) {
@@ -158,38 +143,5 @@ public class HighlightResultApplier {
         }
         highlightFields.put(fieldName, new HighlightField(fieldName, new Text[] { new Text(value) }));
         hit.highlightFields(highlightFields);
-    }
-
-    /**
-     * Walks the validated span list and inserts the pre/post tags into the source text.
-     * Assumes the caller has already confirmed at least one valid span exists.
-     */
-    private static String applyPositionHighlights(String text, List<Map<String, Object>> highlights, String preTag, String postTag) {
-        List<Map<String, Object>> valid = new ArrayList<>();
-        for (Map<String, Object> highlight : highlights) {
-            Object start = highlight.get(SemanticHighlightingConstants.START_KEY);
-            Object end = highlight.get(SemanticHighlightingConstants.END_KEY);
-            if (ProcessorUtils.isNumeric(start) && ProcessorUtils.isNumeric(end)) {
-                valid.add(highlight);
-            }
-        }
-
-        // Apply spans from the end of the string so earlier offsets remain valid.
-        valid.sort((a, b) -> {
-            int sa = ((Number) a.get(SemanticHighlightingConstants.START_KEY)).intValue();
-            int sb = ((Number) b.get(SemanticHighlightingConstants.START_KEY)).intValue();
-            return Integer.compare(sb, sa);
-        });
-
-        StringBuilder result = new StringBuilder(text);
-        for (Map<String, Object> highlight : valid) {
-            int start = ((Number) highlight.get(SemanticHighlightingConstants.START_KEY)).intValue();
-            int end = ((Number) highlight.get(SemanticHighlightingConstants.END_KEY)).intValue();
-            if (start >= 0 && end <= text.length() && start < end) {
-                result.insert(end, postTag);
-                result.insert(start, preTag);
-            }
-        }
-        return result.toString();
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/highlight/single/SemanticHighlighterEngine.java
+++ b/src/main/java/org/opensearch/neuralsearch/highlight/single/SemanticHighlighterEngine.java
@@ -9,6 +9,7 @@ import org.apache.lucene.search.Query;
 import org.opensearch.OpenSearchException;
 import org.opensearch.neuralsearch.highlight.single.extractor.QueryTextExtractorRegistry;
 import org.opensearch.neuralsearch.highlight.utils.HighlightExtractorUtils;
+import org.opensearch.neuralsearch.highlight.utils.HighlightTagApplier;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
 import org.opensearch.neuralsearch.processor.highlight.SentenceHighlightingRequest;
 import org.opensearch.search.fetch.subphase.highlight.FieldHighlightContext;
@@ -16,7 +17,6 @@ import org.opensearch.action.support.PlainActionFuture;
 import lombok.NonNull;
 import lombok.Builder;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -29,8 +29,6 @@ import java.util.Map;
 public class SemanticHighlighterEngine {
     private static final String MODEL_ID_FIELD = "model_id";
     private static final String MODEL_INFERENCE_RESULT_KEY = "highlights";
-    private static final String MODEL_INFERENCE_RESULT_START_KEY = "start";
-    private static final String MODEL_INFERENCE_RESULT_END_KEY = "end";
 
     @NonNull
     private final MLCommonsClientAccessor mlCommonsClient;
@@ -140,10 +138,10 @@ public class SemanticHighlighterEngine {
      * @param preTag The pre tag to use for highlighting
      * @param postTag The post tag to use for highlighting
      * @return Formatted text with highlighting
-     * @throws IllegalArgumentException if highlight positions are invalid
+     * @throws OpenSearchException if highlight positions are invalid, unsorted, duplicated, or overlapping
      */
+    @SuppressWarnings("unchecked")
     public String applyHighlighting(String context, Map<String, Object> highlightResult, String preTag, String postTag) {
-        // Get the "highlights" list from the result
         Object highlightsObj = highlightResult.get(MODEL_INFERENCE_RESULT_KEY);
 
         if (!(highlightsObj instanceof List<?> highlightsList)) {
@@ -152,119 +150,10 @@ public class SemanticHighlighterEngine {
         }
 
         if (highlightsList.isEmpty()) {
-            // No highlights found, return context as is
             return context;
         }
 
-        // Pre-allocate size * 2 since we store start and end positions as consecutive pairs
-        // Format: [start1, end1, start2, end2, start3, end3, ...]
-        ArrayList<Integer> validHighlights = new ArrayList<>(highlightsList.size() * 2);
-
-        for (Object item : highlightsList) {
-            Map<String, Number> map = getHighlightsPositionMap(item);
-
-            Number start = map.get(MODEL_INFERENCE_RESULT_START_KEY);
-            Number end = map.get(MODEL_INFERENCE_RESULT_END_KEY);
-
-            if (start == null || end == null) {
-                throw new OpenSearchException("Missing start or end position in highlight data");
-            }
-
-            // Validate positions and add them as a pair to maintain the start-end relationship
-            validateHighlightPositions(start.intValue(), end.intValue(), context.length());
-            validHighlights.add(start.intValue());  // Even indices (0,2,4,...) store start positions
-            validHighlights.add(end.intValue());    // Odd indices (1,3,5,...) store end positions
-        }
-
-        // Verify highlights are sorted by start position (ascending)
-        // We start from i=2 (second start position) and compare with previous start position (i-2)
-        // Using i+=2 to skip end positions and only compare start positions with each other
-        for (int i = 2; i < validHighlights.size(); i += 2) {
-            // Compare current start position with previous start position
-            if (validHighlights.get(i) < validHighlights.get(i - 2)) {
-                log.error(String.format(Locale.ROOT, "Highlights are not sorted: %s", validHighlights));
-                throw new OpenSearchException("Internal error while applying semantic highlight: received unsorted highlights from model");
-            }
-        }
-
-        return constructHighlightedText(context, validHighlights, preTag, postTag);
-    }
-
-    /**
-     * Validates highlight position values
-     *
-     * @param start The start position
-     * @param end The end position
-     * @param textLength The length of the text being highlighted
-     * @throws OpenSearchException if positions are invalid
-     */
-    private void validateHighlightPositions(int start, int end, int textLength) {
-        if (start < 0 || end > textLength || start >= end) {
-            throw new OpenSearchException(
-                String.format(
-                    Locale.ROOT,
-                    "Invalid highlight positions: start=%d, end=%d, textLength=%d. Positions must satisfy: 0 <= start < end <= textLength",
-                    start,
-                    end,
-                    textLength
-                )
-            );
-        }
-    }
-
-    /**
-     * Constructs highlighted text by iterating through the text once
-     *
-     * @param text The original text
-     * @param highlights The list of valid highlight positions in pairs [start1, end1, start2, end2, ...]
-     * @param preTag The pre tag to use for highlighting
-     * @param postTag The post tag to use for highlighting
-     * @return The highlighted text
-     */
-    private String constructHighlightedText(String text, List<Integer> highlights, String preTag, String postTag) {
-        StringBuilder result = new StringBuilder();
-        int currentPos = 0;
-
-        // Iterate through highlight positions in pairs (start, end)
-        // i increments by 2 to move from one pair to the next
-        for (int i = 0; i < highlights.size(); i += 2) {
-            int start = highlights.get(i);     // Get start position from even index
-            int end = highlights.get(i + 1);   // Get end position from odd index
-
-            // Add text before the highlight if there is any
-            if (start > currentPos) {
-                result.append(text, currentPos, start);
-            }
-
-            // Add the highlighted text with highlight tags
-            result.append(preTag);
-            result.append(text, start, end);
-            result.append(postTag);
-
-            // Update current position to end of this highlight
-            currentPos = end;
-        }
-
-        // Add any remaining text after the last highlight
-        if (currentPos < text.length()) {
-            result.append(text, currentPos, text.length());
-        }
-
-        return result.toString();
-    }
-
-    /**
-     * Extracts the highlight position map from a highlight item
-     *
-     * @param item The highlight item
-     * @return The highlight position map
-     * @throws OpenSearchException if the item cannot be cast to Map<String, Number>
-     */
-    private static Map<String, Number> getHighlightsPositionMap(Object item) {
-        try {
-            return (Map<String, Number>) item;
-        } catch (ClassCastException e) {
-            throw new OpenSearchException(String.format(Locale.ROOT, "Expect item to be map of string to number, but was: %s", item));
-        }
+        String result = HighlightTagApplier.applyTags(context, (List<Map<String, Object>>) highlightsObj, preTag, postTag);
+        return result != null ? result : context;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/highlight/utils/HighlightTagApplier.java
+++ b/src/main/java/org/opensearch/neuralsearch/highlight/utils/HighlightTagApplier.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.highlight.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.neuralsearch.highlight.SemanticHighlightingConstants;
+import org.opensearch.neuralsearch.processor.util.ProcessorUtils;
+
+/**
+ * Applies highlight tags to text based on position spans returned by a model.
+ * Shared by both single-inference and batch-inference highlighting paths.
+ */
+public class HighlightTagApplier {
+
+    /**
+     * Applies highlight tags to text based on position spans from model output.
+     * Expects spans to be sorted by start position with no overlaps or duplicate start positions.
+     * All spans must have numeric start/end values within text bounds.
+     *
+     * @param text The original text to highlight
+     * @param highlights List of maps with "start" and "end" keys representing highlight positions
+     * @param preTag The opening tag for highlighted text
+     * @param postTag The closing tag for highlighted text
+     * @return The text with highlight tags applied, or null if highlights is null or empty
+     * @throws OpenSearchException if any span is invalid (non-numeric, out-of-bounds, unsorted, duplicate start, or overlapping)
+     */
+    public static String applyTags(String text, List<Map<String, Object>> highlights, String preTag, String postTag) {
+        if (highlights == null || highlights.isEmpty()) {
+            return null;
+        }
+
+        List<int[]> spans = new ArrayList<>(highlights.size());
+        for (Map<String, Object> highlight : highlights) {
+            Object startObj = highlight.get(SemanticHighlightingConstants.START_KEY);
+            Object endObj = highlight.get(SemanticHighlightingConstants.END_KEY);
+            if (!ProcessorUtils.isNumeric(startObj) || !ProcessorUtils.isNumeric(endObj)) {
+                throw new OpenSearchException(
+                    String.format(
+                        Locale.ROOT,
+                        "Invalid highlight positions: start and end must be numeric, but got start=%s, end=%s",
+                        startObj,
+                        endObj
+                    )
+                );
+            }
+            int start = ((Number) startObj).intValue();
+            int end = ((Number) endObj).intValue();
+            if (start < 0 || end > text.length() || start >= end) {
+                throw new OpenSearchException(
+                    String.format(
+                        Locale.ROOT,
+                        "Invalid highlight positions: start=%d, end=%d, textLength=%d. Positions must satisfy: 0 <= start < end <= textLength",
+                        start,
+                        end,
+                        text.length()
+                    )
+                );
+            }
+            spans.add(new int[] { start, end });
+        }
+
+        for (int i = 1; i < spans.size(); i++) {
+            int prevStart = spans.get(i - 1)[0];
+            int prevEnd = spans.get(i - 1)[1];
+            int currStart = spans.get(i)[0];
+            if (currStart < prevStart) {
+                throw new OpenSearchException("Invalid highlight positions: highlights are not sorted by start position");
+            }
+            if (currStart == prevStart) {
+                throw new OpenSearchException(
+                    String.format(Locale.ROOT, "Invalid highlight positions: duplicate start position %d", currStart)
+                );
+            }
+            if (currStart < prevEnd) {
+                throw new OpenSearchException(
+                    String.format(
+                        Locale.ROOT,
+                        "Invalid highlight positions: overlapping spans [%d,%d) and [%d,%d)",
+                        prevStart,
+                        prevEnd,
+                        currStart,
+                        spans.get(i)[1]
+                    )
+                );
+            }
+        }
+
+        int resultSize = text.length() + (preTag.length() + postTag.length()) * spans.size();
+        StringBuilder result = new StringBuilder(resultSize);
+        int currentPos = 0;
+        for (int[] span : spans) {
+            if (span[0] > currentPos) {
+                result.append(text, currentPos, span[0]);
+            }
+            result.append(preTag);
+            result.append(text, span[0], span[1]);
+            result.append(postTag);
+            currentPos = span[1];
+        }
+        if (currentPos < text.length()) {
+            result.append(text, currentPos, text.length());
+        }
+        return result.toString();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/highlight/batch/utils/HighlightResultApplierTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/highlight/batch/utils/HighlightResultApplierTests.java
@@ -91,18 +91,20 @@ public class HighlightResultApplierTests extends OpenSearchTestCase {
         assertEquals("abcd", highlightedValue(hit, "body"));
     }
 
-    public void testInvalidSpansAreSkipped() {
+    public void testInvalidSpansThrowException() {
         SearchHit hit = hitWithSource(Map.of("body", "alpha beta gamma"));
-        applier.applyBatchResults(
-            List.of(hit),
-            List.of(List.of(Map.of("start", "not-a-number", "end", 10), Map.of("start", 6, "end", 10))),
-            List.of("body"),
-            List.of("<em>"),
-            List.of("</em>"),
-            List.of(0),
-            List.of("default")
+        expectThrows(
+            Exception.class,
+            () -> applier.applyBatchResults(
+                List.of(hit),
+                List.of(List.of(Map.of("start", "not-a-number", "end", 10), Map.of("start", 6, "end", 10))),
+                List.of("body"),
+                List.of("<em>"),
+                List.of("</em>"),
+                List.of(0),
+                List.of("default")
+            )
         );
-        assertEquals("alpha <em>beta</em> gamma", highlightedValue(hit, "body"));
     }
 
     public void testNestedFieldFallsBackToLeafName() {
@@ -246,25 +248,20 @@ public class HighlightResultApplierTests extends OpenSearchTestCase {
         assertTrue(hit.getHighlightFields().isEmpty());
     }
 
-    public void testInvalidSpanRangesAreSkipped() {
-        // start >= end (invalid) and start beyond text length: those spans are skipped
+    public void testInvalidSpanRangesThrowException() {
         SearchHit hit = hitWithSource(Map.of("body", "alpha beta"));
-        applier.applyBatchResults(
-            List.of(hit),
-            List.of(
-                List.of(
-                    Map.of("start", 5, "end", 5),    // empty range
-                    Map.of("start", 100, "end", 200), // out of bounds
-                    Map.of("start", 0, "end", 5)      // valid
-                )
-            ),
-            List.of("body"),
-            List.of("<em>"),
-            List.of("</em>"),
-            List.of(0),
-            List.of("default")
+        expectThrows(
+            Exception.class,
+            () -> applier.applyBatchResults(
+                List.of(hit),
+                List.of(List.of(Map.of("start", 5, "end", 5))),
+                List.of("body"),
+                List.of("<em>"),
+                List.of("</em>"),
+                List.of(0),
+                List.of("default")
+            )
         );
-        assertEquals("<em>alpha</em> beta", highlightedValue(hit, "body"));
     }
 
     public void testApplyWithIndicesSliceSizeMismatchThrows() {

--- a/src/test/java/org/opensearch/neuralsearch/highlight/utils/HighlightTagApplierTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/highlight/utils/HighlightTagApplierTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.highlight.utils;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class HighlightTagApplierTests extends OpenSearchTestCase {
+
+    public void testNullHighlightsReturnsNull() {
+        assertNull(HighlightTagApplier.applyTags("some text", null, "<em>", "</em>"));
+    }
+
+    public void testEmptyHighlightsReturnsNull() {
+        assertNull(HighlightTagApplier.applyTags("some text", List.of(), "<em>", "</em>"));
+    }
+
+    public void testSingleSpan() {
+        String result = HighlightTagApplier.applyTags("alpha beta gamma", List.of(Map.of("start", 6, "end", 10)), "<em>", "</em>");
+        assertEquals("alpha <em>beta</em> gamma", result);
+    }
+
+    public void testMultipleSpans() {
+        String result = HighlightTagApplier.applyTags(
+            "alpha beta gamma delta",
+            List.of(Map.of("start", 0, "end", 5), Map.of("start", 11, "end", 16)),
+            "<em>",
+            "</em>"
+        );
+        assertEquals("<em>alpha</em> beta <em>gamma</em> delta", result);
+    }
+
+    public void testAdjacentSpans() {
+        String result = HighlightTagApplier.applyTags(
+            "abcdef",
+            List.of(Map.of("start", 0, "end", 3), Map.of("start", 3, "end", 6)),
+            "<b>",
+            "</b>"
+        );
+        assertEquals("<b>abc</b><b>def</b>", result);
+    }
+
+    public void testSpanAtEnd() {
+        String result = HighlightTagApplier.applyTags("hello world", List.of(Map.of("start", 6, "end", 11)), "<em>", "</em>");
+        assertEquals("hello <em>world</em>", result);
+    }
+
+    public void testSpanAtStart() {
+        String result = HighlightTagApplier.applyTags("hello world", List.of(Map.of("start", 0, "end", 5)), "<em>", "</em>");
+        assertEquals("<em>hello</em> world", result);
+    }
+
+    public void testEntireText() {
+        String result = HighlightTagApplier.applyTags("hello", List.of(Map.of("start", 0, "end", 5)), "<em>", "</em>");
+        assertEquals("<em>hello</em>", result);
+    }
+
+    public void testCustomTags() {
+        String result = HighlightTagApplier.applyTags("hello world", List.of(Map.of("start", 0, "end", 5)), "<mark>", "</mark>");
+        assertEquals("<mark>hello</mark> world", result);
+    }
+
+    public void testNonNumericStartThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags("alpha beta", List.of(Map.of("start", "bad", "end", 5)), "<em>", "</em>")
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("start and end must be numeric"));
+    }
+
+    public void testNonNumericEndThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags("alpha beta", List.of(Map.of("start", 0, "end", "bad")), "<em>", "</em>")
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("start and end must be numeric"));
+    }
+
+    public void testNegativeStartThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags("alpha", List.of(Map.of("start", -1, "end", 3)), "<em>", "</em>")
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Positions must satisfy"));
+    }
+
+    public void testEndBeyondTextLengthThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags("alpha", List.of(Map.of("start", 0, "end", 100)), "<em>", "</em>")
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Positions must satisfy"));
+    }
+
+    public void testStartEqualsEndThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags("alpha", List.of(Map.of("start", 3, "end", 3)), "<em>", "</em>")
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Positions must satisfy"));
+    }
+
+    public void testStartGreaterThanEndThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags("alpha", List.of(Map.of("start", 4, "end", 2)), "<em>", "</em>")
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Positions must satisfy"));
+    }
+
+    public void testUnsortedSpansThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags(
+                "alpha beta gamma",
+                List.of(Map.of("start", 6, "end", 10), Map.of("start", 0, "end", 5)),
+                "<em>",
+                "</em>"
+            )
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("not sorted"));
+    }
+
+    public void testDuplicateStartThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags(
+                "alpha beta gamma",
+                List.of(Map.of("start", 0, "end", 5), Map.of("start", 0, "end", 10)),
+                "<em>",
+                "</em>"
+            )
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("duplicate start position"));
+    }
+
+    public void testOverlappingSpansThrowsException() {
+        OpenSearchException ex = expectThrows(
+            OpenSearchException.class,
+            () -> HighlightTagApplier.applyTags(
+                "alpha beta gamma",
+                List.of(Map.of("start", 0, "end", 8), Map.of("start", 6, "end", 15)),
+                "<em>",
+                "</em>"
+            )
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("overlapping spans"));
+    }
+}


### PR DESCRIPTION


### Description
Extract shared HighlightTagApplier utility to replace divergent implementations in SemanticHighlighterEngine (forward iteration) and HighlightResultApplier (reverse insertion). Both paths now use the same forward-iteration algorithm and throw on invalid model output (non-numeric, out-of-bounds, unsorted, duplicate start, or overlapping spans).

### Related Issues
N/A

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
