### PR TITLE
Improve hybrid query filter validation error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 
 ### Enhancements
-
+* Improve hybrid query filter validation error message ([#1870](https://github.com/opensearch-project/neural-search/pull/1870))
 ### Bug Fixes
 
 ### Infrastructure

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -71,6 +71,8 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     public static final String ERROR_MSG_QUERIES_REQUIRED = "[%s] requires 'queries' field with at least one clause";
     public static final String ERROR_MSG_MAX_QUERIES_EXCEEDED = "Number of sub-queries exceeds maximum supported by [%s] query";
     public static final String ERROR_MSG_BOOST_NOT_SUPPORTED = "[%s] query does not support [%s]";
+    public static final String ERROR_MSG_FILTER_MUST_BE_QUERY_OBJECT = "[%s] query's [%s] field must be a query object. "
+        + "For multiple filters, use a bool query with must clauses";
 
     public HybridQueryBuilder(StreamInput in) throws IOException {
         super(in);
@@ -186,12 +188,25 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
      *                          "text": "keyword"
      *                       }
      *                    }
-     *               ]
-     *               "filter":
+     *               ],
+     *               "filter": {
      *                  "term": {
      *                      "text": "keyword"
      *                  }
+     *               }
      *          }
+     *     }
+     * }
+     *
+     * To combine multiple filter clauses, wrap them in a bool query:
+     * {
+     *     "filter": {
+     *         "bool": {
+     *             "must": [
+     *                 {"term": {"field1": "value1"}},
+     *                 {"term": {"field2": "value2"}}
+     *             ]
+     *         }
      *     }
      * }
      *
@@ -218,11 +233,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                 } else if (FILTER_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     filter = parseInnerQueryBuilder(parser);
                 } else {
-                    log.error(String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, currentFieldName));
-                    throw new ParsingException(
-                        parser.getTokenLocation(),
-                        String.format(Locale.ROOT, "Field is not supported by [%s] query", NAME)
-                    );
+                    throwUnsupportedFieldParsingException(parser, currentFieldName);
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (QUERIES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
@@ -236,12 +247,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                         queries.add(parseInnerQueryBuilder(parser));
                         token = parser.nextToken();
                     }
+                } else if (FILTER_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    throwUnsupportedFilterParsingException(parser);
                 } else {
-                    log.error(String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, currentFieldName));
-                    throw new ParsingException(
-                        parser.getTokenLocation(),
-                        String.format(Locale.ROOT, "Field is not supported by [%s] query", NAME)
-                    );
+                    throwUnsupportedFieldParsingException(parser, currentFieldName);
                 }
             } else {
                 if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
@@ -255,12 +264,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                     queryName = parser.text();
                 } else if (PAGINATION_DEPTH_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     paginationDepth = parser.intValue();
+                } else if (FILTER_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    throwUnsupportedFilterParsingException(parser);
                 } else {
-                    log.error(String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, currentFieldName));
-                    throw new ParsingException(
-                        parser.getTokenLocation(),
-                        String.format(Locale.ROOT, "Field is not supported by [%s] query", NAME)
-                    );
+                    throwUnsupportedFieldParsingException(parser, currentFieldName);
                 }
             }
         }
@@ -439,5 +446,16 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         if (hasInnerHits) {
             EventStatsManager.increment(EventStatName.HYBRID_QUERY_INNER_HITS_REQUESTS);
         }
+    }
+
+    private static void throwUnsupportedFilterParsingException(XContentParser parser) {
+        throw new ParsingException(
+            parser.getTokenLocation(),
+            String.format(Locale.ROOT, ERROR_MSG_FILTER_MUST_BE_QUERY_OBJECT, NAME, FILTER_FIELD.getPreferredName())
+        );
+    }
+
+    private static void throwUnsupportedFieldParsingException(XContentParser parser, String fieldName) {
+        throw new ParsingException(parser.getTokenLocation(), String.format(Locale.ROOT, "Field is not supported by [%s] query", NAME));
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -455,6 +455,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     }
 
     private static void throwUnsupportedFieldParsingException(XContentParser parser, String fieldName) {
+        log.error(String.format(Locale.ROOT, "[%s] query does not support [%s]", NAME, fieldName));
         throw new ParsingException(parser.getTokenLocation(), String.format(Locale.ROOT, "Field is not supported by [%s] query", NAME));
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -71,8 +71,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     public static final String ERROR_MSG_QUERIES_REQUIRED = "[%s] requires 'queries' field with at least one clause";
     public static final String ERROR_MSG_MAX_QUERIES_EXCEEDED = "Number of sub-queries exceeds maximum supported by [%s] query";
     public static final String ERROR_MSG_BOOST_NOT_SUPPORTED = "[%s] query does not support [%s]";
-    public static final String ERROR_MSG_FILTER_MUST_BE_QUERY_OBJECT = "[%s] query's [%s] field must be a query object. "
-        + "For multiple filters, use a bool query with must clauses";
+    public static final String ERROR_MSG_FILTER_MUST_BE_QUERY_OBJECT = "[%s] query's [%s] field must be a query object";
 
     public HybridQueryBuilder(StreamInput in) throws IOException {
         super(in);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -619,7 +619,6 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
 
         ParsingException exception = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(contentParser));
         assertThat(exception.getMessage(), containsString("[hybrid] query's [filter] field must be a query object"));
-        assertThat(exception.getMessage(), containsString("bool query with must clauses"));
     }
 
     /**
@@ -662,7 +661,6 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
 
         ParsingException exception = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(contentParser));
         assertThat(exception.getMessage(), containsString("[hybrid] query's [filter] field must be a query object"));
-        assertThat(exception.getMessage(), containsString("bool query with must clauses"));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -565,6 +565,106 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         );
     }
 
+    /**
+     * Tests that array format for filter produces a helpful error message:
+     * {
+     *     "queries": [...],
+     *     "filter": [
+     *         {"term": {"field1": "value1"}},
+     *         {"term": {"field2": "value2"}}
+     *     ]
+     * }
+     */
+    @SneakyThrows
+    public void testFromXContent_whenFilterIsArray_thenFailWithHelpfulMessage() {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startArray("queries")
+            .startObject()
+            .startObject(TermQueryBuilder.NAME)
+            .field(TEXT_FIELD_NAME, TERM_QUERY_TEXT)
+            .endObject()
+            .endObject()
+            .endArray()
+            .startArray("filter")
+            .startObject()
+            .startObject(TermQueryBuilder.NAME)
+            .field("field1", "value1")
+            .endObject()
+            .endObject()
+            .startObject()
+            .startObject(TermQueryBuilder.NAME)
+            .field("field2", "value2")
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject();
+
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(
+            List.of(
+                new NamedXContentRegistry.Entry(QueryBuilder.class, new ParseField(TermQueryBuilder.NAME), TermQueryBuilder::fromXContent),
+                new NamedXContentRegistry.Entry(
+                    QueryBuilder.class,
+                    new ParseField(HybridQueryBuilder.NAME),
+                    HybridQueryBuilder::fromXContent
+                )
+            )
+        );
+        XContentParser contentParser = createParser(
+            namedXContentRegistry,
+            xContentBuilder.contentType().xContent(),
+            BytesReference.bytes(xContentBuilder)
+        );
+        contentParser.nextToken();
+
+        ParsingException exception = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(contentParser));
+        assertThat(exception.getMessage(), containsString("[hybrid] query's [filter] field must be a query object"));
+        assertThat(exception.getMessage(), containsString("bool query with must clauses"));
+    }
+
+    /**
+     * Tests that scalar format for filter produces a helpful error message:
+     * {
+     *     "queries": [...],
+     *     "filter": "invalid"
+     * }
+     */
+    @SneakyThrows
+    public void testFromXContent_whenFilterIsScalarValue_thenFailWithHelpfulMessage() {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startArray("queries")
+            .startObject()
+            .startObject(TermQueryBuilder.NAME)
+            .field(TEXT_FIELD_NAME, TERM_QUERY_TEXT)
+            .endObject()
+            .endObject()
+            .endArray()
+            .field("filter", "invalid")
+            .endObject();
+
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(
+            List.of(
+                new NamedXContentRegistry.Entry(QueryBuilder.class, new ParseField(TermQueryBuilder.NAME), TermQueryBuilder::fromXContent),
+                new NamedXContentRegistry.Entry(
+                    QueryBuilder.class,
+                    new ParseField(HybridQueryBuilder.NAME),
+                    HybridQueryBuilder::fromXContent
+                )
+            )
+        );
+        XContentParser contentParser = createParser(
+            namedXContentRegistry,
+            xContentBuilder.contentType().xContent(),
+            BytesReference.bytes(xContentBuilder)
+        );
+        contentParser.nextToken();
+
+        ParsingException exception = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(contentParser));
+        assertThat(exception.getMessage(), containsString("[hybrid] query's [filter] field must be a query object"));
+        assertThat(exception.getMessage(), containsString("bool query with must clauses"));
+    }
+
     @SneakyThrows
     public void testFromXContent_whenIncorrectFormat_thenFail() {
         XContentBuilder unsupportedFieldXContentBuilder = XContentFactory.jsonBuilder()

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.query;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -661,6 +662,96 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
 
         ParsingException exception = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(contentParser));
         assertThat(exception.getMessage(), containsString("[hybrid] query's [filter] field must be a query object"));
+    }
+
+    /**
+     * Tests that an unsupported top-level object field returns the generic hybrid error
+     * without echoing the customer-provided field name in the exception message.
+     */
+    @SneakyThrows
+    public void testFromXContent_whenUnsupportedFieldIsObject_thenFailWithGenericMessage() {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startArray("queries")
+            .startObject()
+            .startObject(TermQueryBuilder.NAME)
+            .field(TEXT_FIELD_NAME, TERM_QUERY_TEXT)
+            .endObject()
+            .endObject()
+            .endArray()
+            .startObject("random_field")
+            .startObject(TermQueryBuilder.NAME)
+            .field(TEXT_FIELD_NAME, TERM_QUERY_TEXT)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(
+            List.of(
+                new NamedXContentRegistry.Entry(QueryBuilder.class, new ParseField(TermQueryBuilder.NAME), TermQueryBuilder::fromXContent),
+                new NamedXContentRegistry.Entry(
+                    QueryBuilder.class,
+                    new ParseField(HybridQueryBuilder.NAME),
+                    HybridQueryBuilder::fromXContent
+                )
+            )
+        );
+        XContentParser contentParser = createParser(
+            namedXContentRegistry,
+            xContentBuilder.contentType().xContent(),
+            BytesReference.bytes(xContentBuilder)
+        );
+        contentParser.nextToken();
+
+        ParsingException exception = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(contentParser));
+        assertThat(exception.getMessage(), containsString("Field is not supported by [hybrid] query"));
+        assertThat(exception.getMessage(), not(containsString("random_field")));
+    }
+
+    /**
+     * Tests that an unsupported top-level array field returns the generic hybrid error
+     * without echoing the customer-provided field name in the exception message.
+     */
+    @SneakyThrows
+    public void testFromXContent_whenUnsupportedFieldIsArray_thenFailWithGenericMessage() {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startArray("queries")
+            .startObject()
+            .startObject(TermQueryBuilder.NAME)
+            .field(TEXT_FIELD_NAME, TERM_QUERY_TEXT)
+            .endObject()
+            .endObject()
+            .endArray()
+            .startArray("random_field")
+            .startObject()
+            .startObject(TermQueryBuilder.NAME)
+            .field(TEXT_FIELD_NAME, TERM_QUERY_TEXT)
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject();
+
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(
+            List.of(
+                new NamedXContentRegistry.Entry(QueryBuilder.class, new ParseField(TermQueryBuilder.NAME), TermQueryBuilder::fromXContent),
+                new NamedXContentRegistry.Entry(
+                    QueryBuilder.class,
+                    new ParseField(HybridQueryBuilder.NAME),
+                    HybridQueryBuilder::fromXContent
+                )
+            )
+        );
+        XContentParser contentParser = createParser(
+            namedXContentRegistry,
+            xContentBuilder.contentType().xContent(),
+            BytesReference.bytes(xContentBuilder)
+        );
+        contentParser.nextToken();
+
+        ParsingException exception = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(contentParser));
+        assertThat(exception.getMessage(), containsString("Field is not supported by [hybrid] query"));
+        assertThat(exception.getMessage(), not(containsString("random_field")));
     }
 
     @SneakyThrows


### PR DESCRIPTION
Description

Improve validation error messages for invalid hybrid query filter formats.

Currently, when the filter field is provided in an unsupported format (for example, an array), hybrid query parsing returns the generic error:

Field is not supported by [hybrid] query

This change adds a dedicated validation error for invalid filter formats and provides guidance to use a bool query with must clauses when combining multiple filters.

Related Issues

Fixes #1811 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
