### PR TITLE
Fix hybrid explanation single normalization block for nested-field indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Improve hybrid query filter validation error message ([#1870](https://github.com/opensearch-project/neural-search/pull/1870))
 ### Bug Fixes
 * [Hybrid Query] Block hybrid query execution with `search_type=dfs_query_then_fetch` ([#1873](https://github.com/opensearch-project/neural-search/pull/1873))
+* [Hybrid Query] Fix `hybrid_score_explanation` returning a single normalization block for hybrid queries on indices that contain a nested field ([#1876](https://github.com/opensearch-project/neural-search/pull/1876))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessor.java
@@ -40,6 +40,11 @@ public class ExplanationResponseProcessor implements SearchResponseProcessor {
 
     public static final String TYPE = "hybrid_score_explanation";
 
+    // Description emitted by HybridQueryWeight#explain for the hybrid "combined score of:" node, which has
+    // exactly one child per sub-query. Used to locate the hybrid explanation when OpenSearch core wraps the
+    // hybrid query in a BooleanQuery (e.g. for indices that contain a nested field, or with alias/DLS filters).
+    private static final String HYBRID_COMBINED_SCORE_DESCRIPTION = "combined score of:";
+
     private final String description;
     private final String tag;
     private final boolean ignoreFailure;
@@ -100,6 +105,14 @@ public class ExplanationResponseProcessor implements SearchResponseProcessor {
                     CombinedExplanationDetails combinedExplainDetail = combinedExplainDetails.get(searchShard).get(explanationIndexByShard);
                     // Extract various explanation components
                     Explanation queryLevelExplanation = searchHit.getExplanation();
+                    // When the index mapping contains a nested field (or with alias/DLS filters), OpenSearch core
+                    // wraps the hybrid query in a BooleanQuery, so the shard-level explanation is a wrapper (e.g.
+                    // "sum of:") whose child is the hybrid "combined score of:" node. Descend to that node so the
+                    // normalization details map to the hybrid sub-queries instead of the wrapper's clauses.
+                    Explanation hybridQueryExplanation = getHybridQueryExplanation(queryLevelExplanation);
+                    if (Objects.nonNull(hybridQueryExplanation)) {
+                        queryLevelExplanation = hybridQueryExplanation;
+                    }
                     ExplanationDetails normalizationExplanation = combinedExplainDetail.getNormalizationExplanations();
                     ExplanationDetails combinationExplanation = combinedExplainDetail.getCombinationExplanations();
                     // Create normalized explanations for each detail
@@ -152,6 +165,30 @@ public class ExplanationResponseProcessor implements SearchResponseProcessor {
             }
         }
         return response;
+    }
+
+    /**
+     * Locates the hybrid query explanation node within a shard-level explanation tree. {@link
+     * org.opensearch.neuralsearch.query.HybridQueryWeight#explain} emits this node with description
+     * {@code "combined score of:"} and exactly one child per sub-query. When the index mapping contains a nested
+     * field (or with alias/DLS filters), OpenSearch core wraps the hybrid query in a BooleanQuery, nesting the
+     * hybrid node under a wrapper such as {@code "sum of:"}. This method returns the wrapper-free hybrid node so
+     * that normalization details can be mapped to the sub-queries.
+     *
+     * @param explanation shard-level explanation, possibly wrapped in a BooleanQuery
+     * @return the hybrid {@code "combined score of:"} node, or {@code null} if it is not present
+     */
+    private static Explanation getHybridQueryExplanation(final Explanation explanation) {
+        if (HYBRID_COMBINED_SCORE_DESCRIPTION.equals(explanation.getDescription())) {
+            return explanation;
+        }
+        for (Explanation detail : explanation.getDetails()) {
+            Explanation hybridQueryExplanation = getHybridQueryExplanation(detail);
+            if (Objects.nonNull(hybridQueryExplanation)) {
+                return hybridQueryExplanation;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/src/test/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/ExplanationResponseProcessorTests.java
@@ -370,6 +370,103 @@ public class ExplanationResponseProcessorTests extends OpenSearchTestCase {
         assertEquals(0, processedExplanation.getDetails().length);
     }
 
+    @SneakyThrows
+    public void testProcessResponse_whenHybridWrappedInBooleanQueryForNestedField_thenAllNormalizationBlocksPresent() {
+        // Setup: reproduce the shard-level explanation OpenSearch core produces when the index mapping contains a
+        // nested field — the hybrid "combined score of:" node is wrapped in a BooleanQuery ("sum of:") together
+        // with a FieldExistsQuery[_primary_term] filter clause (Queries.newNonNestedFilter()). See GH issue #1875.
+        SearchHit searchHit = new SearchHit(1);
+        SearchShardTarget shardTarget = new SearchShardTarget("node1", new ShardId("index", "_na_", 0), null, null);
+        searchHit.shard(shardTarget);
+
+        Explanation textSubQuery = Explanation.match(0.61f, "weight(name:offshore in 1) [PerFieldSimilarity], result of:");
+        Explanation knnSubQuery = Explanation.match(1.0f, "within top 5 docs");
+        Explanation hybridNode = Explanation.match(1.0f, "combined score of:", textSubQuery, knnSubQuery);
+        Explanation nonNestedFilter = Explanation.match(
+            0.0f,
+            "match on required clause, product of:",
+            Explanation.match(0.0f, "# clause"),
+            Explanation.match(1.0f, "FieldExistsQuery [field=_primary_term]")
+        );
+        Explanation wrappedExplanation = Explanation.match(1.61f, "sum of:", hybridNode, nonNestedFilter);
+        searchHit.explanation(wrappedExplanation);
+
+        // one normalization detail per sub-query
+        ExplanationDetails normalizationExplanation = new ExplanationDetails(
+            Arrays.asList(Pair.of(1.0f, "min_max normalization of:"), Pair.of(0.7f, "min_max normalization of:"))
+        );
+
+        SearchHits searchHits = new SearchHits(new SearchHit[] { searchHit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse searchResponse = createSearchResponse(searchHits);
+        PipelineProcessingContext context = createContextWithExplanations(searchHit.getShard(), normalizationExplanation);
+
+        // Act
+        ExplanationResponseProcessor processor = new ExplanationResponseProcessor(DESCRIPTION, PROCESSOR_TAG, false);
+        SearchResponse processedResponse = processor.processResponse(new SearchRequest(), searchResponse, context);
+
+        // Assert: one normalization block per sub-query (before the fix both sub-queries collapsed into a single block)
+        Explanation processedExplanation = processedResponse.getHits().getHits()[0].getExplanation();
+        Explanation[] details = processedExplanation.getDetails();
+        assertEquals(2, details.length);
+
+        assertEquals("min_max normalization of:", details[0].getDescription());
+        assertEquals(1.0f, details[0].getValue().floatValue(), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(1, details[0].getDetails().length);
+        assertEquals("weight(name:offshore in 1) [PerFieldSimilarity], result of:", details[0].getDetails()[0].getDescription());
+
+        assertEquals("min_max normalization of:", details[1].getDescription());
+        assertEquals(0.7f, details[1].getValue().floatValue(), DELTA_FOR_SCORE_ASSERTION);
+        assertEquals(1, details[1].getDetails().length);
+        assertEquals("within top 5 docs", details[1].getDetails()[0].getDescription());
+    }
+
+    @SneakyThrows
+    public void testProcessResponse_whenHybridWrappedInBooleanQueryWithThreeSubQueries_thenNoMismatchAndAllBlocksPresent() {
+        // Setup: same nested-field wrapper, but three sub-queries. Before the fix, the size check compared the 3
+        // normalization details against the wrapper's 2 top-level clauses and threw IllegalStateException; after
+        // the fix it descends to the hybrid node (3 children) and emits 3 blocks. See GH issue #1875.
+        SearchHit searchHit = new SearchHit(1);
+        SearchShardTarget shardTarget = new SearchShardTarget("node1", new ShardId("index", "_na_", 0), null, null);
+        searchHit.shard(shardTarget);
+
+        Explanation hybridNode = Explanation.match(
+            1.0f,
+            "combined score of:",
+            Explanation.match(0.5f, "weight(name:a) [PerFieldSimilarity], result of:"),
+            Explanation.match(0.6f, "weight(body:b) [PerFieldSimilarity], result of:"),
+            Explanation.match(1.0f, "within top 5 docs")
+        );
+        Explanation nonNestedFilter = Explanation.match(
+            0.0f,
+            "match on required clause, product of:",
+            Explanation.match(0.0f, "# clause"),
+            Explanation.match(1.0f, "FieldExistsQuery [field=_primary_term]")
+        );
+        Explanation wrappedExplanation = Explanation.match(2.1f, "sum of:", hybridNode, nonNestedFilter);
+        searchHit.explanation(wrappedExplanation);
+
+        ExplanationDetails normalizationExplanation = new ExplanationDetails(
+            Arrays.asList(
+                Pair.of(0.5f, "min_max normalization of:"),
+                Pair.of(0.6f, "min_max normalization of:"),
+                Pair.of(1.0f, "min_max normalization of:")
+            )
+        );
+
+        SearchHits searchHits = new SearchHits(new SearchHit[] { searchHit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse searchResponse = createSearchResponse(searchHits);
+        PipelineProcessingContext context = createContextWithExplanations(searchHit.getShard(), normalizationExplanation);
+
+        ExplanationResponseProcessor processor = new ExplanationResponseProcessor(DESCRIPTION, PROCESSOR_TAG, false);
+        SearchResponse processedResponse = processor.processResponse(new SearchRequest(), searchResponse, context);
+
+        Explanation[] details = processedResponse.getHits().getHits()[0].getExplanation().getDetails();
+        assertEquals(3, details.length);
+        for (Explanation detail : details) {
+            assertEquals("min_max normalization of:", detail.getDescription());
+        }
+    }
+
     public void testProcessResponseThrowsExceptionWhenExplanationLengthsMismatch() {
         ExplanationResponseProcessor processor = new ExplanationResponseProcessor("test description", "test tag", false);
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryInnerHitsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryInnerHitsIT.java
@@ -293,49 +293,52 @@ public class HybridQueryInnerHitsIT extends BaseNeuralSearchIT {
         String expectedTopLevelDescription = "arithmetic_mean combination of:";
         assertEquals(expectedTopLevelDescription, explanationForHit1.get("description"));
 
-        // Normalization explanation
+        // Normalization explanation: one "min_max normalization of:" block per sub-query.
+        // Both sub-queries are nested queries, so the index contains nested fields and OpenSearch core wraps the
+        // hybrid query in a BooleanQuery. The explanation processor descends to the hybrid node, so each sub-query
+        // gets its own normalization block (previously they were collapsed into a single block, see issue #1875).
         List<Map<String, Object>> hit1Details = getListOfValues(explanationForHit1, "details");
-        assertEquals(1, hit1Details.size());
-        Map<String, Object> hit1DetailsForHit1 = hit1Details.get(0);
-        assertEquals(0.001f, (double) hit1DetailsForHit1.get("value"), DELTA_FOR_SCORE_ASSERTION);
-        assertEquals("min_max normalization of:", hit1DetailsForHit1.get("description"));
-        assertEquals(1, ((List) hit1DetailsForHit1.get("details")).size());
+        assertEquals(2, hit1Details.size());
 
-        // Combination explanation
-        List<Map<String, Object>> hit1CombinationDetails = getListOfValues(hit1DetailsForHit1, "details");
-        assertEquals(1, hit1CombinationDetails.size());
-        Map<String, Object> internalCombinationDetailsForHit1 = hit1CombinationDetails.get(0);
+        // sub-query 1 (nested field "user") — min score in its result set, normalizes to the min_max floor
+        Map<String, Object> hit1NormalizationBlock1 = hit1Details.get(0);
+        assertEquals("min_max normalization of:", hit1NormalizationBlock1.get("description"));
+        assertEquals(0.001f, (double) hit1NormalizationBlock1.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        List<Map<String, Object>> hit1SubQuery1Details = getListOfValues(hit1NormalizationBlock1, "details");
+        assertEquals(1, hit1SubQuery1Details.size());
+        Map<String, Object> hit1SubQuery1Child = hit1SubQuery1Details.get(0);
         assertEquals(
             scoreOfInnerHits.get(TEST_NESTED_FIELD_NAME_1).get(0),
-            (double) internalCombinationDetailsForHit1.get("value"),
+            (double) hit1SubQuery1Child.get("value"),
             DELTA_FOR_SCORE_ASSERTION
         );
-        assertEquals("combined score of:", internalCombinationDetailsForHit1.get("description"));
-        assertEquals(2, ((List) internalCombinationDetailsForHit1.get("details")).size());
-
-        // InnerHitsChild explanation
-        List<Map<String, Object>> hit1ChildDetails = getListOfValues(internalCombinationDetailsForHit1, "details");
-        assertEquals(2, hit1ChildDetails.size());
-
-        Map<String, Object> child1Details = hit1ChildDetails.get(0);
-        assertEquals(scoreOfInnerHits.get(TEST_NESTED_FIELD_NAME_1).get(0), (double) child1Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
         assertEquals(
             "Score based on "
                 + innerHitCountPerFieldName.get(TEST_NESTED_FIELD_NAME_1).get("total").get(0)
                 + " child docs in range from 0 to 11, using score mode Max",
-            child1Details.get("description")
+            hit1SubQuery1Child.get("description")
         );
-        assertEquals(1, ((List) child1Details.get("details")).size());
+        assertEquals(1, ((List) hit1SubQuery1Child.get("details")).size());
 
-        Map<String, Object> child2Details = hit1ChildDetails.get(1);
-        assertEquals(scoreOfInnerHits.get(TEST_NESTED_FIELD_NAME_2).get(0), (double) child2Details.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        // sub-query 2 (nested field "location") — max score in its result set, normalizes to 1.0
+        Map<String, Object> hit1NormalizationBlock2 = hit1Details.get(1);
+        assertEquals("min_max normalization of:", hit1NormalizationBlock2.get("description"));
+        assertEquals(1.0f, (double) hit1NormalizationBlock2.get("value"), DELTA_FOR_SCORE_ASSERTION);
+        List<Map<String, Object>> hit1SubQuery2Details = getListOfValues(hit1NormalizationBlock2, "details");
+        assertEquals(1, hit1SubQuery2Details.size());
+        Map<String, Object> hit1SubQuery2Child = hit1SubQuery2Details.get(0);
+        assertEquals(
+            scoreOfInnerHits.get(TEST_NESTED_FIELD_NAME_2).get(0),
+            (double) hit1SubQuery2Child.get("value"),
+            DELTA_FOR_SCORE_ASSERTION
+        );
         assertEquals(
             "Score based on "
                 + innerHitCountPerFieldName.get(TEST_NESTED_FIELD_NAME_2).get("total").get(0)
                 + " child docs in range from 0 to 11, using score mode Max",
-            child2Details.get("description")
+            hit1SubQuery2Child.get("description")
         );
-        assertEquals(1, ((List) child2Details.get("details")).size());
+        assertEquals(1, ((List) hit1SubQuery2Child.get("details")).size());
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
Fixed incomplete information in `explain` reply for hybrid query.

When an index mapping contains a nested field, OpenSearch core wraps the hybrid query in a BooleanQuery with a FieldExistsQuery[_primary_term] filter clause (Queries.newNonNestedFilter(), to restrict results to root documents). The query phase already unwraps this via HybridQueryUtil, so results and scores are correct, but ExplanationResponseProcessor iterated the wrapper's top-level details instead of the hybrid "combined score of:" node. As a result all sub-queries collapsed into a single "min_max normalization of:" block, and for sub-query counts other than two the size check threw IllegalStateException.

Descend to the hybrid "combined score of:" node (emitted by HybridQueryWeight#explain with one child per sub-query) before mapping the normalization details, falling back to the original explanation when no hybrid node is found. Because it keys off the hybrid node, this also covers other wrappers around a hybrid query (alias filters, security DLS rules) and resolves the IllegalStateException variant.

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1875

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
