### PR TITLE
Push down hybrid filters to nested neural/kNN queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
-
+* Fix hybrid.filter not propagated as kNN pre-filter for nested neural/kNN sub-queries ([#1874](https://github.com/opensearch-project/neural-search/pull/1874))
 ### Infrastructure
 
 ### Documentation

--- a/src/main/java/org/opensearch/neuralsearch/grpc/proto/request/search/query/HybridQueryBuilderProtoUtils.java
+++ b/src/main/java/org/opensearch/neuralsearch/grpc/proto/request/search/query/HybridQueryBuilderProtoUtils.java
@@ -9,6 +9,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.util.HybridQueryFilterUtil;
 import org.opensearch.transport.grpc.spi.QueryBuilderProtoConverterRegistry;
 import org.opensearch.protobufs.HybridQuery;
 import org.opensearch.protobufs.QueryContainer;
@@ -97,7 +98,7 @@ public class HybridQueryBuilderProtoUtils {
             if (filter == null) {
                 compoundQueryBuilder.add(query);
             } else {
-                compoundQueryBuilder.add(query.filter(filter));
+                compoundQueryBuilder.add(HybridQueryFilterUtil.applyFilterToSubQuery(query, filter));
             }
 
             if (hasInnerHits == false) {

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -41,6 +41,7 @@ import lombok.experimental.Accessors;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.neuralsearch.stats.events.EventStatName;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
+import org.opensearch.neuralsearch.util.HybridQueryFilterUtil;
 
 import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isClusterOnOrAfterMinReqVersionForPaginationInHybridQuery;
 
@@ -120,8 +121,8 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         ListIterator<QueryBuilder> iterator = queries.listIterator();
         while (iterator.hasNext()) {
             QueryBuilder query = iterator.next();
-            // set the query again because query.filter(filter) can return new query.
-            iterator.set(query.filter(filter));
+            // set the query again because applyFilterToSubQuery can return new query.
+            iterator.set(HybridQueryFilterUtil.applyFilterToSubQuery(query, filter));
         }
         return this;
     }
@@ -281,7 +282,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             if (filter == null) {
                 compoundQueryBuilder.add(query);
             } else {
-                compoundQueryBuilder.add(query.filter(filter));
+                compoundQueryBuilder.add(HybridQueryFilterUtil.applyFilterToSubQuery(query, filter));
             }
 
             // Check if children have inner hits for stats

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilder.java
@@ -403,6 +403,21 @@ public class NeuralKNNQueryBuilder extends AbstractQueryBuilder<NeuralKNNQueryBu
     }
 
     /**
+     * Applies a filter to the underlying KNN query so the kNN engine can pre-filter candidates.
+     *
+     * @param filterToBeAdded filter to apply
+     * @return a new builder with the filter applied to the underlying KNN query
+     */
+    @Override
+    public QueryBuilder filter(QueryBuilder filterToBeAdded) {
+        if (validateFilterParams(filterToBeAdded) == false) {
+            return this;
+        }
+        KNNQueryBuilder filteredKnnQueryBuilder = (KNNQueryBuilder) knnQueryBuilder.filter(filterToBeAdded);
+        return new NeuralKNNQueryBuilder(filteredKnnQueryBuilder, originalQueryText);
+    }
+
+    /**
      * Gets the name of this query for serialization purposes.
      *
      * @return The writeable name

--- a/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/NeuralKNNQueryBuilder.java
@@ -414,7 +414,10 @@ public class NeuralKNNQueryBuilder extends AbstractQueryBuilder<NeuralKNNQueryBu
             return this;
         }
         KNNQueryBuilder filteredKnnQueryBuilder = (KNNQueryBuilder) knnQueryBuilder.filter(filterToBeAdded);
-        return new NeuralKNNQueryBuilder(filteredKnnQueryBuilder, originalQueryText);
+        NeuralKNNQueryBuilder result = new NeuralKNNQueryBuilder(filteredKnnQueryBuilder, originalQueryText);
+        result.boost(boost());
+        result.queryName(queryName());
+        return result;
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/util/HybridQueryFilterUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/HybridQueryFilterUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import lombok.experimental.UtilityClass;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.NestedQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralKNNQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+
+/**
+ * Utility for applying hybrid query filters to sub-queries.
+ */
+@UtilityClass
+public class HybridQueryFilterUtil {
+
+    /**
+     * Applies a hybrid filter to a sub-query. For nested queries whose inner query supports efficient
+     * vector pre-filtering, the filter is pushed down to the inner query so the kNN engine can pre-filter
+     * candidates. Other queries use the default {@link QueryBuilder#filter(QueryBuilder)} behavior.
+     *
+     * @param query sub-query to apply the filter to
+     * @param filter hybrid filter to apply
+     * @return query with the filter applied
+     */
+    public static QueryBuilder applyFilterToSubQuery(QueryBuilder query, QueryBuilder filter) {
+        if (AbstractQueryBuilder.validateFilterParams(filter) == false) {
+            return query;
+        }
+        if (query instanceof NestedQueryBuilder nestedQuery && supportsVectorPreFilter(nestedQuery.query())) {
+            QueryBuilder filteredInnerQuery = applyFilterToSubQuery(nestedQuery.query(), filter);
+            return copyNestedQueryBuilder(nestedQuery, filteredInnerQuery);
+        }
+        return query.filter(filter);
+    }
+
+    private static boolean supportsVectorPreFilter(QueryBuilder query) {
+        return query instanceof NeuralQueryBuilder || query instanceof KNNQueryBuilder || query instanceof NeuralKNNQueryBuilder;
+    }
+
+    private static NestedQueryBuilder copyNestedQueryBuilder(NestedQueryBuilder nestedQuery, QueryBuilder innerQuery) {
+        NestedQueryBuilder copy = new NestedQueryBuilder(nestedQuery.path(), innerQuery, nestedQuery.scoreMode());
+        if (nestedQuery.innerHit() != null) {
+            copy.innerHit(nestedQuery.innerHit());
+        }
+        if (nestedQuery.ignoreUnmapped()) {
+            copy.ignoreUnmapped(true);
+        }
+        copy.boost(nestedQuery.boost());
+        copy.queryName(nestedQuery.queryName());
+        return copy;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -1112,6 +1112,110 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertEquals(new MatchAllQueryBuilder(), updatedNeuralSparseQueryBuilder.filter().get(0));
     }
 
+    public void testFilter_whenNestedNeuralQuery_thenFilterPushedToInnerNeuralQuery() {
+        setUpClusterService();
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName("embeddings.embedding")
+            .queryText("search terms")
+            .modelId("my-model-id")
+            .k(100)
+            .build();
+        NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder("embeddings", neuralQueryBuilder, ScoreMode.Max);
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(nestedQueryBuilder);
+
+        TermQueryBuilder filter = new TermQueryBuilder("_id", "target-doc-id");
+        HybridQueryBuilder updatedHybridQueryBuilder = (HybridQueryBuilder) hybridQueryBuilder.filter(filter);
+
+        QueryBuilder updatedSubQuery = updatedHybridQueryBuilder.queries().get(0);
+        assertTrue(updatedSubQuery instanceof NestedQueryBuilder);
+        QueryBuilder innerQuery = ((NestedQueryBuilder) updatedSubQuery).query();
+        assertTrue(innerQuery instanceof NeuralQueryBuilder);
+        assertEquals(filter, ((NeuralQueryBuilder) innerQuery).queryfilter());
+    }
+
+    public void testFilter_whenNestedMatchQuery_thenFilterWrappedInBoolQuery() {
+        setUpClusterService();
+        NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder(
+            "embeddings",
+            new MatchQueryBuilder("embeddings.text", "search terms"),
+            ScoreMode.Max
+        );
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder().add(nestedQueryBuilder);
+
+        TermQueryBuilder filter = new TermQueryBuilder("_id", "target-doc-id");
+        HybridQueryBuilder updatedHybridQueryBuilder = (HybridQueryBuilder) hybridQueryBuilder.filter(filter);
+
+        QueryBuilder updatedSubQuery = updatedHybridQueryBuilder.queries().get(0);
+        assertTrue(updatedSubQuery instanceof BoolQueryBuilder);
+        BoolQueryBuilder boolQueryBuilder = (BoolQueryBuilder) updatedSubQuery;
+        assertTrue(boolQueryBuilder.must().get(0) instanceof NestedQueryBuilder);
+        assertEquals(filter, boolQueryBuilder.filter().get(0));
+    }
+
+    @SneakyThrows
+    public void testFromXContent_whenHybridFilterWithNestedNeuralQuery_thenFilterPushedToInnerNeuralQuery() {
+        setUpClusterService();
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("filter")
+            .startObject(TermQueryBuilder.NAME)
+            .field("_id", "target-doc-id")
+            .endObject()
+            .endObject()
+            .startArray("queries")
+            .startObject()
+            .startObject(NestedQueryBuilder.NAME)
+            .field("path", "embeddings")
+            .startObject("query")
+            .startObject(NeuralQueryBuilder.NAME)
+            .startObject("embeddings.embedding")
+            .field(QUERY_TEXT_FIELD.getPreferredName(), "search terms")
+            .field(MODEL_ID_FIELD.getPreferredName(), "my-model-id")
+            .field(K_FIELD.getPreferredName(), 100)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject();
+
+        NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(
+            List.of(
+                new NamedXContentRegistry.Entry(QueryBuilder.class, new ParseField(TermQueryBuilder.NAME), TermQueryBuilder::fromXContent),
+                new NamedXContentRegistry.Entry(
+                    QueryBuilder.class,
+                    new ParseField(NeuralQueryBuilder.NAME),
+                    NeuralQueryBuilder::fromXContent
+                ),
+                new NamedXContentRegistry.Entry(
+                    QueryBuilder.class,
+                    new ParseField(NestedQueryBuilder.NAME),
+                    NestedQueryBuilder::fromXContent
+                ),
+                new NamedXContentRegistry.Entry(
+                    QueryBuilder.class,
+                    new ParseField(HybridQueryBuilder.NAME),
+                    HybridQueryBuilder::fromXContent
+                )
+            )
+        );
+        XContentParser contentParser = createParser(
+            namedXContentRegistry,
+            xContentBuilder.contentType().xContent(),
+            BytesReference.bytes(xContentBuilder)
+        );
+        contentParser.nextToken();
+
+        HybridQueryBuilder hybridQueryBuilder = HybridQueryBuilder.fromXContent(contentParser);
+        QueryBuilder updatedSubQuery = hybridQueryBuilder.queries().get(0);
+        assertTrue(updatedSubQuery instanceof NestedQueryBuilder);
+        QueryBuilder innerQuery = ((NestedQueryBuilder) updatedSubQuery).query();
+        assertTrue(innerQuery instanceof NeuralQueryBuilder);
+        TermQueryBuilder expectedFilter = new TermQueryBuilder("_id", "target-doc-id");
+        assertEquals(expectedFilter, ((NeuralQueryBuilder) innerQuery).queryfilter());
+    }
+
     public void testExtractInnerHitsBuilders() {
         NestedQueryBuilder nestedQueryBuilder1 = new NestedQueryBuilder(
             "path1",

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryNestedFilterIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryNestedFilterIT.java
@@ -61,6 +61,7 @@ public class HybridQueryNestedFilterIT extends BaseNeuralSearchIT {
         createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
 
         String modelId = prepareModel();
+        waitForModelToBeReady(modelId);
         float[] queryVector = runInference(modelId, QUERY_TEXT);
         float[] decoyVector = queryVector;
         float[] targetVector = createRandomVector(TEST_DIMENSION);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryNestedFilterIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryNestedFilterIT.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.search.join.ScoreMode;
+import org.junit.BeforeClass;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.NestedQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
+import static org.opensearch.neuralsearch.util.TestUtils.getMaxScore;
+import static org.opensearch.neuralsearch.util.TestUtils.TEST_DIMENSION;
+import static org.opensearch.neuralsearch.util.TestUtils.TEST_SPACE_TYPE;
+import static org.opensearch.neuralsearch.util.TestUtils.createRandomVector;
+
+/**
+ * Integration tests for {@link HybridQueryBuilder#filter(org.opensearch.index.query.QueryBuilder)} when
+ * sub-queries are wrapped in nested queries. See https://github.com/opensearch-project/neural-search/issues/1759.
+ */
+public class HybridQueryNestedFilterIT extends BaseNeuralSearchIT {
+
+    private static final String TEST_INDEX = "test-hybrid-nested-filter-index";
+    private static final String SEARCH_PIPELINE = "phase-results-hybrid-nested-filter-pipeline";
+    private static final String NESTED_PATH = "embeddings";
+    private static final String NESTED_TEXT_FIELD = NESTED_PATH + ".text";
+    private static final String NESTED_KNN_FIELD = NESTED_PATH + ".embedding";
+    private static final String TARGET_DOC_ID = "target";
+    private static final String DECOY_DOC_ID = "decoy";
+    private static final String QUERY_TEXT = "search terms";
+    private static final String DECOY_TEXT = "unrelated content";
+    private static final int K = 1;
+
+    @BeforeClass
+    @SneakyThrows
+    public static void setUpCluster() {
+        HybridQueryNestedFilterIT instance = new HybridQueryNestedFilterIT();
+        instance.initClient();
+        instance.updateClusterSettings();
+    }
+
+    /**
+     * When hybrid.filter targets a document whose nested embedding is outside the global top-k, the filter must be
+     * pushed into the nested neural query as a kNN pre-filter so both hybrid sub-queries contribute to the score.
+     */
+    @SneakyThrows
+    public void testHybridFilter_whenNestedNeuralQuery_thenKnnPreFilterFindsTargetDocument() {
+        updateClusterSettings(CONCURRENT_SEGMENT_SEARCH_ENABLED, false);
+        prepareNestedIndexWithDocuments();
+        createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
+
+        String modelId = prepareModel();
+        float[] queryVector = runInference(modelId, QUERY_TEXT);
+        float[] decoyVector = queryVector;
+        float[] targetVector = createRandomVector(TEST_DIMENSION);
+
+        indexNestedDocument(TARGET_DOC_ID, QUERY_TEXT, targetVector);
+        indexNestedDocument(DECOY_DOC_ID, DECOY_TEXT, decoyVector);
+
+        MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery(NESTED_TEXT_FIELD, QUERY_TEXT);
+        NestedQueryBuilder matchNestedQueryBuilder = QueryBuilders.nestedQuery(NESTED_PATH, matchQueryBuilder, ScoreMode.Max);
+
+        NeuralQueryBuilder neuralQueryBuilder = NeuralQueryBuilder.builder()
+            .fieldName(NESTED_KNN_FIELD)
+            .queryText(QUERY_TEXT)
+            .modelId(modelId)
+            .k(K)
+            .build();
+        NestedQueryBuilder neuralNestedQueryBuilder = QueryBuilders.nestedQuery(NESTED_PATH, neuralQueryBuilder, ScoreMode.Max);
+
+        HybridQueryBuilder hybridQueryBuilder = new HybridQueryBuilder();
+        hybridQueryBuilder.add(matchNestedQueryBuilder);
+        hybridQueryBuilder.add(neuralNestedQueryBuilder);
+        hybridQueryBuilder.filter(new TermQueryBuilder("_id", TARGET_DOC_ID));
+
+        Map<String, Object> searchResponse = search(
+            TEST_INDEX,
+            hybridQueryBuilder,
+            null,
+            10,
+            Map.of("search_pipeline", SEARCH_PIPELINE),
+            null
+        );
+
+        assertEquals(1, getHitCount(searchResponse));
+        assertEquals(TARGET_DOC_ID, getFirstInnerHit(searchResponse).get("_id"));
+        assertTrue(getMaxScore(searchResponse).isPresent());
+        assertEquals(1.0f, getMaxScore(searchResponse).get(), DELTA_FOR_SCORE_ASSERTION);
+    }
+
+    @SneakyThrows
+    private void prepareNestedIndexWithDocuments() {
+        if (indexExists(TEST_INDEX)) {
+            return;
+        }
+        String indexConfiguration = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("settings")
+            .field("number_of_shards", 1)
+            .field("number_of_replicas", 0)
+            .field("index.knn", true)
+            .endObject()
+            .startObject("mappings")
+            .startObject("properties")
+            .startObject(NESTED_PATH)
+            .field("type", "nested")
+            .startObject("properties")
+            .startObject("text")
+            .field("type", "text")
+            .endObject()
+            .startObject("embedding")
+            .field("type", "knn_vector")
+            .field("dimension", TEST_DIMENSION)
+            .startObject("method")
+            .field("engine", "lucene")
+            .field("space_type", TEST_SPACE_TYPE.getValue())
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createIndexWithConfiguration(TEST_INDEX, indexConfiguration, "");
+    }
+
+    @SneakyThrows
+    private void indexNestedDocument(final String docId, final String text, final float[] embedding) {
+        String source = XContentFactory.jsonBuilder()
+            .startObject()
+            .startArray(NESTED_PATH)
+            .startObject()
+            .field("text", text)
+            .field("embedding", embedding)
+            .endObject()
+            .endArray()
+            .endObject()
+            .toString();
+        makeRequest(
+            client(),
+            "PUT",
+            String.format(Locale.ROOT, "/%s/_doc/%s?refresh=true", TEST_INDEX, docId),
+            null,
+            toHttpEntity(source),
+            null
+        );
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/util/HybridQueryFilterUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/HybridQueryFilterUtilTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.util;
+
+import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.NestedQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
+import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
+import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+import org.opensearch.neuralsearch.sparse.query.SparseAnnQueryBuilder;
+
+import static org.opensearch.neuralsearch.util.NeuralSearchClusterTestUtils.setUpClusterService;
+import static org.opensearch.neuralsearch.util.TestUtils.TEST_DIMENSION;
+import static org.opensearch.neuralsearch.util.TestUtils.createRandomVector;
+
+public class HybridQueryFilterUtilTests extends OpenSearchQueryTestCase {
+
+    private static final TermQueryBuilder FILTER = new TermQueryBuilder("_id", "target-doc-id");
+
+    public void testApplyFilterToSubQuery_whenNestedNeuralQuery_thenFilterOnInnerNeuralQuery() {
+        setUpClusterService();
+        NeuralQueryBuilder neuralQuery = NeuralQueryBuilder.builder()
+            .fieldName("embeddings.embedding")
+            .queryText("search terms")
+            .modelId("model-id")
+            .k(100)
+            .build();
+        NestedQueryBuilder nestedQuery = new NestedQueryBuilder("embeddings", neuralQuery, ScoreMode.Max);
+
+        QueryBuilder result = HybridQueryFilterUtil.applyFilterToSubQuery(nestedQuery, FILTER);
+
+        assertTrue(result instanceof NestedQueryBuilder);
+        QueryBuilder innerQuery = ((NestedQueryBuilder) result).query();
+        assertTrue(innerQuery instanceof NeuralQueryBuilder);
+        assertEquals(FILTER, ((NeuralQueryBuilder) innerQuery).queryfilter());
+    }
+
+    public void testApplyFilterToSubQuery_whenNestedKnnQuery_thenFilterOnInnerKnnQuery() {
+        KNNQueryBuilder knnQuery = KNNQueryBuilder.builder()
+            .fieldName("embeddings.embedding")
+            .vector(createRandomVector(TEST_DIMENSION))
+            .k(100)
+            .build();
+        NestedQueryBuilder nestedQuery = new NestedQueryBuilder("embeddings", knnQuery, ScoreMode.Max);
+
+        QueryBuilder result = HybridQueryFilterUtil.applyFilterToSubQuery(nestedQuery, FILTER);
+
+        assertTrue(result instanceof NestedQueryBuilder);
+        QueryBuilder innerQuery = ((NestedQueryBuilder) result).query();
+        assertTrue(innerQuery instanceof KNNQueryBuilder);
+        assertEquals(FILTER, ((KNNQueryBuilder) innerQuery).getFilter());
+    }
+
+    public void testApplyFilterToSubQuery_whenNestedMatchQuery_thenFilterWrappedInBoolQuery() {
+        NestedQueryBuilder nestedQuery = new NestedQueryBuilder(
+            "embeddings",
+            new MatchQueryBuilder("embeddings.text", "search terms"),
+            ScoreMode.Max
+        );
+
+        QueryBuilder result = HybridQueryFilterUtil.applyFilterToSubQuery(nestedQuery, FILTER);
+
+        assertTrue(result instanceof BoolQueryBuilder);
+        BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
+        assertTrue(boolQuery.must().get(0) instanceof NestedQueryBuilder);
+        assertEquals(FILTER, boolQuery.filter().get(0));
+    }
+
+    public void testApplyFilterToSubQuery_whenNestedBoolQuery_thenFilterWrappedInBoolQuery() {
+        BoolQueryBuilder innerBool = QueryBuilders.boolQuery()
+            .must(new MatchQueryBuilder("embeddings.text", "search terms"))
+            .filter(new TermQueryBuilder("embeddings.type", "chunk"));
+        NestedQueryBuilder nestedQuery = new NestedQueryBuilder("embeddings", innerBool, ScoreMode.Max);
+
+        QueryBuilder result = HybridQueryFilterUtil.applyFilterToSubQuery(nestedQuery, FILTER);
+
+        assertTrue(result instanceof BoolQueryBuilder);
+        BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
+        assertTrue(boolQuery.must().get(0) instanceof NestedQueryBuilder);
+        assertEquals(FILTER, boolQuery.filter().get(0));
+    }
+
+    public void testApplyFilterToSubQuery_whenNestedNeuralSparseQuery_thenFilterWrappedInBoolQuery() {
+        SparseAnnQueryBuilder sparseAnnQuery = new SparseAnnQueryBuilder().fieldName("embeddings.sparse")
+            .k(10)
+            .queryTokens(java.util.Map.of("1000", 1.0f));
+        NeuralSparseQueryBuilder neuralSparseQuery = new NeuralSparseQueryBuilder().fieldName("embeddings.sparse")
+            .sparseAnnQueryBuilder(sparseAnnQuery);
+        NestedQueryBuilder nestedQuery = new NestedQueryBuilder("embeddings", neuralSparseQuery, ScoreMode.Max);
+
+        QueryBuilder result = HybridQueryFilterUtil.applyFilterToSubQuery(nestedQuery, FILTER);
+
+        assertTrue(result instanceof BoolQueryBuilder);
+        BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
+        assertTrue(boolQuery.must().get(0) instanceof NestedQueryBuilder);
+        assertEquals(FILTER, boolQuery.filter().get(0));
+    }
+
+    public void testApplyFilterToSubQuery_whenNestedHybridQuery_thenFilterWrappedInBoolQuery() {
+        HybridQueryBuilder hybridQuery = new HybridQueryBuilder().add(new MatchQueryBuilder("embeddings.text", "search terms"));
+        NestedQueryBuilder nestedQuery = new NestedQueryBuilder("embeddings", hybridQuery, ScoreMode.Max);
+
+        QueryBuilder result = HybridQueryFilterUtil.applyFilterToSubQuery(nestedQuery, FILTER);
+
+        assertTrue(result instanceof BoolQueryBuilder);
+        BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
+        assertTrue(boolQuery.must().get(0) instanceof NestedQueryBuilder);
+        assertEquals(FILTER, boolQuery.filter().get(0));
+    }
+}


### PR DESCRIPTION
## Summary

Fix `hybrid.filter` propagation for nested neural/kNN sub-queries.

When `hybrid.filter` is applied to a hybrid query containing a nested neural/kNN query, the filter was previously wrapped at the parent level and never reached the underlying kNN query. As a result, ANN search ran against the global candidate set and filtering behaved effectively as a post-filter.

This PR pushes the filter into the inner neural/kNN query so the kNN engine can pre-filter candidates before ANN search.

Fixes #1759.

## Root Cause

`HybridQueryBuilder.filter()` distributes filters by calling:

```java
query.filter(filter)
```

on each sub-query.

`NestedQueryBuilder` does not override `filter()` and inherits the default implementation from `AbstractQueryBuilder`, which wraps the query in a parent-level `BoolQueryBuilder`:

```java
BoolQueryBuilder b = new BoolQueryBuilder();
b.must(this);
b.filter(filter);
```

This keeps the filter outside the nested neural/kNN query, preventing it from reaching the kNN engine as a pre-filter.
This matches the tentative root cause identified by @martin-gaievski in #1759.

## Solution

Introduced `HybridQueryFilterUtil.applyFilterToSubQuery()` and applied it across all hybrid filter entry points:

* `HybridQueryBuilder.filter()`
* `HybridQueryBuilder.fromXContent()` (REST)
* `HybridQueryBuilderProtoUtils.fromProto()` (gRPC)

For nested sub-queries whose inner query supports vector pre-filtering (`NeuralQueryBuilder`, `KNNQueryBuilder`, `NeuralKNNQueryBuilder`), the filter is pushed down to the inner query.

All other query types retain the existing behavior.

Also added `NeuralKNNQueryBuilder.filter()` to delegate filter application to the underlying `KNNQueryBuilder`.

## Tests

Added:

* Unit tests validating filter pushdown for nested neural queries.
* Regression tests verifying non-vector nested queries retain existing behavior.
* REST parsing coverage.
* Integration test reproducing the issue scenario and verifying neural contribution is preserved when `hybrid.filter` is used.

### Validation

```bash
./gradlew test
./gradlew integTest --tests "org.opensearch.neuralsearch.query.HybridQueryNestedFilterIT"
```

## Notes

This change intentionally focuses on dense neural/kNN queries. Sparse ANN query types are left unchanged to avoid expanding scope and can be addressed separately if needed.


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
