### PR TITLE
Fix MergeState constructor to include OneMerge parameter

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/TestsPrepareUtils.java
@@ -296,7 +296,8 @@ public class TestsPrepareUtils {
             maxDocs,
             InfoStream.getDefault(),
             Executors.newSingleThreadExecutor(),
-            false                      // needsIndexSort
+            false,                     // needsIndexSort
+            null                       // oneMerge
         );
         return mergeState;
     }


### PR DESCRIPTION


### Description
The upstream MergeState constructor added a 17th parameter (OneMerge). Pass null to match the updated signature.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
