### PR TITLE
[Backport 3.7] [Sparse ANN] Fold sparse vector tokens into the signed-short range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Text Chunking] Fix text chunking processor ignoring index max_token_count setting when ingesting via alias ([#1803](https://github.com/opensearch-project/neural-search/pull/1803))
 * Fix sparse ANN search failure due to a core change ([#1855](https://github.com/opensearch-project/neural-search/pull/1855))
 * [Semantic Highlighting] Fix batch semantic highlighting on inner_hits fields ([#1858](https://github.com/opensearch-project/neural-search/pull/1858))
+* [Sparse ANN] Fold sparse vector tokens into the signed-short range (modulus 32768) so folded tokens are never sign-extended to a negative value when stored in short[] ([#1926](https://github.com/opensearch-project/neural-search/pull/1926))
 
 ### Infrastructure
 * Fix flaky integration test failure caused by ML memory circuit breaker during model deployment in distribution pipeline ([#1824](https://github.com/opensearch-project/neural-search/pull/1824))

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseConstants.java
@@ -19,7 +19,11 @@ public final class SparseConstants {
     public static final String CLUSTER_RATIO_FIELD = "cluster_ratio";
     public static final String APPROXIMATE_THRESHOLD_FIELD = "approximate_threshold";
     public static final String THREAD_POOL_NAME = "seismic_thread_pool";
-    public static final int MODULUS_FOR_SHORT = 65536;
+    // Tokens are stored in a signed short[] to keep the memory footprint low, so they are folded
+    // into the non-negative signed-short range [0, Short.MAX_VALUE] via this modulus. Using 32768
+    // (not 65536) keeps every folded value <= Short.MAX_VALUE, so it round-trips without being
+    // sign-extended to a negative int on read.
+    public static final int MODULUS_FOR_SHORT = 32768;
 
     /**
      * SEISMIC algorithm configuration constants and default values.

--- a/src/test/java/org/opensearch/neuralsearch/sparse/data/SparseVectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/data/SparseVectorTests.java
@@ -117,7 +117,7 @@ public class SparseVectorTests extends AbstractSparseTestBase {
         List<SparseVector.Item> items = new ArrayList<>();
         items.add(new SparseVector.Item(1, (byte) 10));
         items.add(new SparseVector.Item(65537, (byte) 20));
-        items.add(new SparseVector.Item(131074, (byte) 20)); // % 65536 = 2
+        items.add(new SparseVector.Item(131074, (byte) 20)); // 131074 % 32768 = 2
         items.add(new SparseVector.Item(2, (byte) 30));
         items.add(new SparseVector.Item(65539, (byte) 40));
 
@@ -144,6 +144,57 @@ public class SparseVectorTests extends AbstractSparseTestBase {
         Assert.assertEquals(40, ByteQuantizationUtil.getUnsignedByte(item3.getWeight()));
 
         Assert.assertFalse(iterator.hasNext());
+    }
+
+    public void testConstructorWithTokenFoldingIntoSignedShortRange() {
+        // Tokens are folded via MODULUS_FOR_SHORT (32768) into [0, Short.MAX_VALUE] so they always
+        // fit a signed short and round-trip without sign extension. 40000 -> 7232, 65535 -> 32767.
+        List<SparseVector.Item> items = new ArrayList<>();
+        items.add(new SparseVector.Item(40000, (byte) 50)); // 40000 % 32768 = 7232
+        items.add(new SparseVector.Item(65535, (byte) 60)); // 65535 % 32768 = 32767 (Short.MAX_VALUE)
+
+        SparseVector vector = new SparseVector(items);
+
+        Assert.assertEquals(2, vector.getSize());
+        IteratorWrapper<SparseVector.Item> iterator = vector.iterator();
+        Assert.assertTrue(iterator.hasNext());
+        SparseVector.Item item1 = iterator.next();
+        Assert.assertEquals(7232, item1.getToken());
+        Assert.assertEquals(50, ByteQuantizationUtil.getUnsignedByte(item1.getWeight()));
+
+        Assert.assertTrue(iterator.hasNext());
+        SparseVector.Item item2 = iterator.next();
+        Assert.assertEquals(32767, item2.getToken());
+        Assert.assertEquals(60, ByteQuantizationUtil.getUnsignedByte(item2.getWeight()));
+    }
+
+    public void testToDenseVectorWithTokenFoldingIntoSignedShortRange() {
+        // A token folding to Short.MAX_VALUE (65535 -> 32767) must not become a negative array index.
+        List<SparseVector.Item> items = new ArrayList<>();
+        items.add(new SparseVector.Item(1, (byte) 10));
+        items.add(new SparseVector.Item(65535, (byte) 50)); // 65535 % 32768 = 32767
+
+        SparseVector vector = new SparseVector(items);
+
+        byte[] denseVector = vector.toDenseVector();
+        Assert.assertEquals(32768, denseVector.length); // max folded token (32767) + 1
+        Assert.assertEquals(10, denseVector[1] & 0xFF);
+        Assert.assertEquals(50, denseVector[32767] & 0xFF);
+    }
+
+    public void testDotProductWithTokenFoldingIntoSignedShortRange() {
+        // A token folding to Short.MAX_VALUE must still score correctly (no negative index / bounds bug).
+        List<SparseVector.Item> items = new ArrayList<>();
+        items.add(new SparseVector.Item(1, (byte) 10));
+        items.add(new SparseVector.Item(65535, (byte) 50)); // 65535 % 32768 = 32767
+        SparseVector vector = new SparseVector(items);
+
+        byte[] denseVector = new byte[32768];
+        denseVector[1] = 3;
+        denseVector[32767] = 4;
+
+        // (10*3) + (50*4) = 30 + 200 = 230
+        Assert.assertEquals(230, vector.dotProduct(denseVector));
     }
 
     public void testToDenseVector() {


### PR DESCRIPTION
Backport 936d3c4d7feba5a499dd9c67f7a8e4dccb818151 from #1926.

The automatic backport failed due to a `CHANGELOG.md` conflict only — main's Bug Fixes section carries an unrelated SemanticHighlighter entry (#1906) that isn't on 3.7. The Java changes cherry-picked cleanly; the changelog entry was re-added alongside 3.7's existing Bug Fixes entries.

`SparseVectorTests` passes locally on this branch.