### PR TITLE
Fix Check Workflow Events CI job

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -61,8 +61,6 @@ jobs:
           echo "Running restart-upgrade backwards compatibility tests ..."
           su `id -un 1000` -c "./gradlew :qa:restart-upgrade:testAgainstNewCluster --parallel -D'tests.bwc.version=${{ matrix.bwc_version }}'"
 
-   }}'"
-
   Rolling-Upgrade-BWCTests-NeuralSearch:
     needs: Get-CI-Image-Tag
     strategy:

--- a/.github/workflows/check-workflow-events.yml
+++ b/.github/workflows/check-workflow-events.yml
@@ -17,7 +17,7 @@ jobs:
               yq -r e '.on | keys | .[0]' $file_found | grep -q pull_request_target
               EVENT_FOUND=$?
 
-              if [ "$EVENT_FOUND" = 0 ] && [ "$file_found" != "backport.yml" ] && [ "$file_found" != "copy-linked-issue-labels.yml" ]; then
+              if [ "$EVENT_FOUND" = 0 ] && [ "$file_found" != "backport.yml" ] && [ "$file_found" != "copy-linked-issue-labels.yml" ] && [ "$file_found" != "pr_review.yml" ]; then
                 EVENT_COUNT=$(( EVENT_COUNT+1 ))
                 echo "'$file_found' workflow file contains 'pull_request_target' event, please remove!"
               fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Hybrid Query] Fix `hybrid_score_explanation` returning a single normalization block for hybrid queries on indices that contain a nested field ([#1876](https://github.com/opensearch-project/neural-search/pull/1876))
 
 ### Infrastructure
+* Fix `Check Workflow Events` CI job: allowlist `pr_review.yml` for its required `pull_request_target` event and remove a stray fragment that broke YAML parsing of the BWC workflow ([#1901](https://github.com/opensearch-project/neural-search/pull/1901))
 
 ### Documentation
 


### PR DESCRIPTION
### Description

The **Check Workflow Events** CI job (`.github/workflows/check-workflow-events.yml`) currently fails on every PR, for two reasons that are independent of the PR under review:

1. **`pr_review.yml` uses `pull_request_target` (the actual `exit 1`).** The checker prints `'pr_review.yml' workflow file contains 'pull_request_target' event, please remove!` and exits 1. This event is **intentional and required** — `pr_review.yml` runs the `opensearch-build` code-diff analyzer/reviewer, which needs the `BEDROCK_ACCESS_ROLE` secret and `pull-requests: write` permission to comment on PRs (including those from forks). That is exactly what `pull_request_target` is for. The workflow was onboarded in #1841 (after the checker was added in #1128) and was simply never added to the allowlist alongside `backport.yml` and `copy-linked-issue-labels.yml`.
   → **Fix:** add `pr_review.yml` to the checker's allowlist (do **not** remove the event, which would break the feature and its secret/permission model).

2. **`backwards_compatibility_tests_workflow.yml` fails YAML parsing.** The checker logs `bad file 'backwards_compatibility_tests_workflow.yml': yaml: ... did not find expected key`. A stray `   }}'"` fragment (plus a blank line) was accidentally introduced by the version bump in #1896, right after the Restart-Upgrade job's test command. The parallel Rolling-Upgrade job has no such fragment.
   → **Fix:** remove the stray lines. The `run` block is otherwise unchanged.

### Check List
- [ ] New functionality includes testing.  <!-- N/A: CI-config-only fix; validated by re-running the checker logic -->
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.