### PR TITLE
Allow custom field for previous rerank score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Improve hybrid query filter validation error message ([#1870](https://github.com/opensearch-project/neural-search/pull/1870))
 ### Bug Fixes
+* Add `previous_score_field` to `by_field` rerank processor to avoid overwriting existing document fields ([#1880](https://github.com/opensearch-project/neural-search/pull/1880)) (OpenSearch [#21440](https://github.com/opensearch-project/OpenSearch/issues/21440))
 * [Hybrid Query] Block hybrid query execution with `search_type=dfs_query_then_fetch` ([#1873](https://github.com/opensearch-project/neural-search/pull/1873))
 * [Hybrid Query] Fix `hybrid_score_explanation` returning a single normalization block for hybrid queries on indices that contain a nested field ([#1876](https://github.com/opensearch-project/neural-search/pull/1876))
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/RerankProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/RerankProcessorFactory.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 
 import static org.opensearch.neuralsearch.processor.rerank.ByFieldRerankProcessor.DEFAULT_KEEP_PREVIOUS_SCORE;
+import static org.opensearch.neuralsearch.processor.rerank.ByFieldRerankProcessor.DEFAULT_PREVIOUS_SCORE_FIELD;
 import static org.opensearch.neuralsearch.processor.rerank.ByFieldRerankProcessor.DEFAULT_REMOVE_TARGET_FIELD;
 import static org.opensearch.neuralsearch.processor.rerank.RerankProcessor.processorRequiresContext;
 
@@ -94,6 +95,13 @@ public class RerankProcessorFactory implements Processor.Factory<SearchResponseP
                     ByFieldRerankProcessor.KEEP_PREVIOUS_SCORE,
                     DEFAULT_KEEP_PREVIOUS_SCORE
                 );
+                String previousScoreField = ConfigurationUtils.readStringProperty(
+                    RERANK_PROCESSOR_TYPE,
+                    tag,
+                    rerankerConfig,
+                    ByFieldRerankProcessor.PREVIOUS_SCORE_FIELD,
+                    DEFAULT_PREVIOUS_SCORE_FIELD
+                );
 
                 return new ByFieldRerankProcessor(
                     description,
@@ -102,6 +110,7 @@ public class RerankProcessorFactory implements Processor.Factory<SearchResponseP
                     targetField,
                     removeTargetField,
                     keepPreviousScore,
+                    previousScoreField,
                     contextFetchers
                 );
             default:

--- a/src/main/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessor.java
@@ -48,7 +48,8 @@ import static org.opensearch.neuralsearch.processor.util.ProcessorUtils.validate
  * <ul>
  *   <li>{@code target_field}: The field to be used for reranking (required)</li>
  *   <li>{@code remove_target_field}: Whether to remove the target field from the final results (optional, default: false)</li>
- *   <li>{@code keep_previous_score}: Whether to append the previous score in a field called <code>previous_score</code> (optional, default: false)</li>
+ *   <li>{@code keep_previous_score}: Whether to append the previous score in a configurable field (optional, default: false)</li>
+ *   <li>{@code previous_score_field}: The field name used to store the score calculated before reranking when {@code keep_previous_score} is true (optional, default: {@code previous_score})</li>
  * </ul>
  * <p>
  * Usage example:
@@ -58,7 +59,8 @@ import static org.opensearch.neuralsearch.processor.util.ProcessorUtils.validate
  *     "by_field": {
  *       "target_field": "document.relevance_score",
  *       "remove_target_field": true,
- *       "keep_previous_score": false
+ *       "keep_previous_score": false,
+ *       "previous_score_field": "previous_score"
  *     }
  *   }
  * }
@@ -74,13 +76,16 @@ public class ByFieldRerankProcessor extends RescoringRerankProcessor {
     public static final String TARGET_FIELD = "target_field";
     public static final String REMOVE_TARGET_FIELD = "remove_target_field";
     public static final String KEEP_PREVIOUS_SCORE = "keep_previous_score";
+    public static final String PREVIOUS_SCORE_FIELD = "previous_score_field";
 
     public static final boolean DEFAULT_REMOVE_TARGET_FIELD = false;
     public static final boolean DEFAULT_KEEP_PREVIOUS_SCORE = false;
+    public static final String DEFAULT_PREVIOUS_SCORE_FIELD = "previous_score";
 
     protected final String targetField;
     protected final boolean removeTargetField;
     protected final boolean keepPreviousScore;
+    protected final String previousScoreField;
 
     /**
      * Constructor to pass values to the RerankProcessor constructor.
@@ -91,7 +96,8 @@ public class ByFieldRerankProcessor extends RescoringRerankProcessor {
      *                              continues to run the remaining processors in the search pipeline.
      * @param targetField           The field you want to replace your <code>_score</code> with
      * @param removeTargetField     A flag to let you delete the target_field for better visualization (i.e. removes a duplicate value)
-     * @param keepPreviousScore     A flag to let you decide to stash your previous <code>_score</code> in a field called <code>previous_score</code> (i.e. for debugging purposes)
+     * @param keepPreviousScore     A flag to let you decide to stash your previous <code>_score</code> in {@code previousScoreField} (i.e. for debugging purposes)
+     * @param previousScoreField    The field name used to store the score calculated before reranking when {@code keepPreviousScore} is true
      * @param contextSourceFetchers  Context from some source and puts it in a map for a reranking processor to use <b> (Unused in ByFieldRerankProcessor)</b>
      */
     public ByFieldRerankProcessor(
@@ -101,12 +107,14 @@ public class ByFieldRerankProcessor extends RescoringRerankProcessor {
         final String targetField,
         final boolean removeTargetField,
         final boolean keepPreviousScore,
+        final String previousScoreField,
         final List<ContextSourceFetcher> contextSourceFetchers
     ) {
         super(RerankType.BY_FIELD, description, tag, ignoreFailure, contextSourceFetchers);
         this.targetField = targetField;
         this.removeTargetField = removeTargetField;
         this.keepPreviousScore = keepPreviousScore;
+        this.previousScoreField = previousScoreField;
     }
 
     @Override
@@ -133,7 +141,7 @@ public class ByFieldRerankProcessor extends RescoringRerankProcessor {
             scores.add(score);
 
             if (keepPreviousScore) {
-                sourceAsMap.put("previous_score", hit.getScore());
+                sourceAsMap.put(previousScoreField, hit.getScore());
             }
 
             if (removeTargetField) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/RerankProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/RerankProcessorFactoryTests.java
@@ -264,6 +264,26 @@ public class RerankProcessorFactoryTests extends OpenSearchTestCase {
         assert (processor.getType().equals(RerankProcessor.TYPE));
     }
 
+    public void testByFieldCreation_whenCustomPreviousScoreFieldSpecified_thenSuccessful() {
+        Map<String, Object> config = new HashMap<>(
+            Map.of(
+                RerankType.BY_FIELD.getLabel(),
+                new HashMap<>(
+                    Map.of(
+                        ByFieldRerankProcessor.TARGET_FIELD,
+                        "path.to.target_field",
+                        ByFieldRerankProcessor.KEEP_PREVIOUS_SCORE,
+                        true,
+                        ByFieldRerankProcessor.PREVIOUS_SCORE_FIELD,
+                        "original_query_score"
+                    )
+                )
+            )
+        );
+        SearchResponseProcessor processor = factory.create(Map.of(), TAG, DESC, false, config, pipelineContext);
+        assert (processor instanceof ByFieldRerankProcessor);
+    }
+
     public void testByFieldCreation_WithContext_thenSucceed() {
         // You can pass context but, it won't ever be used by ByFieldRerank
         Map<String, Object> config = new HashMap<>(

--- a/src/test/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/rerank/ByFieldRerankProcessorTests.java
@@ -709,6 +709,59 @@ public class ByFieldRerankProcessorTests extends OpenSearchTestCase {
         }
     }
 
+    /**
+     * When a document already has a field named {@code previous_score}, storing the pre-rerank score in a custom
+     * field must not overwrite the existing document field.
+     */
+    public void testReRank_preservesExistingPreviousScore_whenCustomPreviousScoreFieldConfigured() throws IOException {
+        String targetField = "rank_score";
+        SearchHit hit = new SearchHit(0, "1", Collections.emptyMap(), Collections.emptyMap());
+        hit.sourceRef(new BytesArray("{\"title\":\"sample document\",\"previous_score\":\"0-2\",\"rank_score\":9.5}"));
+        hit.score(0.06069608F);
+
+        SearchHits searchHits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 0.06069608F);
+        SearchResponseSections searchResponseSections = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
+        this.response = new SearchResponse(searchResponseSections, null, 1, 1, 0, 10, null, null);
+
+        Map<String, Object> config = new HashMap<>(
+            Map.of(
+                RerankType.BY_FIELD.getLabel(),
+                new HashMap<>(
+                    Map.of(
+                        ByFieldRerankProcessor.TARGET_FIELD,
+                        targetField,
+                        ByFieldRerankProcessor.REMOVE_TARGET_FIELD,
+                        true,
+                        ByFieldRerankProcessor.KEEP_PREVIOUS_SCORE,
+                        true,
+                        ByFieldRerankProcessor.PREVIOUS_SCORE_FIELD,
+                        "original_query_score"
+                    )
+                )
+            )
+        );
+        processor = (ByFieldRerankProcessor) factory.create(
+            Map.of(),
+            "rerank processor",
+            "processor for 2nd level reranking based on provided field",
+            false,
+            config,
+            pipelineContext
+        );
+
+        ActionListener<SearchResponse> listener = mock(ActionListener.class);
+        processor.rerank(response, Map.of(), listener);
+
+        ArgumentCaptor<SearchResponse> argCaptor = ArgumentCaptor.forClass(SearchResponse.class);
+        verify(listener, times(1)).onResponse(argCaptor.capture());
+        SearchResponse searchResponse = argCaptor.getValue();
+
+        Map<String, Object> sourceMap = searchResponse.getHits().getAt(0).getSourceAsMap();
+        assertEquals("0-2", sourceMap.get("previous_score"));
+        assertEquals(0.06069608F, ((Number) sourceMap.get("original_query_score")).floatValue(), 0.0001);
+        assertFalse(sourceMap.containsKey("rank_score"));
+    }
+
     public void testRerank_keepsTargetFieldAndHasNoPreviousScore_WhenByFieldHasDefaultValues() throws IOException {
         String targetField = "ml.info.score";
         setUpValidSearchResultsWithNestedTargetValue();


### PR DESCRIPTION
### Description
Add optional `previous_score_field` to the `by_field` rerank processor (default: `previous_score`). When `keep_previous_score` is true, the pre-rerank score is stored in the configured field instead of always writing to `previous_score`, which prevents overwriting an existing document field with the same name in search results.

### Related Issues
Fixes opensearch-project/OpenSearch#21440

### Problem
When `keep_previous_score: true` is set, the rerank processor always writes the original query score into `_source.previous_score`. If the index already defines `previous_score` as a document field, that value is overwritten in search results.

### Solution
Introduce `previous_score_field` so users can choose where the pre-rerank score is stored:

```json
"rerank": {
  "by_field": {
    "target_field": "rank_score",
    "remove_target_field": true,
    "keep_previous_score": true,
    "previous_score_field": "original_query_score"
  }
}
```

Default behavior is unchanged when `previous_score_field` is omitted.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

### Test plan
- [x] `./gradlew test --tests "org.opensearch.neuralsearch.processor.rerank.ByFieldRerankProcessorTests.testReRank_preservesExistingPreviousScore_whenCustomPreviousScoreFieldConfigured"`
- [x] `./gradlew test --tests "org.opensearch.neuralsearch.processor.factory.RerankProcessorFactoryTests.testByFieldCreation_whenCustomPreviousScoreFieldSpecified_thenSuccessful"`
- [x] `./gradlew spotlessJavaCheck`
- [x] Manual curl repro on local OpenSearch 3.7 with neural-search plugin