### PR TITLE
Add mavenLocal to pluginManagement repositories (neural-search)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@
 
 pluginManagement {
     repositories {
+        mavenLocal()
         maven { url "https://ci.opensearch.org/maven2/" }
         maven { url "https://ci.opensearch.org/m2/" }
         gradlePluginPortal()


### PR DESCRIPTION
### Description
Add mavenLocal to pluginManagement repositories (neural-search)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803