### PR TITLE
Add Eclipse P2 mirror to avoid download.eclipse.org outages (neural-search)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
   Check-neural-search-linux:
     needs: Get-CI-Image-Tag
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
@@ -69,6 +70,7 @@ jobs:
 
   Check-neural-search-windows:
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
         os: [windows-latest]
@@ -93,6 +95,7 @@ jobs:
   Precommit-neural-search-linux:
     needs: Get-CI-Image-Tag
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
@@ -127,6 +130,7 @@ jobs:
   integTest:
     needs: Precommit-neural-search-linux
     strategy:
+      fail-fast: false
       matrix:
         java: [ 21, 25 ]
         os: [ ubuntu-latest ]
@@ -147,6 +151,7 @@ jobs:
   integMultiNodeTest:
       needs: Precommit-neural-search-linux
       strategy:
+        fail-fast: false
         matrix:
           java: [ 21 ]
           os: [ ubuntu-latest ]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -149,23 +149,23 @@ jobs:
           ./gradlew integTest --parallel
 
   integMultiNodeTest:
-      needs: Precommit-neural-search-linux
-      strategy:
-        fail-fast: false
-        matrix:
-          java: [ 21 ]
-          os: [ ubuntu-latest ]
-          configureNodeRoles: [ false, true ]
-      name: Multi-Node Integ Test JDK${{ matrix.java }}, With Role Assignment ${{ matrix.configureNodeRoles }}
-      runs-on: ${{ matrix.os }}
-      steps:
-        - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        - name: Set up JDK ${{ matrix.java }}
-          uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
-          with:
-            java-version: ${{ matrix.java }}
-            distribution: temurin
-            cache: 'gradle'
-        - name: Build and Run Tests
-          run: |
-            ./gradlew integTest --parallel -PnumNodes=3 -PconfigureNodeRoles=${{ matrix.configureNodeRoles }}
+    needs: Precommit-neural-search-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 21 ]
+        os: [ ubuntu-latest ]
+        configureNodeRoles: [ false, true ]
+    name: Multi-Node Integ Test JDK${{ matrix.java }}, With Role Assignment ${{ matrix.configureNodeRoles }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: 'gradle'
+      - name: Build and Run Tests
+        run: |
+          ./gradlew integTest --parallel -PnumNodes=3 -PconfigureNodeRoles=${{ matrix.configureNodeRoles }}

--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -7,7 +7,7 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
+            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
Add `withP2Mirrors` to Spotless eclipse formatter to use `ci.opensearch.org/eclipse/` CloudFront mirror instead of hitting `download.eclipse.org` directly. This prevents CI failures when Eclipse's download server is down or slow.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421#issuecomment-5271186726

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).