### PR TITLE
[Enhancement] Add model_selection parameter to semantic field to resolve model id from cluster settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 
 ### Enhancements
+- Add `model_selection` (language_option/model_type) parameter to semantic field to resolve the model id from cluster settings ([#1918](https://github.com/opensearch-project/neural-search/issues/1918))
 
 ### Bug Fixes
 * [Hybrid Query] Fix NoSuchElementException in hybrid query with sort/search_after when a shard returns no results ([#1939](https://github.com/opensearch-project/neural-search/pull/1939))

--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -7,7 +7,11 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            // Resolve the Eclipse JDT formatter directly from download.eclipse.org. The prior
+            // withP2Mirrors(... -> https://ci.opensearch.org/) mirror (added in #1940) started timing
+            // out at configuration time (SocketTimeoutException), failing every task on affected
+            // runners. This aligns with the OpenSearch 3.x resolution in opensearch-project/OpenSearch#20826.
+            eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 

--- a/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/constants/SemanticFieldConstants.java
@@ -66,4 +66,23 @@ public class SemanticFieldConstants {
      * model is not changed.
      */
     public static final String SKIP_EXISTING_EMBEDDING = "skip_existing_embedding";
+
+    /**
+     * Name of the model selection parameter. It is a nested object holding {@link #LANGUAGE_OPTION} and
+     * {@link #MODEL_TYPE}. When specified, the system resolves the {@code model_id} from the
+     * {@code plugins.neural_search.model_selection.model_id.*} cluster settings instead of requiring the customer to
+     * provide a {@code model_id} directly.
+     */
+    public static final String MODEL_SELECTION = "model_selection";
+
+    /**
+     * Name of the language option sub-parameter of {@link #MODEL_SELECTION}. Supported values: ENGLISH, MULTILINGUAL.
+     */
+    public static final String LANGUAGE_OPTION = "language_option";
+
+    /**
+     * Name of the model type sub-parameter of {@link #MODEL_SELECTION}. Used together with {@link #LANGUAGE_OPTION} to
+     * resolve the appropriate model. Supported values: SPARSE, DENSE.
+     */
+    public static final String MODEL_TYPE = "model_type";
 }

--- a/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapper.java
@@ -22,6 +22,7 @@ import org.opensearch.index.mapper.TokenCountFieldMapper;
 import org.opensearch.index.mapper.WildcardFieldMapper;
 import org.opensearch.neuralsearch.constants.MappingConstants;
 import org.opensearch.neuralsearch.mapper.dto.ChunkingConfig;
+import org.opensearch.neuralsearch.mapper.dto.ModelSelection;
 import org.opensearch.neuralsearch.mapper.dto.SemanticParameters;
 import org.opensearch.neuralsearch.processor.chunker.ChunkerValidatorFactory;
 import org.opensearch.neuralsearch.mapper.dto.SparseEncodingConfig;
@@ -39,6 +40,7 @@ import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.CHUNK
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DEFAULT_SEMANTIC_INFO_FIELD_NAME_SUFFIX;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.DENSE_EMBEDDING_CONFIG;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_SELECTION;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SKIP_EXISTING_EMBEDDING;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEARCH_MODEL_ID;
@@ -211,6 +213,21 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
             false
         );
 
+        @Getter
+        protected final Parameter<ModelSelection> modelSelection = new Parameter<>(
+            MODEL_SELECTION,
+            true,
+            () -> null,
+            (name, ctx, value) -> value == null ? null : new ModelSelection(name, value),
+            m -> ((SemanticFieldMapper) m).semanticParameters.getModelSelection()
+        ).setSerializer((builder, name, value) -> {
+            if (value == null) {
+                builder.nullField(name);
+            } else {
+                value.toXContent(builder, name);
+            }
+        }, (value) -> value == null ? null : value.toString());
+
         @Setter
         protected ParametrizedFieldMapper.Builder delegateBuilder;
 
@@ -229,7 +246,8 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
                 semanticFieldSearchAnalyzer,
                 denseEmbeddingConfig,
                 sparseEncodingConfig,
-                skipExistingEmbedding
+                skipExistingEmbedding,
+                modelSelection
             );
         }
 
@@ -261,6 +279,7 @@ public class SemanticFieldMapper extends ParametrizedFieldMapper {
                 .denseEmbeddingConfig(denseEmbeddingConfig.getValue())
                 .sparseEncodingConfig(sparseEncodingConfig.getValue())
                 .skipExistingEmbedding(skipExistingEmbedding.getValue())
+                .modelSelection(modelSelection.getValue())
                 .build();
         }
     }

--- a/src/main/java/org/opensearch/neuralsearch/mapper/dto/ModelSelection.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/dto/ModelSelection.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.dto;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.MapperParsingException;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.LANGUAGE_OPTION;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_TYPE;
+
+/**
+ * DTO for the {@code model_selection} nested object of a semantic field. It holds the human readable
+ * description of the model the customer wants (language + model type) which the system resolves to a
+ * concrete {@code model_id} through the {@code plugins.neural_search.model_selection.model_id.*} cluster
+ * settings.
+ * <p>
+ * Example:
+ * <pre>
+ * "model_selection": {
+ *   "language_option": "ENGLISH",
+ *   "model_type": "SPARSE"
+ * }
+ * </pre>
+ */
+@Getter
+public class ModelSelection {
+    public static final String ENGLISH = "ENGLISH";
+    public static final String MULTILINGUAL = "MULTILINGUAL";
+    public static final String SPARSE = "SPARSE";
+    public static final String DENSE = "DENSE";
+
+    public static final Set<String> SUPPORTED_LANGUAGE_OPTIONS = Set.of(ENGLISH, MULTILINGUAL);
+    public static final Set<String> SUPPORTED_MODEL_TYPES = Set.of(SPARSE, DENSE);
+
+    private final String languageOption;
+    private final String modelType;
+
+    /**
+     * Construct a ModelSelection from the raw value defined under {@code model_selection} in the index mappings.
+     * Missing sub-fields default to ENGLISH / SPARSE.
+     *
+     * @param name  parameter name (used for error messages)
+     * @param value raw parameter value, expected to be a Map
+     */
+    @SuppressWarnings("unchecked")
+    public ModelSelection(@NonNull final String name, final Object value) {
+        if (value instanceof Map == false) {
+            throw new MapperParsingException(String.format(Locale.ROOT, "[%s] must be a Map", name));
+        }
+        final Map<String, Object> config = (Map<String, Object>) value;
+
+        for (final String key : config.keySet()) {
+            if (LANGUAGE_OPTION.equals(key) == false && MODEL_TYPE.equals(key) == false) {
+                throw new MapperParsingException(String.format(Locale.ROOT, "Unsupported parameter [%s] in [%s]", key, name));
+            }
+        }
+
+        this.languageOption = normalize(config.get(LANGUAGE_OPTION), LANGUAGE_OPTION, ENGLISH, SUPPORTED_LANGUAGE_OPTIONS);
+        this.modelType = normalize(config.get(MODEL_TYPE), MODEL_TYPE, SPARSE, SUPPORTED_MODEL_TYPES);
+    }
+
+    /**
+     * Construct a ModelSelection directly from its language option and model type.
+     */
+    public ModelSelection(final String languageOption, final String modelType) {
+        this.languageOption = normalize(languageOption, LANGUAGE_OPTION, ENGLISH, SUPPORTED_LANGUAGE_OPTIONS);
+        this.modelType = normalize(modelType, MODEL_TYPE, SPARSE, SUPPORTED_MODEL_TYPES);
+    }
+
+    private static String normalize(final Object rawValue, final String field, final String defaultValue, final Set<String> supported) {
+        if (rawValue == null) {
+            return defaultValue;
+        }
+        final String normalized = rawValue.toString().toUpperCase(Locale.ROOT);
+        if (supported.contains(normalized) == false) {
+            throw new MapperParsingException(
+                String.format(
+                    Locale.ROOT,
+                    "Unsupported [%s] value [%s]. It should be one of [%s].",
+                    field,
+                    rawValue,
+                    String.join(", ", supported)
+                )
+            );
+        }
+        return normalized;
+    }
+
+    /**
+     * @return whether the customer requested a dense model.
+     */
+    public boolean isDense() {
+        return DENSE.equals(modelType);
+    }
+
+    /**
+     * @return the profile key used to look up the resolved model_id from the cluster settings. It is the suffix of the
+     * affix setting {@code plugins.neural_search.model_selection.model_id.} and takes the form {@code <model_type>.<language_option>}
+     * (both lower cased), e.g. {@code sparse.english}.
+     */
+    public String getProfileKey() {
+        return modelType.toLowerCase(Locale.ROOT) + "." + languageOption.toLowerCase(Locale.ROOT);
+    }
+
+    public void toXContent(@NonNull final XContentBuilder builder, final String name) throws IOException {
+        builder.startObject(name);
+        builder.field(LANGUAGE_OPTION, languageOption);
+        builder.field(MODEL_TYPE, modelType);
+        builder.endObject();
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT, "{%s=%s, %s=%s}", LANGUAGE_OPTION, languageOption, MODEL_TYPE, modelType);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj != null && this.getClass() == obj.getClass()) {
+            final ModelSelection other = (ModelSelection) obj;
+            return new EqualsBuilder().append(this.languageOption, other.languageOption).append(this.modelType, other.modelType).isEquals();
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(this.languageOption).append(this.modelType).toHashCode();
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/mapper/dto/SemanticParameters.java
+++ b/src/main/java/org/opensearch/neuralsearch/mapper/dto/SemanticParameters.java
@@ -23,6 +23,7 @@ public class SemanticParameters {
     private final String semanticFieldSearchAnalyzer;
     private final Map<String, Object> denseEmbeddingConfig;
     private final SparseEncodingConfig sparseEncodingConfig;
+    private final ModelSelection modelSelection;
 
     public boolean isChunkingEnabled() {
         if (chunkingConfig == null) {

--- a/src/main/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformer.java
+++ b/src/main/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformer.java
@@ -12,11 +12,17 @@ import org.opensearch.index.mapper.MappingTransformer;
 import org.opensearch.ml.common.FunctionName;
 import org.opensearch.ml.common.MLModel;
 import org.opensearch.neuralsearch.constants.SemanticFieldConstants;
+import org.opensearch.neuralsearch.mapper.dto.ModelSelection;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.ml.resolver.SemanticModelResolver;
+import org.opensearch.neuralsearch.util.SemanticMLModelUtils;
 import lombok.NonNull;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -24,6 +30,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.opensearch.neuralsearch.constants.MappingConstants.PROPERTIES;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_SELECTION;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME;
 import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.SPARSE_ENCODING_CONFIG;
 import static org.opensearch.neuralsearch.util.SemanticMappingUtils.collectSemanticField;
@@ -38,7 +46,28 @@ import static org.opensearch.neuralsearch.util.SemanticMappingUtils.validateSema
 /**
  * SemanticMappingTransformer transforms the index mapping for the semantic field to auto add the semantic info fields
  * based on the ML model id defined in the semantic field.
+ * <p>
+ * This transformer is the single enforcement point for the {@code model_id}/{@code model_selection} rules. The
+ * {@link org.opensearch.neuralsearch.mapper.SemanticFieldMapper} TypeParser intentionally accepts both together (so a
+ * GET mapping response, which contains the resolved {@code model_id} alongside {@code model_selection}, can be reapplied
+ * via PUT). It resolves {@code model_selection} to a {@code model_id}, and, when an explicit {@code model_id} is also
+ * supplied, verifies the two point to the same model. The mapper cannot perform the check itself as it has no access to
+ * the cluster-setting resolution at parse time.
+ * <p>
+ * The mapping transformers are invoked by the core {@code MappingTransformerRegistry} from all mapping-defining
+ * transport actions, so this transformer runs on the raw mapping for every path that can introduce or update a semantic
+ * field:
+ * <ul>
+ *   <li>{@code TransportCreateIndexAction} (create index)</li>
+ *   <li>{@code TransportPutMappingAction} (update mapping)</li>
+ *   <li>{@code TransportPutIndexTemplateAction} (legacy index template)</li>
+ *   <li>{@code TransportPutComponentTemplateAction} (component template)</li>
+ *   <li>{@code TransportPutComposableIndexTemplateAction} (composable index template)</li>
+ * </ul>
+ * Note that for the composable index template path the transformed mapping is persisted into the stored template, so a
+ * {@code model_selection} in a template is resolved to a concrete {@code model_id} at template-creation time.
  */
+@Log4j2
 public class SemanticMappingTransformer implements MappingTransformer {
     public final static Set<String> SUPPORTED_MODEL_ALGORITHMS = Set.of(
         FunctionName.TEXT_EMBEDDING.name(),
@@ -54,6 +83,9 @@ public class SemanticMappingTransformer implements MappingTransformer {
 
     private final MLCommonsClientAccessor mlClientAccessor;
     private final NamedXContentRegistry xContentRegistry;
+
+    @Setter
+    private volatile SemanticModelResolver modelResolver;
 
     public SemanticMappingTransformer(final MLCommonsClientAccessor mlClientAccessor, final NamedXContentRegistry xContentRegistry) {
         this.mlClientAccessor = mlClientAccessor;
@@ -142,13 +174,101 @@ public class SemanticMappingTransformer implements MappingTransformer {
 
             collectSemanticField(properties, semanticFieldPathToConfigMap);
 
-            validateSemanticFields(semanticFieldPathToConfigMap);
+            // Split fields into those that carry a model_selection (need model_id resolution from the cluster settings)
+            // and those that rely on an explicit model_id (existing path). Fields with neither model_selection nor
+            // model_id are kept in fieldsWithModelId so the existing validation surfaces the missing model_id error.
+            // Use a LinkedHashMap for the fields to resolve so resolution order is deterministic.
+            final Map<String, Map<String, Object>> fieldsToResolve = new LinkedHashMap<>();
+            final Map<String, Map<String, Object>> fieldsWithModelId = new HashMap<>();
 
-            fetchModelAndModifyMapping(semanticFieldPathToConfigMap, properties, listener);
+            for (Map.Entry<String, Map<String, Object>> entry : semanticFieldPathToConfigMap.entrySet()) {
+                final Map<String, Object> config = entry.getValue();
+                if (config.get(MODEL_SELECTION) != null) {
+                    fieldsToResolve.put(entry.getKey(), config);
+                } else {
+                    fieldsWithModelId.put(entry.getKey(), config);
+                }
+            }
+
+            validateSemanticFields(fieldsWithModelId);
+
+            // Resolve model_selection fields (a cheap, synchronous cluster-setting lookup) and record the requested
+            // ModelSelection per field so the model type can be verified later, when the model is loaded.
+            final Map<String, ModelSelection> modelSelectionByPath = new HashMap<>();
+            if (fieldsToResolve.isEmpty() == false) {
+                if (modelResolver == null) {
+                    throw new IllegalStateException(
+                        "Cannot resolve the model_selection because the SemanticModelResolver is not configured."
+                    );
+                }
+                for (final Map.Entry<String, Map<String, Object>> entry : fieldsToResolve.entrySet()) {
+                    resolveModelSelectionField(entry.getKey(), entry.getValue(), fieldsWithModelId, modelSelectionByPath);
+                }
+            }
+
+            if (fieldsWithModelId.isEmpty()) {
+                listener.onResponse(null);
+            } else {
+                fetchModelAndModifyMapping(fieldsWithModelId, modelSelectionByPath, properties, listener);
+            }
         } catch (Exception e) {
             listener.onFailure(e);
         }
 
+    }
+
+    private void resolveModelSelectionField(
+        @NonNull final String fieldPath,
+        @NonNull final Map<String, Object> fieldConfig,
+        @NonNull final Map<String, Map<String, Object>> fieldsWithModelId,
+        @NonNull final Map<String, ModelSelection> modelSelectionByPath
+    ) {
+        final ModelSelection modelSelection = new ModelSelection(MODEL_SELECTION, fieldConfig.get(MODEL_SELECTION));
+        final String resolvedModelId = modelResolver.resolve(modelSelection);
+        final Object suppliedModelId = fieldConfig.get(MODEL_ID);
+
+        // Log the resolution so drift is diagnosable. On an update that re-applies a model_selection field, this line
+        // records which model the field resolved to; if the resolved id differs from what an existing field was bound
+        // to, comparing successive log lines surfaces that the field moved off its previous model.
+        log.info(
+            "Resolved model_selection [language_option={}, model_type={}] to model_id [{}] for semantic field at [{}].",
+            modelSelection.getLanguageOption(),
+            modelSelection.getModelType(),
+            resolvedModelId,
+            fieldPath
+        );
+
+        if (suppliedModelId != null) {
+            if (suppliedModelId instanceof String == false) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "The model_id for the semantic field at %s must be a string.", fieldPath)
+                );
+            }
+            // When both model_id and model_selection are provided, they must point to the same model.
+            if (resolvedModelId.equals(suppliedModelId) == false) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "The provided model_id [%s] for the semantic field at %s does not match the model_id [%s] resolved "
+                            + "from model_selection [language_option=%s, model_type=%s]. Provide the matching model_id or omit it.",
+                        suppliedModelId,
+                        fieldPath,
+                        resolvedModelId,
+                        modelSelection.getLanguageOption(),
+                        modelSelection.getModelType()
+                    )
+                );
+            }
+        } else {
+            fieldConfig.put(MODEL_ID, resolvedModelId);
+        }
+
+        // Validate the resolved field consistently with the explicit model_id path (e.g. semantic_info_field_name
+        // format). Model selection fields skip the upfront validateSemanticFields call, so validate them here.
+        validateSemanticFields(Map.of(fieldPath, fieldConfig));
+
+        fieldsWithModelId.put(fieldPath, fieldConfig);
+        modelSelectionByPath.put(fieldPath, modelSelection);
     }
 
     private void validateSemanticFields(@NonNull final Map<String, Map<String, Object>> semanticFieldPathToConfigMap) {
@@ -172,13 +292,14 @@ public class SemanticMappingTransformer implements MappingTransformer {
 
     private void fetchModelAndModifyMapping(
         @NonNull final Map<String, Map<String, Object>> semanticFieldPathToConfigMap,
+        @NonNull final Map<String, ModelSelection> modelSelectionByPath,
         @NonNull final Map<String, Object> mappings,
         @NonNull final ActionListener<Void> listener
     ) {
         final Map<String, List<String>> modelIdToFieldPathMap = extractModelIdToFieldPathMap(semanticFieldPathToConfigMap);
 
         mlClientAccessor.getModels(modelIdToFieldPathMap.keySet(), modelIdToConfigMap -> {
-            modifyMappings(modelIdToConfigMap, mappings, modelIdToFieldPathMap, semanticFieldPathToConfigMap);
+            modifyMappings(modelIdToConfigMap, mappings, modelIdToFieldPathMap, semanticFieldPathToConfigMap, modelSelectionByPath);
             listener.onResponse(null);
         }, listener::onFailure);
     }
@@ -187,7 +308,8 @@ public class SemanticMappingTransformer implements MappingTransformer {
         @NonNull final Map<String, MLModel> modelIdToConfigMap,
         @NonNull final Map<String, Object> mappings,
         @NonNull final Map<String, List<String>> modelIdToFieldPathMap,
-        @NonNull final Map<String, Map<String, Object>> semanticFieldPathToConfigMap
+        @NonNull final Map<String, Map<String, Object>> semanticFieldPathToConfigMap,
+        @NonNull final Map<String, ModelSelection> modelSelectionByPath
     ) {
         for (String modelId : modelIdToFieldPathMap.keySet()) {
             final MLModel mlModel = modelIdToConfigMap.get(modelId);
@@ -195,6 +317,12 @@ public class SemanticMappingTransformer implements MappingTransformer {
             for (String fieldPath : fieldPathList) {
                 try {
                     final Map<String, Object> fieldConfig = semanticFieldPathToConfigMap.get(fieldPath);
+                    // For fields resolved from a model_selection, verify the resolved model's type matches the
+                    // requested model_type now that the model is loaded (single fetch, no separate resolve-time fetch).
+                    final ModelSelection modelSelection = modelSelectionByPath.get(fieldPath);
+                    if (modelSelection != null) {
+                        validateModelTypeMatches(modelSelection, mlModel, modelId);
+                    }
                     final Map<String, Object> semanticInfoConfig = createSemanticInfoField(mlModel, modelId, fieldConfig, fieldPath);
                     setSemanticInfoField(mappings, fieldPath, fieldConfig.get(SEMANTIC_INFO_FIELD_NAME), semanticInfoConfig);
                 } catch (IllegalArgumentException e) {
@@ -203,6 +331,25 @@ public class SemanticMappingTransformer implements MappingTransformer {
                     throw new RuntimeException(getModifyMappingErrorMessage(fieldPath, e.getMessage()), e);
                 }
             }
+        }
+    }
+
+    private void validateModelTypeMatches(
+        @NonNull final ModelSelection modelSelection,
+        @NonNull final MLModel mlModel,
+        @NonNull final String modelId
+    ) {
+        final boolean modelIsDense = SemanticMLModelUtils.isDenseModel(SemanticMLModelUtils.getModelType(mlModel));
+        if (modelIsDense != modelSelection.isDense()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "The model [%s] is a %s model, which does not match the requested model_type [%s].",
+                    modelId,
+                    modelIsDense ? ModelSelection.DENSE : ModelSelection.SPARSE,
+                    modelSelection.getModelType()
+                )
+            );
         }
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/ml/resolver/DefaultSemanticModelResolver.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/resolver/DefaultSemanticModelResolver.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.ml.resolver;
+
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.neuralsearch.mapper.dto.ModelSelection;
+import org.opensearch.neuralsearch.settings.SemanticModelSelectionSettingsAccessor;
+
+import java.util.Locale;
+
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.SEMANTIC_MODEL_SELECTION_MODEL_ID_PREFIX;
+
+/**
+ * Default {@link SemanticModelResolver} implementation. It resolves a {@link ModelSelection} to a model_id by reading
+ * the operator configured {@code plugins.neural_search.model_selection.model_id.<model_type>.<language_option>} cluster
+ * setting. It does not register, deploy, or fetch any model; the operator is expected to deploy the model and configure
+ * the setting. Verification that the resolved model exists and its type matches the requested model type happens later,
+ * where the model is loaded to build the semantic info field.
+ */
+@Log4j2
+public class DefaultSemanticModelResolver implements SemanticModelResolver {
+
+    private final SemanticModelSelectionSettingsAccessor settingsAccessor;
+
+    public DefaultSemanticModelResolver(@NonNull final SemanticModelSelectionSettingsAccessor settingsAccessor) {
+        this.settingsAccessor = settingsAccessor;
+    }
+
+    @Override
+    public String resolve(@NonNull final ModelSelection modelSelection) {
+        final String profileKey = modelSelection.getProfileKey();
+        final String modelId = settingsAccessor.getModelId(profileKey);
+
+        if (modelId == null) {
+            final String settingKey = SEMANTIC_MODEL_SELECTION_MODEL_ID_PREFIX + profileKey;
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "No model_id is configured for the model_selection [language_option=%s, model_type=%s]. "
+                        + "Deploy a %s model and set the cluster setting [%s] to its model_id, then retry.",
+                    modelSelection.getLanguageOption(),
+                    modelSelection.getModelType(),
+                    modelSelection.getModelType(),
+                    settingKey
+                )
+            );
+        }
+
+        return modelId;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/ml/resolver/SemanticModelResolver.java
+++ b/src/main/java/org/opensearch/neuralsearch/ml/resolver/SemanticModelResolver.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.ml.resolver;
+
+import org.opensearch.neuralsearch.mapper.dto.ModelSelection;
+
+/**
+ * Interface for resolving a model_id from a {@link ModelSelection} (language option + model type). Implementations
+ * resolve the model_id from operator configured cluster settings. Resolution is a cheap, local lookup and returns
+ * synchronously; verification that the resolved model exists and its type matches the requested model type happens
+ * later, where the model is loaded to build the semantic info field.
+ */
+public interface SemanticModelResolver {
+
+    /**
+     * Resolve the model_id for the given {@link ModelSelection}.
+     *
+     * @param modelSelection the model selection (language option + model type)
+     * @return the resolved model_id
+     * @throws IllegalArgumentException if no model_id is configured for the given model selection
+     */
+    String resolve(ModelSelection modelSelection);
+}

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -49,6 +49,9 @@ import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MappingTransformer;
 import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
 import org.opensearch.neuralsearch.mappingtransformer.SemanticMappingTransformer;
+import org.opensearch.neuralsearch.ml.resolver.DefaultSemanticModelResolver;
+import org.opensearch.neuralsearch.ml.resolver.SemanticModelResolver;
+import org.opensearch.neuralsearch.settings.SemanticModelSelectionSettingsAccessor;
 import org.opensearch.neuralsearch.processor.factory.SemanticFieldProcessorFactory;
 import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.search.query.QueryCollectorContextSpecFactory;
@@ -192,6 +195,8 @@ public class NeuralSearch extends Plugin
     private PipelineServiceUtil pipelineServiceUtil;
     private InfoStatsManager infoStatsManager;
     private ClusterService clusterService;
+    private SemanticMappingTransformer semanticMappingTransformer;
+    private SemanticModelResolver modelResolver;
     private final SemanticHighlighter semanticHighlighter;
     private final ScoreNormalizationFactory scoreNormalizationFactory = new ScoreNormalizationFactory();
     private final ScoreCombinationFactory scoreCombinationFactory = new ScoreCombinationFactory();
@@ -241,6 +246,14 @@ public class NeuralSearch extends Plugin
 
         // Initialize the semantic highlighter
         this.semanticHighlighter.initialize(semanticHighlighterEngine);
+
+        // Create model resolver for semantic field model_selection support. It resolves the model_id from the
+        // plugins.neural_search.model_selection.model_id.* cluster settings.
+        SemanticModelSelectionSettingsAccessor modelSelectionSettingsAccessor = new SemanticModelSelectionSettingsAccessor(clusterService);
+        modelResolver = new DefaultSemanticModelResolver(modelSelectionSettingsAccessor);
+        if (semanticMappingTransformer != null) {
+            semanticMappingTransformer.setModelResolver(modelResolver);
+        }
 
         // Create and provide the Hybrid query converter for gRPC transport
         HybridQueryBuilderProtoConverter hybridQueryConverter = new HybridQueryBuilderProtoConverter();
@@ -366,7 +379,8 @@ public class NeuralSearch extends Plugin
             SparseSettings.IS_SPARSE_INDEX_SETTING,
             NeuralSearchSettings.SPARSE_ALGO_PARAM_INDEX_THREAD_QTY_SETTING,
             NEURAL_CIRCUIT_BREAKER_LIMIT,
-            NEURAL_CIRCUIT_BREAKER_OVERHEAD
+            NEURAL_CIRCUIT_BREAKER_OVERHEAD,
+            NeuralSearchSettings.SEMANTIC_MODEL_SELECTION_MODEL_ID
         );
     }
 
@@ -466,7 +480,11 @@ public class NeuralSearch extends Plugin
 
     @Override
     public List<MappingTransformer> getMappingTransformers() {
-        return List.of(new SemanticMappingTransformer(clientAccessor, xContentRegistry));
+        semanticMappingTransformer = new SemanticMappingTransformer(clientAccessor, xContentRegistry);
+        if (modelResolver != null) {
+            semanticMappingTransformer.setModelResolver(modelResolver);
+        }
+        return List.of(semanticMappingTransformer);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
+++ b/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
@@ -115,4 +115,23 @@ public final class NeuralSearchSettings {
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
+
+    /**
+     * Prefix of the model selection model id affix setting.
+     * {@link #SEMANTIC_MODEL_SELECTION_MODEL_ID}
+     */
+    public static final String SEMANTIC_MODEL_SELECTION_MODEL_ID_PREFIX = "plugins.neural_search.model_selection.model_id.";
+
+    /**
+     * Affix setting that maps a semantic field {@code model_selection} profile to a deployed model id. The concrete
+     * setting key takes the form {@code plugins.neural_search.model_selection.model_id.<model_type>.<language_option>}
+     * (both lower cased), e.g. {@code plugins.neural_search.model_selection.model_id.sparse.english}.
+     * <p>
+     * Using an affix setting keeps the mapping flexible: additional dimensions can be introduced in the future without
+     * having to define a new fixed setting per combination.
+     */
+    public static final Setting.AffixSetting<String> SEMANTIC_MODEL_SELECTION_MODEL_ID = Setting.prefixKeySetting(
+        SEMANTIC_MODEL_SELECTION_MODEL_ID_PREFIX,
+        key -> Setting.simpleString(key, Setting.Property.NodeScope, Setting.Property.Dynamic)
+    );
 }

--- a/src/main/java/org/opensearch/neuralsearch/settings/SemanticModelSelectionSettingsAccessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/settings/SemanticModelSelectionSettingsAccessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.settings;
+
+import lombok.NonNull;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.SEMANTIC_MODEL_SELECTION_MODEL_ID;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.SEMANTIC_MODEL_SELECTION_MODEL_ID_PREFIX;
+
+/**
+ * Resolves the {@link NeuralSearchSettings#SEMANTIC_MODEL_SELECTION_MODEL_ID} affix setting for a given profile. It
+ * reads node settings (opensearch.yml) merged with the current persistent and transient cluster settings, so it honors
+ * both static configuration and the latest dynamically updated value.
+ */
+public class SemanticModelSelectionSettingsAccessor {
+    private final ClusterService clusterService;
+
+    public SemanticModelSelectionSettingsAccessor(@NonNull final ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    /**
+     * Return the configured model id for the given profile key, or null if none is configured.
+     *
+     * @param profileKey profile key of the form {@code <model_type>.<language_option>} (lower cased), e.g. {@code sparse.english}
+     * @return the configured model id, or null when the operator has not configured this profile
+     */
+    public String getModelId(@NonNull final String profileKey) {
+        final String fullKey = SEMANTIC_MODEL_SELECTION_MODEL_ID_PREFIX + profileKey;
+        // Merge node settings (opensearch.yml) with the merged persistent+transient cluster settings, so both static
+        // (opensearch.yml) and dynamically updated values are honored. Metadata#settings() already merges the
+        // persistent and transient cluster settings.
+        final Settings settings = Settings.builder()
+            .put(clusterService.getSettings())
+            .put(clusterService.state().getMetadata().settings())
+            .build();
+        final Setting<String> concreteSetting = SEMANTIC_MODEL_SELECTION_MODEL_ID.getConcreteSetting(fullKey);
+        final String modelId = concreteSetting.get(settings);
+        if (modelId == null || modelId.isEmpty()) {
+            return null;
+        }
+        return modelId;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/it/SemanticFieldModelSelectionIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/it/SemanticFieldModelSelectionIT.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.it;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import java.util.Map;
+
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_USER_AGENT;
+
+/**
+ * Integration tests for the {@code model_selection} parameter on the semantic field. The model_id is resolved from the
+ * {@code plugins.neural_search.model_selection.model_id.*} cluster settings.
+ */
+public class SemanticFieldModelSelectionIT extends BaseNeuralSearchIT {
+    private static final String SPARSE_ENGLISH_SETTING_KEY = "plugins.neural_search.model_selection.model_id.sparse.english";
+    private static final String DENSE_ENGLISH_SETTING_KEY = "plugins.neural_search.model_selection.model_id.dense.english";
+
+    /**
+     * When model_selection is used but no model_id is configured for the profile, index creation fails with a clear error.
+     */
+    public void testCreateIndex_withModelSelection_whenNoModelConfigured_thenFail() throws Exception {
+        final String indexBody = "{\n"
+            + "  \"mappings\": {\n"
+            + "    \"properties\": {\n"
+            + "      \"content\": {\n"
+            + "        \"type\": \"semantic\",\n"
+            + "        \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+
+        final ResponseException exception = assertThrows(
+            ResponseException.class,
+            () -> createIndex("semantic_model_selection_no_config", indexBody)
+        );
+        final Response response = exception.getResponse();
+        assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatusLine().getStatusCode());
+        final String responseBody = EntityUtils.toString(response.getEntity());
+        assertTrue("Response should explain that no model_id is configured", responseBody.contains("No model_id is configured"));
+    }
+
+    /**
+     * When model_selection is used and the matching model_id is configured, the index is created and the resolved
+     * model_id is written into the mapping alongside the model_selection.
+     */
+    @SuppressWarnings("unchecked")
+    public void testCreateIndex_withModelSelection_whenModelConfigured_thenResolveModelId() throws Exception {
+        final String modelId = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String indexName = "semantic_model_selection_ok";
+            final String indexBody = "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"content\": {\n"
+                + "        \"type\": \"semantic\",\n"
+                + "        \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+            createIndex(indexName, indexBody);
+
+            final Map<String, Object> contentField = getSemanticContentFieldMapping(indexName);
+            assertEquals(modelId, contentField.get("model_id"));
+            assertTrue(contentField.get("model_selection") instanceof Map);
+        } finally {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * When both model_id and model_selection are provided but they resolve to different models, index creation fails.
+     */
+    public void testCreateIndex_withModelSelectionAndMismatchedModelId_thenFail() throws Exception {
+        final String modelId = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String indexBody = "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"content\": {\n"
+                + "        \"type\": \"semantic\",\n"
+                + "        \"model_id\": \"some_other_model_id\",\n"
+                + "        \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+            final ResponseException exception = assertThrows(
+                ResponseException.class,
+                () -> createIndex("semantic_model_selection_mismatch", indexBody)
+            );
+            final Response response = exception.getResponse();
+            assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatusLine().getStatusCode());
+            final String responseBody = EntityUtils.toString(response.getEntity());
+            assertTrue("Response should explain the model_id mismatch", responseBody.contains("does not match the model_id"));
+        } finally {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * Dense path: when a dense model is configured for the dense/english profile, model_selection resolves to it.
+     */
+    @SuppressWarnings("unchecked")
+    public void testCreateIndex_withModelSelection_denseEnglish_whenModelConfigured_thenResolveModelId() throws Exception {
+        final String modelId = prepareModel();
+        try {
+            updateClusterSettings(DENSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String indexName = "semantic_model_selection_dense_ok";
+            // Dense semantic fields build a knn_vector companion field, which requires index.knn = true.
+            final String indexBody = "{\n"
+                + "  \"settings\": { \"index.knn\": true },\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"content\": {\n"
+                + "        \"type\": \"semantic\",\n"
+                + "        \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"DENSE\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+            createIndex(indexName, indexBody);
+
+            final Map<String, Object> contentField = getSemanticContentFieldMapping(indexName);
+            assertEquals(modelId, contentField.get("model_id"));
+            assertTrue(contentField.get("model_selection") instanceof Map);
+        } finally {
+            updateClusterSettings(DENSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * When both model_id and model_selection are provided and they resolve to the same model, the index is created.
+     */
+    @SuppressWarnings("unchecked")
+    public void testCreateIndex_withModelSelectionAndMatchingModelId_thenSucceed() throws Exception {
+        final String modelId = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String indexName = "semantic_model_selection_match_ok";
+            final String indexBody = "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"content\": {\n"
+                + "        \"type\": \"semantic\",\n"
+                + "        \"model_id\": \""
+                + modelId
+                + "\",\n"
+                + "        \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+            createIndex(indexName, indexBody);
+
+            final Map<String, Object> contentField = getSemanticContentFieldMapping(indexName);
+            assertEquals(modelId, contentField.get("model_id"));
+        } finally {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * When the configured model's type does not match the requested model_type, index creation fails.
+     */
+    public void testCreateIndex_withModelSelection_whenModelTypeMismatch_thenFail() throws Exception {
+        // Configure a SPARSE model under the DENSE/english profile, then request DENSE.
+        final String sparseModelId = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(DENSE_ENGLISH_SETTING_KEY, sparseModelId);
+
+            final String indexBody = "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"content\": {\n"
+                + "        \"type\": \"semantic\",\n"
+                + "        \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"DENSE\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+            final ResponseException exception = assertThrows(
+                ResponseException.class,
+                () -> createIndex("semantic_model_selection_type_mismatch", indexBody)
+            );
+            final Response response = exception.getResponse();
+            assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatusLine().getStatusCode());
+            final String responseBody = EntityUtils.toString(response.getEntity());
+            assertTrue("Response should explain the model_type mismatch", responseBody.contains("does not match the requested model_type"));
+        } finally {
+            updateClusterSettings(DENSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * When model_id is not a string, index creation fails with a clear error.
+     */
+    public void testCreateIndex_withModelSelectionAndNonStringModelId_thenFail() throws Exception {
+        final String modelId = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String indexBody = "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"content\": {\n"
+                + "        \"type\": \"semantic\",\n"
+                + "        \"model_id\": { \"unexpected\": \"object\" },\n"
+                + "        \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+            final ResponseException exception = assertThrows(
+                ResponseException.class,
+                () -> createIndex("semantic_model_selection_non_string_model_id", indexBody)
+            );
+            final Response response = exception.getResponse();
+            assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatusLine().getStatusCode());
+            final String responseBody = EntityUtils.toString(response.getEntity());
+            assertTrue("Response should explain model_id must be a string", responseBody.contains("must be a string"));
+        } finally {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * A model_selection field with an invalid semantic_info_field_name (contains '.') is rejected, consistent with the
+     * explicit model_id path.
+     */
+    public void testCreateIndex_withModelSelectionAndInvalidSemanticInfoFieldName_thenFail() throws Exception {
+        final String modelId = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String indexBody = "{\n"
+                + "  \"mappings\": {\n"
+                + "    \"properties\": {\n"
+                + "      \"content\": {\n"
+                + "        \"type\": \"semantic\",\n"
+                + "        \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" },\n"
+                + "        \"semantic_info_field_name\": \"bad.name\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+            final ResponseException exception = assertThrows(
+                ResponseException.class,
+                () -> createIndex("semantic_model_selection_bad_info_field", indexBody)
+            );
+            final Response response = exception.getResponse();
+            assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatusLine().getStatusCode());
+            final String responseBody = EntityUtils.toString(response.getEntity());
+            assertTrue("Response should reject '.' in semantic_info_field_name", responseBody.contains("should not contain '.'"));
+        } finally {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * Adding a semantic field with model_selection via the update-mapping API (PUT _mapping) resolves the model_id.
+     */
+    public void testUpdateMapping_addModelSelectionField_thenResolveModelId() throws Exception {
+        final String modelId = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String indexName = "semantic_model_selection_put_mapping";
+            createIndex(indexName, "{\n  \"mappings\": { \"properties\": { \"title\": { \"type\": \"text\" } } }\n}");
+
+            updateIndexMapping(
+                indexName,
+                "{\n  \"properties\": {\n    \"content\": {\n      \"type\": \"semantic\",\n"
+                    + "      \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" }\n"
+                    + "    }\n  }\n}"
+            );
+
+            final Map<String, Object> contentField = getSemanticContentFieldMapping(indexName);
+            assertEquals(modelId, contentField.get("model_id"));
+            assertTrue(contentField.get("model_selection") instanceof Map);
+        } finally {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * A composable index template with a model_selection semantic field resolves the model_id, and an index created
+     * from that template carries the resolved model_id.
+     */
+    public void testComposableTemplate_withModelSelection_thenResolveModelId() throws Exception {
+        final String modelId = prepareSparseEncodingModel();
+        final String templateName = "semantic_model_selection_template";
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String templateBody = "{\n"
+                + "  \"index_patterns\": [\"semantic-ms-*\"],\n"
+                + "  \"template\": { \"mappings\": { \"properties\": {\n"
+                + "    \"content\": { \"type\": \"semantic\", \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" } }\n"
+                + "  } } }\n"
+                + "}";
+            makeRequest(
+                client(),
+                "PUT",
+                "_index_template/" + templateName,
+                null,
+                toHttpEntity(templateBody),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            );
+
+            final String indexName = "semantic-ms-1";
+            createIndex(indexName, "{}");
+
+            final Map<String, Object> contentField = getSemanticContentFieldMapping(indexName);
+            assertEquals(modelId, contentField.get("model_id"));
+            assertTrue(contentField.get("model_selection") instanceof Map);
+        } finally {
+            try {
+                makeRequest(
+                    client(),
+                    "DELETE",
+                    "_index_template/" + templateName,
+                    null,
+                    null,
+                    ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+                );
+            } catch (Exception ignored) {}
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * After the operator rotates the profile's model_id, reapplying a previously read-back mapping (which carries the
+     * old model_id alongside model_selection) fails with a clear mismatch error.
+     */
+    public void testReapplyMappingAfterProfileRotation_thenFail() throws Exception {
+        final String modelId = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId);
+
+            final String indexName = "semantic_model_selection_rotation";
+            createIndex(
+                indexName,
+                "{\n  \"mappings\": { \"properties\": {\n"
+                    + "    \"content\": { \"type\": \"semantic\", \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" } }\n"
+                    + "  } }\n}"
+            );
+            // The field resolved to the current profile model.
+            assertEquals(modelId, getSemanticContentFieldMapping(indexName).get("model_id"));
+
+            // Operator rotates the profile to a different model_id.
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, "rotated_model_id");
+
+            // Reapplying the read-back mapping (old model_id + model_selection) now conflicts with the rotated profile.
+            final String reapplyBody = "{\n  \"properties\": {\n    \"content\": {\n      \"type\": \"semantic\",\n"
+                + "      \"model_id\": \""
+                + modelId
+                + "\",\n"
+                + "      \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" }\n"
+                + "    }\n  }\n}";
+
+            final ResponseException exception = assertThrows(ResponseException.class, () -> updateIndexMapping(indexName, reapplyBody));
+            final Response response = exception.getResponse();
+            assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatusLine().getStatusCode());
+            final String responseBody = EntityUtils.toString(response.getEntity());
+            assertTrue("Response should explain the model_id mismatch", responseBody.contains("does not match the model_id"));
+        } finally {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    /**
+     * Canary pinning today's behavior: after the operator rotates the profile to a new model, re-applying a
+     * model_selection-only mapping (no model_id) silently rebinds the field to the new model and returns 200.
+     * opensearch-project/neural-search#1963 will make the model binding immutable; when that lands this should instead
+     * be rejected, turning this test red as a signal of the behavior change.
+     */
+    @SuppressWarnings("unchecked")
+    public void testReapplyModelSelectionOnly_afterRotation_silentlyRebinds() throws Exception {
+        final String modelId1 = prepareSparseEncodingModel();
+        final String modelId2 = prepareSparseEncodingModel();
+        try {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId1);
+
+            final String indexName = "semantic_model_selection_silent_rebind";
+            createIndex(
+                indexName,
+                "{\n  \"mappings\": { \"properties\": {\n"
+                    + "    \"content\": { \"type\": \"semantic\", \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" } }\n"
+                    + "  } }\n}"
+            );
+            assertEquals(modelId1, getSemanticContentFieldMapping(indexName).get("model_id"));
+
+            // Operator rotates the profile to a second (same-type) model.
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, modelId2);
+
+            // Re-apply with model_selection ONLY (no model_id). Today this succeeds (200) and rebinds to modelId2.
+            updateIndexMapping(
+                indexName,
+                "{\n  \"properties\": {\n    \"content\": {\n      \"type\": \"semantic\",\n"
+                    + "      \"model_selection\": { \"language_option\": \"ENGLISH\", \"model_type\": \"SPARSE\" }\n"
+                    + "    }\n  }\n}"
+            );
+
+            assertEquals(modelId2, getSemanticContentFieldMapping(indexName).get("model_id"));
+        } finally {
+            updateClusterSettings(SPARSE_ENGLISH_SETTING_KEY, null);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getSemanticContentFieldMapping(final String indexName) {
+        final Map<String, Object> indexMapping = getIndexMapping(indexName);
+        final Map<String, Object> index = (Map<String, Object>) indexMapping.get(indexName);
+        final Map<String, Object> mappings = (Map<String, Object>) index.get("mappings");
+        final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+        return (Map<String, Object>) properties.get("content");
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperModelSelectionTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperModelSelectionTests.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper;
+
+import lombok.NonNull;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.Before;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.Version;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.analysis.AnalyzerScope;
+import org.opensearch.index.analysis.IndexAnalyzers;
+import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.mapper.BinaryFieldMapper;
+import org.opensearch.index.mapper.ContentPath;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.MatchOnlyTextFieldMapper;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.TextFieldMapper;
+import org.opensearch.index.mapper.WildcardFieldMapper;
+import org.opensearch.neuralsearch.mapper.dto.ModelSelection;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.Version.CURRENT;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+import static org.opensearch.neuralsearch.constants.MappingConstants.TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.LANGUAGE_OPTION;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_ID;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_SELECTION;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_TYPE;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.RAW_FIELD_TYPE;
+import static org.opensearch.neuralsearch.util.TestUtils.xContentBuilderToMap;
+
+public class SemanticFieldMapperModelSelectionTests extends OpenSearchTestCase {
+
+    private final String fieldName = "testField";
+    private final SemanticFieldMapper.TypeParser TYPE_PARSER = new SemanticFieldMapper.TypeParser();
+
+    private MapperService mapperService = mock(MapperService.class);
+
+    private static final IndexAnalyzers indexAnalyzers = new IndexAnalyzers(
+        singletonMap("default", new NamedAnalyzer("default", AnalyzerScope.INDEX, new StandardAnalyzer())),
+        emptyMap(),
+        emptyMap()
+    );
+
+    private final Function<String, Mapper.TypeParser> typeParsers = s -> {
+        switch (s) {
+            case TextFieldMapper.CONTENT_TYPE:
+                return TextFieldMapper.PARSER;
+            case MatchOnlyTextFieldMapper.CONTENT_TYPE:
+                return MatchOnlyTextFieldMapper.PARSER;
+            case WildcardFieldMapper.CONTENT_TYPE:
+                return WildcardFieldMapper.PARSER;
+            case BinaryFieldMapper.CONTENT_TYPE:
+                return BinaryFieldMapper.PARSER;
+            case KeywordFieldMapper.CONTENT_TYPE:
+                return KeywordFieldMapper.PARSER;
+        }
+        return null;
+    };
+    private final Mapper.TypeParser.ParserContext parserContext = new Mapper.TypeParser.ParserContext(
+        null,
+        mapperService,
+        typeParsers,
+        Version.CURRENT,
+        null,
+        null,
+        null
+    );
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mapperService.getIndexAnalyzers()).thenReturn(indexAnalyzers);
+    }
+
+    public void testTypeParser_parse_withModelSelection() {
+        Map<String, Object> node = createFieldConfigWithModelSelection("ENGLISH", "SPARSE");
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(fieldName, node, parserContext);
+
+        assertEquals(new ModelSelection("ENGLISH", "SPARSE"), builder.getModelSelection().getValue());
+        assertNull(builder.getModelId().getValue());
+    }
+
+    public void testTypeParser_parse_withModelSelectionDefaults() {
+        // An empty model_selection object defaults to ENGLISH / SPARSE.
+        Map<String, Object> node = new HashMap<>();
+        node.put(TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        node.put(MODEL_SELECTION, new HashMap<>());
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(fieldName, node, parserContext);
+
+        assertEquals(new ModelSelection("ENGLISH", "SPARSE"), builder.getModelSelection().getValue());
+    }
+
+    /**
+     * TypeParser accepts model_id + model_selection coexisting. The match validation lives in the
+     * SemanticMappingTransformer which runs before the mapper parses, on the raw user input.
+     */
+    public void testTypeParser_parse_acceptsModelIdWithModelSelection() {
+        Map<String, Object> node = new HashMap<>();
+        node.put(TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        node.put(MODEL_ID, "some_model_id");
+        node.put(MODEL_SELECTION, Map.of(LANGUAGE_OPTION, "ENGLISH", MODEL_TYPE, "SPARSE"));
+
+        SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(fieldName, node, parserContext);
+
+        assertEquals("some_model_id", builder.getModelId().getValue());
+        assertEquals(new ModelSelection("ENGLISH", "SPARSE"), builder.getModelSelection().getValue());
+    }
+
+    public void testTypeParser_parse_withInvalidLanguageOption_thenThrow() {
+        Map<String, Object> node = createFieldConfigWithModelSelection("KLINGON", "SPARSE");
+
+        expectThrows(MapperParsingException.class, () -> TYPE_PARSER.parse(fieldName, node, parserContext));
+    }
+
+    public void testTypeParser_parse_withInvalidModelType_thenThrow() {
+        Map<String, Object> node = createFieldConfigWithModelSelection("ENGLISH", "HYBRID");
+
+        expectThrows(MapperParsingException.class, () -> TYPE_PARSER.parse(fieldName, node, parserContext));
+    }
+
+    public void testTypeParser_parse_withUnsupportedModelSelectionParam_thenThrow() {
+        Map<String, Object> node = new HashMap<>();
+        node.put(TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        node.put(MODEL_SELECTION, Map.of(LANGUAGE_OPTION, "ENGLISH", "unexpected", "value"));
+
+        expectThrows(MapperParsingException.class, () -> TYPE_PARSER.parse(fieldName, node, parserContext));
+    }
+
+    public void testBuilder_build_withModelSelection() {
+        Map<String, Object> node = createFieldConfigWithModelSelection("ENGLISH", "DENSE");
+        SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(node, parserContext);
+
+        assertNotNull(semanticFieldMapper);
+        assertTrue(semanticFieldMapper.fieldType() instanceof SemanticFieldMapper.SemanticFieldType);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testFieldMapper_doXContentBody_serializesModelSelection() throws IOException {
+        Map<String, Object> config = createFieldConfigWithModelSelection("MULTILINGUAL", "DENSE");
+        SemanticFieldMapper semanticFieldMapper = buildSemanticFieldMapper(config, parserContext);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        semanticFieldMapper.doXContentBody(xContentBuilder, false, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        Map<String, Object> out = xContentBuilderToMap(xContentBuilder);
+
+        assertTrue(out.get(MODEL_SELECTION) instanceof Map);
+        Map<String, Object> modelSelection = (Map<String, Object>) out.get(MODEL_SELECTION);
+        assertEquals("MULTILINGUAL", modelSelection.get(LANGUAGE_OPTION));
+        assertEquals("DENSE", modelSelection.get(MODEL_TYPE));
+        assertFalse(out.containsKey(MODEL_ID));
+    }
+
+    public void testBuilder_getParameters_includesModelSelection() {
+        SemanticFieldMapper.Builder builder = new SemanticFieldMapper.Builder(fieldName);
+        assertEquals(10, builder.getParameters().size());
+        assertTrue(builder.getParameters().stream().anyMatch(p -> MODEL_SELECTION.equals(p.name)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testMerge_modelSelectionIsUpdatable() throws IOException {
+        final SemanticFieldMapper original = buildSemanticFieldMapper(
+            createFieldConfigWithModelSelection("ENGLISH", "SPARSE"),
+            parserContext
+        );
+        final SemanticFieldMapper updated = buildSemanticFieldMapper(
+            createFieldConfigWithModelSelection("MULTILINGUAL", "DENSE"),
+            parserContext
+        );
+
+        // model_selection is an updatable parameter, so the merged mapper should carry the updated value.
+        final SemanticFieldMapper merged = (SemanticFieldMapper) original.merge(updated);
+
+        final XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        merged.doXContentBody(xContentBuilder, false, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        final Map<String, Object> out = xContentBuilderToMap(xContentBuilder);
+
+        final Map<String, Object> modelSelection = (Map<String, Object>) out.get(MODEL_SELECTION);
+        assertEquals("MULTILINGUAL", modelSelection.get(LANGUAGE_OPTION));
+        assertEquals("DENSE", modelSelection.get(MODEL_TYPE));
+    }
+
+    /**
+     * Canary pinning today's behavior: a model_selection field's resolved model_id is updatable on merge. When the
+     * profile is rotated (M1 -> M2) and the mapping is re-applied, the merged mapper carries the NEW model_id (M2), i.e.
+     * the field silently rebinds. If opensearch-project/neural-search#1963 later makes the model binding immutable,
+     * this assertion should flip (the merge should then be rejected), turning this test red as a signal of that change.
+     */
+    public void testMerge_modelSelectionField_modelIdRebindIsAllowedToday() {
+        final Map<String, Object> originalConfig = createFieldConfigWithModelSelection("ENGLISH", "SPARSE");
+        originalConfig.put(MODEL_ID, "M1");
+        final SemanticFieldMapper original = buildSemanticFieldMapper(originalConfig, parserContext);
+
+        final Map<String, Object> updatedConfig = createFieldConfigWithModelSelection("ENGLISH", "SPARSE");
+        updatedConfig.put(MODEL_ID, "M2");
+        final SemanticFieldMapper updated = buildSemanticFieldMapper(updatedConfig, parserContext);
+
+        final SemanticFieldMapper merged = (SemanticFieldMapper) original.merge(updated);
+
+        assertEquals("M2", merged.getMergeBuilder().modelId.getValue());
+    }
+
+    private Map<String, Object> createFieldConfigWithModelSelection(String languageOption, String modelType) {
+        Map<String, Object> modelSelection = new HashMap<>();
+        if (languageOption != null) {
+            modelSelection.put(LANGUAGE_OPTION, languageOption);
+        }
+        if (modelType != null) {
+            modelSelection.put(MODEL_TYPE, modelType);
+        }
+        Map<String, Object> node = new HashMap<>();
+        node.put(TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        node.put(RAW_FIELD_TYPE, TextFieldMapper.CONTENT_TYPE);
+        node.put(MODEL_SELECTION, modelSelection);
+        return node;
+    }
+
+    private SemanticFieldMapper buildSemanticFieldMapper(
+        @NonNull final Map<String, Object> fieldConfig,
+        @NonNull final Mapper.TypeParser.ParserContext parserContext
+    ) {
+        final SemanticFieldMapper.Builder builder = TYPE_PARSER.parse(fieldName, fieldConfig, parserContext);
+
+        final Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        final ParametrizedFieldMapper.BuilderContext builderContext = new ParametrizedFieldMapper.BuilderContext(
+            settings,
+            new ContentPath()
+        );
+
+        return builder.build(builderContext);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/SemanticFieldMapperTests.java
@@ -213,7 +213,7 @@ public class SemanticFieldMapperTests extends OpenSearchTestCase {
 
     public void testBuilder_getParameters() {
         final SemanticFieldMapper.Builder builder = new SemanticFieldMapper.Builder(fieldName);
-        assertEquals(9, builder.getParameters().size());
+        assertEquals(10, builder.getParameters().size());
         List<String> actualParams = builder.getParameters().stream().map(a -> a.name).collect(Collectors.toList());
         List<String> expectedParams = Arrays.asList(
             MODEL_ID,
@@ -224,7 +224,8 @@ public class SemanticFieldMapperTests extends OpenSearchTestCase {
             SEMANTIC_FIELD_SEARCH_ANALYZER,
             DENSE_EMBEDDING_CONFIG,
             SPARSE_ENCODING_CONFIG,
-            SKIP_EXISTING_EMBEDDING
+            SKIP_EXISTING_EMBEDDING,
+            "model_selection"
         );
         assertEquals(expectedParams, actualParams);
     }

--- a/src/test/java/org/opensearch/neuralsearch/mapper/dto/ModelSelectionTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mapper/dto/ModelSelectionTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.mapper.dto;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.LANGUAGE_OPTION;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_SELECTION;
+import static org.opensearch.neuralsearch.constants.SemanticFieldConstants.MODEL_TYPE;
+import static org.opensearch.neuralsearch.util.TestUtils.xContentBuilderToMap;
+
+public class ModelSelectionTests extends OpenSearchTestCase {
+
+    public void testConstruct_fromMap_withBothFields() {
+        final ModelSelection ms = new ModelSelection(MODEL_SELECTION, Map.of(LANGUAGE_OPTION, "ENGLISH", MODEL_TYPE, "SPARSE"));
+        assertEquals("ENGLISH", ms.getLanguageOption());
+        assertEquals("SPARSE", ms.getModelType());
+    }
+
+    public void testConstruct_fromMap_normalizesCase() {
+        final ModelSelection ms = new ModelSelection(MODEL_SELECTION, Map.of(LANGUAGE_OPTION, "multilingual", MODEL_TYPE, "dense"));
+        assertEquals("MULTILINGUAL", ms.getLanguageOption());
+        assertEquals("DENSE", ms.getModelType());
+    }
+
+    public void testConstruct_fromMap_appliesDefaults() {
+        final ModelSelection ms = new ModelSelection(MODEL_SELECTION, new HashMap<>());
+        assertEquals("ENGLISH", ms.getLanguageOption());
+        assertEquals("SPARSE", ms.getModelType());
+    }
+
+    public void testConstruct_fromLanguageAndType() {
+        final ModelSelection ms = new ModelSelection("MULTILINGUAL", "DENSE");
+        assertEquals("MULTILINGUAL", ms.getLanguageOption());
+        assertEquals("DENSE", ms.getModelType());
+    }
+
+    public void testConstruct_fromLanguageAndType_appliesDefaultsForNull() {
+        final ModelSelection ms = new ModelSelection(null, null);
+        assertEquals("ENGLISH", ms.getLanguageOption());
+        assertEquals("SPARSE", ms.getModelType());
+    }
+
+    public void testConstruct_whenValueNotMap_thenThrow() {
+        expectThrows(MapperParsingException.class, () -> new ModelSelection(MODEL_SELECTION, "not_a_map"));
+    }
+
+    public void testConstruct_whenInvalidLanguageOption_thenThrow() {
+        expectThrows(MapperParsingException.class, () -> new ModelSelection(MODEL_SELECTION, Map.of(LANGUAGE_OPTION, "KLINGON")));
+    }
+
+    public void testConstruct_whenInvalidModelType_thenThrow() {
+        expectThrows(MapperParsingException.class, () -> new ModelSelection(MODEL_SELECTION, Map.of(MODEL_TYPE, "HYBRID")));
+    }
+
+    public void testConstruct_whenUnsupportedKey_thenThrow() {
+        expectThrows(MapperParsingException.class, () -> new ModelSelection(MODEL_SELECTION, Map.of("unexpected", "value")));
+    }
+
+    public void testIsDense() {
+        assertTrue(new ModelSelection("ENGLISH", "DENSE").isDense());
+        assertFalse(new ModelSelection("ENGLISH", "SPARSE").isDense());
+    }
+
+    public void testGetProfileKey() {
+        assertEquals("sparse.english", new ModelSelection("ENGLISH", "SPARSE").getProfileKey());
+        assertEquals("dense.multilingual", new ModelSelection("MULTILINGUAL", "DENSE").getProfileKey());
+    }
+
+    public void testToXContent() throws Exception {
+        final ModelSelection ms = new ModelSelection("MULTILINGUAL", "DENSE");
+        final XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        ms.toXContent(builder, MODEL_SELECTION);
+        builder.endObject();
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> out = (Map<String, Object>) xContentBuilderToMap(builder).get(MODEL_SELECTION);
+        assertEquals("MULTILINGUAL", out.get(LANGUAGE_OPTION));
+        assertEquals("DENSE", out.get(MODEL_TYPE));
+    }
+
+    public void testToString() {
+        final String s = new ModelSelection("ENGLISH", "SPARSE").toString();
+        assertTrue(s.contains(LANGUAGE_OPTION));
+        assertTrue(s.contains("ENGLISH"));
+        assertTrue(s.contains(MODEL_TYPE));
+        assertTrue(s.contains("SPARSE"));
+    }
+
+    public void testEqualsAndHashCode() {
+        final ModelSelection a = new ModelSelection("ENGLISH", "SPARSE");
+        final ModelSelection b = new ModelSelection("english", "sparse");
+        final ModelSelection c = new ModelSelection("MULTILINGUAL", "SPARSE");
+        final ModelSelection d = new ModelSelection("ENGLISH", "DENSE");
+
+        assertEquals(a, a);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a, d);
+        assertNotEquals(a, null);
+        assertNotEquals(a, "ENGLISH");
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/mappingtransformer/SemanticMappingTransformerTests.java
@@ -22,6 +22,7 @@ import org.opensearch.neuralsearch.constants.MappingConstants;
 import org.opensearch.neuralsearch.constants.SemanticFieldConstants;
 import org.opensearch.neuralsearch.mapper.SemanticFieldMapper;
 import org.opensearch.neuralsearch.ml.MLCommonsClientAccessor;
+import org.opensearch.neuralsearch.ml.resolver.SemanticModelResolver;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -39,6 +40,8 @@ import java.util.function.Consumer;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.opensearch.neuralsearch.constants.SemanticInfoFieldConstants.KNN_VECTOR_METHOD_SPACE_TYPE_FIELD_NAME;
 
 public class SemanticMappingTransformerTests extends OpenSearchTestCase {
@@ -492,6 +495,146 @@ public class SemanticMappingTransformerTests extends OpenSearchTestCase {
         final String expectedErrorMessage = "Failed to transform the mapping for the semantic field at semantic_field "
             + "due to dense_embedding_config should be a Map<String, Object> for the semantic field at semantic_field";
         assertEquals(expectedErrorMessage, capturedException.getMessage());
+    }
+
+    public void testTransform_whenModelSelectionPresentWithoutResolver_thenFail() {
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticField = new HashMap<>();
+        properties.put("semantic_field", semanticField);
+        semanticField.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticField.put(SemanticFieldConstants.MODEL_SELECTION, Map.of("language_option", "ENGLISH", "model_type", "SPARSE"));
+
+        transformer.transform(mappings, null, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue() instanceof IllegalStateException);
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("SemanticModelResolver is not configured"));
+    }
+
+    public void testTransform_whenModelSelectionAndModelIdMismatch_thenFail() {
+        final SemanticModelResolver resolver = mock(SemanticModelResolver.class);
+        when(resolver.resolve(any())).thenReturn("resolved_model_id");
+        transformer.setModelResolver(resolver);
+
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticField = new HashMap<>();
+        properties.put("semantic_field", semanticField);
+        semanticField.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticField.put(SemanticFieldConstants.MODEL_ID, "some_other_model_id");
+        semanticField.put(SemanticFieldConstants.MODEL_SELECTION, Map.of("language_option", "ENGLISH", "model_type", "SPARSE"));
+
+        transformer.transform(mappings, null, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue() instanceof IllegalArgumentException);
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("does not match the model_id"));
+    }
+
+    public void testTransform_whenModelSelectionAndModelIdMatch_thenSucceed() {
+        final SemanticModelResolver resolver = mock(SemanticModelResolver.class);
+        when(resolver.resolve(any())).thenReturn("resolved_model_id");
+        transformer.setModelResolver(resolver);
+
+        final MLModel sparseModel = MLModel.builder().algorithm(FunctionName.SPARSE_ENCODING).build();
+        doAnswer(invocation -> {
+            final Consumer<Map<String, MLModel>> onSuccess = invocation.getArgument(1);
+            onSuccess.accept(Map.of("resolved_model_id", sparseModel));
+            return null;
+        }).when(mlClientAccessor).getModels(any(), any(), any());
+
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticField = new HashMap<>();
+        properties.put("semantic_field", semanticField);
+        semanticField.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticField.put(SemanticFieldConstants.MODEL_ID, "resolved_model_id");
+        semanticField.put(SemanticFieldConstants.MODEL_SELECTION, Map.of("language_option", "ENGLISH", "model_type", "SPARSE"));
+
+        transformer.transform(mappings, null, listener);
+
+        verify(listener).onResponse(null);
+        assertEquals("resolved_model_id", semanticField.get(SemanticFieldConstants.MODEL_ID));
+    }
+
+    public void testTransform_whenModelSelectionModelTypeMismatch_thenFail() {
+        final SemanticModelResolver resolver = mock(SemanticModelResolver.class);
+        when(resolver.resolve(any())).thenReturn("resolved_model_id");
+        transformer.setModelResolver(resolver);
+
+        // Configured model is dense (TEXT_EMBEDDING) but the request asks for SPARSE.
+        final MLModel denseModel = MLModel.builder().algorithm(FunctionName.TEXT_EMBEDDING).build();
+        doAnswer(invocation -> {
+            final Consumer<Map<String, MLModel>> onSuccess = invocation.getArgument(1);
+            onSuccess.accept(Map.of("resolved_model_id", denseModel));
+            return null;
+        }).when(mlClientAccessor).getModels(any(), any(), any());
+
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticField = new HashMap<>();
+        properties.put("semantic_field", semanticField);
+        semanticField.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticField.put(SemanticFieldConstants.MODEL_SELECTION, Map.of("language_option", "ENGLISH", "model_type", "SPARSE"));
+
+        transformer.transform(mappings, null, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue() instanceof IllegalArgumentException);
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("does not match the requested model_type"));
+    }
+
+    public void testTransform_whenModelSelectionAndNonStringModelId_thenFail() {
+        final SemanticModelResolver resolver = mock(SemanticModelResolver.class);
+        when(resolver.resolve(any())).thenReturn("resolved_model_id");
+        transformer.setModelResolver(resolver);
+
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticField = new HashMap<>();
+        properties.put("semantic_field", semanticField);
+        semanticField.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticField.put(SemanticFieldConstants.MODEL_ID, Map.of("unexpected", "object"));
+        semanticField.put(SemanticFieldConstants.MODEL_SELECTION, Map.of("language_option", "ENGLISH", "model_type", "SPARSE"));
+
+        transformer.transform(mappings, null, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue() instanceof IllegalArgumentException);
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("must be a string"));
+    }
+
+    public void testTransform_whenModelSelectionWithInvalidSemanticInfoFieldName_thenFail() {
+        final SemanticModelResolver resolver = mock(SemanticModelResolver.class);
+        when(resolver.resolve(any())).thenReturn("resolved_model_id");
+        transformer.setModelResolver(resolver);
+
+        final Map<String, Object> mappings = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
+        mappings.put("properties", properties);
+        final Map<String, Object> semanticField = new HashMap<>();
+        properties.put("semantic_field", semanticField);
+        semanticField.put(MappingConstants.TYPE, SemanticFieldMapper.CONTENT_TYPE);
+        semanticField.put(SemanticFieldConstants.MODEL_SELECTION, Map.of("language_option", "ENGLISH", "model_type", "SPARSE"));
+        // invalid: semantic_info_field_name must not contain '.'
+        semanticField.put(SemanticFieldConstants.SEMANTIC_INFO_FIELD_NAME, "bad.name");
+
+        transformer.transform(mappings, null, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue() instanceof IllegalArgumentException);
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("should not contain '.'"));
     }
 
     private Map<String, Object> getBaseMappingsWithOneSemanticField(@NonNull final String modelId) {

--- a/src/test/java/org/opensearch/neuralsearch/ml/resolver/DefaultSemanticModelResolverTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/ml/resolver/DefaultSemanticModelResolverTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.ml.resolver;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.neuralsearch.mapper.dto.ModelSelection;
+import org.opensearch.neuralsearch.settings.SemanticModelSelectionSettingsAccessor;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.when;
+
+public class DefaultSemanticModelResolverTests extends OpenSearchTestCase {
+
+    @Mock
+    private SemanticModelSelectionSettingsAccessor settingsAccessor;
+
+    private DefaultSemanticModelResolver resolver;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        resolver = new DefaultSemanticModelResolver(settingsAccessor);
+    }
+
+    public void testResolve_whenNoModelConfigured_thenThrow() {
+        when(settingsAccessor.getModelId("sparse.english")).thenReturn(null);
+
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> resolver.resolve(new ModelSelection("ENGLISH", "SPARSE"))
+        );
+        assertTrue(e.getMessage().contains("No model_id is configured"));
+        assertTrue(e.getMessage().contains("plugins.neural_search.model_selection.model_id.sparse.english"));
+    }
+
+    public void testResolve_whenSparseModelConfigured_thenReturnModelId() {
+        when(settingsAccessor.getModelId("sparse.english")).thenReturn("sparse_model_id");
+
+        assertEquals("sparse_model_id", resolver.resolve(new ModelSelection("ENGLISH", "SPARSE")));
+    }
+
+    public void testResolve_whenDenseModelConfigured_thenReturnModelId() {
+        when(settingsAccessor.getModelId("dense.multilingual")).thenReturn("dense_model_id");
+
+        assertEquals("dense_model_id", resolver.resolve(new ModelSelection("MULTILINGUAL", "DENSE")));
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -201,7 +201,8 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
 
     public void testGetSettings() {
         List<Setting<?>> settings = plugin.getSettings();
-        assertEquals(8, settings.size());
+        assertEquals(9, settings.size());
+        assertTrue(settings.contains(NeuralSearchSettings.SEMANTIC_MODEL_SELECTION_MODEL_ID));
     }
 
     public void testRequestProcessors() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorTests.java
@@ -309,9 +309,7 @@ public class NeuralSparseTwoPhaseProcessorTests extends OpenSearchTestCase {
         NeuralSparseTwoPhaseProcessor.Factory factory = new NeuralSparseTwoPhaseProcessor.Factory();
         NeuralSparseQueryBuilder neuralQueryBuilder = new NeuralSparseQueryBuilder();
         SearchRequest searchRequest = new SearchRequest();
-        searchRequest.source(
-            new SearchSourceBuilder().query(neuralQueryBuilder).sort(new ScoreSortBuilder()).trackScores(true)
-        );
+        searchRequest.source(new SearchSourceBuilder().query(neuralQueryBuilder).sort(new ScoreSortBuilder()).trackScores(true));
         NeuralSparseTwoPhaseProcessor processor = createTestProcessor(factory, 0.5f, true, 4.0f, 10000);
         processor.processRequest(searchRequest);
         assertNotNull(searchRequest.source().rescores());

--- a/src/test/java/org/opensearch/neuralsearch/settings/SemanticModelSelectionSettingsAccessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/settings/SemanticModelSelectionSettingsAccessorTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.settings;
+
+import org.junit.Before;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SemanticModelSelectionSettingsAccessorTests extends OpenSearchTestCase {
+
+    private static final String SPARSE_ENGLISH_KEY = "plugins.neural_search.model_selection.model_id.sparse.english";
+
+    private ClusterService clusterService;
+
+    @Before
+    public void setup() {
+        clusterService = mock(ClusterService.class);
+    }
+
+    private void stub(final Settings nodeSettings, final Settings clusterMetadataSettings) {
+        final ClusterState clusterState = mock(ClusterState.class);
+        final Metadata metadata = mock(Metadata.class);
+        when(clusterService.getSettings()).thenReturn(nodeSettings);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(metadata.settings()).thenReturn(clusterMetadataSettings);
+    }
+
+    public void testGetModelId_whenConfiguredInClusterSettings_thenReturnIt() {
+        stub(Settings.EMPTY, Settings.builder().put(SPARSE_ENGLISH_KEY, "model_1").build());
+        final SemanticModelSelectionSettingsAccessor accessor = new SemanticModelSelectionSettingsAccessor(clusterService);
+        assertEquals("model_1", accessor.getModelId("sparse.english"));
+    }
+
+    public void testGetModelId_whenConfiguredInNodeSettings_thenReturnIt() {
+        stub(Settings.builder().put(SPARSE_ENGLISH_KEY, "node_model").build(), Settings.EMPTY);
+        final SemanticModelSelectionSettingsAccessor accessor = new SemanticModelSelectionSettingsAccessor(clusterService);
+        assertEquals("node_model", accessor.getModelId("sparse.english"));
+    }
+
+    public void testGetModelId_whenNotConfigured_thenReturnNull() {
+        stub(Settings.EMPTY, Settings.EMPTY);
+        final SemanticModelSelectionSettingsAccessor accessor = new SemanticModelSelectionSettingsAccessor(clusterService);
+        assertNull(accessor.getModelId("sparse.english"));
+    }
+
+    public void testGetModelId_whenEmptyValue_thenReturnNull() {
+        stub(Settings.EMPTY, Settings.builder().put(SPARSE_ENGLISH_KEY, "").build());
+        final SemanticModelSelectionSettingsAccessor accessor = new SemanticModelSelectionSettingsAccessor(clusterService);
+        assertNull(accessor.getModelId("sparse.english"));
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #1918

Adds a `model_selection` parameter to the `semantic` field type so customers can create a semantic field **without specifying a `model_id`**. Instead of a raw model id, they declare *what they want* (language + model type) via `model_selection`, and the system resolves the `model_id` from operator-configured cluster settings.

```json
PUT /my-index
{
  "mappings": {
    "properties": {
      "title": {
        "type": "semantic",
        "model_selection": { "language_option": "ENGLISH", "model_type": "SPARSE" }
      }
    }
  }
}
```

`model_id` remains a top-level parameter. `model_selection` is a sibling nested object holding `language_option` (`ENGLISH` | `MULTILINGUAL`, default `ENGLISH`) and `model_type` (`SPARSE` | `DENSE`, default `SPARSE`).

## How it works

The plugin does **not** register or deploy any model. The operator deploys the model and points a cluster setting at it; the plugin resolves the `model_id` from that setting at index-creation/put-mapping time.

1. Operator deploys the model(s) they want to use for each profile (using the existing ML Commons register/deploy APIs — local or remote).
2. Operator maps each profile to a `model_id` via a dynamic cluster setting:
   ```
   plugins.neural_search.model_selection.model_id.sparse.english: <model-id>
   plugins.neural_search.model_selection.model_id.dense.english: <model-id>
   plugins.neural_search.model_selection.model_id.sparse.multilingual: <model-id>
   plugins.neural_search.model_selection.model_id.dense.multilingual: <model-id>
   ```
   This is an **affix** setting (`plugins.neural_search.model_selection.model_id.<model_type>.<language_option>`), so the mapping stays flexible for additional dimensions in the future. The value is read from node settings (`opensearch.yml`) merged with the persistent/transient cluster settings.
3. Customer creates/updates an index with a `model_selection` on the semantic field; the resolved `model_id` is written into the mapping and returned in the GET mapping response.

### Behavior
- **No shipped defaults (yet):** if no `model_id` is configured for the requested profile, index creation fails fast with a clear error telling the operator which setting to set. (Predictable defaults can be shipped once ml-commons supports stable/custom model ids — [ml-commons#1217](https://github.com/opensearch-project/ml-commons/issues/1217).)
- **Model existence + type check:** the resolved model must exist and its type (dense/sparse) must match the requested `model_type`, otherwise the request is rejected.
- **`model_id` + `model_selection` together:** accepted only if the supplied `model_id` equals the one resolved from `model_selection` (strict match); this keeps the GET→PUT mapping roundtrip working. A mismatch is rejected.
- **No cache, no system-index search, no auto-deploy** — resolution is a cheap, synchronous cluster-setting lookup.

## Key changes
- **`ModelSelection`** DTO — parses/validates the nested `model_selection` object (enum validation, defaults, serialization).
- **`SemanticModelResolver`** interface + **`DefaultSemanticModelResolver`** — synchronous resolution of `model_selection` → `model_id` from the cluster setting (no ml-commons call).
- **`SemanticModelSelectionSettingsAccessor`** + the `SEMANTIC_MODEL_SELECTION_MODEL_ID` affix setting — reads the current value from node + cluster settings.
- **`SemanticFieldMapper`** — replaces the top-level `language_option`/`model_type` params with a single `model_selection` object parameter (`model_id` unchanged).
- **`SemanticMappingTransformer`** — the single enforcement point: iteratively resolves `model_selection` fields, enforces the strict `model_id` match, and validates the model type where the model is loaded (single fetch per field). Documented as the enforcement point.
- **`NeuralSearch`** — wires the resolver + registers the setting.

## Test plan
- [x] Unit — `DefaultSemanticModelResolverTests`: missing-setting error, sparse/dense resolution.
- [x] Unit — `SemanticFieldMapperModelSelectionTests`: parse/serialize `model_selection`, defaults, invalid enum values, unsupported sub-key, coexistence with `model_id`, param count.
- [x] Unit — `SemanticMappingTransformerTests`: no-resolver failure, model_id/model_selection match → success, mismatch → fail, non-string model_id → fail, invalid `semantic_info_field_name` → fail, model-type mismatch → fail.
- [x] Integration — `SemanticFieldModelSelectionIT` (8 cases): no config → error; sparse resolve; dense resolve; model_id+model_selection match → success; mismatched model_id → error; model-type mismatch → error; non-string model_id → error; invalid `semantic_info_field_name` → error.
- [x] Existing tests pass (`SemanticFieldMapperTests`, `SemanticMappingTransformerTests`, `NeuralSearchTests`).
- [x] `./gradlew compileJava compileTestJava spotlessJavaCheck` passes.
