### PR TITLE
Fix stray fragment injection in updateVersion gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -689,15 +689,16 @@ task updateVersion {
                     println "Added ${currentVersionWithoutSnapshot} to Restart-Upgrade BWC version list"
                 }
 
-                // Extract and update Rolling-Upgrade section
-                def rollingSection = updatedContent.substring(rollingStart)
+                // Extract and update Rolling-Upgrade section.
+                // Recompute the offset inline, since updating the restart section above may have
+                // changed the length of updatedContent and invalidated rollingStart.
+                def rollingSection = updatedContent.substring(updatedContent.indexOf('Rolling-Upgrade-BWCTests-NeuralSearch:'))
                 def rollingVersions = extractVersions(rollingSection)
                 if (!rollingVersions.isEmpty() && isCurrentVersionNewer(rollingVersions.last())) {
                     def updatedRollingSection = rollingSection.replaceFirst(
                         /(?m)(^\s*bwc_version:\s*\[([^\]]+))\]/,
                         "\$1, \"${currentVersionWithoutSnapshot}\"]"
                     )
-                    // Need to recalculate rollingStart in case the restart section changed
                     def newRollingStart = updatedContent.indexOf('Rolling-Upgrade-BWCTests-NeuralSearch:')
                     updatedContent = updatedContent.substring(0, newRollingStart) + updatedRollingSection
                     println "Added ${currentVersionWithoutSnapshot} to Rolling-Upgrade BWC version list"


### PR DESCRIPTION


### Description
When appending the current version to the rolling-upgrade BWC list, the
rolling section was sliced from updatedContent using a stale offset. Updating
the restart-upgrade section beforehand changed the string length, so the stale
offset pointed before the rolling job header and captured the tail of the
preceding line, injecting an invalid fragment into the workflow YAML.

Recompute the offset inline when extracting the rolling section, matching the
pattern used by the equivalent task in the search-relevance repo.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
