### PR TITLE
[RRF] Compute rank scores with exact integer arithmetic instead of a BigDecimal per document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Refactoring
 * [SemanticHighlighter] Traverse the query tree with a QueryBuilderVisitor instead of a "manual" walk ([#1915](https://github.com/opensearch-project/neural-search/pull/1915))
-* [RRF] Compute rank scores with exact integer arithmetic instead of allocating a BigDecimal per document ([#1941](https://github.com/opensearch-project/neural-search/issues/1941))
+* [RRF] Compute rank scores with exact integer arithmetic instead of allocating a BigDecimal per document ([#1942](https://github.com/opensearch-project/neural-search/pull/1942))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Refactoring
 * [SemanticHighlighter] Traverse the query tree with a QueryBuilderVisitor instead of a "manual" walk ([#1915](https://github.com/opensearch-project/neural-search/pull/1915))
+* [RRF] Compute rank scores with exact integer arithmetic instead of allocating a BigDecimal per document ([#1941](https://github.com/opensearch-project/neural-search/issues/1941))

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
@@ -4,8 +4,6 @@
  */
 package org.opensearch.neuralsearch.processor.normalization;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +47,9 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
     private static final int MIN_RANK_CONSTANT = 1;
     private static final int MAX_RANK_CONSTANT = 10_000;
     private static final Range<Integer> RANK_CONSTANT_RANGE = Range.of(MIN_RANK_CONSTANT, MAX_RANK_CONSTANT);
+    // Rank scores are quantized to 10 decimal places, i.e. expressed as an integer numerator over 10^10.
+    private static final long SCORE_SCALE_L = 10_000_000_000L;
+    private static final double SCORE_SCALE_D = 1.0e10;
     @ToString.Include
     private final int rankConstant;
     // Comparator to compare ShardResultPerSubQuery
@@ -218,8 +219,29 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
         }
     }
 
+    /**
+     * Computes the rank score of a result, {@code 1 / (rankConstant + position + 1)} rounded HALF_UP to 10
+     * decimal places. This is an allocation-free integer equivalent of the original implementation:
+     * <pre>{@code
+     * BigDecimal.ONE.divide(BigDecimal.valueOf(rankConstant + position + 1), 10, RoundingMode.HALF_UP).floatValue()
+     * }</pre>
+     * Because 10^10 and 2 * 10^10 both fit in a {@code long}, rounding HALF_UP to scale 10 is exactly expressible
+     * as the integer division {@code (2 * 10^10 + d) / (2 * d)}. That quotient is at most 5 * 10^9, well inside
+     * the range a {@code double} represents exactly, as is 10^10 itself, so the single narrowing to {@code float}
+     * reproduces what {@code BigDecimal.floatValue()} produced. Verified bit-identical for every reachable
+     * denominator in [2, Integer.MAX_VALUE].
+     * <p>
+     * The final division is deliberately performed in {@code double}. Narrowing the numerator to {@code float}
+     * first and dividing by {@code 1.0e10f} rounds twice and is <em>not</em> bit-identical: it differs for 167
+     * denominators, starting at 3.
+     *
+     * @param position zero-based rank of the result within its subquery
+     * @return the rank score, to be summed across subqueries in the combination step
+     */
     private float calculateNormalizedScore(int position) {
-        return BigDecimal.ONE.divide(BigDecimal.valueOf(rankConstant + position + 1), 10, RoundingMode.HALF_UP).floatValue();
+        long denominator = (long) rankConstant + position + 1;
+        long numerator = (2 * SCORE_SCALE_L + denominator) / (2 * denominator);
+        return (float) (numerator / SCORE_SCALE_D);
     }
 
     private int getRankConstant(final Map<String, Object> params) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -354,9 +354,56 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
         assertTrue(explanation.containsKey(new DocIdAtSearchShard(0, new SearchShard("test_index", 0, "uuid"))));
     }
 
+    /**
+     * Rank scores are computed in integer arithmetic rather than with {@link BigDecimal}. That is only a safe
+     * substitution if it is exactly equal to the BigDecimal form it replaced, so this asserts on raw float bits
+     * rather than within a delta - a change that rounded even one ULP differently would pass a delta comparison.
+     * The ranks covered span the point where a scale-10 numerator crosses 2^24, where BigDecimal's conversion to
+     * float changes behavior, and rank constants at both ends of the permitted range.
+     */
+    public void testNormalize_whenScoresComputed_thenBitIdenticalToBigDecimalReference() {
+        int numDocs = 1200;
+        float[] scores = new float[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            scores[i] = 1.0f - i / (float) numDocs;
+        }
+
+        for (int rankConstant : new int[] { 1, RANK_CONSTANT, 10_000 }) {
+            CompoundTopDocs compoundTopDocs = createCompoundTopDocs(scores, numDocs);
+            RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(
+                Map.of("rank_constant", rankConstant),
+                scoreNormalizationUtil
+            );
+            normalizationTechnique.normalize(
+                NormalizeScoresDTO.builder()
+                    .queryTopDocs(List.of(compoundTopDocs))
+                    .normalizationTechnique(normalizationTechnique)
+                    .singleShard(true)
+                    .build()
+            );
+
+            ScoreDoc[] scoreDocs = compoundTopDocs.getTopDocs().get(0).scoreDocs;
+            for (int rank = 0; rank < numDocs; rank++) {
+                assertEquals(
+                    "rank_constant [" + rankConstant + "], rank [" + rank + "]",
+                    Float.floatToIntBits(rrfNorm(rank, rankConstant)),
+                    Float.floatToIntBits(scoreDocs[rank].score)
+                );
+            }
+        }
+    }
+
     private float rrfNorm(int rank) {
-        // 1.0f / (float) (rank + RANK_CONSTANT + 1);
-        return BigDecimal.ONE.divide(BigDecimal.valueOf(rank + RANK_CONSTANT + 1), 10, RoundingMode.HALF_UP).floatValue();
+        return rrfNorm(rank, RANK_CONSTANT);
+    }
+
+    /**
+     * The BigDecimal implementation that {@code RRFNormalizationTechnique#calculateNormalizedScore} replaced,
+     * retained here as an independent reference for what the rank score must be.
+     */
+    private float rrfNorm(int rank, int rankConstant) {
+        // 1.0f / (float) (rank + rankConstant + 1);
+        return BigDecimal.ONE.divide(BigDecimal.valueOf(rank + rankConstant + 1), 10, RoundingMode.HALF_UP).floatValue();
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {


### PR DESCRIPTION
### Description

`RRFNormalizationTechnique#calculateNormalizedScore` allocated a throwaway `BigDecimal` per document, per subquery, per shard on the coordinator node — roughly 600 allocations for a shallow hybrid search (20 shards × 10 hits × 3 subqueries) and 60,000 for a deep one, doubled when `explain` is enabled.

The expression reduces to `HALF_UP(10^10 / d) / 10^10` for a single integer denominator `d = rankConstant + position + 1`. Both `10^10` and `2 × 10^10` fit in a `long`, so rounding HALF_UP to scale 10 is exactly expressible as the integer division `(2 × 10^10 + d) / (2 × d)`, with no `BigDecimal` and no allocation:

```java
private float calculateNormalizedScore(int position) {
    long denominator = (long) rankConstant + position + 1;
    long numerator = (2 * SCORE_SCALE_L + denominator) / (2 * denominator);
    return (float) (numerator / SCORE_SCALE_D);
}
```

**This is behavior-preserving, not an approximation.** The new form is bit-identical to the old one for every reachable denominator. Since `rankConstant` and `position` are both `int`, every reachable `d` lies in `[2, Integer.MAX_VALUE]`; all **2,147,483,646** values were compared via `Float.floatToIntBits` with **zero mismatches on JDK 17, 21 and 26**. No existing test or expected score changes.

Measured JIT-warm on Corretto 21, allocation via `ThreadMXBean#getThreadAllocatedBytes`:

| domain of `d` | before | after |
|---|---|---|
| `[61, 260]` — default `rank_constant`, shallow results | 54 – 56 ns, 302 – 322 B/call | **4.9 ns, 0 B** |
| `[61, 20060]` — default `rank_constant`, deep results | 8.5 ns, 85 B/call | **2.6 ns, 0 B** |

Per request that is roughly 180 KB of garbage eliminated for a shallow search and ~5 MB for a deep one.

The gain is largest at small `d` because `BigDecimal.floatValue()` takes a more expensive conversion path once the scale-10 numerator exceeds `2^24`, which is every `d ≤ 596` — so with the default `rank_constant` of 60, ranks 0 through 535 all pay it, i.e. the entire result set for typical `size` values. That threshold is a `BigDecimal` internal specified nowhere; this change removes any dependence on it.

Two notes for reviewers:

- **The final division is deliberately performed in `double`.** Narrowing the numerator to `float` first and dividing by `1.0e10f` rounds twice and is *not* bit-identical — it differs by one ULP for 167 denominators, starting at `d = 3`. The existing tests compare scores within `DELTA_FOR_ASSERTION` of `0.001f` and would not catch that, so `testNormalize_whenScoresComputed_thenBitIdenticalToBigDecimalReference` asserts on raw float bits instead. I verified the test fails on that exact substitution before committing.
- **The scale-10 quantization is preserved as-is**, including where it is arguably wrong (past `d ≈ 10⁴`, ten decimal places is coarser than `float`'s ~7 significant digits, so it discards real precision). Changing that would alter user-visible scores and is a separate decision; this PR deliberately changes no output.

Benchmark caveat: these were standalone single-file probes, JIT-warmed and accumulating into a sink to prevent dead-code elimination, but isolated from the surrounding `PriorityQueue` sort and not JMH with fork isolation — so treat the ns figures as indicative rather than exact. JDK 26 measured the `[61, 260]` window as high as 115 ns/call against JDK 21's 54 ns. The direction and order of magnitude were stable across every run; the allocation figures and the bit-identity result are exact. Probe sources available on request.

### Related Issues
Resolves #1941

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
