### PR TITLE
Use a FunctionName.REMOTE for all ML inference requests

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/ml/NeuralSearchMLInputBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/NeuralSearchMLInputBuilder.java
@@ -62,32 +62,19 @@ public class NeuralSearchMLInputBuilder {
             return createAsymmetricRemoteInput(inputText, inferenceRequest);
         }
 
-        // for symmetric model, pre-process function defined in ml-commons handles both remote/local use cases with funtion name as
-        // TEXT_EMBEDDING
         MLAlgoParams mlAlgoParams = createMLAlgoParams(isAsymmetric, inferenceRequest);
         ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
-        return new MLInput(FunctionName.TEXT_EMBEDDING, mlAlgoParams, inputDataset);
+        return createMLInput(inputDataset, mlAlgoParams);
     }
 
-    /**
-     * Creates MLInput for remote models with flexible parameter format.
-     * Supports both direct parameters and JSON string formats.
-     */
-    private static MLInput createRemoteInput(FunctionName functionName, Map<String, Object> parameters) {
-        Map<String, String> stringParameters = new HashMap<>();
-        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
-            stringParameters.put(entry.getKey(), entry.getValue() != null ? entry.getValue().toString() : null);
-        }
-        RemoteInferenceInputDataSet inputDataset = new RemoteInferenceInputDataSet(stringParameters);
-        return MLInput.builder().algorithm(functionName).inputDataset(inputDataset).build();
+    private static MLInput createRemoteInput(Map<String, String> parameters) {
+        return createMLInput(new RemoteInferenceInputDataSet(parameters), null);
     }
 
-    /**
-     * Creates MLInput with flexible dataset and function types.
-     */
-    private static MLInput createMLInput(FunctionName functionName, MLInputDataset inputDataset, MLAlgoParams mlAlgoParams) {
-        return new MLInput(functionName, mlAlgoParams, inputDataset);
+    private static MLInput createMLInput(MLInputDataset inputDataset, MLAlgoParams mlAlgoParams) {
+        // FunctionName is not used by ml-commons for inference, so any value can be passed.
+        return new MLInput(FunctionName.REMOTE, mlAlgoParams, inputDataset);
     }
 
     /**
@@ -119,7 +106,7 @@ public class NeuralSearchMLInputBuilder {
      */
     public static MLInput createTextSimilarityInput(String query, List<String> inputText) {
         MLInputDataset inputDataset = new TextSimilarityInputDataSet(query, inputText);
-        return createMLInput(FunctionName.TEXT_SIMILARITY, inputDataset, null);
+        return createMLInput(inputDataset, null);
     }
 
     /**
@@ -127,23 +114,22 @@ public class NeuralSearchMLInputBuilder {
      */
     public static MLInput createQuestionAnsweringInput(String question, String context) {
         MLInputDataset inputDataset = new QuestionAnsweringInputDataSet(question, context);
-        return createMLInput(FunctionName.QUESTION_ANSWERING, inputDataset, null);
+        return createMLInput(inputDataset, null);
     }
 
     /**
      * Creates MLInput for remote inference with parameters.
      */
     public static MLInput createRemoteHighlightingInput(Map<String, String> parameters) {
-        return createRemoteInput(FunctionName.REMOTE, new HashMap<>(parameters));
+        return createRemoteInput(new HashMap<>(parameters));
     }
 
     /**
      * Creates MLInput for batch highlighting with multiple question-context pairs.
-     * Uses XContentBuilder because remote highlighting models expect JSON string format.
      */
     public static MLInput createBatchHighlightingInput(List<Map<String, String>> batchRequests) {
         try {
-            Map<String, Object> parameters = new HashMap<>();
+            Map<String, String> parameters = new HashMap<>();
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startArray();
             for (Map<String, String> request : batchRequests) {
@@ -154,7 +140,7 @@ public class NeuralSearchMLInputBuilder {
             }
             builder.endArray();
             parameters.put(SemanticHighlightingConstants.INPUTS_KEY, builder.toString());
-            return createRemoteInput(FunctionName.REMOTE, parameters);
+            return createRemoteInput(parameters);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to create batch highlighting ML input", e);
         }
@@ -162,11 +148,10 @@ public class NeuralSearchMLInputBuilder {
 
     /**
      * Creates MLInput for single remote highlighting request.
-     * Uses XContentBuilder because remote highlighting models expect JSON string format.
      */
     public static MLInput createSingleRemoteHighlightingInput(String question, String context) {
         try {
-            Map<String, Object> parameters = new HashMap<>();
+            Map<String, String> parameters = new HashMap<>();
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.startArray();
             builder.startObject()
@@ -175,7 +160,7 @@ public class NeuralSearchMLInputBuilder {
                 .endObject();
             builder.endArray();
             parameters.put(SemanticHighlightingConstants.INPUTS_KEY, builder.toString());
-            return createRemoteInput(FunctionName.REMOTE, parameters);
+            return createRemoteInput(parameters);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to create remote highlighting ML input", e);
         }
@@ -189,7 +174,6 @@ public class NeuralSearchMLInputBuilder {
         try {
             Map<String, String> parameters = new HashMap<>();
 
-            // Use XContentBuilder to properly serialize texts as JSON array
             XContentBuilder textsBuilder = XContentFactory.jsonBuilder();
             textsBuilder.startArray();
             for (String text : inputText) {
@@ -198,12 +182,10 @@ public class NeuralSearchMLInputBuilder {
             textsBuilder.endArray();
             parameters.put(AsymmetricTextEmbeddingConstants.TEXTS_KEY, textsBuilder.toString());
 
-            // Add content type as string
             EmbeddingContentType contentType = inferenceRequest.getEmbeddingContentType();
             parameters.put(AsymmetricTextEmbeddingConstants.CONTENT_TYPE_KEY, contentType.toString().toLowerCase(Locale.ROOT));
 
-            RemoteInferenceInputDataSet inputDataset = new RemoteInferenceInputDataSet(parameters);
-            return MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(inputDataset).build();
+            return createRemoteInput(parameters);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to create asymmetric remote ML input", e);
         }
@@ -243,6 +225,6 @@ public class NeuralSearchMLInputBuilder {
 
         ModelResultFilter modelResultFilter = new ModelResultFilter(false, true, targetResponseFilters, null);
         MLInputDataset inputDataset = new TextDocsInputDataSet(inputText, modelResultFilter);
-        return new MLInput(FunctionName.TEXT_EMBEDDING, mlAlgoParams, inputDataset);
+        return createMLInput(inputDataset, mlAlgoParams);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/ml/NeuralSearchMLInputBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/NeuralSearchMLInputBuilderTests.java
@@ -8,12 +8,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
@@ -40,9 +38,7 @@ public class NeuralSearchMLInputBuilderTests extends OpenSearchTestCase {
         // Execute
         MLInput result = NeuralSearchMLInputBuilder.createTextEmbeddingInput(model, null, inputTexts, request);
 
-        // Verify
         assertNotNull(result);
-        assertEquals(FunctionName.REMOTE, result.getAlgorithm());
 
         RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) result.getInputDataset();
         assertNotNull(dataset.getParameters());
@@ -75,8 +71,7 @@ public class NeuralSearchMLInputBuilderTests extends OpenSearchTestCase {
         assertEquals("passage", dataset.getParameters().get(AsymmetricTextEmbeddingConstants.CONTENT_TYPE_KEY));
     }
 
-    public void testCreateTextEmbeddingInput_remoteSymmetricModel_throwsException() {
-        // Setup
+    public void testCreateTextEmbeddingInput_remoteSymmetricModel() {
         MLModel model = mock(MLModel.class);
         RemoteModelConfig config = mock(RemoteModelConfig.class);
         InferenceRequest request = mock(InferenceRequest.class);
@@ -86,12 +81,9 @@ public class NeuralSearchMLInputBuilderTests extends OpenSearchTestCase {
 
         List<String> inputTexts = Arrays.asList("test text");
 
-        // Execute
         MLInput result = NeuralSearchMLInputBuilder.createTextEmbeddingInput(model, null, inputTexts, request);
 
-        // Verify
         assertNotNull(result);
-        assertEquals(FunctionName.TEXT_EMBEDDING, result.getAlgorithm());
     }
 
     public void testCreateTextEmbeddingInput_remoteModel_multipleInputs() {
@@ -118,7 +110,6 @@ public class NeuralSearchMLInputBuilderTests extends OpenSearchTestCase {
     }
 
     public void testCreateTextEmbeddingInput_localModel() {
-        // Setup
         MLModel model = mock(MLModel.class);
         TextEmbeddingModelConfig config = mock(TextEmbeddingModelConfig.class);
         InferenceRequest request = mock(InferenceRequest.class);
@@ -130,12 +121,9 @@ public class NeuralSearchMLInputBuilderTests extends OpenSearchTestCase {
 
         List<String> inputTexts = Arrays.asList("test text");
 
-        // Execute
         MLInput result = NeuralSearchMLInputBuilder.createTextEmbeddingInput(model, null, inputTexts, request);
 
-        // Verify
         assertNotNull(result);
-        assertEquals(FunctionName.TEXT_EMBEDDING, result.getAlgorithm());
     }
 
     public void testCreateTextEmbeddingInput_remoteAsymmetricModel_withSpecialCharacters() {

--- a/src/test/resources/processor/UploadAsymmetricModelRequestBody.json
+++ b/src/test/resources/processor/UploadAsymmetricModelRequestBody.json
@@ -2,6 +2,7 @@
   "name": "traced_small_model",
   "version": "1.0.0",
   "model_format": "TORCH_SCRIPT",
+  "function_name": "TEXT_EMBEDDING",
   "model_task_type": "text_embedding",
   "model_content_hash_value": "e13b74006290a9d0f58c1376f9629d4ebc05a0f9385f40db837452b167ae9021",
   "model_group_id": "%s",


### PR DESCRIPTION
### Description
FunctionName is not used by ml-commons for inference, so centralize it as a single FunctionName.REMOTE and remove it from all internal method signatures to avoid confusion.

### Related Issues
https://github.com/opensearch-project/ml-commons/issues/4891

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
