### PR TITLE
Skip two phase rescore for sort query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add `previous_score_field` to `by_field` rerank processor to avoid overwriting existing document fields ([#1880](https://github.com/opensearch-project/neural-search/pull/1880)) (OpenSearch [#21440](https://github.com/opensearch-project/OpenSearch/issues/21440))
 * [Hybrid Query] Block hybrid query execution with `search_type=dfs_query_then_fetch` ([#1873](https://github.com/opensearch-project/neural-search/pull/1873))
 * [Hybrid Query] Fix `hybrid_score_explanation` returning a single normalization block for hybrid queries on indices that contain a nested field ([#1876](https://github.com/opensearch-project/neural-search/pull/1876))
+* [Two-phase] Skip two phase rescore for sort query ([#1898](https://github.com/opensearch-project/neural-search/pull/1898))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessor.java
@@ -27,7 +27,11 @@ import org.opensearch.search.pipeline.Processor;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.rescore.RescorerBuilder;
+import org.opensearch.search.sort.ScoreSortBuilder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortOrder;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -103,6 +107,13 @@ public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements 
         if (!enabled || pruneRatio == 0f) {
             return request;
         }
+        // Two-phase rescore is incompatible with explicit sort (other than _score DESC).
+        // OpenSearch rejects sort + rescore in DefaultSearchContext.preProcess(), so when the
+        // request already has a non-_score-DESC sort, skip the optimization and let the full
+        // neural_sparse query run as a single phase. Correctness over latency.
+        if (hasIncompatibleSort(request.source())) {
+            return request;
+        }
         QueryBuilder queryBuilder = request.source().query();
         // Collect the nested NeuralSparseQueryBuilder in the whole query.
         Multimap<AbstractNeuralQueryBuilder<?>, Float> queryBuilderMap = collectNeuralQueryBuilderWithSparseEmbedding(
@@ -137,6 +148,28 @@ public class NeuralSparseTwoPhaseProcessor extends AbstractProcessor implements 
             boolQueryBuilder.should(neuralQueryBuilderWithSparseEmbedding.boost(reduceBoost));
         });
         return boolQueryBuilder;
+    }
+
+    /**
+     * Returns true when the request specifies a sort that OpenSearch will treat as an explicit
+     * sort at execution time, in which case adding a rescore would cause
+     * {@code DefaultSearchContext.preProcess()} to throw
+     * "Cannot use [sort] option in conjunction with [rescore]".
+     *
+     * Mirrors the optimization in {@code SortBuilder.buildSort}: a single {@code _score DESC}
+     * is collapsed to "no sort" and is therefore compatible. Anything else (a field sort, a
+     * non-default _score order, or a multi-element sort list) is incompatible.
+     */
+    static boolean hasIncompatibleSort(final SearchSourceBuilder searchSourceBuilder) {
+        List<SortBuilder<?>> sorts = searchSourceBuilder.sorts();
+        if (sorts == null || sorts.isEmpty()) {
+            return false;
+        }
+        if (sorts.size() == 1) {
+            SortBuilder<?> only = sorts.get(0);
+            return !(only instanceof ScoreSortBuilder) || only.order() != SortOrder.DESC;
+        }
+        return true;
     }
 
     private float getOriginQueryWeightAfterRescore(final SearchSourceBuilder searchSourceBuilder) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
@@ -18,6 +18,9 @@ import org.opensearch.neuralsearch.util.prune.PruneType;
 import org.opensearch.neuralsearch.util.prune.PruneUtils;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
+import org.opensearch.search.sort.ScoreSortBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collections;
@@ -254,6 +257,64 @@ public class NeuralSparseTwoPhaseProcessorTests extends OpenSearchTestCase {
         processor.processRequest(searchRequest);
 
         assertNull(searchRequest.source().rescores());
+    }
+
+    public void testProcessRequest_whenSortByField_thenSkipRescore() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseQueryBuilder neuralQueryBuilder = new NeuralSparseQueryBuilder();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(
+            new SearchSourceBuilder().query(neuralQueryBuilder).sort(SortBuilders.fieldSort("entityId").order(SortOrder.ASC))
+        );
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory, 0.5f, true, 4.0f, 10000);
+        processor.processRequest(searchRequest);
+        assertNull(searchRequest.source().rescores());
+    }
+
+    public void testProcessRequest_whenSortByScoreDescAndField_thenSkipRescore() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseQueryBuilder neuralQueryBuilder = new NeuralSparseQueryBuilder();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(
+            new SearchSourceBuilder().query(neuralQueryBuilder)
+                .sort(new ScoreSortBuilder())
+                .sort(SortBuilders.fieldSort("entityId").order(SortOrder.ASC))
+        );
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory, 0.5f, true, 4.0f, 10000);
+        processor.processRequest(searchRequest);
+        assertNull(searchRequest.source().rescores());
+    }
+
+    public void testProcessRequest_whenSortByScoreDescOnly_thenAddRescore() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseQueryBuilder neuralQueryBuilder = new NeuralSparseQueryBuilder();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(new SearchSourceBuilder().query(neuralQueryBuilder).sort(new ScoreSortBuilder()));
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory, 0.5f, true, 4.0f, 10000);
+        processor.processRequest(searchRequest);
+        assertNotNull(searchRequest.source().rescores());
+    }
+
+    public void testProcessRequest_whenSortByScoreAsc_thenSkipRescore() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseQueryBuilder neuralQueryBuilder = new NeuralSparseQueryBuilder();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(new SearchSourceBuilder().query(neuralQueryBuilder).sort(new ScoreSortBuilder().order(SortOrder.ASC)));
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory, 0.5f, true, 4.0f, 10000);
+        processor.processRequest(searchRequest);
+        assertNull(searchRequest.source().rescores());
+    }
+
+    public void testProcessRequest_whenSortByScoreDescWithTrackScores_thenAddRescore() throws Exception {
+        NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
+        NeuralSparseQueryBuilder neuralQueryBuilder = new NeuralSparseQueryBuilder();
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(
+            new SearchSourceBuilder().query(neuralQueryBuilder).sort(new ScoreSortBuilder()).trackScores(true)
+        );
+        NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory, 0.5f, true, 4.0f, 10000);
+        processor.processRequest(searchRequest);
+        assertNotNull(searchRequest.source().rescores());
     }
 
     public void testType() throws Exception {


### PR DESCRIPTION
### Description
skip two_phase optimization for query containing sort field.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
