### PR TITLE
Fix SemanticHighlighterExtBuilder.toXContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+* [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/query/ext/SemanticHighlighterExtBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/ext/SemanticHighlighterExtBuilder.java
@@ -4,16 +4,16 @@
  */
 package org.opensearch.neuralsearch.query.ext;
 
-import java.io.IOException;
-import java.util.Locale;
-import java.util.Objects;
-
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.neuralsearch.highlight.SemanticHighlightingConstants;
 import org.opensearch.search.SearchExtBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
 
 /**
  * Search request ext builder that opts a request into batch semantic highlighting.
@@ -61,7 +61,7 @@ public class SemanticHighlighterExtBuilder extends SearchExtBuilder {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.value(enabled);
+        return builder.field(NAME, enabled);
     }
 
     @Override

--- a/src/test/java/org/opensearch/neuralsearch/query/ext/SemanticHighlighterExtBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/ext/SemanticHighlighterExtBuilderTests.java
@@ -4,17 +4,22 @@
  */
 package org.opensearch.neuralsearch.query.ext;
 
-import java.io.IOException;
-import java.util.List;
-
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.ParseField;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.SearchExtBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
 
 public class SemanticHighlighterExtBuilderTests extends OpenSearchTestCase {
 
@@ -57,6 +62,14 @@ public class SemanticHighlighterExtBuilderTests extends OpenSearchTestCase {
         roundTrip(false);
     }
 
+    public void testRoundTripXContentTrue() throws IOException {
+        roundTripXContent(true);
+    }
+
+    public void testRoundTripXContentFalse() throws IOException {
+        roundTripXContent(false);
+    }
+
     public void testParseBooleanTrue() throws IOException {
         SemanticHighlighterExtBuilder result = parseValue("true");
         assertTrue(result.isEnabled());
@@ -94,6 +107,26 @@ public class SemanticHighlighterExtBuilderTests extends OpenSearchTestCase {
                 SemanticHighlighterExtBuilder deserialized = new SemanticHighlighterExtBuilder(in);
                 assertEquals(original, deserialized);
             }
+        }
+    }
+
+    private void roundTripXContent(boolean value) throws IOException {
+        SemanticHighlighterExtBuilder original = new SemanticHighlighterExtBuilder(value);
+        MediaType xContentType = randomFrom(XContentType.values());
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().ext(List.of(original));
+        assertEquals("{\"ext\":{\"semantic_highlighting_batch\":" + value + "}}", sourceBuilder.toString());
+        boolean humanReadable = randomBoolean();
+        BytesReference shuffledXContent = this.toShuffledXContent(
+            sourceBuilder,
+            xContentType,
+            ToXContentObject.EMPTY_PARAMS,
+            humanReadable
+        );
+
+        try (XContentParser parser = this.createParser(xContentType.xContent(), shuffledXContent)) {
+            SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
+            assertEquals(1, searchSourceBuilder.ext().size());
+            assertEquals(original, searchSourceBuilder.ext().getFirst());
         }
     }
 


### PR DESCRIPTION
### Description
SearchExtBuilder expects toXContent to produce their encloding field name.
Add test to ensure we can do a round trip with XContent.

### Related Issues
Resolves #1906


### Check List
- [x] New functionality includes testing.
- ~[ ] New functionality has been documented.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

