### PR TITLE
[Sparse ANN] Fold sparse vector tokens into the signed-short range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))
+* [Sparse ANN] Fold sparse vector tokens into the signed-short range (modulus 32768) so folded tokens are never sign-extended to a negative value when stored in short[]
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))
-* [Sparse ANN] Fold sparse vector tokens into the signed-short range (modulus 32768) so folded tokens are never sign-extended to a negative value when stored in short[]
+* [Sparse ANN] Fold sparse vector tokens into the signed-short range (modulus 32768) so folded tokens are never sign-extended to a negative value when stored in short[] ([#1926](https://github.com/opensearch-project/neural-search/pull/1926))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseConstants.java
@@ -19,7 +19,11 @@ public final class SparseConstants {
     public static final String CLUSTER_RATIO_FIELD = "cluster_ratio";
     public static final String APPROXIMATE_THRESHOLD_FIELD = "approximate_threshold";
     public static final String THREAD_POOL_NAME = "seismic_thread_pool";
-    public static final int MODULUS_FOR_SHORT = 65536;
+    // Tokens are stored in a signed short[] to keep the memory footprint low, so they are folded
+    // into the non-negative signed-short range [0, Short.MAX_VALUE] via this modulus. Using 32768
+    // (not 65536) keeps every folded value <= Short.MAX_VALUE, so it round-trips without being
+    // sign-extended to a negative int on read.
+    public static final int MODULUS_FOR_SHORT = 32768;
 
     /**
      * SEISMIC algorithm configuration constants and default values.

--- a/src/test/java/org/opensearch/neuralsearch/sparse/data/SparseVectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/data/SparseVectorTests.java
@@ -117,7 +117,7 @@ public class SparseVectorTests extends AbstractSparseTestBase {
         List<SparseVector.Item> items = new ArrayList<>();
         items.add(new SparseVector.Item(1, (byte) 10));
         items.add(new SparseVector.Item(65537, (byte) 20));
-        items.add(new SparseVector.Item(131074, (byte) 20)); // % 65536 = 2
+        items.add(new SparseVector.Item(131074, (byte) 20)); // 131074 % 32768 = 2
         items.add(new SparseVector.Item(2, (byte) 30));
         items.add(new SparseVector.Item(65539, (byte) 40));
 
@@ -144,6 +144,57 @@ public class SparseVectorTests extends AbstractSparseTestBase {
         Assert.assertEquals(40, ByteQuantizationUtil.getUnsignedByte(item3.getWeight()));
 
         Assert.assertFalse(iterator.hasNext());
+    }
+
+    public void testConstructorWithTokenFoldingIntoSignedShortRange() {
+        // Tokens are folded via MODULUS_FOR_SHORT (32768) into [0, Short.MAX_VALUE] so they always
+        // fit a signed short and round-trip without sign extension. 40000 -> 7232, 65535 -> 32767.
+        List<SparseVector.Item> items = new ArrayList<>();
+        items.add(new SparseVector.Item(40000, (byte) 50)); // 40000 % 32768 = 7232
+        items.add(new SparseVector.Item(65535, (byte) 60)); // 65535 % 32768 = 32767 (Short.MAX_VALUE)
+
+        SparseVector vector = new SparseVector(items);
+
+        Assert.assertEquals(2, vector.getSize());
+        IteratorWrapper<SparseVector.Item> iterator = vector.iterator();
+        Assert.assertTrue(iterator.hasNext());
+        SparseVector.Item item1 = iterator.next();
+        Assert.assertEquals(7232, item1.getToken());
+        Assert.assertEquals(50, ByteQuantizationUtil.getUnsignedByte(item1.getWeight()));
+
+        Assert.assertTrue(iterator.hasNext());
+        SparseVector.Item item2 = iterator.next();
+        Assert.assertEquals(32767, item2.getToken());
+        Assert.assertEquals(60, ByteQuantizationUtil.getUnsignedByte(item2.getWeight()));
+    }
+
+    public void testToDenseVectorWithTokenFoldingIntoSignedShortRange() {
+        // A token folding to Short.MAX_VALUE (65535 -> 32767) must not become a negative array index.
+        List<SparseVector.Item> items = new ArrayList<>();
+        items.add(new SparseVector.Item(1, (byte) 10));
+        items.add(new SparseVector.Item(65535, (byte) 50)); // 65535 % 32768 = 32767
+
+        SparseVector vector = new SparseVector(items);
+
+        byte[] denseVector = vector.toDenseVector();
+        Assert.assertEquals(32768, denseVector.length); // max folded token (32767) + 1
+        Assert.assertEquals(10, denseVector[1] & 0xFF);
+        Assert.assertEquals(50, denseVector[32767] & 0xFF);
+    }
+
+    public void testDotProductWithTokenFoldingIntoSignedShortRange() {
+        // A token folding to Short.MAX_VALUE must still score correctly (no negative index / bounds bug).
+        List<SparseVector.Item> items = new ArrayList<>();
+        items.add(new SparseVector.Item(1, (byte) 10));
+        items.add(new SparseVector.Item(65535, (byte) 50)); // 65535 % 32768 = 32767
+        SparseVector vector = new SparseVector(items);
+
+        byte[] denseVector = new byte[32768];
+        denseVector[1] = 3;
+        denseVector[32767] = 4;
+
+        // (10*3) + (50*4) = 30 + 200 = 230
+        Assert.assertEquals(230, vector.dotProduct(denseVector));
     }
 
     public void testToDenseVector() {


### PR DESCRIPTION
### Description
Token IDs are folded into [0, MODULUS_FOR_SHORT) via `token % 65536` and stored in a signed short[] to keep the memory footprint low. Reads went directly through tokens[i], so any token folding into [32768, 65535] was sign-extended back to a negative int, causing:

- getToken()/iterator() to return a negative token (e.g. 40000 -> -25536)
- toDenseVector() to throw NegativeArraySizeException on `maxToken + 1`
- dotProduct() to mis-score via a negative index / bad bounds check

Route every token read through a getToken(int) helper that widens with Short.toUnsignedInt. Writes are unchanged since the (short) cast is a lossless reinterpretation; only reads needed to treat the value as unsigned. Sorting in processListItems() is by the folded non-negative value, so ascending order and dotProduct()'s early-exit remain valid.

Note this path is reachable only when the pure-Java SEISMIC path runs (segment doc count >= approximate_threshold, default 1M); below that the query falls back to plain neural sparse, and the native engine passes raw ints to C++ where term_t is uint16_t. That gating is why the defect went unnoticed.

Adds unit tests covering the constructor/iterator round-trip, toDenseVector(), and dotProduct() for a token folding to a negative short.

### Related Issues
Resolves #1925 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
