### PR TITLE
Block hybrid query with dfs_query_then_fetch search type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+* [Hybrid Query] Block hybrid query execution with `search_type=dfs_query_then_fetch` ([#1873](https://github.com/opensearch-project/neural-search/pull/1873))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
@@ -11,11 +11,13 @@ import java.util.Objects;
 
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchType;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.util.HybridQueryUtil;
 import org.opensearch.tasks.Task;
 
 import lombok.extern.log4j.Log4j2;
@@ -24,6 +26,7 @@ import lombok.extern.log4j.Log4j2;
  * An ActionFilter that automatically disables batched reduction for hybrid queries.
  *
  * This filter intercepts all search requests and checks if they contain a hybrid query.
+ * If a hybrid query is detected with search_type=dfs_query_then_fetch, the request is rejected.
  * If a hybrid query is detected, it unconditionally sets batchedReduceSize to Integer.MAX_VALUE
  * to disable batched reduction, regardless of any user-specified value.
  *
@@ -75,6 +78,10 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
             // unconditionally disable batched reduction for hybrid queries
             // batched reduction is incompatible with hybrid query processing
             if (containsHybridQuery(searchRequest)) {
+                if (searchRequest.searchType() == SearchType.DFS_QUERY_THEN_FETCH) {
+                    listener.onFailure(new IllegalArgumentException(HybridQueryUtil.HYBRID_QUERY_DFS_SEARCH_TYPE_NOT_SUPPORTED_MESSAGE));
+                    return;
+                }
                 if (searchRequest.getBatchedReduceSize() != DISABLE_BATCHED_REDUCE) {
                     log.debug(
                         String.format(

--- a/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcher.java
@@ -33,6 +33,7 @@ import lombok.extern.log4j.Log4j2;
 import static org.opensearch.neuralsearch.util.HybridQueryUtil.extractHybridQuery;
 import static org.opensearch.neuralsearch.util.HybridQueryUtil.isHybridQuery;
 import static org.opensearch.neuralsearch.util.HybridQueryUtil.validateHybridQuery;
+import static org.opensearch.neuralsearch.util.HybridQueryUtil.validateHybridQuerySearchType;
 import static org.opensearch.neuralsearch.util.HybridQueryUtil.transformHybridQueryWrappedInBooleanMustQuery;
 
 /**
@@ -66,6 +67,7 @@ public class HybridQueryPhaseSearcher extends QueryPhaseSearcherWrapper {
         if (isHybridQuery(query, searchContext) == false) {
             phaseQuery = validateAndTransformQuery(searchContext, query);
         } else {
+            validateHybridQuerySearchType(searchContext.searchType());
             phaseQuery = extractHybridQuery(searchContext, query);
             validateHybridQuery((HybridQuery) phaseQuery);
         }

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryUtil.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
+import org.opensearch.action.search.SearchType;
 import org.opensearch.index.search.NestedHelper;
 import org.opensearch.neuralsearch.query.HybridQuery;
 import org.opensearch.search.internal.SearchContext;
@@ -30,6 +31,9 @@ import java.util.stream.IntStream;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Log4j2
 public class HybridQueryUtil {
+    public static final String HYBRID_QUERY_DFS_SEARCH_TYPE_NOT_SUPPORTED_MESSAGE =
+        "hybrid query does not support search_type [dfs_query_then_fetch]";
+
     /**
      * This method validates whether the query object is an instance of hybrid query
      */
@@ -244,6 +248,17 @@ public class HybridQueryUtil {
             if (innerQuery instanceof HybridQuery) {
                 throw new IllegalArgumentException("hybrid query cannot be nested in another hybrid query");
             }
+        }
+    }
+
+    /**
+     * Validates that hybrid query is not used with dfs_query_then_fetch search type.
+     * Hybrid query score normalization runs between QUERY and FETCH phases, which is skipped when
+     * dfs_query_then_fetch is used on multi-shard indexes because DFS_QUERY replaces QUERY.
+     */
+    public static void validateHybridQuerySearchType(final SearchType searchType) {
+        if (searchType == SearchType.DFS_QUERY_THEN_FETCH) {
+            throw new IllegalArgumentException(HYBRID_QUERY_DFS_SEARCH_TYPE_NOT_SUPPORTED_MESSAGE);
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
@@ -4,14 +4,18 @@
  */
 package org.opensearch.neuralsearch.search;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import org.mockito.ArgumentCaptor;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchType;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
@@ -37,7 +41,34 @@ public class HybridQuerySearchRequestFilterTests extends OpenSearchQueryTestCase
     }
 
     @SuppressWarnings("unchecked")
-    public void testApply_whenHybridQueryWithDefaultBatchReduceSize_thenDisablesBatchedReduction() {
+    public void testApply_whenHybridQueryWithDfsQueryThenFetchSearchType_thenFails() {
+        HybridQueryBuilder hybridQuery = new HybridQueryBuilder();
+        hybridQuery.add(new MatchQueryBuilder("field", "value"));
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(hybridQuery);
+        searchRequest.source(sourceBuilder);
+        searchRequest.searchType(SearchType.DFS_QUERY_THEN_FETCH);
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        verify(chain, never()).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+        assertTrue(exceptionCaptor.getValue() instanceof IllegalArgumentException);
+        assertThat(
+            exceptionCaptor.getValue().getMessage(),
+            containsString("hybrid query does not support search_type [dfs_query_then_fetch]")
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testApply_whenHybridQueryWithQueryThenFetchSearchType_thenDisablesBatchedReduction() {
         // Setup
         HybridQueryBuilder hybridQuery = new HybridQueryBuilder();
         hybridQuery.add(new MatchQueryBuilder("field", "value"));

--- a/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/query/HybridQueryPhaseSearcherTests.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.common.lucene.search.function.FunctionScoreQuery;
 import org.opensearch.common.lucene.search.function.ScriptScoreQuery;
@@ -50,6 +51,7 @@ import org.junit.Before;
 import org.opensearch.Version;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScoreScript;
+import org.opensearch.action.search.SearchType;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
@@ -72,7 +74,9 @@ import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.SearchOperationListener;
+import org.opensearch.neuralsearch.query.HybridQuery;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.HybridQueryContext;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 import org.opensearch.neuralsearch.search.collector.HybridQueryCollectorContextSpecFactory;
 import org.opensearch.search.SearchShardTarget;
@@ -101,6 +105,27 @@ public class HybridQueryPhaseSearcherTests extends OpenSearchQueryTestCase {
     public void setup() throws Exception {
         super.setUp();
         QueryCollectorContextSpecRegistry.registerFactory(new HybridQueryCollectorContextSpecFactory());
+    }
+
+    public void testQueryType_whenHybridQueryWithDfsQueryThenFetchSearchType_thenFail() {
+        HybridQueryPhaseSearcher hybridQueryPhaseSearcher = new HybridQueryPhaseSearcher();
+        SearchContext searchContext = mock(SearchContext.class);
+        when(searchContext.searchType()).thenReturn(SearchType.DFS_QUERY_THEN_FETCH);
+
+        HybridQuery hybridQuery = new HybridQuery(
+            List.of(new MatchNoDocsQuery()),
+            HybridQueryContext.builder().paginationDepth(10).build()
+        );
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> hybridQueryPhaseSearcher.searchWith(searchContext, null, hybridQuery, new LinkedList<>(), false, false)
+        );
+
+        org.hamcrest.MatcherAssert.assertThat(
+            exception.getMessage(),
+            containsString("hybrid query does not support search_type [dfs_query_then_fetch]")
+        );
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/util/HybridQueryUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/HybridQueryUtilTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.TermQuery;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
+import org.opensearch.action.search.SearchType;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,6 +46,23 @@ public class HybridQueryUtilTests extends OpenSearchQueryTestCase {
     private static final String FROM_TEXT = "123";
     private static final String TO_TEXT = "456";
     private static final String TEXT_FIELD_NAME = "field";
+
+    @SneakyThrows
+    public void testValidateHybridQuerySearchType_whenDfsQueryThenFetch_thenFail() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> HybridQueryUtil.validateHybridQuerySearchType(SearchType.DFS_QUERY_THEN_FETCH)
+        );
+        assertThat(exception.getMessage(), containsString("hybrid query does not support search_type [dfs_query_then_fetch]"));
+    }
+
+    public void testValidateHybridQuerySearchType_whenQueryThenFetch_thenSuccess() {
+        HybridQueryUtil.validateHybridQuerySearchType(SearchType.QUERY_THEN_FETCH);
+    }
+
+    public void testValidateHybridQuerySearchType_whenDefaultSearchType_thenSuccess() {
+        HybridQueryUtil.validateHybridQuerySearchType(SearchType.DEFAULT);
+    }
 
     @SneakyThrows
     public void testIsHybridQueryCheck_whenQueryIsHybridQueryInstance_thenSuccess() {


### PR DESCRIPTION
## Summary

Block hybrid query execution when `search_type=dfs_query_then_fetch`.

Hybrid search relies on `SearchPhaseResultsProcessor` running between the QUERY and FETCH phases to normalize and combine scores from individual sub-queries. For multi-shard searches using `dfs_query_then_fetch`, OpenSearch executes a DFS_QUERY phase instead of QUERY, causing the hybrid normalization step to be skipped and incorrect results to be returned.

As discussed in #1490, this PR adds validation to reject this unsupported combination.

## Changes

* Added request-level validation in `HybridQuerySearchRequestFilter` to reject hybrid queries with `search_type=dfs_query_then_fetch`.
* Added validation in `HybridQueryPhaseSearcher` as a final line of defense for execution paths that may bypass request-level validation (for example DLS-wrapped hybrid queries).
* Added `HybridQueryUtil.validateHybridQuerySearchType(...)` to centralize validation logic and error messaging.
* Added unit tests covering utility, request-filter, and query-phase validation.

## Error Message

```text
hybrid query does not support search_type [dfs_query_then_fetch]
```

Fixes #1490


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
