### PR TITLE
In-query fusion advanced query features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 * In-query fusion in hybrid search. Implement base classes and enable fusion (min_max and arithmetic mean) ([#1933](https://github.com/opensearch-project/neural-search/pull/1933))
-* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, collapse with group expansion, and point in time; refuse fused mode while any node in the cluster is below 3.8.0; cap the leg sub-searches one request may fan out with the `plugins.neural_search.hybrid.fusion.max_leg_searches` cluster setting ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
+* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, collapse with group expansion, and point in time; refuse fused mode while any node in the cluster is below 3.8.0; refuse `scroll` in fused mode with a validation error (use `point_in_time` instead); cap the leg sub-searches one request may fan out with the `plugins.neural_search.hybrid.fusion.max_leg_searches` cluster setting ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 * In-query fusion in hybrid search. Implement base classes and enable fusion (min_max and arithmetic mean) ([#1933](https://github.com/opensearch-project/neural-search/pull/1933))
-* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, collapse with group expansion, and point in time; cap the leg sub-searches one request may fan out with the `plugins.neural_search.hybrid.fusion.max_leg_searches` cluster setting ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
+* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, collapse with group expansion, and point in time; refuse fused mode while any node in the cluster is below 3.8.0; cap the leg sub-searches one request may fan out with the `plugins.neural_search.hybrid.fusion.max_leg_searches` cluster setting ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 * In-query fusion in hybrid search. Implement base classes and enable fusion (min_max and arithmetic mean) ([#1933](https://github.com/opensearch-project/neural-search/pull/1933))
+* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, and point in time ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 * In-query fusion in hybrid search. Implement base classes and enable fusion (min_max and arithmetic mean) ([#1933](https://github.com/opensearch-project/neural-search/pull/1933))
-* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, and point in time ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
+* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, and point in time; cap the leg sub-searches one request may fan out with the `plugins.neural_search.hybrid.fusion.max_leg_searches` cluster setting ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 * In-query fusion in hybrid search. Implement base classes and enable fusion (min_max and arithmetic mean) ([#1933](https://github.com/opensearch-project/neural-search/pull/1933))
-* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, and point in time; cap the leg sub-searches one request may fan out with the `plugins.neural_search.hybrid.fusion.max_leg_searches` cluster setting ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
+* In-query fusion in hybrid search. Support nested hybrid queries, search across multiple indices, aggregations, collapse with group expansion, and point in time; cap the leg sub-searches one request may fan out with the `plugins.neural_search.hybrid.fusion.max_leg_searches` cluster setting ([#1943](https://github.com/opensearch-project/neural-search/pull/1943))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchFusedModeIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/neuralsearch/bwc/rolling/HybridSearchFusedModeIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.bwc.rolling;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.Version;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.core.rest.RestStatus;
+
+import static org.opensearch.neuralsearch.util.TestUtils.NODES_BWC_CLUSTER;
+
+/**
+ * Rolling-upgrade coverage for the hybrid query's fused (resolver) mode, enabled by a {@code fusion} block on the query
+ * body.
+ *
+ * <p>Fused mode runs in two rounds: the coordinator fans the legs out, fuses them, and then self-erases the {@code hybrid}
+ * query into an internal {@code hybrid_fusion} query that every shard has to deserialize. A node predating fused mode
+ * cannot resolve that {@code NamedWriteable} name, and the resulting shard failure is <b>silent</b> under the default
+ * {@code allow_partial_search_results} — an HTTP 200 short of documents, or, when the shard is retried onto an upgraded
+ * copy, an HTTP 200 with no recorded failure at all. So the coordinator refuses fused mode outright while any node in the
+ * cluster is below {@link #FUSED_MODE_MIN_VERSION}.
+ *
+ * <p>The invariant asserted at every stage is therefore not "fused mode works" but the stronger, upgrade-safe one:
+ * <b>a fused query is either served completely or refused with a 400 — never partially served</b>. Which of the two
+ * applies is decided by the cluster's own observed minimum node version, not by the configured {@code bwc.version}, so
+ * the test is correct both in CI (where the base cluster is a real released version below 3.8) and locally (where
+ * {@code bwc.version} defaults to the current snapshot, so no stage is actually mixed and every stage must serve).
+ *
+ * <p>On a mixed cluster either coordinator is acceptable and the two say different things — a pre-3.8 node fails while
+ * parsing the unknown {@code fusion} field, an upgraded one fails on the version guardrail — so the assertions are
+ * deliberately coordinator-agnostic: a 400, and no trace of the internal round-2 query name, which would mean the fused
+ * query was dispatched and a shard rejected it.
+ *
+ * <p>Deliberately not excluded for any {@code bwc_version} row in {@code qa/rolling-upgrade/build.gradle}: the convention
+ * there is to exclude a new feature's test class for base versions predating the feature, which for a 3.8 feature would
+ * exclude every row CI runs today and leave the mixed-cluster refusal — the point of this test — unexercised.
+ */
+public class HybridSearchFusedModeIT extends AbstractRollingUpgradeTestCase {
+
+    private static final String TEXT_FIELD = "passage_text";
+    /**
+     * First version that can run fused mode. Mirrors {@code MinClusterVersionUtil}'s
+     * {@code MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY}, spelled out rather than imported because that class
+     * initializes against k-NN classes which this module has as {@code compileOnly} — they are absent at test runtime.
+     */
+    private static final Version FUSED_MODE_MIN_VERSION = Version.V_3_8_0;
+    /** Documents 0..2 match at least one leg; document 3 matches neither. */
+    private static final String[] DOCS = { "hello world hello", "hello there place", "welcome to the place", "nothing relevant at all" };
+    private static final int MATCHING_DOCS = 3;
+
+    public void testFusedModeHybridQuery_E2EFlow() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        switch (getClusterType()) {
+            case OLD:
+                createIndex(getIndexNameForTest(), indexConfig());
+                for (int docId = 0; docId < DOCS.length; docId++) {
+                    addDocument(getIndexNameForTest(), String.valueOf(docId), TEXT_FIELD, DOCS[docId], null, null);
+                }
+                assertFusedModeIsServedOrRefused(MATCHING_DOCS);
+                break;
+            case MIXED:
+                // Runs twice: one upgraded node in the first round, two in the second. Neither round may serve a partial
+                // answer, and the refusal must not depend on which third of the cluster the request happened to reach.
+                assertFusedModeIsServedOrRefused(MATCHING_DOCS);
+                break;
+            case UPGRADED:
+                try {
+                    // Every node can now read the self-erased query, so this branch is the positive case on every CI row:
+                    // fused mode has to actually work, over a document written before the upgrade and one written after.
+                    addDocument(getIndexNameForTest(), String.valueOf(DOCS.length), TEXT_FIELD, "hello again", null, null);
+                    assertFusedModeIsServedOrRefused(MATCHING_DOCS + 1);
+                } finally {
+                    wipeOfTestResources(getIndexNameForTest(), null, null, null);
+                }
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + getClusterType());
+        }
+    }
+
+    /**
+     * Assert the upgrade-safe invariant against whatever cluster is actually running: a cluster whose every node can read
+     * the self-erased query must serve the fused query completely, and any other cluster must refuse it.
+     *
+     * @param expectedMatchedDocs documents matching at least one leg, used only when the cluster is expected to serve
+     */
+    private void assertFusedModeIsServedOrRefused(final int expectedMatchedDocs) throws Exception {
+        // Once per node: the REST client rotates over the cluster's hosts, so this covers a coordinator of each version a
+        // mixed cluster has. Which one answers decides *why* the query is refused, never whether — a pre-3.8 coordinator
+        // fails parsing `fusion`, an upgraded one on the version guardrail — and only the upgraded coordinator exercises
+        // the guardrail at all, so a single request could miss it entirely.
+        for (int node = 0; node < getClusterHosts().size(); node++) {
+            assertFusedModeIsServedOrRefusedOnce(expectedMatchedDocs);
+        }
+    }
+
+    /** One request's worth of the invariant. Which branch applies is read off the running cluster, not off a stage name. */
+    private void assertFusedModeIsServedOrRefusedOnce(final int expectedMatchedDocs) throws Exception {
+        if (minimumNodeVersion().onOrAfter(FUSED_MODE_MIN_VERSION)) {
+            Map<String, Object> response = search(getIndexNameForTest(), fusedTwoLegQuery(), 10);
+            assertEquals("fused mode must return every matched document", expectedMatchedDocs, getHitCount(response));
+            // The failure this guardrail exists to prevent is silent, so hit count alone does not prove it absent: a shard
+            // that cannot read the self-erased query is booked as a shard failure and the request still returns 200.
+            assertEquals("fused mode must not lose a shard", 0, failedShards(response));
+            return;
+        }
+        ResponseException exception = expectThrows(ResponseException.class, this::searchFused);
+        Response response = exception.getResponse();
+        String body = EntityUtils.toString(response.getEntity());
+        assertEquals(
+            "a cluster that cannot run fused mode on every shard must refuse the query rather than answer it: " + body,
+            RestStatus.BAD_REQUEST.getStatus(),
+            response.getStatusLine().getStatusCode()
+        );
+        assertFalse("the self-erased query must never reach a shard: " + body, body.contains("hybrid_fusion"));
+        assertFalse("no shard-level NamedWriteable failure is acceptable: " + body, body.contains("Unknown NamedWriteable"));
+    }
+
+    /**
+     * A fused two-leg hybrid query with the fusion config inline, so it needs no search pipeline and no index default —
+     * the shortest body that enables the resolver. Raw JSON rather than {@code HybridQueryBuilder} because this request
+     * must be built identically no matter which version of the plugin is being talked to.
+     */
+    private String fusedTwoLegQuery() {
+        return "{\"query\":{\"hybrid\":{\"fusion\":{\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
+            + "\"queries\":[{\"match\":{\""
+            + TEXT_FIELD
+            + "\":\"hello\"}},{\"term\":{\""
+            + TEXT_FIELD
+            + "\":{\"value\":\"place\"}}}]}}}";
+    }
+
+    /** The fused search without the status assertion {@code search(...)} makes, so the refusal can be inspected. */
+    private Response searchFused() throws IOException {
+        Request request = new Request("POST", "/" + getIndexNameForTest() + "/_search");
+        request.setJsonEntity(fusedTwoLegQuery());
+        return client().performRequest(request);
+    }
+
+    private int failedShards(final Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> shards = (Map<String, Object>) searchResponseAsMap.get("_shards");
+        return ((Number) shards.get("failed")).intValue();
+    }
+
+    private String indexConfig() {
+        return "{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":1},\"mappings\":{\"properties\":{\""
+            + TEXT_FIELD
+            + "\":{\"type\":\"text\"}}}}";
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/common/MinClusterVersionUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/common/MinClusterVersionUtil.java
@@ -87,10 +87,12 @@ public final class MinClusterVersionUtil {
     }
 
     /**
-     * Checks if the version from StreamInput/StreamOutput is on or after the minimum required version for the fused
-     * (resolver) mode in the hybrid query. Use this (not the cluster-min-version variant) for wire read/write gating so
-     * the format matches the negotiated version of the specific peer stream — see CR-290524846 for the mixed-version
-     * bug the cluster-based check causes in a coordinator/worker split.
+     * Checks whether the given version is on or after the minimum required version for the fused (resolver) mode in the
+     * hybrid query. What the caller passes in is the whole decision: for wire read/write gating pass the negotiated
+     * version of the specific peer stream, never the cluster minimum — see CR-290524846 for the mixed-version bug the
+     * cluster-based check causes in a coordinator/worker split. The coordinator's rewrite-time refusal is the opposite
+     * case and passes the cluster minimum, because it decides whether a path may be entered at all rather than how one
+     * known peer is addressed ({@code HybridQueryBuilder#requireClusterSupportsFusedMode}).
      *
      * @param version The version to check
      * @return true if the version is on or after the minimum required version

--- a/src/main/java/org/opensearch/neuralsearch/fusion/CoordinatorScoreFusion.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/CoordinatorScoreFusion.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.neuralsearch.fusion;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,43 +35,59 @@ import lombok.NoArgsConstructor;
  *       toward the denominator (its {@code score >= 0.0} participation rule), exactly as classic does.</li>
  * </ul>
  *
- * <p>Current scope: {@code min_max} normalization + the supplied combination technique (arithmetic_mean). Other techniques
- * (z_score, l2, RRF) join this path in a later change. This entry is not reachable from a live request yet — the
- * coordinator rewrite wiring lands with the execution path.
+ * <p>The normalization step is pluggable via {@link ScalarNormalizer} (resolved by name through
+ * {@link ScalarNormalizerFactory}); the combination step is the caller-supplied {@link ScoreCombinationTechnique}. This
+ * class owns only the shape-level work that is identical for every technique: per-leg normalization dispatch, the doc
+ * union, and building each doc's per-leg input array. Adding a technique therefore touches neither this class nor the
+ * orchestrator. Current fused-mode scope is {@code min_max} + arithmetic_mean; the caller gates the rest at rewrite.
+ *
+ * <p>Document keys are treated as <b>opaque strings</b> throughout — this class never parses or builds them — so the
+ * caller can change its document identity scheme (e.g. to disambiguate same-{@code _id} docs across indices) without
+ * touching fusion or any normalizer.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CoordinatorScoreFusion {
 
     /**
-     * Fuse legs with {@code min_max} normalization followed by the given combination technique.
+     * Fuse legs with {@code min_max} normalization followed by the given combination technique. Convenience wrapper over
+     * {@link #fuse(List, ScalarNormalizer, ScoreCombinationTechnique)}; this is the pairing the classic-vs-fused
+     * differential test pins.
      *
-     * @param legRawScores        one entry per leg, each an {@code _id -> raw score} map of that leg's hits (order is
+     * @param legRawScores        one entry per leg, each a {@code key -> raw score} map of that leg's hits (order is
      *                            the leg order; a doc absent from a leg's map did not match that leg)
      * @param combinationTechnique the same combination technique classic would use (e.g. arithmetic_mean with weights)
-     * @return {@code _id -> fused score} for the union of all legs' docs
+     * @return {@code key -> fused score} for the union of all legs' docs
      */
     public static Map<String, Float> fuseMinMax(
         final List<Map<String, Float>> legRawScores,
         final ScoreCombinationTechnique combinationTechnique
     ) {
+        return fuse(legRawScores, MinMaxScalarNormalizer.INSTANCE, combinationTechnique);
+    }
+
+    /**
+     * Fuse legs: normalize each leg with {@code normalizer}, then combine across legs per doc.
+     *
+     * @param legRawScores        one entry per leg, each a {@code key -> raw score} map of that leg's hits
+     * @param normalizer          per-leg normalization step (e.g. {@code min_max})
+     * @param combinationTechnique cross-leg combination step (e.g. arithmetic_mean with weights)
+     * @return {@code key -> fused score} for the union of all legs' docs
+     */
+    public static Map<String, Float> fuse(
+        final List<Map<String, Float>> legRawScores,
+        final ScalarNormalizer normalizer,
+        final ScoreCombinationTechnique combinationTechnique
+    ) {
         final int legCount = legRawScores.size();
 
-        // Per-leg min/max, seeded exactly as classic (getMinScores/getMaxScores)
-        // picking array over List as it's slightly faster, we know size and access by index has identical behavior
-        final float[] minPerLeg = new float[legCount];
-        final float[] maxPerLeg = new float[legCount];
-        for (int leg = 0; leg < legCount; leg++) {
-            float min = Float.MAX_VALUE;
-            float max = Float.MIN_VALUE;
-            for (float raw : legRawScores.get(leg).values()) {
-                min = Math.min(min, raw);
-                max = Math.max(max, raw);
-            }
-            minPerLeg[leg] = min;
-            maxPerLeg[leg] = max;
+        // Normalize each leg independently. A leg's map is already the merged across-shard set, so the normalizer sees
+        // every value it needs to compute its own statistics (min/max here) with no cross-shard merging.
+        final List<Map<String, Float>> normalizedPerLeg = new ArrayList<>(legCount);
+        for (Map<String, Float> leg : legRawScores) {
+            normalizedPerLeg.add(normalizer.normalizeLeg(leg));
         }
 
-        // Union of ids across legs, preserving first-seen order for deterministic output.
+        // Union of keys across legs, preserving first-seen order for deterministic output.
         final Set<String> allIds = new LinkedHashSet<>();
         for (Map<String, Float> leg : legRawScores) {
             allIds.addAll(leg.keySet());
@@ -81,9 +98,9 @@ public final class CoordinatorScoreFusion {
             // float[legCount] initialized to 0.0; only matching legs are filled (mirrors classic per-doc array).
             final float[] perLegNormalized = new float[legCount];
             for (int leg = 0; leg < legCount; leg++) {
-                Float raw = legRawScores.get(leg).get(id);
-                if (raw != null) {
-                    perLegNormalized[leg] = MinMaxScoreNormalizer.normalizeSingleScore(raw, minPerLeg[leg], maxPerLeg[leg]);
+                Float normalized = normalizedPerLeg.get(leg).get(id);
+                if (normalized != null) {
+                    perLegNormalized[leg] = normalized;
                 }
             }
             fused.put(id, combinationTechnique.combine(perLegNormalized));

--- a/src/main/java/org/opensearch/neuralsearch/fusion/CoordinatorScoreFusion.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/CoordinatorScoreFusion.java
@@ -18,11 +18,11 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 /**
- * Coordinator-side score fusion for the resolver (fused) mode, over an {@code _id}-keyed per-leg score view (shape
- * that coordinator has after fanning legs out as a {@code MultiSearch}). It deliberately reuses the same relevance math
- * as classic shard-side hybrid — {@link MinMaxScoreNormalizer} for normalization and the caller-supplied
+ * Coordinator-side score fusion for the resolver (fused) mode, over a per-leg score view keyed by document key (the
+ * shape the coordinator has after fanning legs out as a {@code MultiSearch}). It deliberately reuses the same relevance
+ * math as classic shard-side hybrid — {@link MinMaxScoreNormalizer} for normalization and the caller-supplied
  * {@link ScoreCombinationTechnique#combine(float[])} for combination — so that, for an identical hit set, this path and
- * classic produce identical fused scores to float precision. Only the data shape differs ({@code _id} map here vs.
+ * classic produce identical fused scores to float precision. Only the data shape differs (a key→score map here vs.
  * {@code CompoundTopDocs} there), never the arithmetic.
  *
  * <p>Two classic behaviors are reproduced exactly:
@@ -36,7 +36,7 @@ import lombok.NoArgsConstructor;
  * </ul>
  *
  * <p>The normalization step is pluggable via {@link ScalarNormalizer} (resolved by name through
- * {@link ScalarNormalizerFactory}); the combination step is the caller-supplied {@link ScoreCombinationTechnique}. This
+ * {@link ScalarNormalizers}); the combination step is the caller-supplied {@link ScoreCombinationTechnique}. This
  * class owns only the shape-level work that is identical for every technique: per-leg normalization dispatch, the doc
  * union, and building each doc's per-leg input array. Adding a technique therefore touches neither this class nor the
  * orchestrator. Current fused-mode scope is {@code min_max} + arithmetic_mean; the caller gates the rest at rewrite.
@@ -82,28 +82,28 @@ public final class CoordinatorScoreFusion {
 
         // Normalize each leg independently. A leg's map is already the merged across-shard set, so the normalizer sees
         // every value it needs to compute its own statistics (min/max here) with no cross-shard merging.
-        final List<Map<String, Float>> normalizedPerLeg = new ArrayList<>(legCount);
-        for (Map<String, Float> leg : legRawScores) {
-            normalizedPerLeg.add(normalizer.normalizeLeg(leg));
+        final List<Map<String, Float>> legNormalizedScores = new ArrayList<>(legCount);
+        for (Map<String, Float> legScores : legRawScores) {
+            legNormalizedScores.add(normalizer.normalizeLeg(legScores));
         }
 
         // Union of keys across legs, preserving first-seen order for deterministic output.
-        final Set<String> allIds = new LinkedHashSet<>();
-        for (Map<String, Float> leg : legRawScores) {
-            allIds.addAll(leg.keySet());
+        final Set<String> allKeys = new LinkedHashSet<>();
+        for (Map<String, Float> legScores : legRawScores) {
+            allKeys.addAll(legScores.keySet());
         }
 
         final Map<String, Float> fused = new LinkedHashMap<>();
-        for (String id : allIds) {
+        for (String key : allKeys) {
             // float[legCount] initialized to 0.0; only matching legs are filled (mirrors classic per-doc array).
-            final float[] perLegNormalized = new float[legCount];
+            final float[] docScoresPerLeg = new float[legCount];
             for (int leg = 0; leg < legCount; leg++) {
-                Float normalized = normalizedPerLeg.get(leg).get(id);
-                if (normalized != null) {
-                    perLegNormalized[leg] = normalized;
+                Float normalizedScore = legNormalizedScores.get(leg).get(key);
+                if (normalizedScore != null) {
+                    docScoresPerLeg[leg] = normalizedScore;
                 }
             }
-            fused.put(id, combinationTechnique.combine(perLegNormalized));
+            fused.put(key, combinationTechnique.combine(docScoresPerLeg));
         }
         return fused;
     }

--- a/src/main/java/org/opensearch/neuralsearch/fusion/MinMaxScalarNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/MinMaxScalarNormalizer.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import org.opensearch.neuralsearch.processor.normalization.MinMaxScoreNormalizer;
 import org.opensearch.neuralsearch.processor.normalization.MinMaxScoreNormalizationTechnique;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 /**
  * {@code min_max} implementation of {@link ScalarNormalizer}. Gathers the leg's min/max with classic's exact
  * {@code Float.MAX_VALUE}/{@code Float.MIN_VALUE} seeding (see {@link MinMaxScoreNormalizationTechnique}'s
@@ -17,11 +20,10 @@ import org.opensearch.neuralsearch.processor.normalization.MinMaxScoreNormalizat
  * {@link MinMaxScoreNormalizer} — the same arithmetic the classic shard-side path runs. That shared math is what makes
  * fused and classic produce identical fused scores for an identical hit set (asserted by the differential test).
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MinMaxScalarNormalizer implements ScalarNormalizer {
 
     public static final MinMaxScalarNormalizer INSTANCE = new MinMaxScalarNormalizer();
-
-    private MinMaxScalarNormalizer() {}
 
     @Override
     public Map<String, Float> normalizeLeg(final Map<String, Float> legRawScores) {

--- a/src/main/java/org/opensearch/neuralsearch/fusion/MinMaxScalarNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/MinMaxScalarNormalizer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.fusion;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.opensearch.neuralsearch.processor.normalization.MinMaxScoreNormalizer;
+import org.opensearch.neuralsearch.processor.normalization.MinMaxScoreNormalizationTechnique;
+
+/**
+ * {@code min_max} implementation of {@link ScalarNormalizer}. Gathers the leg's min/max with classic's exact
+ * {@code Float.MAX_VALUE}/{@code Float.MIN_VALUE} seeding (see {@link MinMaxScoreNormalizationTechnique}'s
+ * {@code getMinScores}/{@code getMaxScores}), then rescales each score through the shared
+ * {@link MinMaxScoreNormalizer} — the same arithmetic the classic shard-side path runs. That shared math is what makes
+ * fused and classic produce identical fused scores for an identical hit set (asserted by the differential test).
+ */
+public final class MinMaxScalarNormalizer implements ScalarNormalizer {
+
+    public static final MinMaxScalarNormalizer INSTANCE = new MinMaxScalarNormalizer();
+
+    private MinMaxScalarNormalizer() {}
+
+    @Override
+    public Map<String, Float> normalizeLeg(final Map<String, Float> legRawScores) {
+        float min = Float.MAX_VALUE;
+        float max = Float.MIN_VALUE;
+        for (float raw : legRawScores.values()) {
+            min = Math.min(min, raw);
+            max = Math.max(max, raw);
+        }
+        final Map<String, Float> normalized = new LinkedHashMap<>();
+        for (Map.Entry<String, Float> entry : legRawScores.entrySet()) {
+            normalized.put(entry.getKey(), MinMaxScoreNormalizer.normalizeSingleScore(entry.getValue(), min, max));
+        }
+        return normalized;
+    }
+
+    @Override
+    public String techniqueName() {
+        return MinMaxScoreNormalizationTechnique.TECHNIQUE_NAME;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.fusion;
+
+import java.util.Map;
+
+/**
+ * Per-leg normalization step of coordinator-side fusion: turns one leg's raw scores into that leg's normalized scores.
+ * Paired with {@link org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique}, which combines the
+ * normalized values <i>across</i> legs — one interface normalizes within a leg, the other combines between legs.
+ *
+ * <p>The contract is a whole-leg transform rather than a per-score function on purpose: every technique needs to see the
+ * leg's full value set before it can score any single doc, and each computes different summary state internally
+ * ({@code min_max} → min/max, {@code z_score} → mean/stddev, {@code l2} → the L2 norm). It also lets rank-based
+ * techniques such as RRF fit the same shape — they simply sort the leg and emit {@code 1/(rank_constant + rank + 1)} by
+ * position, deriving rank internally instead of reading a scalar statistic.
+ *
+ * <p>Notes for implementors:
+ * <ul>
+ *   <li><b>Keys are opaque.</b> A key identifies a document to the caller (today {@code _id}); a normalizer must only
+ *       carry keys through unchanged, never parse or construct them. This is what lets the caller change its document
+ *       identity scheme without touching any normalizer.</li>
+ *   <li><b>Return one entry per input entry.</b> {@link CoordinatorScoreFusion} treats a key missing from the returned
+ *       map as "this leg did not match that doc", so dropping keys silently changes fusion input.</li>
+ *   <li><b>No shard merging.</b> On the coordinator a leg's map is already the merged across-shard result set, so a
+ *       technique may compute its statistics directly from the values — no need for the mergeable
+ *       {@code {count, sum, sumSq}} accumulators the classic shard-side path requires.</li>
+ * </ul>
+ */
+public interface ScalarNormalizer {
+
+    /**
+     * Normalize one leg's scores.
+     *
+     * @param legRawScores that leg's {@code key -> raw score} view (never null; may be empty when the leg matched nothing)
+     * @return {@code key -> normalized score} with the same key set as the input
+     */
+    Map<String, Float> normalizeLeg(Map<String, Float> legRawScores);
+
+    /** The technique name this normalizer implements, matching the name used in the {@code fusion} config. */
+    String techniqueName();
+}

--- a/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizer.java
@@ -19,9 +19,9 @@ import java.util.Map;
  *
  * <p>Notes for implementors:
  * <ul>
- *   <li><b>Keys are opaque.</b> A key identifies a document to the caller (today {@code _id}); a normalizer must only
- *       carry keys through unchanged, never parse or construct them. This is what lets the caller change its document
- *       identity scheme without touching any normalizer.</li>
+ *   <li><b>Keys are opaque.</b> A key identifies a document to the caller (today {@code _index} plus {@code _id}); a
+ *       normalizer must only carry keys through unchanged, never parse or construct them. This is what lets the caller
+ *       change its document identity scheme without touching any normalizer.</li>
  *   <li><b>Return one entry per input entry.</b> {@link CoordinatorScoreFusion} treats a key missing from the returned
  *       map as "this leg did not match that doc", so dropping keys silently changes fusion input.</li>
  *   <li><b>No shard merging.</b> On the coordinator a leg's map is already the merged across-shard result set, so a

--- a/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizerFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizerFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.fusion;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Resolves a coordinator-side {@link ScalarNormalizer} by technique name — the extension point for widening fused-mode
+ * normalization support. Adding a technique is a new {@link ScalarNormalizer} plus one entry here; neither
+ * {@link CoordinatorScoreFusion} nor the orchestrator changes.
+ *
+ * <p>Only {@code min_max} is registered today, matching the fused-mode scope gate in
+ * {@code HybridQueryBuilder#requireSupportedTechniques} (which rejects other techniques earlier, at rewrite). This
+ * factory's throw is therefore a defense-in-depth backstop, not the user-facing validation.
+ *
+ * <p>When adding techniques, two things need a decision that this seam intentionally leaves open:
+ * <ul>
+ *   <li><b>{@code l2}/{@code z_score}</b> drop in as plain {@link ScalarNormalizer}s. But note
+ *       {@link CoordinatorScoreFusion} encodes "leg did not match this doc" as a {@code 0.0} slot, and {@code l2} can
+ *       legitimately normalize a real score to {@code 0.0}. That is harmless for arithmetic-mean (which counts
+ *       {@code >= 0.0} slots, matching classic) but ambiguous for geometric/harmonic mean, which skip {@code <= 0}
+ *       scores. Wiring those combiners likely needs an explicit presence mask rather than the {@code 0.0} sentinel —
+ *       changing the sentinel is a deliberate parity decision, since the current behavior is what the classic-vs-fused
+ *       differential test pins.</li>
+ *   <li><b>RRF</b> is rank-based and is modelled as {@code combination=rrf, normalization=none}, so it does not arrive
+ *       here under a normalization name. It fits the {@link ScalarNormalizer} shape (sort the leg, emit
+ *       {@code 1/(rank_constant + rank + 1)} by position) but needs its own routing plus a rank_constant parameter, and
+ *       the classic {@code (doc, shardId)} rank tie-break has no equivalent over the coordinator's already-merged view —
+ *       so a tie-break must be defined explicitly.</li>
+ * </ul>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ScalarNormalizerFactory {
+
+    private static final Map<String, ScalarNormalizer> NORMALIZERS = Map.of(
+        MinMaxScalarNormalizer.INSTANCE.techniqueName(),
+        MinMaxScalarNormalizer.INSTANCE
+    );
+
+    /**
+     * @param techniqueName normalization technique name from the resolved fusion config
+     * @return the normalizer for that technique
+     * @throws IllegalArgumentException when the technique has no coordinator-side implementation yet
+     */
+    public static ScalarNormalizer create(final String techniqueName) {
+        ScalarNormalizer normalizer = Objects.isNull(techniqueName) ? null : NORMALIZERS.get(techniqueName);
+        if (Objects.isNull(normalizer)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "normalization technique [%s] is not supported in fused mode; supported: %s",
+                    techniqueName,
+                    NORMALIZERS.keySet()
+                )
+            );
+        }
+        return normalizer;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizers.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizers.java
@@ -14,11 +14,12 @@ import lombok.NoArgsConstructor;
 /**
  * Resolves a coordinator-side {@link ScalarNormalizer} by technique name — the extension point for widening fused-mode
  * normalization support. Adding a technique is a new {@link ScalarNormalizer} plus one entry here; neither
- * {@link CoordinatorScoreFusion} nor the orchestrator changes.
+ * {@link CoordinatorScoreFusion} nor the orchestrator changes. A static holder rather than a factory, since nothing is
+ * constructed: every technique is a stateless singleton, so the lookup hands back a shared instance.
  *
- * <p>Only {@code min_max} is registered today, matching the fused-mode scope gate in
- * {@code HybridQueryBuilder#requireSupportedTechniques} (which rejects other techniques earlier, at rewrite). This
- * factory's throw is therefore a defense-in-depth backstop, not the user-facing validation.
+ * <p>Only {@code min_max} is wired today, matching the fused-mode scope gate in
+ * {@code HybridQueryBuilder#requireSupportedTechniques} (which rejects other techniques earlier, at rewrite). The throw
+ * below is therefore a defense-in-depth backstop, not the user-facing validation.
  *
  * <p>When adding techniques, two things need a decision that this seam intentionally leaves open:
  * <ul>
@@ -37,7 +38,7 @@ import lombok.NoArgsConstructor;
  * </ul>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class ScalarNormalizerFactory {
+public final class ScalarNormalizers {
 
     private static final Map<String, ScalarNormalizer> NORMALIZERS = Map.of(
         MinMaxScalarNormalizer.INSTANCE.techniqueName(),
@@ -49,7 +50,7 @@ public final class ScalarNormalizerFactory {
      * @return the normalizer for that technique
      * @throws IllegalArgumentException when the technique has no coordinator-side implementation yet
      */
-    public static ScalarNormalizer create(final String techniqueName) {
+    public static ScalarNormalizer forTechnique(final String techniqueName) {
         ScalarNormalizer normalizer = Objects.isNull(techniqueName) ? null : NORMALIZERS.get(techniqueName);
         if (Objects.isNull(normalizer)) {
             throw new IllegalArgumentException(

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -369,7 +369,8 @@ public class NeuralSearch extends Plugin
             SparseSettings.IS_SPARSE_INDEX_SETTING,
             NeuralSearchSettings.SPARSE_ALGO_PARAM_INDEX_THREAD_QTY_SETTING,
             NEURAL_CIRCUIT_BREAKER_LIMIT,
-            NEURAL_CIRCUIT_BREAKER_OVERHEAD
+            NEURAL_CIRCUIT_BREAKER_OVERHEAD,
+            NeuralSearchSettings.MAX_FUSION_LEG_SEARCHES
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/query/CandidateScope.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/CandidateScope.java
@@ -141,9 +141,10 @@ final class CandidateScope {
             table,
             SEARCH_REQUEST,
             "scroll",
-            Disposition.NOT_PROPAGATED,
-            "round 1 is a one-shot candidate query; the scroll context belongs to the user request, which pages through "
-                + "Top then Tail the same way a size beyond the window already does"
+            Disposition.REJECTED,
+            "a scroll pages one reader snapshot to exhaustion, and that snapshot is round 2's alone: the legs that chose "
+                + "the window ran as one-shot searches against their own reader instants and are never re-run. Classic "
+                + "hybrid rejects scroll too — use point_in_time instead, which every leg and round 2 do share"
         );
         put(
             table,
@@ -207,7 +208,9 @@ final class CandidateScope {
             SEARCH_SOURCE,
             "sliceBuilder",
             Disposition.PROPAGATED,
-            "round 2 returns only the slice, so unsliced legs would fill the window with documents outside it"
+            "round 2 returns only the slice, so unsliced legs would fill the window with documents outside it and leave "
+                + "the slice an arbitrary fraction of it. A slice is legal only alongside a point_in_time or a scroll, "
+                + "and scroll is rejected, so the reachable shape is a slice over a PIT — inherited together with it"
         );
         put(
             table,
@@ -287,7 +290,10 @@ final class CandidateScope {
             SEARCH_SOURCE,
             "explain",
             Disposition.NOT_PROPAGATED,
-            "round 2 can only explain the self-erased query, a known fused-mode limitation independent of the legs"
+            "round 2 explains the self-erased query, where a matching Top clause is a childless constant_score carrying "
+                + "the fused score — the right number with no breakdown under it. Normalization and combination run on "
+                + "the coordinator, so assembling the full tree is a response-side concern, exactly as it is for classic "
+                + "hybrid. Tracked as a fused-mode parity follow-up"
         );
         put(table, SEARCH_SOURCE, "version", Disposition.NOT_PROPAGATED, "fetch-phase metadata; a leg fetches nothing but ids");
         put(table, SEARCH_SOURCE, "seqNoAndPrimaryTerm", Disposition.NOT_PROPAGATED, "as version");
@@ -306,7 +312,15 @@ final class CandidateScope {
         put(table, SEARCH_SOURCE, "suggestBuilder", Disposition.NOT_PROPAGATED, "suggestions do not depend on the query");
         put(table, SEARCH_SOURCE, "stats", Disposition.NOT_PROPAGATED, "propagating would count every leg into the user's stats groups");
         put(table, SEARCH_SOURCE, "extBuilders", Disposition.NOT_PROPAGATED, "plugin response extensions, not selection");
-        put(table, SEARCH_SOURCE, "profile", Disposition.NOT_PROPAGATED, "profiles the user's search, not the candidate query");
+        put(
+            table,
+            SEARCH_SOURCE,
+            "profile",
+            Disposition.NOT_PROPAGATED,
+            "only a leg's hits are read from its response, so a leg profile tree has nowhere to go: cost with no output, "
+                + "and profiling perturbs the execution that picks the window. The request profiles round 2 instead, "
+                + "where the legs do appear, timed as the non-scoring Tail filters they are there"
+        );
         put(table, SEARCH_SOURCE, "verbosePipeline", Disposition.NOT_PROPAGATED, "pipeline debug output, and a leg runs no pipeline");
 
         return Map.copyOf(table);
@@ -376,16 +390,22 @@ final class CandidateScope {
      * request never trips one, and the messages name the field the user wrote rather than the field this class keys on.
      */
     private static void rejectUnsupported(final SearchRequest request) {
-        // A remote hit's _index is "cluster:index", which no shard of the remote index matches, so the _index-qualified
-        // Top clauses would silently drop every remote document.
+        // Cross-cluster first, since this runs before index resolution: a literal `cluster:index` would otherwise fail
+        // as `no such index`, which says nothing about fused mode, while a wildcard alias (`*:index`) resolves cleanly
+        // and would reach round 2 — so neither case can be left to resolution.
         for (String index : request.indices()) {
             if (index.indexOf(':') >= 0) {
                 throw unsupported(
                     "cross-cluster search",
-                    "the fused candidate window addresses documents by [_index] plus [_id], and a remote document's "
-                        + "[_index] carries a cluster alias that no shard of the remote index matches"
+                    "the fused window keys and addresses documents by [_index] plus [_id], and neither survives a cluster "
+                        + "hop: a remote hit carries the bare index name with its alias held separately, so same-named "
+                        + "indices in two clusters collapse into one key, and round 2's [_index] term never matches on a "
+                        + "remote shard. Remote documents would reach the user through the Tail alone, at [_score: 0.0]"
                 );
             }
+        }
+        if (Objects.nonNull(request.scroll())) {
+            throw unsupported("scroll", reasonFor(SEARCH_REQUEST, "scroll"));
         }
         SearchSourceBuilder source = request.source();
         if (Objects.isNull(source)) {

--- a/src/main/java/org/opensearch/neuralsearch/query/CandidateScope.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/CandidateScope.java
@@ -268,9 +268,11 @@ final class CandidateScope {
             table,
             SEARCH_SOURCE,
             "collapse",
-            Disposition.NOT_PROPAGATED,
-            "collapsing applies to the fused result, as it does to classic hybrid's; collapsing a leg would instead "
-                + "change which documents are candidates"
+            Disposition.FORCES_TAIL,
+            "collapsing applies to the fused result, as it does to classic hybrid's, and collapsing a leg would instead "
+                + "change which documents are candidates — but collapse.inner_hits expands each group by re-running the "
+                + "round-2 query per group, and a group's members are not confined to the fused window, so Top only would "
+                + "silently drop every member that ranked outside it"
         );
         put(
             table,
@@ -426,6 +428,22 @@ final class CandidateScope {
             }
         }
         return false;
+    }
+
+    /**
+     * True when the request asks for collapse groups to be expanded, i.e. {@code collapse} carries {@code inner_hits}.
+     * Core's {@code ExpandSearchPhase} then issues one extra search per returned group whose query is
+     * {@code bool{filter: group key, must: source().query()}} — by then the self-erased fused query. A group's members are
+     * whichever documents share the representative's collapse key, which is unrelated to the fused window, so with Top
+     * only they match no {@code constant_score} clause and the expansion comes back holding just the members that happened
+     * to rank inside the window. The Tail is what makes the expansion cover the group — see {@link Disposition#FORCES_TAIL}.
+     *
+     * <p>Plain {@code collapse} with no {@code inner_hits} needs nothing: grouping is a query-phase operation over the
+     * documents round 2 already returns, and core runs no expansion at all (its own {@code isCollapseRequest} likewise
+     * tests for a non-empty inner-hits list).
+     */
+    static boolean collapseExpandsGroups(final SearchSourceBuilder source) {
+        return Objects.nonNull(source) && Objects.nonNull(source.collapse()) && source.collapse().getInnerHits().isEmpty() == false;
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/query/CandidateScope.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/CandidateScope.java
@@ -1,0 +1,505 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchType;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.search.builder.PointInTimeBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.pipeline.SearchPipelineService;
+import org.opensearch.search.slice.SliceBuilder;
+import org.opensearch.search.sort.ScoreSortBuilder;
+import org.opensearch.search.sort.SortBuilder;
+
+/**
+ * The slice of a search request that decides <b>which documents are candidates</b> and <b>how they score</b> — the only
+ * part of the request a resolver (fused) mode leg sub-search is allowed to inherit, and the part it must never silently
+ * drop.
+ *
+ * <p>Fused mode answers one user request with two searches: round 1 fans the legs out as a {@code MultiSearch} to pick
+ * the candidate window, and round 2 runs the self-erased {@code bool{Top + Tail}} over the user's original request. The
+ * two rounds must agree on the candidate set, and when they disagree the failure is silent and always shaped alike:
+ * round 1 selects documents round 2 cannot return, round 2 backfills the shortfall from the Tail, and the user gets
+ * correctly-ranked hits followed by arbitrary documents at {@code _score: 0.0} instead of an error. Building the leg
+ * request field by field from scratch is what allows that: every request field nobody thought about defaults to "not
+ * propagated", which is the wrong default for anything selection-relevant.
+ *
+ * <p>This class inverts the default. Every declared field of {@link SearchRequest} and {@link SearchSourceBuilder}
+ * carries an explicit {@link Disposition} in {@link #CLASSIFICATION}, {@code CandidateScopeTests} fails the build when a
+ * field of either class is unclassified (or when an entry names a field that no longer exists), and leg requests are
+ * built only through {@link #newLegRequest}. A core upgrade that adds a request field therefore cannot reach a leg
+ * unexamined.
+ *
+ * <p><b>Cost.</b> {@link Disposition#REJECTED} fields fail the request at rewrite, before the leg fan-out, so a refusal
+ * costs strictly less than the search it replaces. Every {@link Disposition#PROPAGATED} field either narrows a leg's
+ * work (routing, preference, pre-filter, shard concurrency, timeout, slice) or is free at the leg (post_filter, PIT), so
+ * honoring them does not make a leg more expensive than it is today. The one exception is
+ * {@code search_type=dfs_query_then_fetch}, which adds a term-statistics round trip per leg — that cost is the user's
+ * explicit choice, and the alternative is picking candidates with statistics they asked us not to use.
+ */
+final class CandidateScope {
+
+    private static final String FUSION_FIELD_NAME = "fusion";
+
+    /** What fused mode does with a given request field. Exactly one applies to each field of the two request classes. */
+    enum Disposition {
+        /** Copied onto every leg: it changes which documents are candidates, or it makes the leg cheaper. */
+        PROPAGATED,
+        /** Fused mode sets its own value on the leg; the user's value is deliberately not honored there. */
+        OVERRIDDEN,
+        /** Cannot be honored correctly in fused mode — the request fails at rewrite with an explanatory message. */
+        REJECTED,
+        /** Not copied, but forces the Tail on, so round 2 ranks over the full leg union rather than only the window. */
+        FORCES_TAIL,
+        /** Deliberately left off the leg: it cannot affect which documents a leg returns, or it belongs to round 2. */
+        NOT_PROPAGATED
+    }
+
+    /** A disposition plus the reason it is correct, so the table is reviewable without reading the implementation. */
+    record Classification(Disposition disposition, String reason) {
+    }
+
+    static final String SEARCH_REQUEST = SearchRequest.class.getSimpleName();
+    static final String SEARCH_SOURCE = SearchSourceBuilder.class.getSimpleName();
+
+    /**
+     * Every declared instance field of {@link SearchRequest} and {@link SearchSourceBuilder}, keyed {@code Class#field}.
+     * Kept complete and current by {@code CandidateScopeTests}, which reflects over both classes in both directions.
+     */
+    static final Map<String, Classification> CLASSIFICATION = classification();
+
+    private static Map<String, Classification> classification() {
+        Map<String, Classification> table = new LinkedHashMap<>();
+
+        // ---------------------------------------------- SearchRequest ----------------------------------------------
+        put(table, SEARCH_REQUEST, "indices", Disposition.PROPAGATED, "a leg must draw its candidates from the same indices");
+        put(table, SEARCH_REQUEST, "indicesOptions", Disposition.PROPAGATED, "same expansion and ignore-unavailable semantics");
+        put(
+            table,
+            SEARCH_REQUEST,
+            "routing",
+            Disposition.PROPAGATED,
+            "round 2 only searches routed shards, so unrouted legs pick candidates round 2 cannot return"
+        );
+        put(table, SEARCH_REQUEST, "preference", Disposition.PROPAGATED, "pins the legs and round 2 to the same shard copies");
+        put(
+            table,
+            SEARCH_REQUEST,
+            "searchType",
+            Disposition.PROPAGATED,
+            "dfs_query_then_fetch changes term statistics, and therefore leg scores and the window"
+        );
+        put(
+            table,
+            SEARCH_REQUEST,
+            "allowPartialSearchResults",
+            Disposition.PROPAGATED,
+            "propagated only when explicitly set, so an unset flag still resolves the cluster default per leg as usual"
+        );
+        put(
+            table,
+            SEARCH_REQUEST,
+            "maxConcurrentShardRequests",
+            Disposition.PROPAGATED,
+            "the user's per-node shard fan-out cap must bound the legs too, which multiply that fan-out"
+        );
+        put(table, SEARCH_REQUEST, "preFilterShardSize", Disposition.PROPAGATED, "can-match pre-filtering makes a leg cheaper");
+        put(
+            table,
+            SEARCH_REQUEST,
+            "cancelAfterTimeInterval",
+            Disposition.PROPAGATED,
+            "a leg must honor the request's cancellation budget or it outlives the request that spawned it"
+        );
+        put(table, SEARCH_REQUEST, "source", Disposition.OVERRIDDEN, "a leg source is built explicitly, field by field");
+        put(
+            table,
+            SEARCH_REQUEST,
+            "pipeline",
+            Disposition.OVERRIDDEN,
+            "pinned to _none so request/response processors run once for the user request, not once per leg"
+        );
+        put(
+            table,
+            SEARCH_REQUEST,
+            "ccsMinimizeRoundtrips",
+            Disposition.REJECTED,
+            "cross-cluster search is refused outright, so its round-trip mode is moot"
+        );
+        put(
+            table,
+            SEARCH_REQUEST,
+            "scroll",
+            Disposition.NOT_PROPAGATED,
+            "round 1 is a one-shot candidate query; the scroll context belongs to the user request, which pages through "
+                + "Top then Tail the same way a size beyond the window already does"
+        );
+        put(
+            table,
+            SEARCH_REQUEST,
+            "requestCache",
+            Disposition.NOT_PROPAGATED,
+            "caching is selection-neutral, and it still applies to the round-2 query the shards receive, which already "
+                + "embeds the window ids"
+        );
+        put(table, SEARCH_REQUEST, "batchedReduceSize", Disposition.NOT_PROPAGATED, "coordinator reduce batching; selection-neutral");
+        put(table, SEARCH_REQUEST, "phaseTook", Disposition.NOT_PROPAGATED, "response timing only");
+        put(
+            table,
+            SEARCH_REQUEST,
+            "localClusterAlias",
+            Disposition.NOT_PROPAGATED,
+            "set only by core's own cross-cluster sub-request constructor; not reachable from a user request"
+        );
+        put(table, SEARCH_REQUEST, "absoluteStartMillis", Disposition.NOT_PROPAGATED, "as localClusterAlias");
+        put(table, SEARCH_REQUEST, "finalReduce", Disposition.NOT_PROPAGATED, "as localClusterAlias");
+
+        // ------------------------------------------- SearchSourceBuilder -------------------------------------------
+        put(table, SEARCH_SOURCE, "queryBuilder", Disposition.OVERRIDDEN, "each leg runs exactly one sub-query");
+        put(
+            table,
+            SEARCH_SOURCE,
+            "postQueryBuilder",
+            Disposition.PROPAGATED,
+            "round 2 applies post_filter above the top-docs collector, so its window is post-filtered; an unfiltered leg "
+                + "window would be decimated in round 2 and backfilled with score-0 Tail documents"
+        );
+        put(table, SEARCH_SOURCE, "size", Disposition.OVERRIDDEN, "a leg returns exactly the candidate window");
+        put(table, SEARCH_SOURCE, "from", Disposition.OVERRIDDEN, "a leg always starts at 0; paging is a round-2 concern");
+        put(table, SEARCH_SOURCE, "fetchSourceContext", Disposition.OVERRIDDEN, "legs are id-only, so _source is switched off");
+        put(
+            table,
+            SEARCH_SOURCE,
+            "trackTotalHitsUpTo",
+            Disposition.OVERRIDDEN,
+            "legs disable totals; the user's value is read instead to decide whether round 2 needs the Tail"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "aggregations",
+            Disposition.OVERRIDDEN,
+            "not run per leg; their presence turns the Tail on so round 2 aggregates the full leg union"
+        );
+        put(table, SEARCH_SOURCE, "highlightBuilder", Disposition.OVERRIDDEN, "as aggregations");
+        put(
+            table,
+            SEARCH_SOURCE,
+            "searchPipelineSource",
+            Disposition.OVERRIDDEN,
+            "an inline pipeline body is not applied per leg; the leg pipeline is pinned to _none"
+        );
+        put(table, SEARCH_SOURCE, "searchPipeline", Disposition.OVERRIDDEN, "as searchPipelineSource");
+        put(table, SEARCH_SOURCE, "timeout", Disposition.PROPAGATED, "bounds a leg's per-shard work as the user intended");
+        put(
+            table,
+            SEARCH_SOURCE,
+            "sliceBuilder",
+            Disposition.PROPAGATED,
+            "round 2 returns only the slice, so unsliced legs would fill the window with documents outside it"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "pointInTimeBuilder",
+            Disposition.PROPAGATED,
+            "all legs and round 2 then read one immutable view instead of N+1 independent reader instants"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "terminateAfter",
+            Disposition.REJECTED,
+            "round 2's early-termination collector sits below the filter collectors and counts every match in docid "
+                + "order, so with the Tail present it spends the whole budget on Tail documents before reaching the window"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "indexBoosts",
+            Disposition.REJECTED,
+            "in round 2 core wraps the whole self-erased query in a BoostQuery, which classic hybrid rejects outright; "
+                + "the boost cannot influence which documents enter the window, and propagating it would apply it twice"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "derivedFieldsObject",
+            Disposition.REJECTED,
+            "a leg query over a derived field would silently rewrite to match_none, and core exposes no setter for "
+                + "propagating derived-field definitions onto a leg source"
+        );
+        put(table, SEARCH_SOURCE, "derivedFields", Disposition.REJECTED, "as derivedFieldsObject");
+        put(
+            table,
+            SEARCH_SOURCE,
+            "sorts",
+            Disposition.FORCES_TAIL,
+            "a non-_score sort ranks by the sort key instead of the fused score, so sorting only the window would sort "
+                + "an arbitrary subset of the matches; the Tail widens round 2 to the full leg union, over which the "
+                + "user's sort is the plain-search answer"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "minScore",
+            Disposition.NOT_PROPAGATED,
+            "a threshold on the normalized fused score is meaningless against a leg's raw scores"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "searchAfterBuilder",
+            Disposition.NOT_PROPAGATED,
+            "round-2 paging over Top then Tail, the same way a size beyond the window already pages"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "collapse",
+            Disposition.NOT_PROPAGATED,
+            "collapsing applies to the fused result, as it does to classic hybrid's; collapsing a leg would instead "
+                + "change which documents are candidates"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "rescoreBuilders",
+            Disposition.NOT_PROPAGATED,
+            "rescoring reorders round 2's top documents after fusion, which is the intended post-fusion rerank; on a leg "
+                + "it would change the candidates instead"
+        );
+        put(
+            table,
+            SEARCH_SOURCE,
+            "explain",
+            Disposition.NOT_PROPAGATED,
+            "round 2 can only explain the self-erased query, a known fused-mode limitation independent of the legs"
+        );
+        put(table, SEARCH_SOURCE, "version", Disposition.NOT_PROPAGATED, "fetch-phase metadata; a leg fetches nothing but ids");
+        put(table, SEARCH_SOURCE, "seqNoAndPrimaryTerm", Disposition.NOT_PROPAGATED, "as version");
+        put(table, SEARCH_SOURCE, "storedFieldsContext", Disposition.NOT_PROPAGATED, "as version");
+        put(table, SEARCH_SOURCE, "docValueFields", Disposition.NOT_PROPAGATED, "as version");
+        put(table, SEARCH_SOURCE, "scriptFields", Disposition.NOT_PROPAGATED, "as version");
+        put(table, SEARCH_SOURCE, "fetchFields", Disposition.NOT_PROPAGATED, "as version");
+        put(table, SEARCH_SOURCE, "trackScores", Disposition.NOT_PROPAGATED, "a leg always scores; this only affects reporting");
+        put(
+            table,
+            SEARCH_SOURCE,
+            "includeNamedQueriesScore",
+            Disposition.NOT_PROPAGATED,
+            "matched_queries reporting, which the self-erased round-2 query cannot carry anyway"
+        );
+        put(table, SEARCH_SOURCE, "suggestBuilder", Disposition.NOT_PROPAGATED, "suggestions do not depend on the query");
+        put(table, SEARCH_SOURCE, "stats", Disposition.NOT_PROPAGATED, "propagating would count every leg into the user's stats groups");
+        put(table, SEARCH_SOURCE, "extBuilders", Disposition.NOT_PROPAGATED, "plugin response extensions, not selection");
+        put(table, SEARCH_SOURCE, "profile", Disposition.NOT_PROPAGATED, "profiles the user's search, not the candidate query");
+        put(table, SEARCH_SOURCE, "verbosePipeline", Disposition.NOT_PROPAGATED, "pipeline debug output, and a leg runs no pipeline");
+
+        return Map.copyOf(table);
+    }
+
+    private static void put(
+        final Map<String, Classification> table,
+        final String owner,
+        final String field,
+        final Disposition disposition,
+        final String reason
+    ) {
+        table.put(key(owner, field), new Classification(disposition, reason));
+    }
+
+    static String key(final String owner, final String field) {
+        return owner + "#" + field;
+    }
+
+    // The captured PROPAGATED values. A null means the user left the field unset, and an unset value is never forced
+    // onto a leg — the leg then resolves the same default the outer request would.
+    private final String[] indices;
+    private final IndicesOptions indicesOptions;
+    private final String routing;
+    private final String preference;
+    private final SearchType searchType;
+    private final Boolean allowPartialSearchResults;
+    private final int maxConcurrentShardRequests;
+    private final Integer preFilterShardSize;
+    private final TimeValue cancelAfterTimeInterval;
+    private final TimeValue timeout;
+    private final QueryBuilder postFilter;
+    private final SliceBuilder slice;
+    private final String pointInTimeId;
+
+    private CandidateScope(final SearchRequest request) {
+        SearchSourceBuilder source = request.source();
+        this.indices = request.indices();
+        this.indicesOptions = request.indicesOptions();
+        this.routing = request.routing();
+        this.preference = request.preference();
+        this.searchType = request.searchType();
+        this.allowPartialSearchResults = request.allowPartialSearchResults();
+        this.maxConcurrentShardRequests = request.getMaxConcurrentShardRequestsRaw();
+        this.preFilterShardSize = request.getPreFilterShardSize();
+        this.cancelAfterTimeInterval = request.getCancelAfterTimeInterval();
+        this.timeout = Objects.isNull(source) ? null : source.timeout();
+        this.postFilter = Objects.isNull(source) ? null : source.postFilter();
+        this.slice = Objects.isNull(source) ? null : source.slice();
+        PointInTimeBuilder pointInTime = Objects.isNull(source) ? null : source.pointInTimeBuilder();
+        this.pointInTimeId = Objects.isNull(pointInTime) ? null : pointInTime.getId();
+    }
+
+    /**
+     * Capture the candidate-defining part of {@code request}, refusing the request shapes fused mode cannot answer
+     * correctly. Called at rewrite, before the leg fan-out, so a refusal replaces the search instead of following it.
+     *
+     * @throws IllegalArgumentException for any {@link Disposition#REJECTED} field the request actually sets
+     */
+    static CandidateScope from(final SearchRequest request) {
+        rejectUnsupported(request);
+        return new CandidateScope(request);
+    }
+
+    /**
+     * Fail the {@link Disposition#REJECTED} shapes. Each check tests for a value the user actually supplied, so a plain
+     * request never trips one, and the messages name the field the user wrote rather than the field this class keys on.
+     */
+    private static void rejectUnsupported(final SearchRequest request) {
+        // A remote hit's _index is "cluster:index", which no shard of the remote index matches, so the _index-qualified
+        // Top clauses would silently drop every remote document.
+        for (String index : request.indices()) {
+            if (index.indexOf(':') >= 0) {
+                throw unsupported(
+                    "cross-cluster search",
+                    "the fused candidate window addresses documents by [_index] plus [_id], and a remote document's "
+                        + "[_index] carries a cluster alias that no shard of the remote index matches"
+                );
+            }
+        }
+        SearchSourceBuilder source = request.source();
+        if (Objects.isNull(source)) {
+            return;
+        }
+        if (source.terminateAfter() != SearchContext.DEFAULT_TERMINATE_AFTER) {
+            throw unsupported("terminate_after", reasonFor(SEARCH_SOURCE, "terminateAfter"));
+        }
+        if (source.indexBoosts().isEmpty() == false) {
+            throw unsupported("indices_boost", reasonFor(SEARCH_SOURCE, "indexBoosts"));
+        }
+        if (Objects.nonNull(source.getDerivedFieldsObject())
+            || (Objects.nonNull(source.getDerivedFields()) && source.getDerivedFields().isEmpty() == false)) {
+            throw unsupported("derived", reasonFor(SEARCH_SOURCE, "derivedFieldsObject"));
+        }
+    }
+
+    private static IllegalArgumentException unsupported(final String what, final String why) {
+        return new IllegalArgumentException(
+            String.format(Locale.ROOT, "[%s] query [%s] does not support [%s]: %s", HybridQueryBuilder.NAME, FUSION_FIELD_NAME, what, why)
+        );
+    }
+
+    private static String reasonFor(final String owner, final String field) {
+        return CLASSIFICATION.get(key(owner, field)).reason();
+    }
+
+    /**
+     * True when the request ranks by something other than {@code _score}. The fused scores then only pick the candidate
+     * set while the user's sort decides the order, so the candidate set has to be the whole leg union rather than the
+     * window — see {@link Disposition#FORCES_TAIL}.
+     */
+    static boolean sortDiscardsFusedRanking(final SearchSourceBuilder source) {
+        if (Objects.isNull(source) || Objects.isNull(source.sorts())) {
+            return false;
+        }
+        for (SortBuilder<?> sort : source.sorts()) {
+            if ((sort instanceof ScoreSortBuilder) == false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The single place a leg sub-search is constructed: the captured candidate scope, plus this leg's own query and the
+     * candidate window. Every {@link Disposition#OVERRIDDEN} value is set here explicitly rather than inherited, so no
+     * field of the outer request can reach a leg by accident. Legs are id-only (no {@code _source}) with totals disabled,
+     * since the Tail supplies the full-match-set count when the request needs one.
+     *
+     * <p>Notes on three of the propagated fields, whose correctness depends on details not obvious from the table:
+     * <ul>
+     *   <li><b>pipeline</b> is pinned to {@code _none}. Otherwise a leg — a plain {@link SearchRequest} with no explicit
+     *       pipeline — would inherit the index's {@code index.search.default_pipeline} and re-run its request/response
+     *       processors once per leg: redundant, and incorrect for processors like {@code rerank} that expect request
+     *       context an id-only leg does not have. The outer fused request still carries the pipeline, so top-level
+     *       processors run exactly once. A nested fused hybrid therefore cannot read its own config from a leg request,
+     *       which is why the enclosing rewrite projects the config down instead (see
+     *       {@code HybridQueryBuilder#projectResolvedConfigOntoLegs}).</li>
+     *   <li><b>allow_partial_search_results</b> is propagated only when the user set it explicitly; left unset, the leg
+     *       flag stays unset and resolves the cluster default at execution (default {@code true}) exactly like a normal
+     *       search. The distinction matters because the outer flag is a nullable {@code Boolean} that core has not yet
+     *       resolved at rewrite time, so an unconditional pass-through would unbox {@code null}. With an effective
+     *       {@code true} a shard failure degrades that one leg to partial results; with {@code false} the leg fails and
+     *       {@code HybridFusionOrchestrator#groupLegHits} turns that into a whole-request failure. Fused-specific caveat:
+     *       normalization is per-leg, so a partially-degraded leg shifts its own min/max and the fused ranking can differ
+     *       from a complete run rather than merely returning fewer documents.</li>
+     *   <li><b>point_in_time</b> is passed through so every leg and the self-erased round-2 query read one immutable view
+     *       instead of N+1 independent reader instants — the consistency window that otherwise exists on a live-ingest
+     *       index. Copying the request's indices alongside a PIT is safe: core's REST layer has already resolved a PIT
+     *       request's indices to the PIT's own, and the transport layer derives shards from the PIT context regardless.</li>
+     * </ul>
+     */
+    SearchRequest newLegRequest(final QueryBuilder leg, final int windowSize) {
+        SearchSourceBuilder legSource = new SearchSourceBuilder().query(leg)
+            .size(windowSize)
+            .from(0)
+            .fetchSource(false)
+            .trackTotalHits(false);
+        if (Objects.nonNull(timeout)) {
+            legSource.timeout(timeout);
+        }
+        if (Objects.nonNull(postFilter)) {
+            legSource.postFilter(postFilter);
+        }
+        if (Objects.nonNull(slice)) {
+            legSource.slice(slice);
+        }
+        if (Objects.nonNull(pointInTimeId)) {
+            // keepAlive is deliberately left unset: the PIT's original keep-alive governs, and a leg never extends it.
+            legSource.pointInTimeBuilder(new PointInTimeBuilder(pointInTimeId));
+        }
+
+        SearchRequest legRequest = new SearchRequest(indices).indicesOptions(indicesOptions)
+            .searchType(searchType)
+            .source(legSource)
+            .pipeline(SearchPipelineService.NOOP_PIPELINE_ID);
+        if (Objects.nonNull(routing)) {
+            legRequest.routing(routing);
+        }
+        if (Objects.nonNull(preference)) {
+            legRequest.preference(preference);
+        }
+        if (Objects.nonNull(allowPartialSearchResults)) {
+            legRequest.allowPartialSearchResults(allowPartialSearchResults);
+        }
+        // The raw getter reports 0 for "unset" and the setters reject anything below 1, so only forward real values.
+        if (maxConcurrentShardRequests > 0) {
+            legRequest.setMaxConcurrentShardRequests(maxConcurrentShardRequests);
+        }
+        if (Objects.nonNull(preFilterShardSize)) {
+            legRequest.setPreFilterShardSize(preFilterShardSize);
+        }
+        if (Objects.nonNull(cancelAfterTimeInterval)) {
+            legRequest.setCancelAfterTimeInterval(cancelAfterTimeInterval);
+        }
+        return legRequest;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -20,6 +20,7 @@ import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.common.logging.HeaderWarning;
+import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.IdsQueryBuilder;
 import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
@@ -313,29 +314,62 @@ final class HybridFusionOrchestrator {
 
     /** The sub-query legs in their Tail form. groupLegHits fails fast on any leg failure, so every leg is present here
      *  (legHits.length == legs.size(), no null slots). A kNN/neural leg's match set IS its returned top-k, so it is
-     *  materialized as an {@link IdsQueryBuilder} of its already-retrieved ids rather than re-walking the HNSW graph in
-     *  the Tail purely to count; other legs are used as-is. */
+     *  materialized as the documents it already retrieved rather than re-walking the HNSW graph in the Tail purely to
+     *  count; other legs are used as-is. */
     private static List<QueryBuilder> legQueriesForTail(List<QueryBuilder> legs, SearchHit[][] legHits) {
         List<QueryBuilder> tail = new ArrayList<>(legs.size());
         for (int legIndex = 0; legIndex < legs.size(); legIndex++) {
             QueryBuilder leg = legs.get(legIndex);
-            if (isMaterializableLeg(leg)) {
-                IdsQueryBuilder ids = new IdsQueryBuilder();
-                for (SearchHit hit : legHits[legIndex]) {
-                    ids.addIds(hit.getId());
-                }
-                tail.add(ids);
-            } else {
-                tail.add(leg);
-            }
+            tail.add(isMaterializableLeg(leg) ? materializedLeg(legHits[legIndex]) : leg);
         }
         return tail;
     }
 
     /**
+     * A materialized leg addresses the documents it returned the same way the Top addresses ranked documents — through
+     * the shared {@link HybridFusionQueryBuilder#addressDocuments}, by {@code _index} and {@code _id} together.
+     *
+     * <p>The Tail is a {@code filter}, so it decides the match set. Addressing it by {@code _id} alone made every
+     * same-{@code _id} sibling document in another index part of that set: it was counted into {@code total_hits}, fed
+     * every aggregation bucket, and came back to the user as a score-0 hit — inflating precisely the numbers the Tail
+     * exists to make correct. This is not the same defect as the Top's, and qualifying the Top did not fix it: the Tail was
+     * built from the raw leg hits without reference to the ranked window's resolved indices at all.
+     *
+     * <p>Hits are grouped by index — one qualified clause per index, OR-ed — rather than one clause per hit, so a
+     * single-index search still presents a single clause and, since {@code _index} is a constant field whose filter
+     * rewrites to MatchAll on its own shard and MatchNoDocs elsewhere, the post-rewrite leaf count per leg is unchanged.
+     *
+     * <p>An empty leg is returned as an explicit {@code match_none}. {@code bool{should: []}} compiles to
+     * {@code MatchAllDocsQuery}, so an ANN leg that matched nothing would otherwise flip to matching <i>every</i> document
+     * in the Tail. Today's bare ids query avoids that only by accident — core rewrites an empty {@link IdsQueryBuilder} to
+     * {@code match_none} — and that accident does not survive wrapping the leg in a bool, so state the guard here.
+     */
+    private static QueryBuilder materializedLeg(SearchHit[] hits) {
+        if (hits.length == 0) {
+            return new MatchNoneQueryBuilder();
+        }
+        // Insertion-ordered and null-tolerant: a hit carrying no resolvable _index groups under the null key and is
+        // addressed by _id alone, matching documentKey and the Top's own fallback.
+        Map<String, List<String>> idsByIndex = new LinkedHashMap<>();
+        for (SearchHit hit : hits) {
+            idsByIndex.computeIfAbsent(hit.getIndex(), index -> new ArrayList<>()).add(hit.getId());
+        }
+        List<QueryBuilder> perIndex = new ArrayList<>(idsByIndex.size());
+        for (Map.Entry<String, List<String>> group : idsByIndex.entrySet()) {
+            perIndex.add(HybridFusionQueryBuilder.addressDocuments(group.getKey(), group.getValue().toArray(new String[0])));
+        }
+        if (perIndex.size() == 1) {
+            return perIndex.get(0);
+        }
+        BoolQueryBuilder inAnyIndex = new BoolQueryBuilder();
+        perIndex.forEach(inAnyIndex::should);
+        return inAnyIndex;
+    }
+
+    /**
      * Legs whose full Lucene match set equals their returned top-k, so re-running them in the Tail would be a redundant
-     * ANN pass (kNN/neural re-walk the HNSW graph). Only such legs are safe to materialize as an {@link IdsQueryBuilder}
-     * of the already-retrieved window ids. A leg whose match set is NOT bounded to its top-k — e.g. {@code neural_sparse},
+     * ANN pass (kNN/neural re-walk the HNSW graph). Only such legs are safe to replace with a direct address of the
+     * already-retrieved hits. A leg whose match set is NOT bounded to its top-k — e.g. {@code neural_sparse},
      * whose match set is every doc containing a query token (far larger than the window) — must NOT be materialized, or
      * the Tail would drop the rest and undercount total_hits/aggregations (and re-running it is cheap: no graph to walk).
      */

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -28,7 +28,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.neuralsearch.fusion.CoordinatorScoreFusion;
 import org.opensearch.neuralsearch.fusion.ScalarNormalizer;
-import org.opensearch.neuralsearch.fusion.ScalarNormalizerFactory;
+import org.opensearch.neuralsearch.fusion.ScalarNormalizers;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationFactory;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationUtil;
@@ -124,6 +124,9 @@ final class HybridFusionOrchestrator {
      * response {@code Warning} header names the affected legs so the degradation is not silent. Under an effective
      * {@code allow_partial_search_results=false} the leg itself fails, which the check below turns into a whole-request
      * failure — so honoring that flag needs no separate handling here.
+     *
+     * <p>Every leg's hits enter fusion through this method and nowhere else, which makes it the one place to assert the
+     * per-hit {@code _index} invariant both the Top and the Tail depend on — see {@link #requireHitsCarryTheirIndex}.
      */
     private static SearchHit[][] groupLegHits(MultiSearchResponse.Item[] items, int legCount) {
         if (items.length != legCount) {
@@ -156,10 +159,37 @@ final class HybridFusionOrchestrator {
             if (Objects.nonNull(shardFailures) && shardFailures.length > 0) {
                 degradedLegs.add(leg);
             }
-            legHits[leg] = item.getResponse().getHits().getHits();
+            legHits[leg] = requireHitsCarryTheirIndex(item.getResponse().getHits().getHits(), leg);
         }
         warnOnDegradedLegs(degradedLegs);
         return legHits;
+    }
+
+    /**
+     * Assert the property everything downstream relies on: every leg hit carries its {@code _index}. Fusion keys documents
+     * by {@code _index} + {@code _id} and round 2 addresses them the same way, so a hit without an index can neither be
+     * kept apart from a same-{@code _id} document in a sibling index nor addressed without also matching it.
+     *
+     * <p>An {@link IllegalStateException} rather than a fallback, on both counts: a coordinator sets a hit's index from its
+     * shard target, so a hit missing one means the leg response was not produced the way a search response is; and the only
+     * fallback available — {@code _id}-only addressing — merges distinct documents for the whole window, since its clauses
+     * are qualified as a set, not per hit.
+     */
+    private static SearchHit[] requireHitsCarryTheirIndex(final SearchHit[] hits, final int leg) {
+        for (SearchHit hit : hits) {
+            if (Objects.isNull(hit.getIndex())) {
+                throw new IllegalStateException(
+                    String.format(
+                        Locale.ROOT,
+                        "[hybrid] fused-mode sub-query %d returned a hit [_id: %s] with no [_index]; fused documents are "
+                            + "identified and addressed by [_index] plus [_id], so this hit cannot be fused",
+                        leg,
+                        hit.getId()
+                    )
+                );
+            }
+        }
+        return hits;
     }
 
     /**
@@ -209,26 +239,29 @@ final class HybridFusionOrchestrator {
             fusion.combinationTechnique(),
             weightsParams(fusion.weights())
         );
-        // Normalization is resolved by name, so widening technique support is a new ScalarNormalizer + factory entry —
-        // no change here. The caller already rejected techniques outside the current scope at rewrite.
-        ScalarNormalizer normalizer = ScalarNormalizerFactory.create(fusion.normalizationTechnique());
+        // Normalization is resolved by name, so widening technique support is a new ScalarNormalizer plus one entry in
+        // ScalarNormalizers — no change here. The caller already rejected out-of-scope techniques at rewrite.
+        ScalarNormalizer normalizer = ScalarNormalizers.forTechnique(fusion.normalizationTechnique());
         Map<String, Float> combined = CoordinatorScoreFusion.fuse(legRawScores, normalizer, combination);
         return toRankedDocs(combined, identityByKey, windowSize);
     }
 
     /**
-     * Fusion key for a hit: {@code _index}-qualified when the hit carries an index, else the bare {@code _id}.
+     * Fusion key for a hit: its {@code _index}, the separator, and its {@code _id}. Every leg hit carries an index —
+     * {@link #requireHitsCarryTheirIndex} asserts it as the hits enter — so the key is always qualified.
      *
-     * <p>Limitation in custom routing. {@code _index} + {@code _id} is not a total identity when custom routing is
-     * used: the same {@code _id} can be written to different shards of one index under different routing values, giving
-     * two genuinely distinct documents that share this key and are therefore fused as one. Qualifying further is not
-     * possible from here — a leg's {@link SearchHit} exposes {@link SearchHit#getShard()} but no routing value, so the
-     * coordinator has nothing to add to the key, and the {@code _routing} metadata field (queryable in principle) would
-     * first have to be fetched per leg hit, which the id-only leg deliberately does not do. One possible way to resolve this
-     * is leg-fetch.
+     * <p>Limitation in custom routing. {@code _index} + {@code _id} is not a total identity when custom routing is used:
+     * the same {@code _id} can be written to different shards of one index under different routing values, giving two
+     * genuinely distinct documents that share this key and are therefore fused as one.
+     *
+     * <p>Adding the routing value to the key would not fix it. Reading it is not the obstacle — round 2's matching surface
+     * is: the self-erased query addresses documents by {@code _id} and an {@code _index} term, with no way to express
+     * routing, so two docs split apart in the key resolve to the same clause, and Lucene folds identical SHOULD clauses by
+     * <i>summing</i> their boosts — both would come back scored as the sum, which is worse than fusing them as one. This
+     * is a limitation of how documents are addressed, not of how they are keyed.
      */
     private static String documentKey(SearchHit hit) {
-        return Objects.isNull(hit.getIndex()) ? hit.getId() : hit.getIndex() + KEY_SEPARATOR + hit.getId();
+        return hit.getIndex() + KEY_SEPARATOR + hit.getId();
     }
 
     /**
@@ -285,11 +318,9 @@ final class HybridFusionOrchestrator {
      * MatchNoDocs required clause and collapses away entirely. Measured post-rewrite, the qualified Top presents the same
      * number of clauses to Lucene's ceiling as the unqualified one.
      *
-     * <p>The returned {@code indices} array is null-or-fully-populated, never an array with null holes: a hole would NPE
-     * inside {@code StreamOutput.writeOptionalStringArray} (it handles a null array, not null elements) while the
-     * coordinator serializes the round-2 shard request — a 500 on a query that already succeeded through fusion. If any
-     * window hit cannot be resolved to a concrete index, the whole array is dropped and every clause falls back to
-     * {@code _id}-only.
+     * <p>The returned {@code indices} array is fully populated, with no null holes: every key came from a hit whose
+     * {@code _index} {@link #requireHitsCarryTheirIndex} already asserted, and the side map is built from those same hits.
+     * Nothing here tolerates a missing index on purpose — see that method for why a fallback would be worse.
      */
     private static RankedDocs toRankedDocs(Map<String, Float> scoresByKey, Map<String, SearchHit> identityByKey, int windowSize) {
         List<Map.Entry<String, Float>> ranked = new ArrayList<>(scoresByKey.entrySet());
@@ -300,18 +331,15 @@ final class HybridFusionOrchestrator {
         String[] ids = new String[ranked.size()];
         String[] indices = new String[ranked.size()];
         float[] scores = new float[ranked.size()];
-        boolean everyHitCarriesItsIndex = true;
         for (int i = 0; i < ranked.size(); i++) {
             String key = ranked.get(i).getKey();
+            // Resolved through the side map, never by parsing the composite key — an _id may contain the separator.
             SearchHit hit = identityByKey.get(key);
-            // Defensive: a key always has an identity (both maps are built from the same hits), but never fall back to
-            // parsing the composite key — an _id may contain the separator.
-            ids[i] = Objects.isNull(hit) ? key : hit.getId();
-            indices[i] = Objects.isNull(hit) ? null : hit.getIndex();
+            ids[i] = hit.getId();
+            indices[i] = hit.getIndex();
             scores[i] = ranked.get(i).getValue();
-            everyHitCarriesItsIndex &= Objects.nonNull(indices[i]);
         }
-        return new RankedDocs(ids, everyHitCarriesItsIndex ? indices : null, scores);
+        return new RankedDocs(ids, indices, scores);
     }
 
     /** The sub-query legs in their Tail form. groupLegHits fails fast on any leg failure, so every leg is present here
@@ -351,8 +379,9 @@ final class HybridFusionOrchestrator {
         if (hits.length == 0) {
             return new MatchNoneQueryBuilder();
         }
-        // Insertion-ordered and null-tolerant: a hit carrying no resolvable _index groups under the null key and is
-        // addressed by _id alone, matching documentKey and the Top's own fallback.
+        // Insertion-ordered, so a leg's clauses come out in the order its hits arrived — deterministic for the same
+        // response. Every hit carries an _index by the invariant requireHitsCarryTheirIndex asserts, so there is no
+        // unqualified group to address by _id alone.
         Map<String, List<String>> idsByIndex = new LinkedHashMap<>();
         for (SearchHit hit : hits) {
             idsByIndex.computeIfAbsent(hit.getIndex(), index -> new ArrayList<>()).add(hit.getId());
@@ -403,9 +432,15 @@ final class HybridFusionOrchestrator {
      *
      * <p>Deliberately NOT triggers:
      * <ul>
-     *   <li>{@code explain}/{@code profile} — the fused score is computed on the coordinator and the Top is a
-     *       {@code constant_score}, so the Lucene tree carries no fusion breakdown to explain, and profiling the Tail
-     *       would only time a redundant re-execution of legs that already ran in the fan-out.</li>
+     *   <li>{@code explain} — the Tail cannot recover a fused explanation: the fused score is arithmetic the coordinator
+     *       already did, and the clause carrying it into round 2 is a childless {@code constant_score} with nothing to
+     *       descend into (the Tail explains as a non-scoring filter either way). Describing the fusion belongs on the
+     *       response side, where classic hybrid puts it too — tracked as a fused-mode parity follow-up, see
+     *       {@link CandidateScope.Disposition#NOT_PROPAGATED}.</li>
+     *   <li>{@code profile} — the tree covers round 2, which is what executes under it, and only a leg's hits are read
+     *       from its response, so a leg tree has nowhere to go. Forcing the Tail would not add the legs' own timings: it
+     *       would time a fresh re-execution of them and change the very execution being measured. A materialized leg
+     *       appears there as the id/index filter it was reduced to, not as the ANN query it came from.</li>
      *   <li>leg {@code inner_hits} — inner_hits are built in the fetch phase from the <i>registered</i> inner-hit
      *       contexts per returned parent doc, so the leg never has to be executed for them to be returned. They are
      *       carried separately (see {@link #innerHitsLegs}), which keeps a Top-only query cheap without losing them.
@@ -449,7 +484,8 @@ final class HybridFusionOrchestrator {
         return Objects.isNull(trackTotalHitsUpTo) || trackTotalHitsUpTo > numRankedDocs;
     }
 
-    /** The fused window in score order. {@code indices} is parallel to {@code ids} and null-or-fully-populated. */
+    /** The fused window in score order. {@code indices} is parallel to {@code ids} and fully populated — every entry names
+     *  the index the document was found in, which is what lets round 2 address it unambiguously. */
     private record RankedDocs(String[] ids, String[] indices, float[] scores) {
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -13,6 +13,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequest;
@@ -131,8 +133,17 @@ final class HybridFusionOrchestrator {
         for (int leg = 0; leg < legCount; leg++) {
             MultiSearchResponse.Item item = items[leg];
             if (item.isFailure()) {
-                throw new IllegalStateException(
+                // Carry the leg's own status instead of inventing one. A malformed query bound is the user's 400, a
+                // queue rejection is a retryable 429, a cluster block is a 403 — and ExceptionsHelper.status has no
+                // IllegalStateException case, so wrapping in one turned every leg failure into a 500 with the real
+                // status buried under caused_by: a client's retry-on-429 never fired and a bad request read as a
+                // server bug. SearchPhaseExecutionException#status derives from its shard failures and
+                // OpenSearchException#status unwraps transport wrappers, so the leg's own failure carries the right
+                // code with no unwrapping here. The message is passed with no format args, so LoggerMessageFormat
+                // returns it verbatim and a stray {} inside the leg's message cannot mangle it.
+                throw new OpenSearchStatusException(
                     String.format(Locale.ROOT, "[hybrid] fused-mode sub-query %d failed: %s", leg, item.getFailureMessage()),
+                    ExceptionsHelper.status(item.getFailure()),
                     item.getFailure()
                 );
             }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -16,16 +16,21 @@ import java.util.Objects;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.index.query.IdsQueryBuilder;
 import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.neuralsearch.fusion.CoordinatorScoreFusion;
+import org.opensearch.neuralsearch.fusion.ScalarNormalizer;
+import org.opensearch.neuralsearch.fusion.ScalarNormalizerFactory;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationFactory;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationUtil;
 import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.SearchPipelineService;
 
@@ -64,23 +69,38 @@ final class HybridFusionOrchestrator {
      * request context absent from an id-only leg). The outer fused request still carries the pipeline, so top-level
      * processors run exactly once.
      *
-     * <p>Legs do NOT override {@code allow_partial_search_results}: the flag is left unset, so each leg resolves the
-     * cluster default at execution (default {@code true}) exactly like a normal search — a shard that fails for a leg
-     * degrades that leg to partial results rather than failing the request. A wholly-failed leg (all shards down, or a
-     * non-partial error) is still a hard failure surfaced by {@link #groupLegHits}. Caveats: a request-level
-     * {@code allow_partial_search_results=false} is intentionally NOT propagated to the legs yet (unsupported), and
-     * because min_max is per-leg a partially-degraded leg can shift its own min/max, so the fused ranking may differ
-     * from a complete run — see the LLD "Partial-leg failure" note under *Consistency*.
+     * <p>{@code allow_partial_search_results} follows the request: an explicitly set value is propagated to every leg,
+     * and when the user left it unset the leg flag is left unset too so each leg resolves the cluster default at
+     * execution (default {@code true}) exactly like a normal search. Propagating only the explicit value matters because
+     * the outer flag is a nullable {@code Boolean} that core has not yet resolved to the cluster default at rewrite
+     * time, so an unconditional pass-through would unbox {@code null}. With an effective {@code true} a shard failing
+     * for one leg degrades that leg to partial results; with {@code false} the leg fails and {@link #groupLegHits} turns
+     * that into a whole-request failure. Note the fused-specific caveat: because normalization is per-leg, a
+     * partially-degraded leg shifts its own min/max, so the fused ranking may differ from a complete run — not merely
+     * return fewer docs (see {@link #groupLegHits} and the LLD "Partial-leg failure" note under *Consistency*).
+     *
+     * <p>A user-supplied point-in-time is passed through to every leg, so all legs and the self-erased round-2 query read
+     * the same immutable view instead of N+1 independent reader instants — the consistency window that otherwise exists
+     * on a live-ingest index. {@code keepAlive} is deliberately left unset on the legs so the PIT's original keep-alive
+     * governs; the legs never extend it. Copying the request's indices alongside a PIT is safe: core's REST layer has
+     * already resolved a PIT request's indices to the PIT's own, and the transport layer derives shards from the PIT
+     * context regardless, so the leg is consistent with the outer request rather than in conflict with it.
      */
     static MultiSearchRequest buildLegMultiSearch(SearchRequest request, List<QueryBuilder> legs, int windowSize) {
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
+        PointInTimeBuilder pointInTime = Objects.isNull(request.source()) ? null : request.source().pointInTimeBuilder();
         for (QueryBuilder leg : legs) {
             SearchSourceBuilder legSource = new SearchSourceBuilder().query(leg).size(windowSize).fetchSource(false).trackTotalHits(false);
-            multiSearchRequest.add(
-                new SearchRequest(request.indices()).indicesOptions(request.indicesOptions())
-                    .source(legSource)
-                    .pipeline(SearchPipelineService.NOOP_PIPELINE_ID)
-            );
+            if (Objects.nonNull(pointInTime)) {
+                legSource.pointInTimeBuilder(new PointInTimeBuilder(pointInTime.getId()));
+            }
+            SearchRequest legRequest = new SearchRequest(request.indices()).indicesOptions(request.indicesOptions())
+                .source(legSource)
+                .pipeline(SearchPipelineService.NOOP_PIPELINE_ID);
+            if (Objects.nonNull(request.allowPartialSearchResults())) {
+                legRequest.allowPartialSearchResults(request.allowPartialSearchResults());
+            }
+            multiSearchRequest.add(legRequest);
         }
         return multiSearchRequest;
     }
@@ -91,17 +111,21 @@ final class HybridFusionOrchestrator {
      * mutates nothing.
      *
      * <p>The Tail (non-scoring {@code bool{should: legs}} surfacing the full match set) is included only when the request
-     * needs it (aggregations / highlight / leg inner_hits / totals beyond the window — see {@link #needsTail}) and this
-     * marker is the whole query. A nested fused query is always Top-only, so an enclosing filter intersects the fused
-     * window at the query phase (fuse-then-filter).
+     * needs it (aggregations / highlight / leg inner_hits / totals beyond the window — see {@link #needsTail}).
+     *
+     * <p>The Tail decision is <b>depth-independent</b>: it is derived from the request alone, not from whether this
+     * hybrid is the whole query or nested inside a container. A nested fused query still self-erases into
+     * {@code bool{Top + Tail}}, and an enclosing clause simply intersects that (fuse-then-filter), so aggregations and
+     * {@code total_hits} stay correct at any nesting depth. This deliberately avoids inferring nesting from the query
+     * instance (a reference-identity check against {@code source().query()} would silently drop the Tail — and with it
+     * agg/total_hits accuracy — for any request-rewrite layer that clones the query first).
      */
     static QueryBuilder buildFusedQuery(
         SearchSourceBuilder source,
         MultiSearchResponse multiSearchResponse,
         List<QueryBuilder> legs,
         FusionSpec fusion,
-        int windowSize,
-        boolean topLevel
+        int windowSize
     ) {
         MultiSearchResponse.Item[] items = multiSearchResponse.getResponses();
         SearchHit[][] legHits = groupLegHits(items, legs.size());
@@ -109,10 +133,7 @@ final class HybridFusionOrchestrator {
         if (ranked.ids().length == 0) {
             return new MatchNoneQueryBuilder();
         }
-        // A nested fused query is always Top-only (an enclosing filter intersects the fused window at the query phase);
-        // a top-level query keeps the Tail only when it genuinely needs the full match set executed (see needsTail).
-        boolean topOnly = topLevel == false || needsTail(source, legs, ranked.ids().length) == false;
-        List<QueryBuilder> tail = topOnly ? List.of() : legQueriesForTail(legs, legHits);
+        List<QueryBuilder> tail = needsTail(source, legs, ranked.ids().length) ? legQueriesForTail(legs, legHits) : List.of();
         return new HybridFusionQueryBuilder(ranked.ids(), ranked.scores(), tail);
     }
 
@@ -120,8 +141,12 @@ final class HybridFusionOrchestrator {
      * Reduce the raw MultiSearch items into a per-leg array of hits (one item per leg). A wholly-failed leg (all shards
      * down or a non-partial error → {@code Item.isFailure()}) fails the whole request — fusing over a missing leg would
      * silently change the ranking function, not merely return fewer docs. A leg that only lost some shards under
-     * {@code allow_partial_search_results=true} comes back as a successful item with fewer hits and is fused as-is
-     * (matching OpenSearch's default partial-results behavior; the relevance caveat is in the LLD *Consistency* note).
+     * {@code allow_partial_search_results=true} comes back as a successful item with fewer hits and is fused as-is —
+     * matching OpenSearch's default partial-results behavior. Because normalization is per-leg, that degraded leg shifts
+     * its own min/max, so the fused <i>ranking</i> can differ from a complete run rather than merely losing docs; a
+     * response {@code Warning} header names the affected legs so the degradation is not silent. Under an effective
+     * {@code allow_partial_search_results=false} the leg itself fails, which the check below turns into a whole-request
+     * failure — so honoring that flag needs no separate handling here.
      */
     private static SearchHit[][] groupLegHits(MultiSearchResponse.Item[] items, int legCount) {
         if (items.length != legCount) {
@@ -130,6 +155,7 @@ final class HybridFusionOrchestrator {
             );
         }
         SearchHit[][] legHits = new SearchHit[legCount][];
+        List<Integer> degradedLegs = new ArrayList<>();
         for (int leg = 0; leg < legCount; leg++) {
             MultiSearchResponse.Item item = items[leg];
             if (item.isFailure()) {
@@ -138,9 +164,36 @@ final class HybridFusionOrchestrator {
                     item.getFailure()
                 );
             }
+            // Shard failures (not successful<total) — skipped/can-match shards are not failures. Read the array rather
+            // than getFailedShards(), which dereferences it unguarded.
+            ShardSearchFailure[] shardFailures = item.getResponse().getShardFailures();
+            if (Objects.nonNull(shardFailures) && shardFailures.length > 0) {
+                degradedLegs.add(leg);
+            }
             legHits[leg] = item.getResponse().getHits().getHits();
         }
+        warnOnDegradedLegs(degradedLegs);
         return legHits;
+    }
+
+    /**
+     * Surface partially-degraded legs as a response {@code Warning} header. Uses the same mechanism as deprecation
+     * warnings, emitted from the coordinator rewrite's async callback so it rides the request's thread context onto the
+     * response.
+     */
+    private static void warnOnDegradedLegs(final List<Integer> degradedLegs) {
+        if (degradedLegs.isEmpty()) {
+            return;
+        }
+        HeaderWarning.addWarning(
+            String.format(
+                Locale.ROOT,
+                "[hybrid] fused-mode sub-quer%s %s returned partial results (shard failures); fused scores were computed "
+                    + "over an incomplete result set, so ranking may differ from a complete run",
+                degradedLegs.size() == 1 ? "y" : "ies",
+                degradedLegs
+            )
+        );
     }
 
     /**
@@ -162,7 +215,10 @@ final class HybridFusionOrchestrator {
             fusion.combinationTechnique(),
             weightsParams(fusion.weights())
         );
-        Map<String, Float> combined = CoordinatorScoreFusion.fuseMinMax(legRawScores, combination);
+        // Normalization is resolved by name, so widening technique support is a new ScalarNormalizer + factory entry —
+        // no change here. The caller already rejected techniques outside the current scope at rewrite.
+        ScalarNormalizer normalizer = ScalarNormalizerFactory.create(fusion.normalizationTechnique());
+        Map<String, Float> combined = CoordinatorScoreFusion.fuse(legRawScores, normalizer, combination);
         return toRankedDocs(combined, windowSize);
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -32,9 +32,7 @@ import org.opensearch.neuralsearch.processor.combination.ScoreCombinationFactory
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationUtil;
 import org.opensearch.search.SearchHit;
-import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.search.pipeline.SearchPipelineService;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -58,7 +56,12 @@ final class HybridFusionOrchestrator {
 
     /**
      * Build the leg MultiSearch: one standalone search per sub-query, each reduced to the global top-{@code windowSize}.
-     * Id-only (no {@code _source}); totals disabled (the Tail supplies the full-match-set count when needed).
+     *
+     * <p>What each leg inherits from the user's request is decided in exactly one place — {@link CandidateScope}, which
+     * classifies every field of {@link SearchRequest} and {@link SearchSourceBuilder} as propagated, overridden,
+     * rejected, Tail-forcing, or deliberately dropped, with the reason recorded next to it. This method only assembles
+     * the per-leg requests it produces; it holds no propagation policy of its own, so no request field can reach a leg
+     * (or fail to) by omission here.
      *
      * <p>Note on ANN legs: {@code size} sets how many hits a leg returns, but an ANN leg's retrieval depth is bounded by
      * its own {@code k} (collected per shard), not by {@code size} — a {@code knn}/{@code neural} leg with a small or
@@ -66,45 +69,11 @@ final class HybridFusionOrchestrator {
      * classic hybrid, which likewise never rewrites {@code k}; for a full window, set {@code k >= window_size} on the
      * sub-query. We deliberately do NOT rewrite {@code k} here — it would diverge from classic and has no analog for
      * radial knn ({@code min_score}/{@code max_distance} have no {@code k}).
-     *
-     * <p>Each leg is pinned to the no-op search pipeline ({@code _none}). Otherwise a leg — a plain {@link SearchRequest}
-     * with no explicit pipeline — would inherit the index's {@code index.search.default_pipeline} and re-run its
-     * request/response processors once per leg (redundant, and incorrect for processors like {@code rerank} that expect
-     * request context absent from an id-only leg). The outer fused request still carries the pipeline, so top-level
-     * processors run exactly once.
-     *
-     * <p>{@code allow_partial_search_results} follows the request: an explicitly set value is propagated to every leg,
-     * and when the user left it unset the leg flag is left unset too so each leg resolves the cluster default at
-     * execution (default {@code true}) exactly like a normal search. Propagating only the explicit value matters because
-     * the outer flag is a nullable {@code Boolean} that core has not yet resolved to the cluster default at rewrite
-     * time, so an unconditional pass-through would unbox {@code null}. With an effective {@code true} a shard failing
-     * for one leg degrades that leg to partial results; with {@code false} the leg fails and {@link #groupLegHits} turns
-     * that into a whole-request failure. Note the fused-specific caveat: because normalization is per-leg, a
-     * partially-degraded leg shifts its own min/max, so the fused ranking may differ from a complete run — not merely
-     * return fewer docs (see {@link #groupLegHits} and the LLD "Partial-leg failure" note under *Consistency*).
-     *
-     * <p>A user-supplied point-in-time is passed through to every leg, so all legs and the self-erased round-2 query read
-     * the same immutable view instead of N+1 independent reader instants — the consistency window that otherwise exists
-     * on a live-ingest index. {@code keepAlive} is deliberately left unset on the legs so the PIT's original keep-alive
-     * governs; the legs never extend it. Copying the request's indices alongside a PIT is safe: core's REST layer has
-     * already resolved a PIT request's indices to the PIT's own, and the transport layer derives shards from the PIT
-     * context regardless, so the leg is consistent with the outer request rather than in conflict with it.
      */
-    static MultiSearchRequest buildLegMultiSearch(SearchRequest request, List<QueryBuilder> legs, int windowSize) {
+    static MultiSearchRequest buildLegMultiSearch(CandidateScope scope, List<QueryBuilder> legs, int windowSize) {
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
-        PointInTimeBuilder pointInTime = Objects.isNull(request.source()) ? null : request.source().pointInTimeBuilder();
         for (QueryBuilder leg : legs) {
-            SearchSourceBuilder legSource = new SearchSourceBuilder().query(leg).size(windowSize).fetchSource(false).trackTotalHits(false);
-            if (Objects.nonNull(pointInTime)) {
-                legSource.pointInTimeBuilder(new PointInTimeBuilder(pointInTime.getId()));
-            }
-            SearchRequest legRequest = new SearchRequest(request.indices()).indicesOptions(request.indicesOptions())
-                .source(legSource)
-                .pipeline(SearchPipelineService.NOOP_PIPELINE_ID);
-            if (Objects.nonNull(request.allowPartialSearchResults())) {
-                legRequest.allowPartialSearchResults(request.allowPartialSearchResults());
-            }
-            multiSearchRequest.add(legRequest);
+            multiSearchRequest.add(scope.newLegRequest(leg, windowSize));
         }
         return multiSearchRequest;
     }
@@ -351,8 +320,11 @@ final class HybridFusionOrchestrator {
 
     /**
      * Single source of truth for whether a fused query needs the executed Tail (the non-scoring
-     * {@code bool{should: legs}}): aggregations or highlighting need the full match set in the query phase, and an
-     * accurate index-wide {@code total_hits} beyond the fused window needs the legs counted.
+     * {@code bool{should: legs}}): aggregations or highlighting need the full match set in the query phase, an accurate
+     * index-wide {@code total_hits} beyond the fused window needs the legs counted, and a sort that is not by
+     * {@code _score} ranks over the match set rather than the fused window (see
+     * {@link CandidateScope.Disposition#FORCES_TAIL}) — with
+     * Top only, such a request would sort an arbitrary window-sized subset of its matches.
      *
      * <p>Deliberately NOT triggers:
      * <ul>
@@ -366,6 +338,9 @@ final class HybridFusionOrchestrator {
      */
     private static boolean needsTail(SearchSourceBuilder source, int numRankedDocs) {
         if (Objects.nonNull(source) && (Objects.nonNull(source.aggregations()) || Objects.nonNull(source.highlighter()))) {
+            return true;
+        }
+        if (CandidateScope.sortDiscardsFusedRanking(source)) {
             return true;
         }
         return wantsTotalsBeyondWindow(source, numRankedDocs);

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -7,11 +7,13 @@ package org.opensearch.neuralsearch.query;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
@@ -51,6 +53,8 @@ import lombok.NoArgsConstructor;
 final class HybridFusionOrchestrator {
 
     private static final ScoreCombinationFactory SCORE_COMBINATION_FACTORY = new ScoreCombinationFactory();
+    /** Separator for the composite _index+_id fusion key. Never parsed back — see computeRankedDocs. */
+    private static final String KEY_SEPARATOR = "#";
 
     /**
      * Build the leg MultiSearch: one standalone search per sub-query, each reduced to the global top-{@code windowSize}.
@@ -133,8 +137,9 @@ final class HybridFusionOrchestrator {
         if (ranked.ids().length == 0) {
             return new MatchNoneQueryBuilder();
         }
-        List<QueryBuilder> tail = needsTail(source, legs, ranked.ids().length) ? legQueriesForTail(legs, legHits) : List.of();
-        return new HybridFusionQueryBuilder(ranked.ids(), ranked.scores(), tail);
+        List<QueryBuilder> tail = needsTail(source, ranked.ids().length) ? legQueriesForTail(legs, legHits) : List.of();
+        // inner_hits are registered from the legs themselves, independent of whether the Tail executes them.
+        return new HybridFusionQueryBuilder(ranked.ids(), ranked.indices(), ranked.scores(), tail, innerHitsLegs(legs));
     }
 
     /**
@@ -197,19 +202,27 @@ final class HybridFusionOrchestrator {
     }
 
     /**
-     * Fuse via the shared {@link CoordinatorScoreFusion} core (min_max + arithmetic_mean), then rank by fused score and
-     * cut to the window. Converts the coordinator's {@code SearchHit[][]} view into the {@code _id}-keyed per-leg maps
-     * the shared core consumes; a leg that matched nothing contributes an empty map (groupLegHits fails fast on failures,
-     * so every slot is non-null).
+     * Fuse via the shared {@link CoordinatorScoreFusion} core, then rank by fused score and cut to the window. Converts
+     * the coordinator's {@code SearchHit[][]} view into the per-leg key→score maps the shared core consumes; a leg that
+     * matched nothing contributes an empty map (groupLegHits fails fast on failures, so every slot is non-null).
+     *
+     * <p>Documents are keyed by {@code _index} + {@code _id}, not {@code _id} alone: {@code _id} is unique only within an
+     * index, so across indices two different documents can share one and fusion would otherwise combine their scores as
+     * if they were one document. The composite key is built with a separator but is never parsed back — an {@code _id}
+     * may itself contain the separator, so the original identity is carried in a side map instead. To fusion and to every
+     * normalizer the key stays opaque.
      */
     private static RankedDocs computeRankedDocs(SearchHit[][] legHits, FusionSpec fusion, int windowSize) {
         List<Map<String, Float>> legRawScores = new ArrayList<>(legHits.length);
+        Map<String, SearchHit> identityByKey = new HashMap<>();
         for (SearchHit[] hits : legHits) {
-            Map<String, Float> byId = new LinkedHashMap<>();
+            Map<String, Float> byKey = new LinkedHashMap<>();
             for (SearchHit hit : hits) {
-                byId.put(hit.getId(), hit.getScore());
+                String key = documentKey(hit);
+                byKey.put(key, hit.getScore());
+                identityByKey.putIfAbsent(key, hit);
             }
-            legRawScores.add(byId);
+            legRawScores.add(byKey);
         }
         ScoreCombinationTechnique combination = SCORE_COMBINATION_FACTORY.createCombination(
             fusion.combinationTechnique(),
@@ -219,7 +232,12 @@ final class HybridFusionOrchestrator {
         // no change here. The caller already rejected techniques outside the current scope at rewrite.
         ScalarNormalizer normalizer = ScalarNormalizerFactory.create(fusion.normalizationTechnique());
         Map<String, Float> combined = CoordinatorScoreFusion.fuse(legRawScores, normalizer, combination);
-        return toRankedDocs(combined, windowSize);
+        return toRankedDocs(combined, identityByKey, windowSize);
+    }
+
+    /** Fusion key for a hit: {@code _index}-qualified when the hit carries an index, else the bare {@code _id}. */
+    private static String documentKey(SearchHit hit) {
+        return Objects.isNull(hit.getIndex()) ? hit.getId() : hit.getIndex() + KEY_SEPARATOR + hit.getId();
     }
 
     /**
@@ -259,19 +277,33 @@ final class HybridFusionOrchestrator {
         return Map.of(ScoreCombinationUtil.PARAM_NAME_WEIGHTS, weightsList);
     }
 
-    private static RankedDocs toRankedDocs(Map<String, Float> scoresById, int windowSize) {
-        List<Map.Entry<String, Float>> ranked = new ArrayList<>(scoresById.entrySet());
+    /**
+     * Rank the fused scores, cut to the window, and resolve each key back to its {@code (_index, _id)} identity via the
+     * side map — never by parsing the key. The returned {@code indices} array is null unless the window actually spans
+     * more than one index, so a single-index search keeps the leaner {@code _id}-only Top clause.
+     */
+    private static RankedDocs toRankedDocs(Map<String, Float> scoresByKey, Map<String, SearchHit> identityByKey, int windowSize) {
+        List<Map.Entry<String, Float>> ranked = new ArrayList<>(scoresByKey.entrySet());
         ranked.sort(Comparator.<Map.Entry<String, Float>>comparingDouble(e -> -e.getValue()).thenComparing(Map.Entry::getKey));
         if (ranked.size() > windowSize) {
             ranked = ranked.subList(0, windowSize);
         }
         String[] ids = new String[ranked.size()];
+        String[] indices = new String[ranked.size()];
         float[] scores = new float[ranked.size()];
+        Set<String> distinctIndices = new HashSet<>();
         for (int i = 0; i < ranked.size(); i++) {
-            ids[i] = ranked.get(i).getKey();
+            String key = ranked.get(i).getKey();
+            SearchHit hit = identityByKey.get(key);
+            // Defensive: a key always has an identity (both maps are built from the same hits), but never fall back to
+            // parsing the composite key — an _id may contain the separator.
+            ids[i] = Objects.isNull(hit) ? key : hit.getId();
+            indices[i] = Objects.isNull(hit) ? null : hit.getIndex();
             scores[i] = ranked.get(i).getValue();
+            distinctIndices.add(indices[i]);
         }
-        return new RankedDocs(ids, scores);
+        boolean needsIndexQualification = distinctIndices.size() > 1;
+        return new RankedDocs(ids, needsIndexQualification ? indices : null, scores);
     }
 
     /** The sub-query legs in their Tail form. groupLegHits fails fast on any leg failure, so every leg is present here
@@ -308,30 +340,43 @@ final class HybridFusionOrchestrator {
     }
 
     /**
-     * Single source of truth for whether a top-level fused query needs the executed Tail (the non-scoring
-     * {@code bool{should: legs}}): aggregations or highlighting need the full match set in the query phase, leg
-     * inner_hits currently require the legs registered via the Tail, and an accurate index-wide {@code total_hits}
-     * beyond the fused window needs the legs counted. {@code explain}/{@code profile} are intentionally NOT triggers —
-     * the fused score is computed on the coordinator and the Top is a {@code constant_score(ids)}, so the Lucene tree
-     * carries no fusion breakdown to explain, and profiling the Tail would only time a redundant re-execution of legs
-     * that already ran in the fan-out (fusion-aware explain/profile is scoped to a later PR).
+     * Single source of truth for whether a fused query needs the executed Tail (the non-scoring
+     * {@code bool{should: legs}}): aggregations or highlighting need the full match set in the query phase, and an
+     * accurate index-wide {@code total_hits} beyond the fused window needs the legs counted.
+     *
+     * <p>Deliberately NOT triggers:
+     * <ul>
+     *   <li>{@code explain}/{@code profile} — the fused score is computed on the coordinator and the Top is a
+     *       {@code constant_score}, so the Lucene tree carries no fusion breakdown to explain, and profiling the Tail
+     *       would only time a redundant re-execution of legs that already ran in the fan-out.</li>
+     *   <li>leg {@code inner_hits} — inner_hits are built in the fetch phase from the <i>registered</i> inner-hit
+     *       contexts per returned parent doc, so the leg never has to be executed for them to be returned. They are
+     *       carried separately (see {@link #innerHitsLegs}), which keeps a Top-only query cheap without losing them.</li>
+     * </ul>
      */
-    private static boolean needsTail(SearchSourceBuilder source, List<QueryBuilder> legs, int numRankedDocs) {
+    private static boolean needsTail(SearchSourceBuilder source, int numRankedDocs) {
         if (Objects.nonNull(source) && (Objects.nonNull(source.aggregations()) || Objects.nonNull(source.highlighter()))) {
-            return true;
-        }
-        if (legsHaveInnerHits(legs)) {
             return true;
         }
         return wantsTotalsBeyondWindow(source, numRankedDocs);
     }
 
-    private static boolean legsHaveInnerHits(List<QueryBuilder> legs) {
-        Map<String, InnerHitContextBuilder> innerHits = new HashMap<>();
+    /**
+     * The legs that declare {@code inner_hits}, in their original (un-materialized) form, for fetch-phase registration.
+     * Only legs actually carrying an inner_hits definition are kept, so the common case registers nothing. Note these are
+     * the original leg builders rather than the Tail's possibly id-materialized form — a kNN/neural leg materialized to
+     * ids has no inner_hits definition left to extract.
+     */
+    private static List<QueryBuilder> innerHitsLegs(List<QueryBuilder> legs) {
+        List<QueryBuilder> withInnerHits = new ArrayList<>();
         for (QueryBuilder leg : legs) {
+            Map<String, InnerHitContextBuilder> innerHits = new HashMap<>();
             InnerHitContextBuilder.extractInnerHits(leg, innerHits);
+            if (innerHits.isEmpty() == false) {
+                withInnerHits.add(leg);
+            }
         }
-        return innerHits.isEmpty() == false;
+        return withInnerHits;
     }
 
     private static boolean wantsTotalsBeyondWindow(SearchSourceBuilder source, int numRankedDocs) {
@@ -342,6 +387,6 @@ final class HybridFusionOrchestrator {
         return Objects.isNull(trackTotalHitsUpTo) || trackTotalHitsUpTo > numRankedDocs;
     }
 
-    private record RankedDocs(String[] ids, float[] scores) {
+    private record RankedDocs(String[] ids, String[] indices, float[] scores) {
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -7,13 +7,11 @@ package org.opensearch.neuralsearch.query;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
@@ -258,8 +256,26 @@ final class HybridFusionOrchestrator {
 
     /**
      * Rank the fused scores, cut to the window, and resolve each key back to its {@code (_index, _id)} identity via the
-     * side map — never by parsing the key. The returned {@code indices} array is null unless the window actually spans
-     * more than one index, so a single-index search keeps the leaner {@code _id}-only Top clause.
+     * side map — never by parsing the key.
+     *
+     * <p>Every ranked document is addressed by its {@code _index} as well as its {@code _id}, unconditionally. The window
+     * is not evidence about the request: a multi-index search whose window happens to be filled from one index still runs
+     * round 2 against every requested index, where a sibling index's same-{@code _id} document would match the bare
+     * {@code ids} clause and inherit that document's fused score. Deciding qualification from the window was exactly that
+     * bug — fusion keys documents by {@code _index + _id} (see {@link #documentKey}), and addressing them by {@code _id}
+     * alone merges back together what keying had correctly separated.
+     *
+     * <p>Qualifying always is free rather than a trade: {@code _index} is a constant field, so on the shard's own index
+     * the added filter is a MatchAll that {@code BooleanQuery.rewrite} removes — the clause collapses to exactly the
+     * {@code constant_score(ids)} it would have been — and on any other index's shard the all-FILTER bool has a
+     * MatchNoDocs required clause and collapses away entirely. Measured post-rewrite, the qualified Top presents the same
+     * number of clauses to Lucene's ceiling as the unqualified one.
+     *
+     * <p>The returned {@code indices} array is null-or-fully-populated, never an array with null holes: a hole would NPE
+     * inside {@code StreamOutput.writeOptionalStringArray} (it handles a null array, not null elements) while the
+     * coordinator serializes the round-2 shard request — a 500 on a query that already succeeded through fusion. If any
+     * window hit cannot be resolved to a concrete index, the whole array is dropped and every clause falls back to
+     * {@code _id}-only.
      */
     private static RankedDocs toRankedDocs(Map<String, Float> scoresByKey, Map<String, SearchHit> identityByKey, int windowSize) {
         List<Map.Entry<String, Float>> ranked = new ArrayList<>(scoresByKey.entrySet());
@@ -270,7 +286,7 @@ final class HybridFusionOrchestrator {
         String[] ids = new String[ranked.size()];
         String[] indices = new String[ranked.size()];
         float[] scores = new float[ranked.size()];
-        Set<String> distinctIndices = new HashSet<>();
+        boolean everyHitCarriesItsIndex = true;
         for (int i = 0; i < ranked.size(); i++) {
             String key = ranked.get(i).getKey();
             SearchHit hit = identityByKey.get(key);
@@ -279,10 +295,9 @@ final class HybridFusionOrchestrator {
             ids[i] = Objects.isNull(hit) ? key : hit.getId();
             indices[i] = Objects.isNull(hit) ? null : hit.getIndex();
             scores[i] = ranked.get(i).getValue();
-            distinctIndices.add(indices[i]);
+            everyHitCarriesItsIndex &= Objects.nonNull(indices[i]);
         }
-        boolean needsIndexQualification = distinctIndices.size() > 1;
-        return new RankedDocs(ids, needsIndexQualification ? indices : null, scores);
+        return new RankedDocs(ids, everyHitCarriesItsIndex ? indices : null, scores);
     }
 
     /** The sub-query legs in their Tail form. groupLegHits fails fast on any leg failure, so every leg is present here
@@ -372,6 +387,7 @@ final class HybridFusionOrchestrator {
         return Objects.isNull(trackTotalHitsUpTo) || trackTotalHitsUpTo > numRankedDocs;
     }
 
+    /** The fused window in score order. {@code indices} is parallel to {@code ids} and null-or-fully-populated. */
     private record RankedDocs(String[] ids, String[] indices, float[] scores) {
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -235,7 +235,17 @@ final class HybridFusionOrchestrator {
         return toRankedDocs(combined, identityByKey, windowSize);
     }
 
-    /** Fusion key for a hit: {@code _index}-qualified when the hit carries an index, else the bare {@code _id}. */
+    /**
+     * Fusion key for a hit: {@code _index}-qualified when the hit carries an index, else the bare {@code _id}.
+     *
+     * <p>Limitation in custom routing. {@code _index} + {@code _id} is not a total identity when custom routing is
+     * used: the same {@code _id} can be written to different shards of one index under different routing values, giving
+     * two genuinely distinct documents that share this key and are therefore fused as one. Qualifying further is not
+     * possible from here — a leg's {@link SearchHit} exposes {@link SearchHit#getShard()} but no routing value, so the
+     * coordinator has nothing to add to the key, and the {@code _routing} metadata field (queryable in principle) would
+     * first have to be fetched per leg hit, which the id-only leg deliberately does not do. One possible way to resolve this
+     * is leg-fetch.
+     */
     private static String documentKey(SearchHit hit) {
         return Objects.isNull(hit.getIndex()) ? hit.getId() : hit.getIndex() + KEY_SEPARATOR + hit.getId();
     }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -84,8 +84,10 @@ final class HybridFusionOrchestrator {
      * (Top + conditional Tail), or a {@link MatchNoneQueryBuilder} when nothing fused. Pure: returns the query and
      * mutates nothing.
      *
-     * <p>The Tail (non-scoring {@code bool{should: legs}} surfacing the full match set) is included only when the request
-     * needs it (aggregations / highlight / leg inner_hits / totals beyond the window — see {@link #needsTail}).
+     * <p>The Tail (non-scoring {@code bool{should: legs}} surfacing the full match set) is included when the request needs
+     * it: aggregations, highlighting, a non-{@code _score} sort, collapse group expansion, or totals beyond the window —
+     * see {@link #needsTail} for the list and for what deliberately does not trigger it. Since a request that sets none of
+     * those still wants an accurate {@code total_hits}, the Tail is present by default and Top-only is the opt-out.
      *
      * <p>The Tail decision is <b>depth-independent</b>: it is derived from the request alone, not from whether this
      * hybrid is the whole query or nested inside a container. A nested fused query still self-erases into
@@ -313,9 +315,10 @@ final class HybridFusionOrchestrator {
     }
 
     /** The sub-query legs in their Tail form. groupLegHits fails fast on any leg failure, so every leg is present here
-     *  (legHits.length == legs.size(), no null slots). A kNN/neural leg's match set IS its returned top-k, so it is
-     *  materialized as the documents it already retrieved rather than re-walking the HNSW graph in the Tail purely to
-     *  count; other legs are used as-is. */
+     *  (legHits.length == legs.size(), no null slots). A kNN/neural leg retrieves a bounded candidate set rather than a
+     *  term-defined one, so it is materialized as the documents it already retrieved rather than re-walking the HNSW graph
+     *  in the Tail purely to count; other legs are used as-is. See {@link #isMaterializableLeg} for the bound this relies
+     *  on and the one configuration where it under-counts. */
     private static List<QueryBuilder> legQueriesForTail(List<QueryBuilder> legs, SearchHit[][] legHits) {
         List<QueryBuilder> tail = new ArrayList<>(legs.size());
         for (int legIndex = 0; legIndex < legs.size(); legIndex++) {
@@ -367,11 +370,23 @@ final class HybridFusionOrchestrator {
     }
 
     /**
-     * Legs whose full Lucene match set equals their returned top-k, so re-running them in the Tail would be a redundant
-     * ANN pass (kNN/neural re-walk the HNSW graph). Only such legs are safe to replace with a direct address of the
-     * already-retrieved hits. A leg whose match set is NOT bounded to its top-k — e.g. {@code neural_sparse},
+     * Legs whose match set is bounded by their own retrieval depth rather than by the data, so re-running them in the Tail
+     * would be a redundant ANN pass (kNN/neural re-walk the HNSW graph). Only such legs are safe to replace with a direct
+     * address of the already-retrieved hits. A leg whose match set is NOT so bounded — e.g. {@code neural_sparse},
      * whose match set is every doc containing a query token (far larger than the window) — must NOT be materialized, or
      * the Tail would drop the rest and undercount total_hits/aggregations (and re-running it is cheap: no graph to walk).
+     *
+     * <p><b>Known limitation — materialization is exact only when the leg was not truncated.</b> A materialized leg stands
+     * for the documents it <i>returned</i>, which is {@code min(matches, window_size)}: {@code newLegRequest} sets the
+     * leg's {@code size} to the window. The leg's real match set is up to its own {@code k} per shard, which fused mode
+     * deliberately does not rewrite (see {@link #buildLegMultiSearch}), so with {@code k} × shards greater than
+     * {@code window_size} the leg matched documents it never returned, and the Tail — a {@code filter}, hence the match set
+     * — leaves them out of {@code total_hits} and out of every aggregation bucket. Classic hybrid counts them, so this is
+     * an under-count relative to classic in exactly that configuration. Default {@code k} (10) is below the default
+     * {@code window_size} (100), which is why the common case is exact; a leg that returned fewer than {@code window_size}
+     * hits is exact by construction, since it was not truncated. Raising {@code window_size} to at least {@code k} ×
+     * shards restores an exact count. The fix — using the original leg in the Tail when a materialized leg came back full —
+     * is deferred: it costs a second ANN walk in precisely the case a user chose a deep {@code k} for.
      */
     private static boolean isMaterializableLeg(QueryBuilder leg) {
         String name = leg.getWriteableName();
@@ -381,10 +396,10 @@ final class HybridFusionOrchestrator {
     /**
      * Single source of truth for whether a fused query needs the executed Tail (the non-scoring
      * {@code bool{should: legs}}): aggregations or highlighting need the full match set in the query phase, an accurate
-     * index-wide {@code total_hits} beyond the fused window needs the legs counted, and a sort that is not by
-     * {@code _score} ranks over the match set rather than the fused window (see
-     * {@link CandidateScope.Disposition#FORCES_TAIL}) — with
-     * Top only, such a request would sort an arbitrary window-sized subset of its matches.
+     * index-wide {@code total_hits} beyond the fused window needs the legs counted, a sort that is not by
+     * {@code _score} ranks over the match set rather than the fused window, and {@code collapse.inner_hits} expands each
+     * group over the match set (see {@link CandidateScope.Disposition#FORCES_TAIL}) — with
+     * Top only, such a request would sort, or expand a group over, an arbitrary window-sized subset of its matches.
      *
      * <p>Deliberately NOT triggers:
      * <ul>
@@ -393,14 +408,16 @@ final class HybridFusionOrchestrator {
      *       would only time a redundant re-execution of legs that already ran in the fan-out.</li>
      *   <li>leg {@code inner_hits} — inner_hits are built in the fetch phase from the <i>registered</i> inner-hit
      *       contexts per returned parent doc, so the leg never has to be executed for them to be returned. They are
-     *       carried separately (see {@link #innerHitsLegs}), which keeps a Top-only query cheap without losing them.</li>
+     *       carried separately (see {@link #innerHitsLegs}), which keeps a Top-only query cheap without losing them.
+     *       This is unlike {@code collapse.inner_hits} above, which is not a fetch-phase expansion of the returned
+     *       document at all but a whole extra search per group, and so does depend on what round 2 matches.</li>
      * </ul>
      */
     private static boolean needsTail(SearchSourceBuilder source, int numRankedDocs) {
         if (Objects.nonNull(source) && (Objects.nonNull(source.aggregations()) || Objects.nonNull(source.highlighter()))) {
             return true;
         }
-        if (CandidateScope.sortDiscardsFusedRanking(source)) {
+        if (CandidateScope.sortDiscardsFusedRanking(source) || CandidateScope.collapseExpandsGroups(source)) {
             return true;
         }
         return wantsTotalsBeyondWindow(source, numRankedDocs);

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -42,11 +42,14 @@ import org.opensearch.index.query.TermQueryBuilder;
  *       needs the full match set; omitted (Top-only) for plain top-K.</li>
  * </ul>
  *
- * <p><b>Document identity.</b> A ranked doc is addressed by {@code _id}, optionally qualified by its {@code _index}.
- * {@code _id} is unique only within an index, so for a multi-index search two different documents can share an
- * {@code _id}; qualifying the Top clause with an {@code _index} filter keeps them distinct and stops one doc's fused
- * score from being applied to the other. Index qualification is opt-in per instance ({@code indices} may be null) so a
- * single-index search keeps the leaner {@code ids}-only clause and its original performance profile.
+ * <p><b>Document identity.</b> A ranked doc is addressed by its {@code _index} and {@code _id} together, always.
+ * {@code _id} is unique only within an index, so two different documents in two indices can share one; without the
+ * {@code _index} filter each would match the other's Top clause and inherit its fused score. Qualification is not
+ * conditional on the search looking like it needs it — the fused window is not evidence about which indices round 2 will
+ * execute against — and it is not a trade either: {@code _index} is a constant field, so on the shard's own index the
+ * added filter is a MatchAll that {@code BooleanQuery.rewrite} removes (the clause collapses to exactly
+ * {@code constant_score(ids)}), and on any other index's shard the clause collapses to MatchNoDocs. {@code indices} is
+ * null only for a window whose hits carried no resolvable {@code _index}; when non-null it has no null elements.
  *
  * <p><b>inner_hits registration is decoupled from the Tail.</b> inner_hits are computed in the fetch phase from the
  * registered {@link InnerHitContextBuilder}s (per returned parent doc), not from whatever ran in the query phase — so a
@@ -77,7 +80,11 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
     private static final String INDEX_FIELD = "_index";
 
     private final String[] ids;
-    /** Parallel to {@code ids}; null when the search targets a single index and needs no qualification. */
+    /**
+     * Parallel to {@code ids}. Either null — no clause is qualified — or fully populated, one concrete index name per
+     * ranked doc. Never an array with null holes: {@code writeOptionalStringArray} handles a null array but writes
+     * elements through {@code writeString}, which NPEs on a null.
+     */
     private final String[] indices;
     private final float[] scores;
     /** Legs executed in the query phase as the non-scoring Tail (empty for a Top-only query). */
@@ -92,6 +99,9 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
         List<QueryBuilder> tailQueries,
         List<QueryBuilder> innerHitsQueries
     ) {
+        assert Objects.isNull(indices) || indices.length == ids.length : "indices must be parallel to ids";
+        assert Objects.isNull(indices) || Arrays.stream(indices).noneMatch(Objects::isNull)
+            : "indices must be null or fully populated — a null element NPEs in writeOptionalStringArray";
         this.ids = ids;
         this.indices = indices;
         this.scores = scores;
@@ -99,7 +109,7 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
         this.innerHitsQueries = Objects.isNull(innerHitsQueries) ? new ArrayList<>() : innerHitsQueries;
     }
 
-    /** Single-index convenience: no index qualification, and the Tail legs are also the inner_hits source. */
+    /** Unqualified convenience: {@code _id}-only Top clauses, and the Tail legs are also the inner_hits source. */
     public HybridFusionQueryBuilder(String[] ids, float[] scores, List<QueryBuilder> tailQueries) {
         this(ids, null, scores, tailQueries, tailQueries);
     }
@@ -173,8 +183,9 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
             composite.should(new ConstantScoreQueryBuilder(rankedDocQuery(i)).boost(scores[i]));
         }
         // Tail: all leg matches as a non-scoring filter -> total hits and aggregations cover the full match set, and
-        // highlighting has the sub-queries' terms available. Non-window docs match at score 0 and sort below the fused
-        // window, so a request with size <= window_size returns exactly the fused window.
+        // highlighting has the sub-queries' terms available. A doc outside the window matches no Top clause — including
+        // a doc in another index that shares a window doc's _id, which is why the Top is _index-qualified — so it scores
+        // 0 and sorts below the window, and a request with size <= window_size returns exactly the fused window.
         if (tailQueries.isEmpty() == false) {
             BoolQueryBuilder tail = new BoolQueryBuilder();
             for (QueryBuilder q : tailQueries) {
@@ -186,12 +197,13 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
     }
 
     /**
-     * Address one ranked document: by {@code _id} alone, or {@code _id} intersected with its {@code _index} when the
-     * fused set spans indices (where {@code _id} is not unique on its own).
+     * Address one ranked document by {@code _id} intersected with its {@code _index} — {@code _id} is not unique on its
+     * own, and the fused score belongs to exactly one document. Falls back to {@code _id} alone only when no index could
+     * be resolved for the window at all; per-element fallback is impossible by the {@code indices} invariant.
      */
     private QueryBuilder rankedDocQuery(int position) {
         IdsQueryBuilder idQuery = new IdsQueryBuilder().addIds(ids[position]);
-        if (Objects.isNull(indices) || Objects.isNull(indices[position])) {
+        if (Objects.isNull(indices)) {
             return idQuery;
         }
         return new BoolQueryBuilder().filter(idQuery).filter(new TermQueryBuilder(INDEX_FIELD, indices[position]));

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -137,9 +137,13 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         boolean changed = false;
+        // Both lists hold the original leg builders, and this query needs them for what they match, never for what they
+        // score — the fused scores are already baked into the Top. Rewriting them under a match-set marker is what keeps a
+        // leg that is itself a fused hybrid from firing its own legs a second time (see MatchSetRewriteContext).
+        QueryRewriteContext matchSetContext = MatchSetRewriteContext.wrap(queryRewriteContext);
         List<QueryBuilder> rewrittenTail = new ArrayList<>(tailQueries.size());
         for (QueryBuilder q : tailQueries) {
-            QueryBuilder r = q.rewrite(queryRewriteContext);
+            QueryBuilder r = q.rewrite(matchSetContext);
             rewrittenTail.add(r);
             changed |= r != q;
         }
@@ -147,7 +151,7 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
         // inner-hit context from the registered builder, so an un-rewritten builder would be a different definition.
         List<QueryBuilder> rewrittenInnerHits = new ArrayList<>(innerHitsQueries.size());
         for (QueryBuilder q : innerHitsQueries) {
-            QueryBuilder r = q.rewrite(queryRewriteContext);
+            QueryBuilder r = q.rewrite(matchSetContext);
             rewrittenInnerHits.add(r);
             changed |= r != q;
         }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -25,6 +25,7 @@ import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.TermQueryBuilder;
 
 /**
  * Internal query produced by {@link HybridQueryBuilder} when the resolver (fused) mode is enabled via the {@code fusion}
@@ -33,55 +34,109 @@ import org.opensearch.index.query.QueryShardContext;
  * on a plain query with no hybrid-specific special-casing:
  *
  * <ul>
- *   <li><b>Top</b> — one {@code constant_score(ids: [id])^fusedScore} clause per ranked document. These are the
- *       scoring {@code should} clauses, so the fused window is returned in fused-score order.</li>
- *   <li><b>Tail</b> — a {@code bool{ should: [sourceQuery...] }} added as a non-scoring {@code filter}. It matches the
+ *   <li><b>Top</b> — one {@code constant_score(...)^fusedScore} clause per ranked document. These are the scoring
+ *       {@code should} clauses, so the fused window is returned in fused-score order.</li>
+ *   <li><b>Tail</b> — a {@code bool{ should: [tailQuery...] }} added as a non-scoring {@code filter}. It matches the
  *       full set of documents any sub-query matched, so {@code total_hits} and aggregations cover all matches (not just
  *       the ranked window) and the highlighter has the sub-queries' terms available. Included only when the request
- *       needs the full match set; omitted (Top-only) for plain top-K and for a nested fused query.</li>
+ *       needs the full match set; omitted (Top-only) for plain top-K.</li>
  * </ul>
  *
- * <p>This query is created internally by the coordinator self-erase and is never parseable from a search request.
+ * <p><b>Document identity.</b> A ranked doc is addressed by {@code _id}, optionally qualified by its {@code _index}.
+ * {@code _id} is unique only within an index, so for a multi-index search two different documents can share an
+ * {@code _id}; qualifying the Top clause with an {@code _index} filter keeps them distinct and stops one doc's fused
+ * score from being applied to the other. Index qualification is opt-in per instance ({@code indices} may be null) so a
+ * single-index search keeps the leaner {@code ids}-only clause and its original performance profile.
+ *
+ * <p><b>inner_hits registration is decoupled from the Tail.</b> inner_hits are computed in the fetch phase from the
+ * registered {@link InnerHitContextBuilder}s (per returned parent doc), not from whatever ran in the query phase — so a
+ * leg only needs to be <i>registered</i>, never <i>executed</i>, for its inner_hits to be returned. {@code tailQueries}
+ * is therefore what gets executed, while {@code innerHitsQueries} is what gets registered; the two are populated
+ * independently, which lets a Top-only query still return leg inner_hits without paying to re-run the legs.
+ *
+ * <p>This query is created internally by the coordinator self-erase and is never parseable from a search request. Its
+ * wire form needs no version gate: the whole query type is new in the same version that introduced fused mode, and a
+ * node predating that version cannot resolve this {@code NamedWriteable} name at all — so it fails on the query name
+ * long before reading any field.
  */
 public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQueryBuilder> {
 
     public static final String NAME = "hybrid_fusion";
 
-    private final String[] ids;
-    private final float[] scores;
-    private final List<QueryBuilder> sourceQueries;
+    /** Metadata field used to disambiguate same-{@code _id} docs across indices. */
+    private static final String INDEX_FIELD = "_index";
 
-    public HybridFusionQueryBuilder(String[] ids, float[] scores, List<QueryBuilder> sourceQueries) {
+    private final String[] ids;
+    /** Parallel to {@code ids}; null when the search targets a single index and needs no qualification. */
+    private final String[] indices;
+    private final float[] scores;
+    /** Legs executed in the query phase as the non-scoring Tail (empty for a Top-only query). */
+    private final List<QueryBuilder> tailQueries;
+    /** Legs registered for fetch-phase inner_hits extraction; never executed by this query. */
+    private final List<QueryBuilder> innerHitsQueries;
+
+    public HybridFusionQueryBuilder(
+        String[] ids,
+        String[] indices,
+        float[] scores,
+        List<QueryBuilder> tailQueries,
+        List<QueryBuilder> innerHitsQueries
+    ) {
         this.ids = ids;
+        this.indices = indices;
         this.scores = scores;
-        this.sourceQueries = Objects.isNull(sourceQueries) ? new ArrayList<>() : sourceQueries;
+        this.tailQueries = Objects.isNull(tailQueries) ? new ArrayList<>() : tailQueries;
+        this.innerHitsQueries = Objects.isNull(innerHitsQueries) ? new ArrayList<>() : innerHitsQueries;
+    }
+
+    /** Single-index convenience: no index qualification, and the Tail legs are also the inner_hits source. */
+    public HybridFusionQueryBuilder(String[] ids, float[] scores, List<QueryBuilder> tailQueries) {
+        this(ids, null, scores, tailQueries, tailQueries);
     }
 
     public HybridFusionQueryBuilder(StreamInput in) throws IOException {
         super(in);
         this.ids = in.readStringArray();
+        this.indices = in.readOptionalStringArray();
         this.scores = in.readFloatArray();
-        this.sourceQueries = in.readNamedWriteableList(QueryBuilder.class);
+        this.tailQueries = in.readNamedWriteableList(QueryBuilder.class);
+        this.innerHitsQueries = in.readNamedWriteableList(QueryBuilder.class);
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeStringArray(ids);
+        out.writeOptionalStringArray(indices);
         out.writeFloatArray(scores);
-        out.writeNamedWriteableList(sourceQueries);
+        out.writeNamedWriteableList(tailQueries);
+        out.writeNamedWriteableList(innerHitsQueries);
     }
 
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
         boolean changed = false;
-        List<QueryBuilder> rewritten = new ArrayList<>(sourceQueries.size());
-        for (QueryBuilder q : sourceQueries) {
+        List<QueryBuilder> rewrittenTail = new ArrayList<>(tailQueries.size());
+        for (QueryBuilder q : tailQueries) {
             QueryBuilder r = q.rewrite(queryRewriteContext);
-            rewritten.add(r);
+            rewrittenTail.add(r);
+            changed |= r != q;
+        }
+        // The inner_hits sources must be rewritten too — they are not executed, but the fetch phase builds each
+        // inner-hit context from the registered builder, so an un-rewritten builder would be a different definition.
+        List<QueryBuilder> rewrittenInnerHits = new ArrayList<>(innerHitsQueries.size());
+        for (QueryBuilder q : innerHitsQueries) {
+            QueryBuilder r = q.rewrite(queryRewriteContext);
+            rewrittenInnerHits.add(r);
             changed |= r != q;
         }
         if (changed) {
-            HybridFusionQueryBuilder rewrittenBuilder = new HybridFusionQueryBuilder(ids, scores, rewritten);
+            HybridFusionQueryBuilder rewrittenBuilder = new HybridFusionQueryBuilder(
+                ids,
+                indices,
+                scores,
+                rewrittenTail,
+                rewrittenInnerHits
+            );
             rewrittenBuilder.boost(boost());
             rewrittenBuilder.queryName(queryName());
             return rewrittenBuilder;
@@ -97,22 +152,22 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
     /**
      * Build the self-erased {@code bool} query (Top + optional Tail) as a standard {@link BoolQueryBuilder}, before it
      * is compiled to a Lucene query. Kept separate from {@link #doToQuery} so the structural contract — one scoring
-     * {@code should} per ranked id, and a single non-scoring {@code filter} Tail iff any source query is present — is
+     * {@code should} per ranked id, and a single non-scoring {@code filter} Tail iff any Tail query is present — is
      * unit-testable without a shard context.
      */
     BoolQueryBuilder buildSelfErasedQuery() {
-        // Top: constant_score(IdsQuery)^fusedScore per ranked doc — the scoring should-clauses that return the fused
-        // window in fused-score order.
+        // Top: constant_score(...)^fusedScore per ranked doc — the scoring should-clauses that return the fused window
+        // in fused-score order.
         BoolQueryBuilder composite = new BoolQueryBuilder();
         for (int i = 0; i < ids.length; i++) {
-            composite.should(new ConstantScoreQueryBuilder(new IdsQueryBuilder().addIds(ids[i])).boost(scores[i]));
+            composite.should(new ConstantScoreQueryBuilder(rankedDocQuery(i)).boost(scores[i]));
         }
-        // Tail: all source-query matches as a non-scoring filter -> total hits and aggregations cover the full match
-        // set, and highlighting has the sub-queries' terms available. Non-window docs match at score 0 and sort below
-        // the fused window, so a request with size <= window_size returns exactly the fused window.
-        if (sourceQueries.isEmpty() == false) {
+        // Tail: all leg matches as a non-scoring filter -> total hits and aggregations cover the full match set, and
+        // highlighting has the sub-queries' terms available. Non-window docs match at score 0 and sort below the fused
+        // window, so a request with size <= window_size returns exactly the fused window.
+        if (tailQueries.isEmpty() == false) {
             BoolQueryBuilder tail = new BoolQueryBuilder();
-            for (QueryBuilder q : sourceQueries) {
+            for (QueryBuilder q : tailQueries) {
                 tail.should(q);
             }
             composite.filter(tail);
@@ -121,30 +176,47 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
     }
 
     /**
-     * Recurse into the Tail sub-queries so that inner_hits declared on a leg (e.g. a {@code nested} or {@code has_child}
-     * sub-query) are registered and fetched per returned parent hit. Mirrors
+     * Address one ranked document: by {@code _id} alone, or {@code _id} intersected with its {@code _index} when the
+     * fused set spans indices (where {@code _id} is not unique on its own).
+     */
+    private QueryBuilder rankedDocQuery(int position) {
+        IdsQueryBuilder idQuery = new IdsQueryBuilder().addIds(ids[position]);
+        if (Objects.isNull(indices) || Objects.isNull(indices[position])) {
+            return idQuery;
+        }
+        return new BoolQueryBuilder().filter(idQuery).filter(new TermQueryBuilder(INDEX_FIELD, indices[position]));
+    }
+
+    /**
+     * Recurse into the registered inner_hits sources so that inner_hits declared on a leg (e.g. a {@code nested} or
+     * {@code has_child} sub-query) are registered and fetched per returned parent hit. Mirrors
      * {@link HybridQueryBuilder#extractInnerHitBuilders}. Without this override the self-erased query would silently drop
      * leg-level inner_hits, because {@link AbstractQueryBuilder}'s default implementation is a no-op and the coordinator
-     * self-erase replaces the original {@code hybrid} builder with this one before the shard extracts inner_hits. The
-     * leg builders survive intact in {@code sourceQueries} (only KNN/neural legs are materialized to ids, and those do
-     * not support inner_hits), and the Tail is retained whenever a leg declares inner_hits (see
-     * {@code HybridFusionOrchestrator#buildFusedQuery}), so the definition is always reachable here.
+     * self-erase replaces the original {@code hybrid} builder with this one before the shard extracts inner_hits.
+     *
+     * <p>This reads {@code innerHitsQueries}, which is independent of the executed Tail — so inner_hits keep working on a
+     * Top-only query. KNN/neural legs materialized to ids are deliberately not part of that list (they cannot carry
+     * inner_hits), so the un-materialized leg builders are the ones registered here.
      */
     @Override
     protected void extractInnerHitBuilders(Map<String, InnerHitContextBuilder> innerHits) {
-        for (QueryBuilder sourceQuery : sourceQueries) {
-            InnerHitContextBuilder.extractInnerHits(sourceQuery, innerHits);
+        for (QueryBuilder innerHitsQuery : innerHitsQueries) {
+            InnerHitContextBuilder.extractInnerHits(innerHitsQuery, innerHits);
         }
     }
 
     @Override
     protected boolean doEquals(HybridFusionQueryBuilder other) {
-        return Arrays.equals(ids, other.ids) && Arrays.equals(scores, other.scores) && Objects.equals(sourceQueries, other.sourceQueries);
+        return Arrays.equals(ids, other.ids)
+            && Arrays.equals(indices, other.indices)
+            && Arrays.equals(scores, other.scores)
+            && Objects.equals(tailQueries, other.tailQueries)
+            && Objects.equals(innerHitsQueries, other.innerHitsQueries);
     }
 
     @Override
     protected int doHashCode() {
-        return Objects.hash(Arrays.hashCode(ids), Arrays.hashCode(scores), sourceQueries);
+        return Objects.hash(Arrays.hashCode(ids), Arrays.hashCode(indices), Arrays.hashCode(scores), tailQueries, innerHitsQueries);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -54,6 +54,16 @@ import org.opensearch.index.query.TermQueryBuilder;
  * is therefore what gets executed, while {@code innerHitsQueries} is what gets registered; the two are populated
  * independently, which lets a Top-only query still return leg inner_hits without paying to re-run the legs.
  *
+ * <p><b>{@code collapse} semantics.</b> Collapse <i>grouping</i> is identical to classic hybrid — it is a plain
+ * query-phase operation over the fused ranking. {@code collapse.inner_hits} scores differ from classic, in fused mode's
+ * favour: core's {@code ExpandSearchPhase} re-runs {@code source().query()} per group, which here is this self-erased
+ * query, so every expanded member is scored by its own Top clause and therefore carries <b>its own fused score</b> —
+ * on the same scale as the group representative, and equal to the score it would receive in the ungrouped fused search.
+ * Classic instead re-runs the real sub-queries and reports their <b>raw, un-normalized</b> scores, which are on a
+ * different scale from the representative's normalized score (e.g. representative {@code 1.0} beside members
+ * {@code 198.0}). Leg-level {@code inner_hits} (a {@code nested}/{@code has_child} sub-query with its own
+ * {@code inner_hits} block) match classic exactly, because core re-runs the inner query there rather than the parent.
+ *
  * <p>This query is created internally by the coordinator self-erase and is never parseable from a search request. Its
  * wire form needs no version gate: the whole query type is new in the same version that introduced fused mode, and a
  * node predating that version cannot resolve this {@code NamedWriteable} name at all — so it fails on the query name

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -42,7 +42,9 @@ import org.opensearch.index.query.TermQueryBuilder;
  *       needs the full match set; omitted (Top-only) for plain top-K.</li>
  * </ul>
  *
- * <p><b>Document identity.</b> A ranked doc is addressed by its {@code _index} and {@code _id} together, always.
+ * <p><b>Document identity.</b> Addressing is defined once, in {@link #addressDocuments}, and used by both halves: the Top
+ * addresses one ranked document, the Tail addresses each index group of a leg materialized to its returned ids. A ranked
+ * doc is addressed by its {@code _index} and {@code _id} together, always.
  * {@code _id} is unique only within an index, so two different documents in two indices can share one; without the
  * {@code _index} filter each would match the other's Top clause and inherit its fused score. Qualification is not
  * conditional on the search looking like it needs it — the fused window is not evidence about which indices round 2 will
@@ -202,11 +204,30 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
      * be resolved for the window at all; per-element fallback is impossible by the {@code indices} invariant.
      */
     private QueryBuilder rankedDocQuery(int position) {
-        IdsQueryBuilder idQuery = new IdsQueryBuilder().addIds(ids[position]);
-        if (Objects.isNull(indices)) {
+        return addressDocuments(Objects.isNull(indices) ? null : indices[position], ids[position]);
+    }
+
+    /**
+     * The one definition of document addressing for fused mode: the given {@code _id}s intersected with the one
+     * {@code _index} they live in. The Top calls it per ranked document; the Tail calls it per index group of a
+     * materialized kNN/neural leg (see {@code HybridFusionOrchestrator#materializedLeg}). Sharing it is the point — the
+     * scoring half and the matching half of this query must identify a document the same way, and they previously did not:
+     * the Top was {@code _index}-qualified while the Tail addressed a materialized leg by {@code _id} alone, so every
+     * same-{@code _id} sibling document in another index passed the Tail {@code filter} and was counted.
+     *
+     * <p>{@code index} is null only when the caller could resolve no index for those hits, where addressing degrades to
+     * {@code _id} alone rather than failing. That degradation is per-call, so the Top (which drops its whole
+     * {@code indices} array if any window hit lacks an index) can be unqualified while the Tail still qualifies the groups
+     * it could resolve. That combination loses no legitimate document: every window document came from some leg, so it
+     * matches that leg's Tail clause, and the only docs the narrower Tail removes from the wider Top are the same-id
+     * siblings that should never have matched.
+     */
+    static QueryBuilder addressDocuments(String index, String... ids) {
+        IdsQueryBuilder idQuery = new IdsQueryBuilder().addIds(ids);
+        if (Objects.isNull(index)) {
             return idQuery;
         }
-        return new BoolQueryBuilder().filter(idQuery).filter(new TermQueryBuilder(INDEX_FIELD, indices[position]));
+        return new BoolQueryBuilder().filter(idQuery).filter(new TermQueryBuilder(INDEX_FIELD, index));
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -55,7 +55,9 @@ import org.opensearch.index.query.TermQueryBuilder;
  * execute against — and it is not a trade either: {@code _index} is a constant field, so on the shard's own index the
  * added filter is a MatchAll that {@code BooleanQuery.rewrite} removes (the clause collapses to exactly
  * {@code constant_score(ids)}), and on any other index's shard the clause collapses to MatchNoDocs. {@code indices} is
- * null only for a window whose hits carried no resolvable {@code _index}; when non-null it has no null elements.
+ * therefore required, not optional: there is no unqualified form of this query. A coordinator-side hit always carries its
+ * {@code _index} — it is set from the shard target the response came from — and {@code HybridFusionOrchestrator} asserts
+ * that on every leg's hits before fusing them, so the qualified form is always constructible.
  *
  * <p><b>inner_hits registration is decoupled from the Tail.</b> inner_hits are computed in the fetch phase from the
  * registered {@link InnerHitContextBuilder}s (per returned parent doc), not from whatever ran in the query phase — so a
@@ -102,9 +104,8 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
 
     private final String[] ids;
     /**
-     * Parallel to {@code ids}. Either null — no clause is qualified — or fully populated, one concrete index name per
-     * ranked doc. Never an array with null holes: {@code writeOptionalStringArray} handles a null array but writes
-     * elements through {@code writeString}, which NPEs on a null.
+     * Parallel to {@code ids} and required: one concrete index name per ranked doc, never null and with no null elements.
+     * Every Top clause is {@code _index}-qualified, so this array is what makes each one address exactly one document.
      */
     private final String[] indices;
     private final float[] scores;
@@ -120,9 +121,10 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
         List<QueryBuilder> tailQueries,
         List<QueryBuilder> innerHitsQueries
     ) {
-        assert Objects.isNull(indices) || indices.length == ids.length : "indices must be parallel to ids";
-        assert Objects.isNull(indices) || Arrays.stream(indices).noneMatch(Objects::isNull)
-            : "indices must be null or fully populated — a null element NPEs in writeOptionalStringArray";
+        Objects.requireNonNull(indices, "indices is required: a fused document is addressed by its _index and _id together");
+        assert indices.length == ids.length : "indices must be parallel to ids";
+        assert Arrays.stream(indices).noneMatch(Objects::isNull)
+            : "indices must be fully populated — a null element NPEs in writeStringArray";
         this.ids = ids;
         this.indices = indices;
         this.scores = scores;
@@ -130,15 +132,15 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
         this.innerHitsQueries = Objects.isNull(innerHitsQueries) ? new ArrayList<>() : innerHitsQueries;
     }
 
-    /** Unqualified convenience: {@code _id}-only Top clauses, and the Tail legs are also the inner_hits source. */
-    public HybridFusionQueryBuilder(String[] ids, float[] scores, List<QueryBuilder> tailQueries) {
-        this(ids, null, scores, tailQueries, tailQueries);
+    /** Convenience for the common shape where the Tail legs are also the inner_hits source. */
+    public HybridFusionQueryBuilder(String[] ids, String[] indices, float[] scores, List<QueryBuilder> tailQueries) {
+        this(ids, indices, scores, tailQueries, tailQueries);
     }
 
     public HybridFusionQueryBuilder(StreamInput in) throws IOException {
         super(in);
         this.ids = in.readStringArray();
-        this.indices = in.readOptionalStringArray();
+        this.indices = in.readStringArray();
         this.scores = in.readFloatArray();
         this.tailQueries = in.readNamedWriteableList(QueryBuilder.class);
         this.innerHitsQueries = in.readNamedWriteableList(QueryBuilder.class);
@@ -147,7 +149,7 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeStringArray(ids);
-        out.writeOptionalStringArray(indices);
+        out.writeStringArray(indices);
         out.writeFloatArray(scores);
         out.writeNamedWriteableList(tailQueries);
         out.writeNamedWriteableList(innerHitsQueries);
@@ -223,11 +225,11 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
 
     /**
      * Address one ranked document by {@code _id} intersected with its {@code _index} — {@code _id} is not unique on its
-     * own, and the fused score belongs to exactly one document. Falls back to {@code _id} alone only when no index could
-     * be resolved for the window at all; per-element fallback is impossible by the {@code indices} invariant.
+     * own, and the fused score belongs to exactly one document. There is no unqualified variant: {@code indices} is
+     * required, so every position resolves to the index the ranked document was found in.
      */
     private QueryBuilder rankedDocQuery(int position) {
-        return addressDocuments(Objects.isNull(indices) ? null : indices[position], ids[position]);
+        return addressDocuments(indices[position], ids[position]);
     }
 
     /**
@@ -238,18 +240,13 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
      * the Top was {@code _index}-qualified while the Tail addressed a materialized leg by {@code _id} alone, so every
      * same-{@code _id} sibling document in another index passed the Tail {@code filter} and was counted.
      *
-     * <p>{@code index} is null only when the caller could resolve no index for those hits, where addressing degrades to
-     * {@code _id} alone rather than failing. That degradation is per-call, so the Top (which drops its whole
-     * {@code indices} array if any window hit lacks an index) can be unqualified while the Tail still qualifies the groups
-     * it could resolve. That combination loses no legitimate document: every window document came from some leg, so it
-     * matches that leg's Tail clause, and the only docs the narrower Tail removes from the wider Top are the same-id
-     * siblings that should never have matched.
+     * <p>{@code index} is required. An unqualified form was the previous fallback for hits whose {@code _index} could not
+     * be resolved, but no coordinator-side hit is in that state, and the fallback's own semantics were the defect above:
+     * it addresses every same-{@code _id} document in the cluster. Both callers get their index from a leg hit, so both
+     * always have one.
      */
     static QueryBuilder addressDocuments(String index, String... ids) {
         IdsQueryBuilder idQuery = new IdsQueryBuilder().addIds(ids);
-        if (Objects.isNull(index)) {
-            return idQuery;
-        }
         return new BoolQueryBuilder().filter(idQuery).filter(new TermQueryBuilder(INDEX_FIELD, index));
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -38,8 +38,12 @@ import org.opensearch.index.query.TermQueryBuilder;
  *       {@code should} clauses, so the fused window is returned in fused-score order.</li>
  *   <li><b>Tail</b> — a {@code bool{ should: [tailQuery...] }} added as a non-scoring {@code filter}. It matches the
  *       full set of documents any sub-query matched, so {@code total_hits} and aggregations cover all matches (not just
- *       the ranked window) and the highlighter has the sub-queries' terms available. Included only when the request
- *       needs the full match set; omitted (Top-only) for plain top-K.</li>
+ *       the ranked window) and the highlighter has the sub-queries' terms available. It is present <b>by default</b>:
+ *       an accurate {@code total_hits} is itself a Tail trigger, and requests do not set {@code track_total_hits} unless
+ *       they mean to give that up. Top-only is the opt-out — {@code track_total_hits} at or below the window, with no
+ *       aggregations, highlighting, collapse expansion or non-{@code _score} sort. So the default cost of fused mode is
+ *       the legs in round 1 plus the legs re-matched (not re-ranked) inside round 2's filter; see
+ *       {@code HybridFusionOrchestrator#needsTail} for the exact trigger set.</li>
  * </ul>
  *
  * <p><b>Document identity.</b> Addressing is defined once, in {@link #addressDocuments}, and used by both halves: the Top
@@ -60,14 +64,26 @@ import org.opensearch.index.query.TermQueryBuilder;
  * independently, which lets a Top-only query still return leg inner_hits without paying to re-run the legs.
  *
  * <p><b>{@code collapse} semantics.</b> Collapse <i>grouping</i> is identical to classic hybrid — it is a plain
- * query-phase operation over the fused ranking. {@code collapse.inner_hits} scores differ from classic, in fused mode's
- * favour: core's {@code ExpandSearchPhase} re-runs {@code source().query()} per group, which here is this self-erased
- * query, so every expanded member is scored by its own Top clause and therefore carries <b>its own fused score</b> —
- * on the same scale as the group representative, and equal to the score it would receive in the ungrouped fused search.
- * Classic instead re-runs the real sub-queries and reports their <b>raw, un-normalized</b> scores, which are on a
- * different scale from the representative's normalized score (e.g. representative {@code 1.0} beside members
- * {@code 198.0}). Leg-level {@code inner_hits} (a {@code nested}/{@code has_child} sub-query with its own
- * {@code inner_hits} block) match classic exactly, because core re-runs the inner query there rather than the parent.
+ * query-phase operation over the fused ranking. {@code collapse.inner_hits} is different in kind: core's
+ * {@code ExpandSearchPhase} issues one more search per returned group, whose query is this self-erased query under a
+ * filter on the group key. A group's members are whatever shares the representative's collapse key, which has nothing to
+ * do with the fused window, so the expansion is only as wide as what this query matches — which is why declaring
+ * {@code collapse.inner_hits} forces the Tail on ({@code CandidateScope.Disposition#FORCES_TAIL}). With the Tail, every
+ * member of the group comes back, matching classic's recall. Member <i>scores</i> then split by window membership:
+ * <ul>
+ *   <li>a member inside the fused window has its own Top clause, so it carries <b>its own fused score</b> — on the same
+ *       scale as the group representative, and equal to the score it would receive in the ungrouped fused search;</li>
+ *   <li>a member outside the window has no Top clause and matches only the non-scoring Tail, so it expands at
+ *       <b>{@code 0.0}</b>. There is no fused score to give it: fusion ranked the window, and this document is not in it.
+ *       Consequence to be aware of: within one group's {@code inner_hits}, in-window members sort above out-of-window ones
+ *       regardless of their relative relevance, so an {@code inner_hits.size} smaller than the group returns the
+ *       window's members first. Classic instead re-runs the real sub-queries and reports their <b>raw, un-normalized</b>
+ *       scores — a consistent order among members, but on a different scale from the representative's normalized score
+ *       (e.g. representative {@code 1.0} beside members {@code 198.0}). Raise {@code window_size} to cover the groups to
+ *       be expanded if member ordering matters.</li>
+ * </ul>
+ * Leg-level {@code inner_hits} (a {@code nested}/{@code has_child} sub-query with its own {@code inner_hits} block) are
+ * unaffected by any of this: core re-runs the inner query per returned parent there rather than the parent query.
  *
  * <p>This query is created internally by the coordinator self-erase and is never parseable from a search request. Its
  * wire form needs no version gate: the whole query type is new in the same version that introduced fused mode, and a

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -88,7 +88,10 @@ import org.opensearch.index.query.TermQueryBuilder;
  * <p>This query is created internally by the coordinator self-erase and is never parseable from a search request. Its
  * wire form needs no version gate: the whole query type is new in the same version that introduced fused mode, and a
  * node predating that version cannot resolve this {@code NamedWriteable} name at all — so it fails on the query name
- * long before reading any field.
+ * long before reading any field. Which is precisely why it must never be sent to one: that failure is a shard failure,
+ * and a shard failure is a silently short answer under the default {@code allow_partial_search_results}. The coordinator
+ * refuses fused mode outright while the cluster's minimum node version is below it, so this query is only ever built for
+ * a cluster that can read it — see {@code HybridQueryBuilder#requireClusterSupportsFusedMode}.
  */
 public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQueryBuilder> {
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -76,10 +76,14 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     /**
      * Resolver (fused) mode config: the raw inline {@code fusion} block from the query body. Its <b>presence</b> is the
      * resolver on/off flag; its <b>shape</b> carries the config. {@code null} = classic hybrid (byte-identical wire
-     * form). A string {@code "pipeline"} is normalized to {@code {source: "pipeline"}} at parse. In this build the
-     * parameter is parsed, validated, and round-tripped, but execution is not yet wired — a well-formed {@code fusion}
-     * fails fast at {@link #doRewrite} (see PR sequencing in the LLD/tracker). Not serialized over the transport wire
-     * yet (binary wire gate lands with the execution path).
+     * form). A string {@code "pipeline"} is normalized to {@code {source: "pipeline"}} at parse.
+     *
+     * <p>A well-formed {@code fusion} block drives execution: {@link #doRewrite} routes to {@link #doRewriteFused}, which
+     * fans the legs out and self-erases into a standard query on the coordinator.
+     *
+     * <p>Serialized over the transport wire behind a peer-stream-version gate, so a request carrying {@code fusion} keeps
+     * a wire form a pre-fused-mode node can still read: the field is written only when the peer understands it, and its
+     * absence costs a single {@code false} boolean.
      */
     private Map<String, Object> fusion;
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -39,6 +40,7 @@ import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
 import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.search.SearchService;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -110,6 +112,8 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     public static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
     private static final int LOWER_BOUND_OF_PAGINATION_DEPTH = 0;
     private static final int DEFAULT_FUSION_WINDOW_SIZE = 100;
+    /** The one clause the Tail filter takes in the self-erased bool, alongside one should-clause per ranked doc. */
+    private static final int TAIL_CLAUSE_RESERVE = 1;
 
     // Allowed top-level keys inside a `fusion` object; anything else is a parse-time 400.
     private static final String FUSION_KEY_SOURCE = "source";
@@ -492,6 +496,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         // index.max_result_window (resolved coordinator-side from the targeted indices), mirroring classic hybrid's
         // pagination_depth ceiling.
         validateWindowSizeAgainstMaxResultWindow(searchRequest, window);
+        // The self-erased query holds one bool clause per ranked doc, so the window is also bounded by Lucene's clause
+        // ceiling — a different (and much lower) limit than max_result_window, and the only one that would otherwise be
+        // discovered at query time on every shard.
+        validateWindowSizeAgainstMaxClauseCount(window);
         // Decide, in one place, what each leg inherits from this request — and refuse the shapes fused mode cannot answer
         // correctly. Done here, before the fan-out is registered, so a refusal costs less than the search it replaces.
         CandidateScope candidateScope = CandidateScope.from(searchRequest);
@@ -681,6 +689,43 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                     )
                 );
             }
+        }
+    }
+
+    /**
+     * Reject a {@code window_size} the self-erased query could not be assembled from. Its Top is one {@code should}
+     * clause per ranked document in a single {@code bool}, plus one {@code filter} clause when the Tail is present, and
+     * {@code BooleanQuery.Builder#add} throws {@code TooManyClauses} as soon as one bool exceeds
+     * {@code indices.query.bool.max_clause_count}. That ceiling defaults to 1024 and is unrelated to
+     * {@code index.max_result_window} (default 10000) — the only bound the other window check applies — so without this a
+     * {@code window_size} in the thousands parses, fans out, fuses, and only then fails on every shard. The setting is a
+     * dynamic node setting that {@code SearchService} keeps in sync with Lucene's static, so reading the static here
+     * reflects the live value on this coordinator.
+     *
+     * <p>Necessary, not sufficient: the Tail's own clauses are the user's legs and cannot be counted at rewrite, so a
+     * request within this bound can still exceed the ceiling through an enormous leg query. The {@code _index}
+     * qualification on each Top clause costs nothing against this bound — on the shard's own index the {@code _index}
+     * filter is a MatchAll that {@code BooleanQuery.rewrite} removes, collapsing the clause back to
+     * {@code constant_score(ids)}.
+     */
+    private static void validateWindowSizeAgainstMaxClauseCount(final int window) {
+        int maxClauseCount = IndexSearcher.getMaxClauseCount();
+        // Reserve the one clause the Tail filter occupies in the same bool. Whether a request needs the Tail is only known
+        // once the legs have answered, so the window has to fit either way.
+        if (window > maxClauseCount - TAIL_CLAUSE_RESERVE) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] query [%s.%s] (%d) must be less than [%s] (%d): the fused query holds one clause per ranked "
+                        + "document plus one for the tail",
+                    NAME,
+                    FUSION_FIELD.getPreferredName(),
+                    FUSION_KEY_WINDOW_SIZE,
+                    window,
+                    SearchService.INDICES_MAX_CLAUSE_COUNT_SETTING.getKey(),
+                    maxClauseCount
+                )
+            );
         }
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -20,6 +20,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.SetOnce;
@@ -525,10 +527,12 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                         listener.onFailure(e);
                     }
                     // Whole-MultiSearch transport failure (cancellation, rejection, coordinator error) — not a per-leg
-                    // Item failure. Frame it as the user's hybrid/fused query rather than surfacing a bare multiSearch error.
+                    // Item failure. Frame it as the user's hybrid/fused query rather than surfacing a bare multiSearch
+                    // error, but keep the underlying status: a cancellation, a rejection and a coordinator bug are three
+                    // different answers, and IllegalStateException collapses all of them to 500.
                 },
                     e -> listener.onFailure(
-                        new IllegalStateException(
+                        new OpenSearchStatusException(
                             String.format(
                                 Locale.ROOT,
                                 "[%s] query [%s] failed to execute fused-mode sub-queries: %s",
@@ -536,6 +540,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                                 FUSION_FIELD.getPreferredName(),
                                 e.getMessage()
                             ),
+                            ExceptionsHelper.status(e),
                             e
                         )
                     )

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -491,6 +491,12 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         // First, before any config resolution: the whole request's fan-out has to be within the cluster's budget. A body
         // whose only purpose is to multiply sub-searches should cost one tree walk, not a pipeline lookup per hybrid.
         validateFusedLegSearchBudget(searchRequest);
+        // Then the request's own shape, in one place: what each leg inherits, and a refusal for the shapes fused mode
+        // cannot answer correctly. Ahead of every check that resolves index metadata — config resolution reads the
+        // targeted indices' default pipelines, and the window ceiling reads their max_result_window — because a request
+        // naming a remote index dies in index resolution with `no such index [cluster:index]`, which would hide this
+        // class's explanation of why fused mode refuses cross-cluster search at all.
+        CandidateScope candidateScope = CandidateScope.from(searchRequest);
 
         FusionSpec fusionSpec = resolveFusionSpec(searchRequest);
         if (Objects.isNull(fusionSpec)) {
@@ -523,9 +529,6 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         // ceiling — a different (and much lower) limit than max_result_window, and the only one that would otherwise be
         // discovered at query time on every shard.
         validateWindowSizeAgainstMaxClauseCount(window);
-        // Decide, in one place, what each leg inherits from this request — and refuse the shapes fused mode cannot answer
-        // correctly. Done here, before the fan-out is registered, so a refusal costs less than the search it replaces.
-        CandidateScope candidateScope = CandidateScope.from(searchRequest);
         List<QueryBuilder> legs = queries;
         // Validate weights (range, sum, count) before the leg fan-out — a bad weights array otherwise burns a full
         // MultiSearch before the combiner is built in the async callback.

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -40,6 +40,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
 import org.opensearch.index.query.QueryBuilderVisitor;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -93,6 +94,18 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
      * on a freshly parsed builder (classic path never touches it).
      */
     private Supplier<QueryBuilder> fusedSupplier;
+
+    /**
+     * Fusion config projected onto this builder by an <b>enclosing</b> fused hybrid, when this builder is one of its legs.
+     * A leg sub-search runs with the search pipeline pinned to {@code _none} (see
+     * {@link HybridFusionOrchestrator#buildLegMultiSearch}), so a nested fused hybrid cannot resolve its own config from
+     * the leg request; the enclosing rewrite hands down the config it already resolved from the user's request instead.
+     * Only ever set on a private copy made by {@link #withResolvedFusionSpec}, never parsed, never serialized, and
+     * deliberately absent from {@link #doEquals}/{@link #doHashCode} — exactly like {@link #fusedSupplier}.
+     */
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private FusionSpec resolvedFusionSpec;
 
     public static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
     private static final int LOWER_BOUND_OF_PAGINATION_DEPTH = 0;
@@ -452,19 +465,19 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         }
         SearchRequest searchRequest = (SearchRequest) coordinatorContext.getSearchRequest();
 
-        // Precedence: an inline `fusion` block on the query body wins; else resolve from the attached search pipeline
-        // (inline body / named param / index default). Fail fast if neither yields a config rather than emitting
-        // unfused scores.
-        FusionSpec fusionSpec = Objects.nonNull(this.fusion) && hasInlineConfig(this.fusion)
-            ? FusionSpec.fromInlineFusion(this.fusion)
-            : FusionConfigResolver.resolve(searchRequest);
+        FusionSpec fusionSpec = resolveFusionSpec(searchRequest);
         if (Objects.isNull(fusionSpec)) {
             throw new IllegalArgumentException(
                 String.format(
                     Locale.ROOT,
                     "[%s] query [%s] requires a normalization or score-ranker processor: the resolved search pipeline "
                         + "(from ?search_pipeline= or index.search.default_pipeline) has none, and no inline fusion block "
-                        + "was provided (a missing pipeline id is rejected earlier by core)",
+                        + "was provided (a missing pipeline id is rejected earlier by core). A fused [%s] nested inside "
+                        + "another compound query (for example [bool] or [dis_max]) within a leg of an enclosing fused [%s] "
+                        + "must carry an inline [%s] config, because a leg sub-search runs with the search pipeline disabled",
+                    NAME,
+                    FUSION_FIELD.getPreferredName(),
+                    NAME,
                     NAME,
                     FUSION_FIELD.getPreferredName()
                 )
@@ -483,11 +496,14 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         // Validate weights (range, sum, count) before the leg fan-out — a bad weights array otherwise burns a full
         // MultiSearch before the combiner is built in the async callback.
         HybridFusionOrchestrator.validateFusionParams(fusionSpec, legs.size());
+        // The Tail keeps the original legs (it is rewritten against the user's request, which still carries the
+        // pipeline), but the fanned-out legs run with the pipeline disabled — so hand the resolved config down.
+        List<QueryBuilder> fanOutLegs = projectResolvedConfigOntoLegs(legs, fusionSpec);
 
         SetOnce<QueryBuilder> fused = new SetOnce<>();
         queryRewriteContext.registerAsyncAction(
             (client, listener) -> client.multiSearch(
-                HybridFusionOrchestrator.buildLegMultiSearch(searchRequest, legs, window),
+                HybridFusionOrchestrator.buildLegMultiSearch(searchRequest, fanOutLegs, window),
                 ActionListener.wrap(multiSearchResponse -> {
                     try {
                         fused.set(
@@ -523,8 +539,83 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         marker.queryName(queryName);
         marker.boost(boost);
         marker.fusion(this.fusion);
+        marker.resolvedFusionSpec = this.resolvedFusionSpec;
         marker.fusedSupplier = fused::get;
         return marker;
+    }
+
+    /**
+     * Resolve the fusion config for this rewrite, in precedence order:
+     * <ol>
+     *   <li>an inline {@code fusion} block on this query body (explicit user intent, wins outright);</li>
+     *   <li>a config projected down by an enclosing fused hybrid ({@link #resolvedFusionSpec}) — this builder is one of
+     *       its legs, and the leg request has no pipeline to read;</li>
+     *   <li>the search pipeline attached to the request (inline body / {@code ?search_pipeline=} / index default).</li>
+     * </ol>
+     * {@code null} when none of the three yields a config; the caller fails fast rather than emitting unfused scores.
+     */
+    private FusionSpec resolveFusionSpec(final SearchRequest searchRequest) {
+        if (Objects.nonNull(this.fusion) && hasInlineConfig(this.fusion)) {
+            return FusionSpec.fromInlineFusion(this.fusion);
+        }
+        if (Objects.nonNull(resolvedFusionSpec)) {
+            return resolvedFusionSpec;
+        }
+        return FusionConfigResolver.resolve(searchRequest);
+    }
+
+    /**
+     * Hand the already-resolved fusion config down to any leg that is itself a fused hybrid without an inline config.
+     *
+     * <p>Legs are fanned out with {@code pipeline=_none} so that per-leg request/response processors do not run
+     * ({@link HybridFusionOrchestrator#buildLegMultiSearch}); a nested fused hybrid would therefore resolve no config
+     * from its own leg request and fail with a message blaming a pipeline the user has correctly configured. Projecting
+     * the enclosing config is faithful: resolving from the pipeline is exactly what the nested query would have done,
+     * and it is the same request and therefore the same pipeline.
+     *
+     * <p>Reaches direct legs only, at any nesting depth (each level projects onto its own legs). A fused hybrid buried
+     * inside a container query within a leg (e.g. {@code bool{must: hybrid{fusion}}}) is not reachable —
+     * {@link QueryBuilder} exposes no generic child accessor — and still fails, now with a message that names the real
+     * cause and the inline-config workaround.
+     *
+     * @return the original list when nothing needed projecting (the common case), else a copy with legs substituted
+     */
+    static List<QueryBuilder> projectResolvedConfigOntoLegs(final List<QueryBuilder> legs, final FusionSpec resolved) {
+        List<QueryBuilder> projected = null;
+        for (int i = 0; i < legs.size(); i++) {
+            QueryBuilder leg = legs.get(i);
+            if ((leg instanceof HybridQueryBuilder) == false) {
+                continue;
+            }
+            HybridQueryBuilder nested = (HybridQueryBuilder) leg;
+            if (Objects.isNull(nested.fusion) || hasInlineConfig(nested.fusion)) {
+                continue;
+            }
+            if (Objects.isNull(projected)) {
+                projected = new ArrayList<>(legs);
+            }
+            projected.set(i, nested.withResolvedFusionSpec(resolved));
+        }
+        return Objects.isNull(projected) ? legs : projected;
+    }
+
+    /**
+     * Copy of this builder carrying a fusion config resolved by an enclosing fused hybrid. A copy rather than in-place
+     * mutation because the same leg instance is also reused for the Tail, and because {@code fusion} participates in
+     * {@link #doEquals}.
+     */
+    private HybridQueryBuilder withResolvedFusionSpec(final FusionSpec resolved) {
+        HybridQueryBuilder copy = new HybridQueryBuilder();
+        for (QueryBuilder query : queries) {
+            copy.add(query);
+        }
+        copy.queryName(queryName);
+        copy.boost(boost);
+        // Always null on a fused builder (`pagination_depth` with `fusion` is a parse-time 400), copied for exactness.
+        copy.paginationDepth(paginationDepth);
+        copy.fusion(fusion);
+        copy.resolvedFusionSpec = resolved;
+        return copy;
     }
 
     /** True when the inline {@code fusion} block carries an actual config (not just {@code source: pipeline} / empty). */

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -469,9 +469,6 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         // Current scope (first working slice): min_max + arithmetic_mean only. Other techniques parse but are not wired
         // into the coordinator fusion path yet — fail fast rather than silently mis-fuse.
         requireSupportedTechniques(fusionSpec);
-        // Fusion keys leg hits by _id, which is only unique within one index; reject multi-index until keying + the
-        // self-erase are index-aware (follow-up), rather than conflate same-_id docs from different indices.
-        validateSingleIndexForFusedMode(searchRequest);
 
         int window = effectiveWindowSize();
         // Each leg fires size=window per shard, so an unbounded window is a per-shard memory/CPU amplifier. Cap it at
@@ -557,33 +554,6 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             return ((Number) fusion.get(FUSION_KEY_WINDOW_SIZE)).intValue();
         }
         return DEFAULT_FUSION_WINDOW_SIZE;
-    }
-
-    /**
-     * Reject a fused-mode query that targets more than one concrete index. Fusion keys leg hits by {@code _id} on the
-     * coordinator, but {@code _id} is unique only within an index — across two indices the same {@code _id} denotes
-     * different docs, which would be conflated during fusion and both matched by the self-erased {@code _id} Top. Until
-     * fusion keying and the self-erase are index-aware (a follow-up), fail fast rather than return silently-wrong scores.
-     * (A single index under custom routing can still collide on {@code _id} across shards — a narrower case the follow-up
-     * also addresses.)
-     */
-    private static void validateSingleIndexForFusedMode(final SearchRequest searchRequest) {
-        long concreteIndices = NeuralSearchClusterUtil.instance()
-            .getIndexMetadataList(searchRequest)
-            .stream()
-            .filter(Objects::nonNull)
-            .count();
-        if (concreteIndices > 1) {
-            throw new IllegalArgumentException(
-                String.format(
-                    Locale.ROOT,
-                    "[%s] query [%s] (resolver/fused mode) does not yet support searching multiple indices; the request resolved to %d indices",
-                    NAME,
-                    FUSION_FIELD.getPreferredName(),
-                    concreteIndices
-                )
-            );
-        }
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -473,15 +473,6 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         // self-erase are index-aware (follow-up), rather than conflate same-_id docs from different indices.
         validateSingleIndexForFusedMode(searchRequest);
 
-        // Whether this query is the whole request (=> conditional Tail for accurate totals/aggs) or nested inside a
-        // container (=> Top-only, so an enclosing filter intersects at the query phase). The `== this` is an INTENTIONAL
-        // reference-identity check: it holds only because the coordinator rewrite runs on the exact instance still parked
-        // at source().query(). If a request-rewrite layer ever clones the query before this point, a genuinely top-level
-        // query would compare != and be misclassified as nested -> forced Top-only -> the Tail is silently dropped, so
-        // scores and top hits stay correct but total_hits and aggregations would be computed over just the fused window.
-        // TODO: once nested fusion is wired and validated end-to-end, thread the top-level/nesting signal down explicitly
-        // (e.g. via the coordinator context) so it survives cloning instead of relying on this invariant.
-        boolean topLevel = Objects.nonNull(searchRequest.source()) && searchRequest.source().query() == this;
         int window = effectiveWindowSize();
         // Each leg fires size=window per shard, so an unbounded window is a per-shard memory/CPU amplifier. Cap it at
         // index.max_result_window (resolved coordinator-side from the targeted indices), mirroring classic hybrid's
@@ -499,14 +490,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                 ActionListener.wrap(multiSearchResponse -> {
                     try {
                         fused.set(
-                            HybridFusionOrchestrator.buildFusedQuery(
-                                searchRequest.source(),
-                                multiSearchResponse,
-                                legs,
-                                fusionSpec,
-                                window,
-                                topLevel
-                            )
+                            HybridFusionOrchestrator.buildFusedQuery(searchRequest.source(), multiSearchResponse, legs, fusionSpec, window)
                         );
                         listener.onResponse(null);
                     } catch (Exception e) {

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.Version;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
@@ -59,6 +60,7 @@ import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
 
 import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.MAX_FUSION_LEG_SEARCHES;
+import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY;
 import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isClusterOnOrAfterMinReqVersionForPaginationInHybridQuery;
 import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isVersionOnOrAfterMinReqVersionForFusedModeInHybridQuery;
 
@@ -477,6 +479,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         if (Objects.isNull(coordinatorContext)) {
             return this;
         }
+        // Before anything about the request itself: a cluster that cannot run round 2 on every shard cannot run fused mode
+        // at all. Ahead of the SearchRequest cast on purpose — _explain and _validate/query rewrite on the coordinator with
+        // a non-search request and are dispatched still-fused, so they need the same refusal.
+        requireClusterSupportsFusedMode();
         if ((coordinatorContext.getSearchRequest() instanceof SearchRequest) == false) {
             return this;
         }
@@ -610,6 +616,45 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         matchSet.queryName(queryName);
         matchSet.boost(boost);
         return matchSet;
+    }
+
+    /**
+     * Refuse fused mode while any node in the cluster predates it.
+     *
+     * <p>Round 2 dispatches a {@link HybridFusionQueryBuilder} — a query type introduced together with fused mode — to
+     * every shard the request touches, and a node predating that version cannot resolve the {@code hybrid_fusion}
+     * {@link org.opensearch.core.common.io.stream.NamedWriteable} name at all, so it fails while deserializing the shard
+     * request. That is not a clean error to the client: with {@code allow_partial_search_results} at its default the
+     * request still answers 200, with every document on those shards silently missing. A leg fan-out that reached an old
+     * node fails the same way, and a still-fused builder dispatched by {@code _explain} / {@code _validate/query} is worse
+     * — the {@code fusion} field is gated off the wire, so the old node answers for a <i>classic</i> hybrid instead.
+     *
+     * <p>Cluster-wide minimum here, where the wire gates on the {@code fusion} field ({@link #doWriteTo} and the
+     * {@link StreamInput} constructor) use the peer stream's negotiated version: those pick a serialization format for one
+     * known peer, this decides whether the coordinator may enter a path whose recipients are not known yet. Checked at
+     * rewrite on the coordinator, before the fan-out, so the refusal costs less than the search it replaces.
+     *
+     * <p>Over-refuses in one shape — a cluster whose only lagging node holds none of the targeted shards, a
+     * cluster-manager-only or coordinating-only node — and that is the intended trade: routing is not knowable at rewrite,
+     * and the alternative is answering some of those requests with results silently missing.
+     */
+    private static void requireClusterSupportsFusedMode() {
+        Version clusterMinVersion = NeuralSearchClusterUtil.instance().getClusterMinVersion();
+        if (isVersionOnOrAfterMinReqVersionForFusedModeInHybridQuery(clusterMinVersion) == false) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] query [%s] requires all nodes in the cluster to be on version [%s] or later, but the minimum node "
+                        + "version is [%s], so the fused query cannot be dispatched to every shard. Upgrade the remaining "
+                        + "nodes, or drop the [%s] block and use classic hybrid with a normalization or score-ranker processor",
+                    NAME,
+                    FUSION_FIELD.getPreferredName(),
+                    MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY,
+                    clusterMinVersion,
+                    FUSION_FIELD.getPreferredName()
+                )
+            );
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -492,6 +492,9 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         // index.max_result_window (resolved coordinator-side from the targeted indices), mirroring classic hybrid's
         // pagination_depth ceiling.
         validateWindowSizeAgainstMaxResultWindow(searchRequest, window);
+        // Decide, in one place, what each leg inherits from this request — and refuse the shapes fused mode cannot answer
+        // correctly. Done here, before the fan-out is registered, so a refusal costs less than the search it replaces.
+        CandidateScope candidateScope = CandidateScope.from(searchRequest);
         List<QueryBuilder> legs = queries;
         // Validate weights (range, sum, count) before the leg fan-out — a bad weights array otherwise burns a full
         // MultiSearch before the combiner is built in the async callback.
@@ -503,7 +506,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         SetOnce<QueryBuilder> fused = new SetOnce<>();
         queryRewriteContext.registerAsyncAction(
             (client, listener) -> client.multiSearch(
-                HybridFusionOrchestrator.buildLegMultiSearch(searchRequest, fanOutLegs, window),
+                HybridFusionOrchestrator.buildLegMultiSearch(candidateScope, fanOutLegs, window),
                 ActionListener.wrap(multiSearchResponse -> {
                     try {
                         fused.set(

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -24,8 +24,10 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.lucene.search.Queries;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.ParsingException;
@@ -35,7 +37,9 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.InnerHitContextBuilder;
+import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryCoordinatorContext;
 import org.opensearch.index.query.QueryRewriteContext;
@@ -54,6 +58,7 @@ import org.opensearch.neuralsearch.stats.events.EventStatName;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
 
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.MAX_FUSION_LEG_SEARCHES;
 import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isClusterOnOrAfterMinReqVersionForPaginationInHybridQuery;
 import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.isVersionOnOrAfterMinReqVersionForFusedModeInHybridQuery;
 
@@ -457,6 +462,12 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
      * </ul>
      */
     private QueryBuilder doRewriteFused(QueryRewriteContext queryRewriteContext) throws IOException {
+        // Only the match set is wanted (this builder is a leg inside an enclosing fused query's Tail): contribute what the
+        // legs match and do not fan them out again — they already ran, as the enclosing query's leg sub-search. Checked
+        // ahead of everything else: it is the one case where the correct answer is to do no work at all.
+        if (MatchSetRewriteContext.isMatchSetOnly(queryRewriteContext)) {
+            return matchSetQuery();
+        }
         // Round 2: the async self-erase already produced the standard query — swap to it (or stay put until it lands).
         if (Objects.nonNull(fusedSupplier)) {
             QueryBuilder fused = fusedSupplier.get();
@@ -470,6 +481,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             return this;
         }
         SearchRequest searchRequest = (SearchRequest) coordinatorContext.getSearchRequest();
+
+        // First, before any config resolution: the whole request's fan-out has to be within the cluster's budget. A body
+        // whose only purpose is to multiply sub-searches should cost one tree walk, not a pipeline lookup per hybrid.
+        validateFusedLegSearchBudget(searchRequest);
 
         FusionSpec fusionSpec = resolveFusionSpec(searchRequest);
         if (Objects.isNull(fusionSpec)) {
@@ -558,6 +573,139 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         marker.resolvedFusionSpec = this.resolvedFusionSpec;
         marker.fusedSupplier = fused::get;
         return marker;
+    }
+
+    /**
+     * This query's match set, as a plain {@code bool{should: legs}} that costs no fan-out.
+     *
+     * <p>Equal to what the fused query matches, clause for clause. A fused hybrid compiles to
+     * {@code bool{ should: [Top...], filter: Tail }} with no {@code minimum_should_match}, so its matches are its Tail's —
+     * and the Tail is {@code bool{should: legs}}, the union of the legs. The scores differ (this loses them entirely), which
+     * is exactly why this form is only ever used where scores are not read: inside the enclosing query's Tail
+     * {@code filter}. A doc that this bool matches while the real fused query would not (or the reverse) does not exist.
+     *
+     * <p>The legs are handed over as-is rather than rewritten here — the caller's rewrite loop keeps going. The one
+     * exception is a leg that is itself a fused hybrid: it contributes <i>its</i> match set in this same pass, rather than
+     * being left for the next rewrite round. Rewrite descends one level per round ({@code BoolQueryBuilder} rewrites each
+     * clause exactly once), and core allows {@link org.opensearch.index.query.Rewriteable#MAX_REWRITE_ROUNDS} rounds for the
+     * whole request, so substituting level by level would spend a round per level of nesting — a chain the leg budget admits
+     * would exhaust them and fail as an internal error instead of running. Collapsing the chain here makes the cost of a
+     * nested chain constant in rounds. Nesting reached through a container leg (a fused hybrid inside a {@code bool} inside
+     * a leg) is still substituted a level per round, since only core can rewrite core's containers.
+     *
+     * <p>{@code match_none} for a legless builder: {@code bool{should: []}} compiles to a {@code MatchAllDocsQuery}, which
+     * in a Tail {@code filter} would open the match set to the whole corpus (the same trap
+     * {@code HybridFusionOrchestrator#materializedLeg} guards for an empty ANN leg). Parsing rejects an empty
+     * {@code queries} array, so this is unreachable from a request — and stated rather than relied upon.
+     */
+    private QueryBuilder matchSetQuery() {
+        if (queries.isEmpty()) {
+            return new MatchNoneQueryBuilder();
+        }
+        BoolQueryBuilder matchSet = new BoolQueryBuilder();
+        for (QueryBuilder query : queries) {
+            boolean legIsFusedHybrid = query instanceof HybridQueryBuilder && Objects.nonNull(((HybridQueryBuilder) query).fusion());
+            matchSet.should(legIsFusedHybrid ? ((HybridQueryBuilder) query).matchSetQuery() : query);
+        }
+        matchSet.queryName(queryName);
+        matchSet.boost(boost);
+        return matchSet;
+    }
+
+    /**
+     * Reject a request that would fan out more leg sub-searches than the cluster allows.
+     *
+     * <p>The counted quantity is <b>declared leg sub-searches</b> — the sum of {@code queries} sizes over every fused
+     * {@code hybrid} in the request body — deliberately modelled on {@code indices.query.bool.max_clause_count}: one
+     * whole-request count of the units the user actually wrote, checked once at rewrite, against a dynamic cluster
+     * setting. Shards are not a factor. A user cannot be asked to reason about legs × shards × nesting: the shard count
+     * is a property of the indices they searched, not of the query they wrote, so folding it in would make the same body
+     * legal on one cluster and rejected on another, and the number in the error message unreproducible.
+     *
+     * <p>The default, {@value org.opensearch.neuralsearch.settings.NeuralSearchSettings#DEFAULT_MAX_FUSION_LEG_SEARCHES},
+     * is {@link #MAX_NUMBER_OF_SUB_QUERIES} squared — a hybrid may declare 5 legs, so 5 levels of fully-nested hybrids is
+     * the shape this admits, and the setting's own floor is {@code MAX_NUMBER_OF_SUB_QUERIES} so that a legal single-level
+     * hybrid can never be rejected by it.
+     *
+     * <p>Counted from the request's own query, not from this builder, so every fused hybrid in a request agrees on one
+     * number: sibling hybrids in a {@code bool} each pay for the others, which is the point — the request is what fans
+     * out. Nesting is walked through {@link QueryBuilder#visit}, so the count is exact for the query builders that expose
+     * their children (all of core's compound queries do) and a lower bound for one that does not — a {@code wrapper} query
+     * carries its inner query as bytes, so a hybrid hidden inside one is invisible here and is counted when the leg
+     * sub-search carrying it rewrites on its own coordinator. That leaves total cost linear in the size of the body the
+     * user had to spell out, which is the property this guard exists to keep.
+     */
+    private static void validateFusedLegSearchBudget(final SearchRequest searchRequest) {
+        if (Objects.isNull(searchRequest.source())) {
+            return;
+        }
+        int maxLegSearches = maxFusionLegSearches();
+        int legSearches = countFusedLegSearches(searchRequest.source().query());
+        if (legSearches > maxLegSearches) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] query [%s] declares %d leg sub-searches in this request, more than [%s] (%d). Each leg of each "
+                        + "fused [%s] runs as its own search across the targeted shards; reduce the number of legs or of "
+                        + "nested fused [%s] queries, or raise the setting",
+                    NAME,
+                    FUSION_FIELD.getPreferredName(),
+                    legSearches,
+                    MAX_FUSION_LEG_SEARCHES.getKey(),
+                    maxLegSearches,
+                    NAME,
+                    NAME
+                )
+            );
+        }
+    }
+
+    /**
+     * The live value of {@link NeuralSearchSettings#MAX_FUSION_LEG_SEARCHES} on this coordinator. Read from
+     * {@link org.opensearch.cluster.service.ClusterService}'s cluster settings so a dynamic update takes effect on the
+     * next request; falls back to the default when there is no cluster service to read (no running node — a guardrail
+     * must not become a new way to fail).
+     */
+    private static int maxFusionLegSearches() {
+        ClusterService clusterService = NeuralSearchClusterUtil.instance().getClusterService();
+        if (Objects.isNull(clusterService) || Objects.isNull(clusterService.getClusterSettings())) {
+            return MAX_FUSION_LEG_SEARCHES.getDefault(Settings.EMPTY);
+        }
+        return clusterService.getClusterSettings().get(MAX_FUSION_LEG_SEARCHES);
+    }
+
+    /**
+     * Total leg sub-searches the given query declares: the legs of every fused {@code hybrid} in the tree, itself
+     * included. Package-private so the count can be asserted per query shape without a cluster.
+     */
+    static int countFusedLegSearches(final QueryBuilder query) {
+        if (Objects.isNull(query)) {
+            return 0;
+        }
+        LegSearchCounter counter = new LegSearchCounter();
+        query.visit(counter);
+        return counter.legSearches;
+    }
+
+    /**
+     * Counts the legs of every fused hybrid it is shown. One instance walks the whole tree — it hands itself back as the
+     * child visitor, and {@link #visit} recurses into the legs — so a nested fused hybrid is counted at every depth the
+     * builders expose.
+     */
+    private static final class LegSearchCounter implements QueryBuilderVisitor {
+        private int legSearches;
+
+        @Override
+        public void accept(final QueryBuilder queryBuilder) {
+            if (queryBuilder instanceof HybridQueryBuilder && Objects.nonNull(((HybridQueryBuilder) queryBuilder).fusion())) {
+                legSearches += ((HybridQueryBuilder) queryBuilder).queries().size();
+            }
+        }
+
+        @Override
+        public QueryBuilderVisitor getChildVisitor(final Occur occur) {
+            return this;
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/query/MatchSetRewriteContext.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/MatchSetRewriteContext.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.util.Objects;
+
+import org.opensearch.index.query.QueryCoordinatorContext;
+import org.opensearch.index.query.QueryRewriteContext;
+
+/**
+ * A coordinator rewrite context that marks the subtree being rewritten as needed for its <b>match set only</b>: nothing
+ * rewritten under it will be asked to score, so a query that would fan out sub-searches purely to produce scores must
+ * contribute what it matches instead.
+ *
+ * <p>Its one user is {@link HybridFusionQueryBuilder}, which rewrites the Tail (and the inner_hits sources) under this
+ * context. Those hold the enclosing query's original leg builders, so a leg that is itself a fused
+ * {@link HybridQueryBuilder} would otherwise reach {@code doRewriteFused} a <i>second</i> time and fire its legs again —
+ * once as the enclosing query's leg sub-search, and once more here. That doubling compounds per nesting level: a chain
+ * of fused hybrids {@code D} deep costs {@code 2^(D+1) - 2} leg sub-searches while its request body grows only linearly,
+ * and near {@code D = 8} the extra rewrite rounds trip core's {@code Rewriteable.MAX_REWRITE_ROUNDS} and the user gets a
+ * 500 instead of an answer. Under this context the nested fused hybrid returns {@code bool{should: legs}} — the same set
+ * of documents it matches, at no fan-out — and cost becomes linear in the number of hybrids the body actually spells out
+ * (see {@link HybridQueryBuilder#matchSetQuery()}).
+ *
+ * <p>The marker is a <b>hint, not a restriction</b>: every {@link QueryRewriteContext} method delegates unchanged, so a
+ * builder that has real work to do in a rewrite (a {@code neural} query resolving its embedding through
+ * {@code registerAsyncAction}, say) behaves exactly as it does under the context it wraps. Only a builder that opts in by
+ * checking {@link #isMatchSetOnly} sees any difference.
+ */
+class MatchSetRewriteContext extends QueryCoordinatorContext {
+
+    /**
+     * Delegates every method to the coordinator context being wrapped — which is itself a {@link QueryRewriteContext},
+     * so the wrapped context can stand in for the {@code rewriteContext} the superclass delegates to, and the async
+     * actions registered under the marker land on the real queue.
+     */
+    private MatchSetRewriteContext(final QueryCoordinatorContext delegate) {
+        super(delegate, delegate.getSearchRequest());
+    }
+
+    /**
+     * Mark {@code queryRewriteContext} as match-set-only for the subtree about to be rewritten with the returned context.
+     * Returned unchanged when there is nothing to mark (a shard-side rewrite, where no fan-out can happen anyway) or when
+     * the mark is already in place (a Tail within a Tail).
+     */
+    static QueryRewriteContext wrap(final QueryRewriteContext queryRewriteContext) {
+        QueryCoordinatorContext coordinatorContext = queryRewriteContext.convertToCoordinatorContext();
+        if (Objects.isNull(coordinatorContext) || coordinatorContext instanceof MatchSetRewriteContext) {
+            return queryRewriteContext;
+        }
+        return new MatchSetRewriteContext(coordinatorContext);
+    }
+
+    /** Whether the query being rewritten under this context is needed for its match set only. */
+    static boolean isMatchSetOnly(final QueryRewriteContext queryRewriteContext) {
+        return queryRewriteContext.convertToCoordinatorContext() instanceof MatchSetRewriteContext;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
+++ b/src/main/java/org/opensearch/neuralsearch/settings/NeuralSearchSettings.java
@@ -9,6 +9,7 @@ import org.opensearch.common.settings.Setting;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 
 /**
  * Class defines settings specific to neural-search plugin
@@ -112,6 +113,33 @@ public final class NeuralSearchSettings {
     public static final Setting<ByteSizeValue> NEURAL_CIRCUIT_BREAKER_LIMIT = Setting.memorySizeSetting(
         "plugins.neural_search.circuit_breaker.limit",
         DEFAULT_CIRCUIT_BREAKER_LIMIT,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Kept in step with the per-query leg limit rather than picked: one {@code hybrid} may declare
+     * {@link HybridQueryBuilder#MAX_NUMBER_OF_SUB_QUERIES} legs, so the square is what a request nesting fused hybrids
+     * that deep costs, and no shape a single {@code hybrid} can express is affected by this ceiling.
+     */
+    public static final int DEFAULT_MAX_FUSION_LEG_SEARCHES = HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES
+        * HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES;
+
+    /**
+     * Ceiling on the leg sub-searches one search request may fan out in the {@code hybrid} query's fused mode — the sum of
+     * {@code queries} sizes over every fused {@code hybrid} in the request body, whether nested or side by side. Each such
+     * leg is a full search across the request's shards, so this is the request's fan-out multiplier and the reason the
+     * limit is expressed in the same units the user wrote.
+     *
+     * <p>Counterpart to {@code indices.query.bool.max_clause_count}, and deliberately shaped like it: a whole-request count
+     * of a declared unit, checked once, adjustable per cluster. The floor is
+     * {@link HybridQueryBuilder#MAX_NUMBER_OF_SUB_QUERIES} — lowering it below the number of legs a single {@code hybrid}
+     * is already allowed to declare would reject a plain, un-nested fused query, so that is not an available setting.
+     */
+    public static final Setting<Integer> MAX_FUSION_LEG_SEARCHES = Setting.intSetting(
+        "plugins.neural_search.hybrid.fusion.max_leg_searches",
+        DEFAULT_MAX_FUSION_LEG_SEARCHES,
+        HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/src/test/java/org/opensearch/neuralsearch/fusion/ScalarNormalizerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/fusion/ScalarNormalizerTests.java
@@ -30,25 +30,26 @@ public class ScalarNormalizerTests extends OpenSearchTestCase {
         return leg;
     }
 
-    // ---- factory ----
+    // ---- technique lookup ----
 
-    public void testFactory_resolvesMinMax() {
-        ScalarNormalizer normalizer = ScalarNormalizerFactory.create("min_max");
+    public void testForTechnique_resolvesMinMax() {
+        ScalarNormalizer normalizer = ScalarNormalizers.forTechnique("min_max");
         assertSame(MinMaxScalarNormalizer.INSTANCE, normalizer);
         assertEquals("min_max", normalizer.techniqueName());
     }
 
-    public void testFactory_whenTechniqueNotWiredYet_thenThrows() {
+    public void testForTechnique_whenTechniqueNotWiredYet_thenThrows() {
         // z_score / l2 / rrf parse but have no coordinator implementation yet — the caller rejects them at rewrite, so
         // this is the defense-in-depth backstop.
         for (String notWired : List.of("z_score", "l2", "rrf", "none")) {
-            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ScalarNormalizerFactory.create(notWired));
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ScalarNormalizers.forTechnique(notWired));
             assertTrue(e.getMessage().contains("is not supported in fused mode"));
         }
     }
 
-    public void testFactory_whenNullTechnique_thenThrows() {
-        expectThrows(IllegalArgumentException.class, () -> ScalarNormalizerFactory.create(null));
+    public void testForTechnique_whenNullTechnique_thenThrows() {
+        // A null technique reaches the same refusal rather than an NPE from the immutable lookup map.
+        expectThrows(IllegalArgumentException.class, () -> ScalarNormalizers.forTechnique(null));
     }
 
     // ---- min_max normalizer ----

--- a/src/test/java/org/opensearch/neuralsearch/fusion/ScalarNormalizerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/fusion/ScalarNormalizerTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.fusion;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.neuralsearch.processor.combination.ArithmeticMeanScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.combination.ScoreCombinationUtil;
+import org.opensearch.neuralsearch.processor.normalization.MinMaxScoreNormalizer;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ScalarNormalizerTests extends OpenSearchTestCase {
+
+    private static final float DELTA = 1e-6f;
+
+    private ScoreCombinationTechnique arithmeticMean() {
+        return new ArithmeticMeanScoreCombinationTechnique(Map.of(), new ScoreCombinationUtil());
+    }
+
+    private Map<String, Float> leg(Object... idScorePairs) {
+        Map<String, Float> leg = new LinkedHashMap<>();
+        for (int i = 0; i < idScorePairs.length; i += 2) {
+            leg.put((String) idScorePairs[i], (Float) idScorePairs[i + 1]);
+        }
+        return leg;
+    }
+
+    // ---- factory ----
+
+    public void testFactory_resolvesMinMax() {
+        ScalarNormalizer normalizer = ScalarNormalizerFactory.create("min_max");
+        assertSame(MinMaxScalarNormalizer.INSTANCE, normalizer);
+        assertEquals("min_max", normalizer.techniqueName());
+    }
+
+    public void testFactory_whenTechniqueNotWiredYet_thenThrows() {
+        // z_score / l2 / rrf parse but have no coordinator implementation yet — the caller rejects them at rewrite, so
+        // this is the defense-in-depth backstop.
+        for (String notWired : List.of("z_score", "l2", "rrf", "none")) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ScalarNormalizerFactory.create(notWired));
+            assertTrue(e.getMessage().contains("is not supported in fused mode"));
+        }
+    }
+
+    public void testFactory_whenNullTechnique_thenThrows() {
+        expectThrows(IllegalArgumentException.class, () -> ScalarNormalizerFactory.create(null));
+    }
+
+    // ---- min_max normalizer ----
+
+    public void testMinMaxNormalizeLeg_matchesSharedScalarMath() {
+        // The normalizer must be a pure re-expression of the shared classic math, per score.
+        Map<String, Float> raw = leg("a", 1.0f, "b", 1.5f, "c", 2.0f);
+
+        Map<String, Float> normalized = MinMaxScalarNormalizer.INSTANCE.normalizeLeg(raw);
+
+        assertEquals(raw.keySet(), normalized.keySet());
+        assertEquals(MinMaxScoreNormalizer.normalizeSingleScore(1.0f, 1.0f, 2.0f), normalized.get("a"), DELTA);
+        assertEquals(MinMaxScoreNormalizer.normalizeSingleScore(1.5f, 1.0f, 2.0f), normalized.get("b"), DELTA);
+        assertEquals(MinMaxScoreNormalizer.normalizeSingleScore(2.0f, 1.0f, 2.0f), normalized.get("c"), DELTA);
+    }
+
+    public void testMinMaxNormalizeLeg_whenEmptyLeg_thenEmptyResult() {
+        // A leg that matched nothing must stay empty — CoordinatorScoreFusion reads a missing key as "leg didn't match".
+        assertTrue(MinMaxScalarNormalizer.INSTANCE.normalizeLeg(Map.of()).isEmpty());
+    }
+
+    public void testMinMaxNormalizeLeg_whenSingleScore_thenOne() {
+        // min == max single-result edge case: classic returns 1.0.
+        Map<String, Float> normalized = MinMaxScalarNormalizer.INSTANCE.normalizeLeg(leg("only", 0.7f));
+        assertEquals(1.0f, normalized.get("only"), DELTA);
+    }
+
+    public void testMinMaxNormalizeLeg_preservesEveryKey() {
+        Map<String, Float> raw = leg("a", 0.1f, "b", 0.2f, "c", 0.3f, "d", 0.4f);
+        assertEquals(raw.size(), MinMaxScalarNormalizer.INSTANCE.normalizeLeg(raw).size());
+    }
+
+    // ---- fuse(normalizer) is behavior-identical to the fuseMinMax it replaced ----
+
+    public void testFuse_withMinMaxNormalizer_equalsFuseMinMax() {
+        // Locks in that routing normalization through the ScalarNormalizer seam changed nothing: same fused scores,
+        // same key order. This is the guard that the refactor stayed behavior-preserving.
+        List<Map<String, Float>> legs = List.of(leg("1", 0.9f, "2", 0.5f), leg("2", 0.8f, "3", 0.4f));
+
+        Map<String, Float> viaSeam = CoordinatorScoreFusion.fuse(legs, MinMaxScalarNormalizer.INSTANCE, arithmeticMean());
+        Map<String, Float> viaConvenience = CoordinatorScoreFusion.fuseMinMax(legs, arithmeticMean());
+
+        assertEquals(viaConvenience.keySet(), viaSeam.keySet());
+        assertEquals(List.copyOf(viaConvenience.keySet()), List.copyOf(viaSeam.keySet()));
+        for (String id : viaConvenience.keySet()) {
+            assertEquals(viaConvenience.get(id), viaSeam.get(id), 0.0f);
+        }
+    }
+
+    public void testFuse_withCustomNormalizer_isPluggedIn() {
+        // A stand-in normalizer proves the seam is real: fusion uses whatever the normalizer returns, and a key the
+        // normalizer omits is treated as "leg did not match" (0.0 slot).
+        ScalarNormalizer constantHalf = new ScalarNormalizer() {
+            @Override
+            public Map<String, Float> normalizeLeg(Map<String, Float> legRawScores) {
+                Map<String, Float> out = new LinkedHashMap<>();
+                legRawScores.keySet().forEach(id -> out.put(id, 0.5f));
+                return out;
+            }
+
+            @Override
+            public String techniqueName() {
+                return "constant_half";
+            }
+        };
+        List<Map<String, Float>> legs = List.of(leg("1", 0.9f), leg("1", 0.2f));
+
+        Map<String, Float> fused = CoordinatorScoreFusion.fuse(legs, constantHalf, arithmeticMean());
+
+        // Both legs matched doc 1 and both normalized to 0.5 → unweighted arithmetic mean is 0.5.
+        assertEquals(0.5f, fused.get("1"), DELTA);
+    }
+
+    public void testFuse_whenKeysAreOpaqueComposites_thenCarriedThroughUnchanged() {
+        // Keys are opaque to fusion and to normalizers: a composite identity string round-trips untouched, which is what
+        // lets the caller change its document identity scheme without touching this layer.
+        List<Map<String, Float>> legs = List.of(leg("idx-a#1", 0.9f), leg("idx-b#1", 0.8f));
+
+        Map<String, Float> fused = CoordinatorScoreFusion.fuse(legs, MinMaxScalarNormalizer.INSTANCE, arithmeticMean());
+
+        assertEquals(2, fused.size());
+        assertTrue(fused.containsKey("idx-a#1"));
+        assertTrue(fused.containsKey("idx-b#1"));
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -201,7 +201,10 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
 
     public void testGetSettings() {
         List<Setting<?>> settings = plugin.getSettings();
-        assertEquals(8, settings.size());
+        assertEquals(9, settings.size());
+        // A setting the plugin defines but never registers here cannot be set on a cluster at all, dynamically or in
+        // opensearch.yml — the fused fan-out budget would silently stay at its default.
+        assertTrue(settings.contains(NeuralSearchSettings.MAX_FUSION_LEG_SEARCHES));
     }
 
     public void testRequestProcessors() {

--- a/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
@@ -17,6 +17,7 @@ import java.util.TreeSet;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.XContentParser;
@@ -105,6 +106,8 @@ public class CandidateScopeTests extends OpenSearchTestCase {
         }
     }
 
+    @SuppressForbidden(reason = "the guard exists to see core's private state: getFields() returns only public fields, of which "
+        + "SearchRequest and SearchSourceBuilder have none, so it would pass vacuously")
     private List<Field> instanceFields(Class<?> type) {
         List<Field> fields = new ArrayList<>();
         for (Field field : type.getDeclaredFields()) {

--- a/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
@@ -20,6 +20,7 @@ import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
@@ -27,6 +28,7 @@ import org.opensearch.script.Script;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.opensearch.search.pipeline.SearchPipelineService;
 import org.opensearch.search.slice.SliceBuilder;
@@ -304,6 +306,23 @@ public class CandidateScopeTests extends OpenSearchTestCase {
             "a field sort anywhere in the sort list counts, not just first",
             CandidateScope.sortDiscardsFusedRanking(
                 new SearchSourceBuilder().sort(SortBuilders.scoreSort()).sort(SortBuilders.fieldSort("price"))
+            )
+        );
+    }
+
+    // ---- FORCES_TAIL: collapse.inner_hits expands a group over the match set, not over the window ----
+
+    public void testCollapseExpandsGroups() {
+        assertFalse("null source", CandidateScope.collapseExpandsGroups(null));
+        assertFalse("no collapse", CandidateScope.collapseExpandsGroups(new SearchSourceBuilder()));
+        assertFalse(
+            "grouping alone runs no expansion search — core's own isCollapseRequest tests the same non-empty inner-hits list",
+            CandidateScope.collapseExpandsGroups(new SearchSourceBuilder().collapse(new CollapseBuilder("grp")))
+        );
+        assertTrue(
+            "inner_hits expands each group by re-running round 2, so round 2 must match the whole group",
+            CandidateScope.collapseExpandsGroups(
+                new SearchSourceBuilder().collapse(new CollapseBuilder("grp").setInnerHits(new InnerHitBuilder("members")))
             )
         );
     }

--- a/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
@@ -272,10 +272,40 @@ public class CandidateScopeTests extends OpenSearchTestCase {
         }
     }
 
+    /**
+     * A scroll pages one reader snapshot, and that snapshot covers round 2 alone: the legs that chose the window ran as
+     * separate one-shot searches against their own reader instants and are never re-run. Classic hybrid refuses scroll too.
+     * Note this is refused from {@code SearchRequest} rather than the source, and before the {@code source == null} return —
+     * a scroll needs no source to be a scroll.
+     */
+    public void testRejectsScroll() {
+        SearchRequest request = new SearchRequest(INDEX).scroll(TimeValue.timeValueMinutes(1));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CandidateScope.from(request));
+
+        assertThat(e.getMessage(), containsString("does not support [scroll]"));
+        assertThat("points at the shape that does work", e.getMessage(), containsString("point_in_time instead"));
+    }
+
     public void testRejectsCrossClusterSearch() {
-        // A remote hit's _index carries the cluster alias, which no shard of the remote index matches, so the
-        // _index-qualified Top clauses would silently drop every remote document.
+        // Neither half of a fused document's identity works across clusters: a remote hit's _index arrives as the bare
+        // index name with the cluster alias held separately, so two clusters holding an index of the same name collapse into
+        // one fusion key, and round 2's _index term matches nothing on a remote shard, which tests that term against its
+        // cluster-aliased target. Remote documents would reach the user through the Tail only, unranked at _score 0.
         SearchRequest request = new SearchRequest("local-index", "remote-cluster:other-index");
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CandidateScope.from(request));
+
+        assertThat(e.getMessage(), containsString("does not support [cross-cluster search]"));
+    }
+
+    /**
+     * A wildcard cluster pattern is the shape that would otherwise slip through. Index resolution rejects a literal
+     * {@code cluster:index} on its own (as {@code no such index}), but {@code *:index} resolves without error, so this
+     * guard is what refuses it — and it must not depend on where in the rewrite index resolution happens to run.
+     */
+    public void testRejectsWildcardClusterPattern() {
+        SearchRequest request = new SearchRequest("*:other-index");
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CandidateScope.from(request));
 

--- a/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchType;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.script.Script;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.builder.PointInTimeBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.opensearch.search.pipeline.SearchPipelineService;
+import org.opensearch.search.slice.SliceBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import lombok.SneakyThrows;
+
+public class CandidateScopeTests extends OpenSearchTestCase {
+
+    private static final String INDEX = "test-index";
+    private static final QueryBuilder LEG = new MatchQueryBuilder("text", "hello");
+
+    // ---- the guard: the classification table must cover both request classes, exactly ----
+
+    /**
+     * The reason this class exists. Round 1 and round 2 must agree on which documents are candidates, and the silent way
+     * to break that is for a request field to reach a leg (or fail to) because nobody considered it. So every declared
+     * field of both request classes must carry an explicit disposition, and this test fails the build until it does — a
+     * core upgrade that adds a search-request field cannot land unexamined.
+     */
+    public void testEveryRequestFieldIsClassified() {
+        Set<String> unclassified = new TreeSet<>();
+        for (Field field : instanceFields(SearchRequest.class)) {
+            String key = CandidateScope.key(CandidateScope.SEARCH_REQUEST, field.getName());
+            if (CandidateScope.CLASSIFICATION.containsKey(key) == false) {
+                unclassified.add(key);
+            }
+        }
+        for (Field field : instanceFields(SearchSourceBuilder.class)) {
+            String key = CandidateScope.key(CandidateScope.SEARCH_SOURCE, field.getName());
+            if (CandidateScope.CLASSIFICATION.containsKey(key) == false) {
+                unclassified.add(key);
+            }
+        }
+
+        assertTrue(
+            "New search-request field(s) "
+                + unclassified
+                + " are not classified in CandidateScope. Decide whether each one changes WHICH documents a leg returns "
+                + "or HOW they score: if it does, propagate it (or reject the request); if it does not, mark it "
+                + "NOT_PROPAGATED with the reason. Do not delete this assertion.",
+            unclassified.isEmpty()
+        );
+    }
+
+    /**
+     * The other direction: an entry naming a field core has renamed or removed would leave the table looking complete
+     * while silently classifying nothing.
+     */
+    public void testNoStaleClassificationEntries() {
+        Set<String> declared = new TreeSet<>();
+        for (Field field : instanceFields(SearchRequest.class)) {
+            declared.add(CandidateScope.key(CandidateScope.SEARCH_REQUEST, field.getName()));
+        }
+        for (Field field : instanceFields(SearchSourceBuilder.class)) {
+            declared.add(CandidateScope.key(CandidateScope.SEARCH_SOURCE, field.getName()));
+        }
+
+        Set<String> stale = new TreeSet<>(CandidateScope.CLASSIFICATION.keySet());
+        stale.removeAll(declared);
+
+        assertTrue(
+            "CandidateScope classifies field(s) " + stale + " that no longer exist in core — remove or rename them.",
+            stale.isEmpty()
+        );
+    }
+
+    public void testEveryClassificationStatesAReason() {
+        for (Map.Entry<String, CandidateScope.Classification> entry : CandidateScope.CLASSIFICATION.entrySet()) {
+            assertNotNull(entry.getKey(), entry.getValue().disposition());
+            assertFalse("[" + entry.getKey() + "] must state why its disposition is correct", entry.getValue().reason().isBlank());
+        }
+    }
+
+    private List<Field> instanceFields(Class<?> type) {
+        List<Field> fields = new ArrayList<>();
+        for (Field field : type.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers()) || field.isSynthetic()) {
+                continue;
+            }
+            fields.add(field);
+        }
+        assertFalse(
+            "reflection found no instance fields on " + type.getSimpleName() + " — the guard would pass vacuously",
+            fields.isEmpty()
+        );
+        return fields;
+    }
+
+    // ---- PROPAGATED: what defines the candidate set must reach every leg ----
+
+    public void testPropagatedFieldsReachTheLeg() {
+        SliceBuilder slice = new SliceBuilder("_id", 1, 4);
+        TermQueryBuilder postFilter = new TermQueryBuilder("grp", "a");
+        SearchRequest request = new SearchRequest(INDEX).indicesOptions(IndicesOptions.lenientExpandOpen())
+            .routing("r1")
+            .preference("_local")
+            .searchType(SearchType.DFS_QUERY_THEN_FETCH)
+            .allowPartialSearchResults(false)
+            .source(new SearchSourceBuilder().postFilter(postFilter).slice(slice).timeout(TimeValue.timeValueSeconds(7)));
+        request.setMaxConcurrentShardRequests(3);
+        request.setPreFilterShardSize(64);
+        request.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(11));
+
+        SearchRequest leg = CandidateScope.from(request).newLegRequest(LEG, 50);
+
+        assertArrayEquals(new String[] { INDEX }, leg.indices());
+        assertEquals(IndicesOptions.lenientExpandOpen(), leg.indicesOptions());
+        assertEquals("round 2 only searches routed shards", "r1", leg.routing());
+        assertEquals("legs and round 2 must hit the same shard copies", "_local", leg.preference());
+        assertEquals("dfs changes term stats, and so the window", SearchType.DFS_QUERY_THEN_FETCH, leg.searchType());
+        assertEquals(Boolean.FALSE, leg.allowPartialSearchResults());
+        assertEquals(3, leg.getMaxConcurrentShardRequestsRaw());
+        assertEquals(Integer.valueOf(64), leg.getPreFilterShardSize());
+        assertEquals(TimeValue.timeValueSeconds(11), leg.getCancelAfterTimeInterval());
+        assertEquals(TimeValue.timeValueSeconds(7), leg.source().timeout());
+        assertEquals("round 2 post-filters its window, so the leg must too", postFilter, leg.source().postFilter());
+        assertEquals("round 2 returns only the slice", slice, leg.source().slice());
+    }
+
+    public void testUnsetFieldsAreLeftUnsetOnTheLeg() {
+        // An unset value must not be forced onto a leg: the leg has to resolve the same default the outer request would.
+        SearchRequest leg = CandidateScope.from(new SearchRequest(INDEX)).newLegRequest(LEG, 50);
+
+        assertNull(leg.routing());
+        assertNull(leg.preference());
+        assertNull("unset → each leg resolves the cluster default (true) at execution", leg.allowPartialSearchResults());
+        assertEquals("0 is core's 'unset' for max_concurrent_shard_requests", 0, leg.getMaxConcurrentShardRequestsRaw());
+        assertNull(leg.getPreFilterShardSize());
+        assertNull(leg.getCancelAfterTimeInterval());
+        assertNull(leg.source().timeout());
+        assertNull(leg.source().postFilter());
+        assertNull(leg.source().slice());
+        assertNull(leg.source().pointInTimeBuilder());
+    }
+
+    public void testAllowPartialSearchResultsPropagatesEitherExplicitValue() {
+        // false in particular must reach the legs: that is what makes a leg with a failing shard fail outright, which
+        // HybridFusionOrchestrator#groupLegHits turns into a whole-request failure instead of a re-normalized ranking.
+        for (boolean explicit : new boolean[] { true, false }) {
+            SearchRequest request = new SearchRequest(INDEX).allowPartialSearchResults(explicit);
+
+            SearchRequest leg = CandidateScope.from(request).newLegRequest(LEG, 50);
+
+            assertEquals(explicit, leg.allowPartialSearchResults());
+        }
+    }
+
+    public void testPointInTimePropagatesWithoutExtendingKeepAlive() {
+        SearchRequest request = new SearchRequest(INDEX).source(
+            new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("pit-id-42").setKeepAlive(TimeValue.timeValueMinutes(5)))
+        );
+
+        SearchRequest leg = CandidateScope.from(request).newLegRequest(LEG, 50);
+
+        assertEquals("all legs and round 2 must read one immutable view", "pit-id-42", leg.source().pointInTimeBuilder().getId());
+        assertNull("a leg never extends the PIT keep-alive", leg.source().pointInTimeBuilder().getKeepAlive());
+    }
+
+    public void testScopeIsCapturedOnceAndReusedByEveryLeg() {
+        // The scope is captured before the fan-out, so mutating the request afterwards cannot change what a leg inherits.
+        SearchRequest request = new SearchRequest(INDEX).routing("r1");
+        CandidateScope scope = CandidateScope.from(request);
+        request.routing("r2");
+
+        assertEquals("r1", scope.newLegRequest(LEG, 50).routing());
+        assertEquals("r1", scope.newLegRequest(new TermQueryBuilder("text", "place"), 50).routing());
+    }
+
+    // ---- OVERRIDDEN: fused mode dictates the leg's own shape ----
+
+    public void testOverriddenFieldsAreSetByFusedModeNotInherited() {
+        SearchRequest request = new SearchRequest(INDEX).pipeline("norm-pipeline")
+            .source(
+                new SearchSourceBuilder().query(new TermQueryBuilder("text", "outer"))
+                    .from(30)
+                    .size(10)
+                    .trackTotalHits(true)
+                    .fetchSource(true)
+                    .aggregation(AggregationBuilders.terms("t").field("f"))
+                    .highlighter(new HighlightBuilder().field("text"))
+                    .searchPipelineSource(Map.of("response_processors", List.of()))
+            );
+
+        SearchRequest leg = CandidateScope.from(request).newLegRequest(LEG, 50);
+
+        assertEquals("a leg runs its own sub-query", LEG, leg.source().query());
+        assertEquals("a leg returns exactly the candidate window", 50, leg.source().size());
+        assertEquals("paging is a round-2 concern", 0, leg.source().from());
+        assertFalse("legs are id-only", leg.source().fetchSource().fetchSource());
+        assertEquals("legs disable totals; the Tail supplies them", Integer.valueOf(-1), leg.source().trackTotalHitsUpTo());
+        assertNull("aggregations run once, in round 2", leg.source().aggregations());
+        assertNull("highlighting runs once, in round 2", leg.source().highlighter());
+        assertNull("an inline pipeline body is not applied per leg", leg.source().searchPipelineSource());
+        assertEquals("processors run once for the user request, not once per leg", SearchPipelineService.NOOP_PIPELINE_ID, leg.pipeline());
+    }
+
+    // ---- REJECTED: shapes fused mode cannot answer correctly, refused before the fan-out ----
+
+    public void testRejectsTerminateAfter() {
+        SearchRequest request = new SearchRequest(INDEX).source(new SearchSourceBuilder().terminateAfter(100));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CandidateScope.from(request));
+
+        assertThat(e.getMessage(), containsString("[hybrid] query [fusion] does not support [terminate_after]"));
+        assertThat(e.getMessage(), containsString("counts every match in docid order"));
+    }
+
+    public void testRejectsIndicesBoost() {
+        SearchRequest request = new SearchRequest(INDEX).source(new SearchSourceBuilder().indexBoost(INDEX, 2.0f));
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CandidateScope.from(request));
+
+        assertThat(e.getMessage(), containsString("does not support [indices_boost]"));
+    }
+
+    /**
+     * Both shapes a user can write. The map form is only reachable by parsing a request body — core exposes no setter for
+     * it, which is also why fused mode rejects derived fields instead of propagating them onto the leg source.
+     */
+    @SneakyThrows
+    public void testRejectsDerivedFieldsInBothForms() {
+        XContentParser parser = createParser(
+            JsonXContent.jsonXContent,
+            "{\"derived\":{\"d\":{\"type\":\"keyword\",\"script\":\"emit('x')\"}}}"
+        );
+        SearchRequest mapForm = new SearchRequest(INDEX).source(SearchSourceBuilder.fromXContent(parser));
+        SearchRequest listForm = new SearchRequest(INDEX).source(
+            new SearchSourceBuilder().derivedField("d", "keyword", new Script("emit('x')"))
+        );
+
+        for (SearchRequest request : List.of(mapForm, listForm)) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CandidateScope.from(request));
+            assertThat(e.getMessage(), containsString("does not support [derived]"));
+            assertThat(e.getMessage(), containsString("would silently rewrite to match_none"));
+        }
+    }
+
+    public void testRejectsCrossClusterSearch() {
+        // A remote hit's _index carries the cluster alias, which no shard of the remote index matches, so the
+        // _index-qualified Top clauses would silently drop every remote document.
+        SearchRequest request = new SearchRequest("local-index", "remote-cluster:other-index");
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CandidateScope.from(request));
+
+        assertThat(e.getMessage(), containsString("does not support [cross-cluster search]"));
+    }
+
+    public void testPlainRequestIsAccepted() {
+        // The rejections must test for values the user actually supplied — an ordinary request must not trip any of them.
+        CandidateScope.from(new SearchRequest(INDEX).source(new SearchSourceBuilder().query(LEG).size(10)));
+        CandidateScope.from(new SearchRequest(INDEX));
+    }
+
+    // ---- FORCES_TAIL: a non-_score sort ranks over the match set, not the window ----
+
+    public void testSortDiscardsFusedRanking() {
+        assertFalse("no sort → the fused score is the ranking", CandidateScope.sortDiscardsFusedRanking(new SearchSourceBuilder()));
+        assertFalse("null source", CandidateScope.sortDiscardsFusedRanking(null));
+        assertFalse(
+            "_score sort IS the fused ranking",
+            CandidateScope.sortDiscardsFusedRanking(new SearchSourceBuilder().sort(SortBuilders.scoreSort()))
+        );
+        assertTrue(
+            "a field sort ranks by the field, so round 2 must see the full union",
+            CandidateScope.sortDiscardsFusedRanking(new SearchSourceBuilder().sort(SortBuilders.fieldSort("price").order(SortOrder.ASC)))
+        );
+        assertTrue(
+            "_doc order likewise discards the fused ranking",
+            CandidateScope.sortDiscardsFusedRanking(new SearchSourceBuilder().sort(SortBuilders.fieldSort("_doc")))
+        );
+        assertTrue(
+            "a field sort anywhere in the sort list counts, not just first",
+            CandidateScope.sortDiscardsFusedRanking(
+                new SearchSourceBuilder().sort(SortBuilders.scoreSort()).sort(SortBuilders.fieldSort("price"))
+            )
+        );
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -22,6 +22,8 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.SearchPipelineService;
 import org.opensearch.test.OpenSearchTestCase;
@@ -50,7 +52,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         }
         SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
         SearchResponseSections sections = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
-        SearchResponse response = new SearchResponse(sections, null, 1, 1, 0, 10, null, null);
+        SearchResponse response = new SearchResponse(sections, null, 1, 1, 0, 10, ShardSearchFailure.EMPTY_ARRAY, null);
         return new MultiSearchResponse.Item(response, null);
     }
 
@@ -94,10 +96,51 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             assertEquals(50, source.size());
             assertFalse(source.fetchSource().fetchSource());
             assertEquals(SearchPipelineService.NOOP_PIPELINE_ID, leg.pipeline());
-            // Legs don't override allow_partial_search_results — left unset so each resolves the cluster default (true)
-            // at execution, like a normal search.
+            // Unset on the request → left unset on the leg so each resolves the cluster default (true) at execution.
             assertNull(leg.allowPartialSearchResults());
         }
+    }
+
+    public void testBuildLegMultiSearch_whenAllowPartialExplicitlySet_thenPropagatedToLegs() {
+        // An explicit request-level value is honored by the legs. Notably false must reach them: that is what makes a
+        // leg with a failing shard fail outright, which groupLegHits turns into a whole-request failure.
+        for (boolean explicit : new boolean[] { true, false }) {
+            SearchRequest request = new SearchRequest(INDEX).allowPartialSearchResults(explicit);
+            List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+
+            MultiSearchRequest ms = HybridFusionOrchestrator.buildLegMultiSearch(request, legs, 50);
+
+            for (SearchRequest leg : ms.requests()) {
+                assertEquals(explicit, leg.allowPartialSearchResults());
+            }
+        }
+    }
+
+    public void testBuildLegMultiSearch_whenRequestHasPit_thenPassedToEveryLeg() {
+        // A user-supplied PIT must reach every leg so all legs (and round 2) read one immutable view instead of N+1
+        // independent reader instants. keepAlive is left unset on legs so the PIT's original keep-alive governs.
+        SearchRequest request = new SearchRequest(INDEX).source(
+            new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("pit-id-42").setKeepAlive(TimeValue.timeValueMinutes(5)))
+        );
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+
+        MultiSearchRequest ms = HybridFusionOrchestrator.buildLegMultiSearch(request, legs, 50);
+
+        assertEquals(2, ms.requests().size());
+        for (SearchRequest leg : ms.requests()) {
+            assertNotNull("each leg must carry the PIT", leg.source().pointInTimeBuilder());
+            assertEquals("pit-id-42", leg.source().pointInTimeBuilder().getId());
+            assertNull("legs must not extend the PIT keep-alive", leg.source().pointInTimeBuilder().getKeepAlive());
+        }
+    }
+
+    public void testBuildLegMultiSearch_whenNoPit_thenLegsHaveNone() {
+        SearchRequest request = new SearchRequest(INDEX);
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"));
+
+        MultiSearchRequest ms = HybridFusionOrchestrator.buildLegMultiSearch(request, legs, 50);
+
+        assertNull(ms.requests().get(0).source().pointInTimeBuilder());
     }
 
     // ---- buildFusedQuery: Top+Tail / Top-only / match_none ----
@@ -109,7 +152,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             org.opensearch.search.aggregations.AggregationBuilders.terms("t").field("f")
         );
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
 
         assertTrue(fused instanceof HybridFusionQueryBuilder);
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
@@ -123,32 +166,34 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         // track_total_hits:false, no aggs/highlight/explain → plain top-K, Tail dropped.
         SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false);
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
 
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
         assertEquals(2, self.should().size());
         assertEquals("plain top-K → no Tail", 0, self.filter().size());
     }
 
-    public void testBuildFusedQuery_nested_alwaysTopOnly() {
+    public void testBuildFusedQuery_tailDecisionIsDepthIndependent() {
+        // The Tail decision comes from the REQUEST alone, never from whether this hybrid is top-level or nested: the
+        // fused query self-erases the same way at any depth, and an enclosing clause simply intersects it. So with aggs
+        // present the Tail is retained — nesting no longer silently downgrades agg/total_hits accuracy.
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
         MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
-        // Even with aggs present, a nested (topLevel=false) fused query is Top-only.
         SearchSourceBuilder source = new SearchSourceBuilder().aggregation(
             org.opensearch.search.aggregations.AggregationBuilders.terms("t").field("f")
         );
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10, false);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
 
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
-        assertEquals("nested → no Tail regardless of aggs", 0, self.filter().size());
+        assertEquals("aggs → Tail retained regardless of nesting depth", 1, self.filter().size());
     }
 
     public void testBuildFusedQuery_emptyResult_matchNone() {
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"));
         MultiSearchResponse ms = multiSearch(legItem(Map.of()));
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10);
 
         assertTrue(fused instanceof MatchNoneQueryBuilder);
     }
@@ -162,8 +207,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             ms,
             legs,
             minMaxArithmetic(),
-            2,
-            true
+            2
         );
 
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
@@ -186,8 +230,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
                 ms,
                 legs,
                 minMaxArithmetic(),
-                10,
-                true
+                10
             )
         );
         assertTrue("reports the failing leg index", e.getMessage().contains("fused-mode sub-query 1 failed"));
@@ -202,16 +245,17 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
 
         IllegalStateException e = expectThrows(
             IllegalStateException.class,
-            () -> HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10, true)
+            () -> HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10)
         );
         assertTrue(e.getMessage().contains("fused-mode sub-query 0 failed"));
         assertNotNull(e.getCause());
     }
 
-    public void testBuildFusedQuery_whenLegPartiallyFailed_thenFused() {
+    public void testBuildFusedQuery_whenLegPartiallyFailed_thenFusedWithWarning() {
         // A leg that lost some shards under allow_partial_search_results=true is a SUCCESSFUL item with fewer hits — it
         // is fused (degrade, matching OpenSearch's default), not rejected. groupLegHits only hard-fails a wholly-failed
-        // item, so a partial-but-successful leg flows through.
+        // item, so a partial-but-successful leg flows through — but emits a Warning header naming it, because per-leg
+        // normalization means the degraded leg can shift the fused ranking, not just drop docs.
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
         MultiSearchResponse ms = multiSearch(partialLegItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
 
@@ -220,8 +264,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             ms,
             legs,
             minMaxArithmetic(),
-            10,
-            true
+            10
         );
 
         assertTrue(fused instanceof HybridFusionQueryBuilder);
@@ -230,6 +273,18 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             2,
             ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().should().size()
         );
+        assertWarnings(
+            "[hybrid] fused-mode sub-query [0] returned partial results (shard failures); fused scores were computed "
+                + "over an incomplete result set, so ranking may differ from a complete run"
+        );
+    }
+
+    public void testBuildFusedQuery_whenNoLegDegraded_thenNoWarning() {
+        // Clean legs must not emit a warning (OpenSearchTestCase fails the test on any unasserted warning).
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
+
+        HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder().trackTotalHits(false), ms, legs, minMaxArithmetic(), 10);
     }
 
     // ---- knn/neural leg materialized as Ids in the Tail (no second ANN walk) ----
@@ -251,7 +306,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             org.opensearch.search.aggregations.AggregationBuilders.terms("t").field("f")
         );
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
 
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
         BoolQueryBuilder tail = (BoolQueryBuilder) self.filter().get(0);
@@ -279,8 +334,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             ms,
             legs,
             weighted,
-            10,
-            true
+            10
         );
 
         assertTrue(fused instanceof HybridFusionQueryBuilder);
@@ -295,7 +349,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)));
         SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false).explain(true);
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
 
         assertEquals("explain alone → no Tail", 0, ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().size());
     }
@@ -307,7 +361,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)));
         SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false).profile(true);
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
 
         assertEquals("profile alone → no Tail", 0, ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().size());
     }
@@ -317,7 +371,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"));
         MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f, "2", 0.5f)));
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10);
 
         assertEquals("default totals → Tail retained", 1, ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().size());
     }
@@ -327,7 +381,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"));
         MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)));
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(null, ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(null, ms, legs, minMaxArithmetic(), 10);
 
         assertEquals(1, ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().size());
     }
@@ -346,7 +400,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             org.opensearch.search.aggregations.AggregationBuilders.terms("t").field("f")
         );
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10, true);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
 
         BoolQueryBuilder tail = (BoolQueryBuilder) ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().get(0);
         long idsClauses = tail.should().stream().filter(q -> q instanceof IdsQueryBuilder).count();

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -53,19 +53,16 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         );
     }
 
-    /** One MultiSearch item wrapping a SearchResponse whose hits carry the given (_id -> score) pairs. */
+    /**
+     * One MultiSearch item wrapping a SearchResponse whose hits carry the given (_id -> score) pairs, all from the default
+     * index. Every hit carries an {@code _index}, as a real leg response's hits always do — it comes from the shard target
+     * the response was read from — and fusion requires it.
+     */
     private MultiSearchResponse.Item legItem(Map<String, Float> idToScore) {
-        SearchHit[] hits = new SearchHit[idToScore.size()];
-        int i = 0;
-        for (Map.Entry<String, Float> e : idToScore.entrySet()) {
-            SearchHit hit = new SearchHit(i, e.getKey(), Map.of(), Map.of());
-            hit.score(e.getValue());
-            hits[i++] = hit;
-        }
-        return successfulItem(hits);
+        return legItemFromIndex(INDEX, idToScore);
     }
 
-    /** Like {@link #legItem} but the hits carry an {@code _index}, as real leg responses do. */
+    /** Like {@link #legItem} but from a named index, for asserting cross-index document identity. */
     private MultiSearchResponse.Item legItemFromIndex(String index, Map<String, Float> idToScore) {
         SearchHit[] hits = new SearchHit[idToScore.size()];
         int i = 0;
@@ -98,6 +95,22 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         return hit;
     }
 
+    /**
+     * A leg item whose hits carry no {@code _index} — no shard target was ever set on them. Not a shape a real leg response
+     * can have (a coordinator-side hit's {@code _index} comes from the shard it was read from), which is exactly why fusion
+     * treats it as an invariant violation rather than something to work around.
+     */
+    private MultiSearchResponse.Item indexlessLegItem(Map<String, Float> idToScore) {
+        SearchHit[] hits = new SearchHit[idToScore.size()];
+        int i = 0;
+        for (Map.Entry<String, Float> e : idToScore.entrySet()) {
+            SearchHit hit = new SearchHit(i, e.getKey(), Map.of(), Map.of());
+            hit.score(e.getValue());
+            hits[i++] = hit;
+        }
+        return successfulItem(hits);
+    }
+
     private MultiSearchResponse.Item successfulItem(SearchHit[] hits) {
         SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
         SearchResponseSections sections = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
@@ -120,9 +133,8 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         SearchHit[] hits = new SearchHit[idToScore.size()];
         int i = 0;
         for (Map.Entry<String, Float> e : idToScore.entrySet()) {
-            SearchHit hit = new SearchHit(i, e.getKey(), Map.of(), Map.of());
-            hit.score(e.getValue());
-            hits[i++] = hit;
+            hits[i] = hitFrom(i, INDEX, e.getKey(), e.getValue());
+            i++;
         }
         SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
         SearchResponseSections sections = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
@@ -452,29 +464,28 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         }
     }
 
-    public void testBuildFusedQuery_whenHitsCarryNoIndex_thenTopFallsBackToIdOnlyForEveryClause() {
-        // The array handed to the self-erased query is null-or-fully-populated: a null hole would NPE in
-        // writeOptionalStringArray while serializing the round-2 shard request. Hits with no resolvable _index drop it
-        // wholesale rather than leaving holes.
+    /**
+     * A hit with no {@code _index} cannot be fused, and the request fails rather than degrading. The previous behaviour was
+     * to drop the whole {@code indices} array and address the window by {@code _id} alone — which is the same-{@code _id}
+     * conflation the two tests above exist to prevent, reintroduced for every clause because one hit lacked an index. Since
+     * a coordinator-side hit always carries its {@code _index}, this shape is a broken invariant, not user input.
+     */
+    public void testBuildFusedQuery_whenAnyHitCarriesNoIndex_thenFailsRatherThanDegrading() {
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
-        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItemFromIndex("idx-a", Map.of("2", 0.8f)));
+        MultiSearchResponse ms = multiSearch(legItemFromIndex("idx-a", Map.of("2", 0.8f)), indexlessLegItem(Map.of("1", 0.9f)));
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(
-            new SearchSourceBuilder().trackTotalHits(false),
-            ms,
-            legs,
-            minMaxArithmetic(),
-            10
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> HybridFusionOrchestrator.buildFusedQuery(
+                new SearchSourceBuilder().trackTotalHits(false),
+                ms,
+                legs,
+                minMaxArithmetic(),
+                10
+            )
         );
-
-        BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
-        assertEquals(2, self.should().size());
-        for (QueryBuilder clause : self.should()) {
-            assertTrue(
-                "one unresolvable index drops qualification for the whole window, not just its own clause",
-                ((ConstantScoreQueryBuilder) clause).innerQuery() instanceof IdsQueryBuilder
-            );
-        }
+        assertTrue("names the offending leg and hit: " + e.getMessage(), e.getMessage().contains("sub-query 1 returned a hit [_id: 1]"));
+        assertTrue(e.getMessage().contains("no [_index]"));
     }
 
     // ---- inner_hits are registered without executing the legs ----
@@ -603,17 +614,18 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         assertEquals("Top and Tail must address the same document identically", topAddress, tailAddress);
     }
 
-    public void testBuildFusedQuery_whenKnnLegHitsCarryNoIndex_thenTailFallsBackToIdsOnly() {
-        // Defensive parity with documentKey and the Top: a hit with no resolvable _index is addressed by _id alone rather
-        // than failing or dropping the leg.
+    public void testBuildFusedQuery_whenMaterializedLegHitsCarryNoIndex_thenFailsRatherThanDegrading() {
+        // The Tail is a filter, so an _id-only clause here widens the match set to every same-_id document in the cluster —
+        // inflating total_hits and every aggregation bucket. The invariant is asserted once, where every leg's hits enter
+        // fusion, so the Tail path refuses the same shape the Top path does.
         List<QueryBuilder> legs = List.of(legNamed("knn"));
-        MultiSearchResponse ms = multiSearch(legItem(Map.of("2", 0.8f, "3", 0.7f)));
+        MultiSearchResponse ms = multiSearch(indexlessLegItem(Map.of("2", 0.8f, "3", 0.7f)));
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(sourceWithAggregation(), ms, legs, minMaxArithmetic(), 10);
-
-        QueryBuilder legClause = tailOf(fused).should().get(0);
-        assertTrue("no index to qualify with → bare ids, not a bool", legClause instanceof IdsQueryBuilder);
-        assertEquals(Set.of("2", "3"), ((IdsQueryBuilder) legClause).ids());
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> HybridFusionOrchestrator.buildFusedQuery(sourceWithAggregation(), ms, legs, minMaxArithmetic(), 10)
+        );
+        assertTrue(e.getMessage().contains("cannot be fused"));
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -27,8 +27,6 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
-import org.opensearch.common.unit.TimeValue;
-import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.SearchPipelineService;
 import org.opensearch.test.OpenSearchTestCase;
@@ -105,63 +103,23 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
 
     // ---- buildLegMultiSearch ----
 
-    public void testBuildLegMultiSearch_perLegSourceShape() {
+    /**
+     * The assembly contract only: one leg request per sub-query, each carrying that sub-query and the window. What a leg
+     * inherits from the user's request is {@link CandidateScope}'s job and is covered by {@code CandidateScopeTests}.
+     */
+    public void testBuildLegMultiSearch_oneRequestPerLegBuiltFromTheScope() {
         SearchRequest request = new SearchRequest(INDEX);
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
 
-        MultiSearchRequest ms = HybridFusionOrchestrator.buildLegMultiSearch(request, legs, 50);
+        MultiSearchRequest ms = HybridFusionOrchestrator.buildLegMultiSearch(CandidateScope.from(request), legs, 50);
 
         assertEquals(2, ms.requests().size());
-        for (SearchRequest leg : ms.requests()) {
-            SearchSourceBuilder source = leg.source();
-            assertEquals(50, source.size());
-            assertFalse(source.fetchSource().fetchSource());
+        for (int i = 0; i < legs.size(); i++) {
+            SearchRequest leg = ms.requests().get(i);
+            assertEquals("leg " + i + " runs its own sub-query", legs.get(i), leg.source().query());
+            assertEquals(50, leg.source().size());
             assertEquals(SearchPipelineService.NOOP_PIPELINE_ID, leg.pipeline());
-            // Unset on the request → left unset on the leg so each resolves the cluster default (true) at execution.
-            assertNull(leg.allowPartialSearchResults());
         }
-    }
-
-    public void testBuildLegMultiSearch_whenAllowPartialExplicitlySet_thenPropagatedToLegs() {
-        // An explicit request-level value is honored by the legs. Notably false must reach them: that is what makes a
-        // leg with a failing shard fail outright, which groupLegHits turns into a whole-request failure.
-        for (boolean explicit : new boolean[] { true, false }) {
-            SearchRequest request = new SearchRequest(INDEX).allowPartialSearchResults(explicit);
-            List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
-
-            MultiSearchRequest ms = HybridFusionOrchestrator.buildLegMultiSearch(request, legs, 50);
-
-            for (SearchRequest leg : ms.requests()) {
-                assertEquals(explicit, leg.allowPartialSearchResults());
-            }
-        }
-    }
-
-    public void testBuildLegMultiSearch_whenRequestHasPit_thenPassedToEveryLeg() {
-        // A user-supplied PIT must reach every leg so all legs (and round 2) read one immutable view instead of N+1
-        // independent reader instants. keepAlive is left unset on legs so the PIT's original keep-alive governs.
-        SearchRequest request = new SearchRequest(INDEX).source(
-            new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("pit-id-42").setKeepAlive(TimeValue.timeValueMinutes(5)))
-        );
-        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
-
-        MultiSearchRequest ms = HybridFusionOrchestrator.buildLegMultiSearch(request, legs, 50);
-
-        assertEquals(2, ms.requests().size());
-        for (SearchRequest leg : ms.requests()) {
-            assertNotNull("each leg must carry the PIT", leg.source().pointInTimeBuilder());
-            assertEquals("pit-id-42", leg.source().pointInTimeBuilder().getId());
-            assertNull("legs must not extend the PIT keep-alive", leg.source().pointInTimeBuilder().getKeepAlive());
-        }
-    }
-
-    public void testBuildLegMultiSearch_whenNoPit_thenLegsHaveNone() {
-        SearchRequest request = new SearchRequest(INDEX);
-        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"));
-
-        MultiSearchRequest ms = HybridFusionOrchestrator.buildLegMultiSearch(request, legs, 50);
-
-        assertNull(ms.requests().get(0).source().pointInTimeBuilder());
     }
 
     // ---- buildFusedQuery: Top+Tail / Top-only / match_none ----
@@ -208,6 +166,31 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
 
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
         assertEquals("aggs → Tail retained regardless of nesting depth", 1, self.filter().size());
+    }
+
+    public void testBuildFusedQuery_whenSortedByField_keepsTail() {
+        // A non-_score sort ranks by the sort key, so the fused scores only pick the candidate set. With Top only, the
+        // request would sort a window-sized arbitrary subset of its matches; the Tail widens round 2 to the full union.
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
+        SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false).sort("price");
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
+
+        BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
+        assertEquals("field sort → Tail retained so the sort covers the full leg union", 1, self.filter().size());
+    }
+
+    public void testBuildFusedQuery_whenSortedByScoreOnly_staysTopOnly() {
+        // Sorting by _score is the fused ranking itself, so it must not drag in a Tail the request does not need.
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
+        SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false).sort("_score");
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
+
+        BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
+        assertEquals("_score sort → still plain top-K, no Tail", 0, self.filter().size());
     }
 
     public void testBuildFusedQuery_emptyResult_matchNone() {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -317,8 +317,13 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         }
     }
 
-    public void testBuildFusedQuery_whenSingleIndex_thenTopStaysIdOnly() {
-        // Single-index searches need no disambiguation, so they keep the leaner ids-only clause (and its original cost).
+    /**
+     * The blocker this guards. Qualification used to be dropped when the window spanned a single index, but the window is
+     * not evidence about the request — one index outranking its siblings, or a window_size below the fused set size, both
+     * yield a single-index window for a search that round 2 still executes against every requested index, where a sibling
+     * index's same-_id doc matches the bare ids clause and inherits the fused score. So qualify unconditionally.
+     */
+    public void testBuildFusedQuery_whenWindowSpansOneIndex_thenTopIsStillQualified() {
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
         MultiSearchResponse ms = multiSearch(legItemFromIndex("idx-a", Map.of("1", 0.9f)), legItemFromIndex("idx-a", Map.of("2", 0.8f)));
 
@@ -333,8 +338,32 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
         assertEquals(2, self.should().size());
         for (QueryBuilder clause : self.should()) {
+            QueryBuilder inner = ((ConstantScoreQueryBuilder) clause).innerQuery();
+            assertTrue("a single-index window must not drop the _index qualification", inner instanceof BoolQueryBuilder);
+            assertEquals("qualified by _id AND _index", 2, ((BoolQueryBuilder) inner).filter().size());
+        }
+    }
+
+    public void testBuildFusedQuery_whenHitsCarryNoIndex_thenTopFallsBackToIdOnlyForEveryClause() {
+        // The array handed to the self-erased query is null-or-fully-populated: a null hole would NPE in
+        // writeOptionalStringArray while serializing the round-2 shard request. Hits with no resolvable _index drop it
+        // wholesale rather than leaving holes.
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItemFromIndex("idx-a", Map.of("2", 0.8f)));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().trackTotalHits(false),
+            ms,
+            legs,
+            minMaxArithmetic(),
+            10
+        );
+
+        BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
+        assertEquals(2, self.should().size());
+        for (QueryBuilder clause : self.should()) {
             assertTrue(
-                "single-index Top clause stays a bare ids query",
+                "one unresolvable index drops qualification for the whole window, not just its own clause",
                 ((ConstantScoreQueryBuilder) clause).innerQuery() instanceof IdsQueryBuilder
             );
         }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -4,8 +4,10 @@
  */
 package org.opensearch.neuralsearch.query;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.ExceptionsHelper;
@@ -58,10 +60,7 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             hit.score(e.getValue());
             hits[i++] = hit;
         }
-        SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
-        SearchResponseSections sections = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
-        SearchResponse response = new SearchResponse(sections, null, 1, 1, 0, 10, ShardSearchFailure.EMPTY_ARRAY, null);
-        return new MultiSearchResponse.Item(response, null);
+        return successfulItem(hits);
     }
 
     /** Like {@link #legItem} but the hits carry an {@code _index}, as real leg responses do. */
@@ -69,11 +68,35 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         SearchHit[] hits = new SearchHit[idToScore.size()];
         int i = 0;
         for (Map.Entry<String, Float> e : idToScore.entrySet()) {
-            SearchHit hit = new SearchHit(i, e.getKey(), Map.of(), Map.of());
-            hit.score(e.getValue());
-            hit.shard(new SearchShardTarget("node-1", new ShardId(new Index(index, index + "-uuid"), 0), null, OriginalIndices.NONE));
-            hits[i++] = hit;
+            hits[i] = hitFrom(i, index, e.getKey(), e.getValue());
+            i++;
         }
+        return successfulItem(hits);
+    }
+
+    /**
+     * One leg whose own hits span several indices — {@code "index/_id" -> score} — which is what a leg of a multi-index
+     * search actually returns. Insertion-ordered so the clause order under assertion is deterministic.
+     */
+    private MultiSearchResponse.Item legItemAcrossIndices(LinkedHashMap<String, Float> indexAndIdToScore) {
+        SearchHit[] hits = new SearchHit[indexAndIdToScore.size()];
+        int i = 0;
+        for (Map.Entry<String, Float> e : indexAndIdToScore.entrySet()) {
+            String[] indexAndId = e.getKey().split("/", 2);
+            hits[i] = hitFrom(i, indexAndId[0], indexAndId[1], e.getValue());
+            i++;
+        }
+        return successfulItem(hits);
+    }
+
+    private SearchHit hitFrom(int docId, String index, String id, float score) {
+        SearchHit hit = new SearchHit(docId, id, Map.of(), Map.of());
+        hit.score(score);
+        hit.shard(new SearchShardTarget("node-1", new ShardId(new Index(index, index + "-uuid"), 0), null, OriginalIndices.NONE));
+        return hit;
+    }
+
+    private MultiSearchResponse.Item successfulItem(SearchHit[] hits) {
         SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
         SearchResponseSections sections = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
         SearchResponse response = new SearchResponse(sections, null, 1, 1, 0, 10, ShardSearchFailure.EMPTY_ARRAY, null);
@@ -453,33 +476,131 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         assertFalse("inner_hits must still be registered for the fetch phase", innerHits.isEmpty());
     }
 
-    // ---- knn/neural leg materialized as Ids in the Tail (no second ANN walk) ----
+    // ---- knn/neural leg materialized in the Tail (no second ANN walk), addressed by _index + _id ----
 
-    public void testBuildFusedQuery_knnLeg_materializedAsIdsInTail() {
-        // A leg whose writeable name is a materializable one ("knn") — its Lucene match set IS its returned top-k, so
-        // legQueriesForTail rewrites it to an IdsQuery in the Tail rather than re-walking the ANN graph. Using a
-        // minimal MatchQuery wrapper reporting name "knn" keeps the test off KNN-internal construction/validation.
-        QueryBuilder knnLeg = new MatchQueryBuilder("vec", "q") {
+    /** A leg reporting a materializable writeable name, without touching KNN-internal construction/validation. */
+    private QueryBuilder legNamed(String writeableName) {
+        return new MatchQueryBuilder("vec", "q") {
             @Override
             public String getWriteableName() {
-                return "knn";
+                return writeableName;
             }
         };
-        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), knnLeg);
-        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f, "3", 0.7f)));
-        // aggregation forces Tail retention so we can inspect leg materialization.
-        SearchSourceBuilder source = new SearchSourceBuilder().aggregation(
-            org.opensearch.search.aggregations.AggregationBuilders.terms("t").field("f")
+    }
+
+    /** An aggregation is the cheapest Tail trigger, so the materialized leg is there to inspect. */
+    private SearchSourceBuilder sourceWithAggregation() {
+        return new SearchSourceBuilder().aggregation(org.opensearch.search.aggregations.AggregationBuilders.terms("t").field("f"));
+    }
+
+    private BoolQueryBuilder tailOf(QueryBuilder fused) {
+        return (BoolQueryBuilder) ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().get(0);
+    }
+
+    /** Asserts a clause addresses exactly these ids inside exactly this index. */
+    private void assertAddressedTo(QueryBuilder clause, String index, String... ids) {
+        assertTrue("expected an _index-qualified bool, got " + clause, clause instanceof BoolQueryBuilder);
+        BoolQueryBuilder qualified = (BoolQueryBuilder) clause;
+        assertEquals("qualified by _id AND _index", 2, qualified.filter().size());
+        assertEquals(Set.of(ids), ((IdsQueryBuilder) qualified.filter().get(0)).ids());
+        TermQueryBuilder indexTerm = (TermQueryBuilder) qualified.filter().get(1);
+        assertEquals("_index", indexTerm.fieldName());
+        assertEquals(index, indexTerm.value());
+    }
+
+    public void testBuildFusedQuery_knnLeg_materializedAsQualifiedDocsInTail() {
+        // A materializable leg's Lucene match set IS its returned top-k, so legQueriesForTail replaces it with a direct
+        // address of those hits rather than re-walking the ANN graph — and addresses them by _index + _id, because the
+        // Tail is a filter and therefore decides the match set.
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), legNamed("knn"));
+        MultiSearchResponse ms = multiSearch(
+            legItemFromIndex(INDEX, Map.of("1", 0.9f)),
+            legItemFromIndex(INDEX, Map.of("2", 0.8f, "3", 0.7f))
         );
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(sourceWithAggregation(), ms, legs, minMaxArithmetic(), 10);
+
+        BoolQueryBuilder tail = tailOf(fused);
+        assertEquals(2, tail.should().size());
+        assertEquals("the lexical leg stays a real query", legs.get(0), tail.should().get(0));
+        assertAddressedTo(tail.should().get(1), INDEX, "2", "3");
+    }
+
+    /**
+     * The blocker this guards. A leg of a multi-index search returns hits from several indices, and each id must be
+     * addressed inside the index it came from. Addressed by {@code _id} alone, every same-{@code _id} sibling document in
+     * the other index passed the Tail filter — counted into {@code total_hits}, into every aggregation bucket, and
+     * returned as a score-0 hit — which inflates exactly the numbers the Tail exists to make correct. Qualifying the Top
+     * did not help: the Tail was built straight from the leg hits, never from the ranked window's resolved indices.
+     */
+    public void testBuildFusedQuery_whenKnnLegSpansTwoIndices_thenTailAddressesEachIndexSeparately() {
+        LinkedHashMap<String, Float> knnHits = new LinkedHashMap<>();
+        knnHits.put("idx-a/1", 0.9f);
+        knnHits.put("idx-a/2", 0.8f);
+        knnHits.put("idx-b/1", 0.7f);
+        List<QueryBuilder> legs = List.of(legNamed("knn"));
+        MultiSearchResponse ms = multiSearch(legItemAcrossIndices(knnHits));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(sourceWithAggregation(), ms, legs, minMaxArithmetic(), 10);
+
+        BoolQueryBuilder tail = tailOf(fused);
+        assertEquals(1, tail.should().size());
+        BoolQueryBuilder perIndex = (BoolQueryBuilder) tail.should().get(0);
+        assertEquals("one qualified clause per index the leg returned hits from", 2, perIndex.should().size());
+        assertAddressedTo(perIndex.should().get(0), "idx-a", "1", "2");
+        assertAddressedTo(perIndex.should().get(1), "idx-b", "1");
+        assertTrue(
+            "no clause may address an _id without its _index",
+            perIndex.should().stream().noneMatch(clause -> clause instanceof IdsQueryBuilder)
+        );
+    }
+
+    /**
+     * The Top and the Tail must identify a document the same way — they are the scoring half and the matching half of one
+     * query, and a Tail narrower than the Top would filter away the very documents the Top scored. Both go through
+     * {@link HybridFusionQueryBuilder#addressDocuments}, so this compares the two builders directly rather than
+     * re-describing the shape.
+     */
+    public void testBuildFusedQuery_whenLegIsMaterialized_thenTopAndTailAddressTheDocumentIdentically() {
+        List<QueryBuilder> legs = List.of(legNamed("knn"));
+        MultiSearchResponse ms = multiSearch(legItemFromIndex(INDEX, Map.of("1", 0.9f)));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(sourceWithAggregation(), ms, legs, minMaxArithmetic(), 10);
 
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
-        BoolQueryBuilder tail = (BoolQueryBuilder) self.filter().get(0);
+        QueryBuilder topAddress = ((ConstantScoreQueryBuilder) self.should().get(0)).innerQuery();
+        QueryBuilder tailAddress = ((BoolQueryBuilder) self.filter().get(0)).should().get(0);
+        assertEquals("Top and Tail must address the same document identically", topAddress, tailAddress);
+    }
+
+    public void testBuildFusedQuery_whenKnnLegHitsCarryNoIndex_thenTailFallsBackToIdsOnly() {
+        // Defensive parity with documentKey and the Top: a hit with no resolvable _index is addressed by _id alone rather
+        // than failing or dropping the leg.
+        List<QueryBuilder> legs = List.of(legNamed("knn"));
+        MultiSearchResponse ms = multiSearch(legItem(Map.of("2", 0.8f, "3", 0.7f)));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(sourceWithAggregation(), ms, legs, minMaxArithmetic(), 10);
+
+        QueryBuilder legClause = tailOf(fused).should().get(0);
+        assertTrue("no index to qualify with → bare ids, not a bool", legClause instanceof IdsQueryBuilder);
+        assertEquals(Set.of("2", "3"), ((IdsQueryBuilder) legClause).ids());
+    }
+
+    /**
+     * An ANN leg that matched nothing must keep matching nothing. {@code bool{should: []}} compiles to
+     * {@code MatchAllDocsQuery}, so an empty leg rendered as an empty bool would make the Tail match every document in the
+     * index — total_hits and every aggregation would report the whole corpus. The bare ids query this replaced was only
+     * accidentally safe (core rewrites an empty ids query to {@code match_none}), so the guard is explicit here.
+     */
+    public void testBuildFusedQuery_whenKnnLegReturnedNothing_thenTailClauseIsMatchNoneNotMatchAll() {
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), legNamed("knn"));
+        MultiSearchResponse ms = multiSearch(legItemFromIndex(INDEX, Map.of("1", 0.9f)), legItemFromIndex(INDEX, Map.of()));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(sourceWithAggregation(), ms, legs, minMaxArithmetic(), 10);
+
+        BoolQueryBuilder tail = tailOf(fused);
         assertEquals(2, tail.should().size());
-        // lexical leg stays a real query; knn/neural leg is materialized as an IdsQuery of its returned hits.
-        long idsClauses = tail.should().stream().filter(q -> q instanceof IdsQueryBuilder).count();
-        assertEquals("knn leg materialized as IdsQuery", 1, idsClauses);
+        assertTrue("an empty ANN leg must be match_none, never an empty bool", tail.should().get(1) instanceof MatchNoneQueryBuilder);
     }
 
     // ---- weighted combination + highlight/totals tail triggers (explain/profile do NOT trigger the Tail) ----
@@ -552,24 +673,13 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         assertEquals(1, ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().size());
     }
 
-    public void testBuildFusedQuery_neuralNamedLeg_materializedAsIds() {
-        // "neural" is also a materializable name → its leg is materialized to IdsQuery in the Tail (not re-walked).
-        QueryBuilder neuralLeg = new MatchQueryBuilder("vec", "q") {
-            @Override
-            public String getWriteableName() {
-                return "neural";
-            }
-        };
-        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), neuralLeg);
-        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
-        SearchSourceBuilder source = new SearchSourceBuilder().aggregation(
-            org.opensearch.search.aggregations.AggregationBuilders.terms("t").field("f")
-        );
+    public void testBuildFusedQuery_neuralNamedLeg_materializedAsQualifiedDocs() {
+        // "neural" is also a materializable name → its leg is addressed by its returned hits in the Tail, not re-walked.
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), legNamed("neural"));
+        MultiSearchResponse ms = multiSearch(legItemFromIndex(INDEX, Map.of("1", 0.9f)), legItemFromIndex(INDEX, Map.of("2", 0.8f)));
 
-        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(sourceWithAggregation(), ms, legs, minMaxArithmetic(), 10);
 
-        BoolQueryBuilder tail = (BoolQueryBuilder) ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().get(0);
-        long idsClauses = tail.should().stream().filter(q -> q instanceof IdsQueryBuilder).count();
-        assertEquals("neural leg materialized as IdsQuery", 1, idsClauses);
+        assertAddressedTo(tailOf(fused).should().get(1), INDEX, "2");
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -32,9 +32,11 @@ import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.collapse.CollapseBuilder;
 import org.opensearch.search.pipeline.SearchPipelineService;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -224,6 +226,34 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
 
         BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
         assertEquals("_score sort → still plain top-K, no Tail", 0, self.filter().size());
+    }
+
+    public void testBuildFusedQuery_whenCollapseInnerHits_keepsTail() {
+        // collapse.inner_hits makes core re-run THIS query once per group, filtered to the group key. A group's members
+        // are whatever shares that key — unrelated to the fused window — so with Top only every member that ranked outside
+        // the window matches nothing and silently vanishes from the expansion, where classic hybrid returns all of them.
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
+        SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false)
+            .collapse(new CollapseBuilder("grp").setInnerHits(new InnerHitBuilder("members")));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
+
+        BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
+        assertEquals("collapse.inner_hits → Tail retained so a group expands to all of its members", 1, self.filter().size());
+    }
+
+    public void testBuildFusedQuery_whenCollapseWithoutInnerHits_staysTopOnly() {
+        // Plain collapse groups the documents round 2 already returns — core runs no expansion search at all — so it must
+        // not drag in a Tail the request did not ask for.
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
+        SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false).collapse(new CollapseBuilder("grp"));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
+
+        BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
+        assertEquals("collapse grouping alone → still plain top-K, no Tail", 0, self.filter().size());
     }
 
     public void testBuildFusedQuery_emptyResult_matchNone() {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -8,15 +8,20 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.search.TotalHits;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
+import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.OriginalIndices;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.search.SearchShardTarget;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -77,6 +82,11 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
 
     private MultiSearchResponse.Item failedItem() {
         return new MultiSearchResponse.Item(null, new RuntimeException("leg boom"));
+    }
+
+    /** A wholly-failed leg whose failure carries a specific status, the way a real sub-search failure does. */
+    private MultiSearchResponse.Item failedItemWithCause(Exception cause) {
+        return new MultiSearchResponse.Item(null, cause);
     }
 
     /** A SUCCESSFUL MultiSearch item that lost a shard under allow_partial=true: HTTP 200, fewer hits, non-empty
@@ -227,8 +237,8 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
         MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f, "2", 0.5f)), failedItem());
 
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
+        OpenSearchStatusException e = expectThrows(
+            OpenSearchStatusException.class,
             () -> HybridFusionOrchestrator.buildFusedQuery(
                 new SearchSourceBuilder().trackTotalHits(false),
                 ms,
@@ -240,6 +250,8 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         assertTrue("reports the failing leg index", e.getMessage().contains("fused-mode sub-query 1 failed"));
         assertNotNull("chains the leg failure as cause", e.getCause());
         assertTrue(e.getCause().getMessage().contains("leg boom"));
+        // A bare RuntimeException really is a server error, so 500 here is the derived status, not a default.
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, e.status());
     }
 
     public void testBuildFusedQuery_whenAllLegsFailed_thenFailsFast() {
@@ -247,12 +259,55 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
         MultiSearchResponse ms = multiSearch(failedItem(), failedItem());
 
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
+        OpenSearchStatusException e = expectThrows(
+            OpenSearchStatusException.class,
             () -> HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10)
         );
         assertTrue(e.getMessage().contains("fused-mode sub-query 0 failed"));
         assertNotNull(e.getCause());
+    }
+
+    /**
+     * A leg failure must keep the status the leg itself reported. The user's own mistake — say a malformed range bound,
+     * which classic hybrid answers with 400 {@code query_shard_exception} — was arriving as a 500 because the wrapper was
+     * an {@code IllegalStateException} and {@code ExceptionsHelper#status} has no case for it, leaving the real status
+     * reachable only under {@code caused_by}.
+     */
+    public void testBuildFusedQuery_whenLegFailedWithClientError_thenStatusStaysBadRequest() {
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(
+            legItem(Map.of("1", 0.9f)),
+            failedItemWithCause(
+                new SearchPhaseExecutionException(
+                    "query",
+                    "all shards failed",
+                    new ShardSearchFailure[] { new ShardSearchFailure(new IllegalArgumentException("bad range bound")) }
+                )
+            )
+        );
+
+        OpenSearchStatusException e = expectThrows(
+            OpenSearchStatusException.class,
+            () -> HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10)
+        );
+        assertEquals("the leg's own 400 must survive the wrapper", RestStatus.BAD_REQUEST, e.status());
+        assertEquals("and the status a REST layer derives must agree", RestStatus.BAD_REQUEST, ExceptionsHelper.status(e));
+    }
+
+    /** Same for a queue rejection: masking 429 as 500 means a client's retry-on-429 never fires. */
+    public void testBuildFusedQuery_whenLegRejected_thenStatusStaysTooManyRequests() {
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(
+            legItem(Map.of("1", 0.9f)),
+            failedItemWithCause(new OpenSearchRejectedExecutionException("search queue full"))
+        );
+
+        OpenSearchStatusException e = expectThrows(
+            OpenSearchStatusException.class,
+            () -> HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder(), ms, legs, minMaxArithmetic(), 10)
+        );
+        assertEquals(RestStatus.TOO_MANY_REQUESTS, e.status());
+        assertEquals(RestStatus.TOO_MANY_REQUESTS, ExceptionsHelper.status(e));
     }
 
     public void testBuildFusedQuery_whenLegPartiallyFailed_thenFusedWithWarning() {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -14,6 +14,11 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.action.OriginalIndices;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
+import org.opensearch.search.SearchShardTarget;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.IdsQueryBuilder;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
@@ -48,6 +53,22 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         for (Map.Entry<String, Float> e : idToScore.entrySet()) {
             SearchHit hit = new SearchHit(i, e.getKey(), Map.of(), Map.of());
             hit.score(e.getValue());
+            hits[i++] = hit;
+        }
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponseSections sections = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
+        SearchResponse response = new SearchResponse(sections, null, 1, 1, 0, 10, ShardSearchFailure.EMPTY_ARRAY, null);
+        return new MultiSearchResponse.Item(response, null);
+    }
+
+    /** Like {@link #legItem} but the hits carry an {@code _index}, as real leg responses do. */
+    private MultiSearchResponse.Item legItemFromIndex(String index, Map<String, Float> idToScore) {
+        SearchHit[] hits = new SearchHit[idToScore.size()];
+        int i = 0;
+        for (Map.Entry<String, Float> e : idToScore.entrySet()) {
+            SearchHit hit = new SearchHit(i, e.getKey(), Map.of(), Map.of());
+            hit.score(e.getValue());
+            hit.shard(new SearchShardTarget("node-1", new ShardId(new Index(index, index + "-uuid"), 0), null, OriginalIndices.NONE));
             hits[i++] = hit;
         }
         SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
@@ -285,6 +306,84 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
 
         HybridFusionOrchestrator.buildFusedQuery(new SearchSourceBuilder().trackTotalHits(false), ms, legs, minMaxArithmetic(), 10);
+    }
+
+    // ---- document identity: _index + _id ----
+
+    public void testBuildFusedQuery_whenSameIdInDifferentIndices_thenNotConflated() {
+        // The bug this guards: keying on _id alone made a doc in idx-a and a DIFFERENT doc in idx-b with the same _id
+        // fuse as one entity, and the self-erased _id Top then boosted both to that one score. Keyed by _index + _id they
+        // stay two documents, and each Top clause is index-qualified so a score lands on exactly one of them.
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItemFromIndex("idx-a", Map.of("1", 0.9f)), legItemFromIndex("idx-b", Map.of("1", 0.8f)));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().trackTotalHits(false),
+            ms,
+            legs,
+            minMaxArithmetic(),
+            10
+        );
+
+        BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
+        assertEquals("same _id in two indices stays two distinct fused docs", 2, self.should().size());
+        for (QueryBuilder clause : self.should()) {
+            QueryBuilder inner = ((ConstantScoreQueryBuilder) clause).innerQuery();
+            assertTrue("multi-index Top clause must be index-qualified", inner instanceof BoolQueryBuilder);
+            assertEquals("qualified by _id AND _index", 2, ((BoolQueryBuilder) inner).filter().size());
+        }
+    }
+
+    public void testBuildFusedQuery_whenSingleIndex_thenTopStaysIdOnly() {
+        // Single-index searches need no disambiguation, so they keep the leaner ids-only clause (and its original cost).
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItemFromIndex("idx-a", Map.of("1", 0.9f)), legItemFromIndex("idx-a", Map.of("2", 0.8f)));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().trackTotalHits(false),
+            ms,
+            legs,
+            minMaxArithmetic(),
+            10
+        );
+
+        BoolQueryBuilder self = ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery();
+        assertEquals(2, self.should().size());
+        for (QueryBuilder clause : self.should()) {
+            assertTrue(
+                "single-index Top clause stays a bare ids query",
+                ((ConstantScoreQueryBuilder) clause).innerQuery() instanceof IdsQueryBuilder
+            );
+        }
+    }
+
+    // ---- inner_hits are registered without executing the legs ----
+
+    public void testBuildFusedQuery_whenLegHasInnerHits_thenRegisteredWithoutTail() {
+        // inner_hits are built in the fetch phase from the registered contexts, so a leg only needs to be REGISTERED,
+        // never executed. With track_total_hits:false and no aggs there is nothing else needing the Tail, so the query
+        // stays Top-only (no redundant leg re-execution) while inner_hits are still extractable.
+        QueryBuilder nestedLeg = new org.opensearch.index.query.NestedQueryBuilder(
+            "user",
+            new MatchQueryBuilder("user.name", "alice"),
+            org.apache.lucene.search.join.ScoreMode.None
+        ).innerHit(new org.opensearch.index.query.InnerHitBuilder());
+        List<QueryBuilder> legs = List.of(nestedLeg, new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)));
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().trackTotalHits(false),
+            ms,
+            legs,
+            minMaxArithmetic(),
+            10
+        );
+
+        HybridFusionQueryBuilder fusedBuilder = (HybridFusionQueryBuilder) fused;
+        assertEquals("leg inner_hits no longer force the Tail", 0, fusedBuilder.buildSelfErasedQuery().filter().size());
+        Map<String, org.opensearch.index.query.InnerHitContextBuilder> innerHits = new java.util.HashMap<>();
+        fusedBuilder.extractInnerHitBuilders(innerHits);
+        assertFalse("inner_hits must still be registered for the fetch phase", innerHits.isEmpty());
     }
 
     // ---- knn/neural leg materialized as Ids in the Tail (no second ANN walk) ----

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilderTests.java
@@ -23,8 +23,22 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
     }
 
     public void testWriteableName() {
-        HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(new String[] { "d1" }, new float[] { 1.0f }, List.of());
+        HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(
+            new String[] { "d1" },
+            new String[] { "idx" },
+            new float[] { 1.0f },
+            List.of()
+        );
         assertEquals("hybrid_fusion", query.getWriteableName());
+    }
+
+    public void testIndicesAreRequired() {
+        // A fused document is addressed by _index and _id together; there is no unqualified form of this query, so a
+        // caller that lost the per-doc index fails here rather than silently addressing every same-_id document.
+        expectThrows(
+            NullPointerException.class,
+            () -> new HybridFusionQueryBuilder(new String[] { "d1" }, null, new float[] { 1.0f }, List.of())
+        );
     }
 
     public void testNotParseableFromXContent() {
@@ -35,6 +49,7 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
     public void testSerializationRoundTrip() throws Exception {
         HybridFusionQueryBuilder original = new HybridFusionQueryBuilder(
             new String[] { "d1", "d2" },
+            new String[] { "idx", "idx" },
             new float[] { 0.9f, 0.4f },
             List.of(new MatchQueryBuilder("title", "apple"), new MatchQueryBuilder("body", "banana"))
         );
@@ -46,6 +61,7 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
     public void testSelfErasedShape_whenSourceQueriesPresent_thenTopPlusTail() {
         HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(
             new String[] { "d1", "d2" },
+            new String[] { "idx", "idx" },
             new float[] { 0.9f, 0.4f },
             List.of(new MatchQueryBuilder("title", "apple"), new MatchQueryBuilder("body", "banana"))
         );
@@ -60,7 +76,12 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
     }
 
     public void testSelfErasedShape_whenNoSourceQueries_thenTopOnly() {
-        HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(new String[] { "d1", "d2" }, new float[] { 0.9f, 0.4f }, List.of());
+        HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(
+            new String[] { "d1", "d2" },
+            new String[] { "idx", "idx" },
+            new float[] { 0.9f, 0.4f },
+            List.of()
+        );
         BoolQueryBuilder self = query.buildSelfErasedQuery();
         assertEquals(2, self.should().size());
         assertEquals("Top-only fused query carries no Tail filter", 0, self.filter().size());
@@ -68,7 +89,7 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
 
     public void testSelfErasedShape_whenEmptyWindow_thenEmptyBool() {
         // An empty fused window produces an empty bool (no should, no filter) → compiles to match-no-docs.
-        HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(new String[0], new float[0], List.of());
+        HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(new String[0], new String[0], new float[0], List.of());
         BoolQueryBuilder self = query.buildSelfErasedQuery();
         assertEquals(0, self.should().size());
         assertEquals(0, self.filter().size());
@@ -77,6 +98,7 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
     public void testDoXContent_isInformationalOnly() throws Exception {
         HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(
             new String[] { "d1", "d2", "d3" },
+            new String[] { "idx", "idx", "idx" },
             new float[] { 0.9f, 0.5f, 0.1f },
             List.of()
         );
@@ -92,6 +114,7 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
         // Tail source queries that don't rewrite (already terminal term queries) → doRewrite returns the same instance.
         HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(
             new String[] { "d1" },
+            new String[] { "idx" },
             new float[] { 0.7f },
             List.of(new org.opensearch.index.query.TermQueryBuilder("text", "keyword"))
         );
@@ -110,6 +133,7 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
         };
         HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(
             new String[] { "d1", "d2" },
+            new String[] { "idx", "idx" },
             new float[] { 0.7f, 0.3f },
             List.of(alwaysRewrites)
         );
@@ -130,7 +154,12 @@ public class HybridFusionQueryBuilderTests extends OpenSearchTestCase {
             new org.opensearch.index.query.MatchQueryBuilder("user.name", "alice"),
             org.apache.lucene.search.join.ScoreMode.None
         ).innerHit(new org.opensearch.index.query.InnerHitBuilder());
-        HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(new String[] { "d1" }, new float[] { 0.9f }, List.of(nested));
+        HybridFusionQueryBuilder query = new HybridFusionQueryBuilder(
+            new String[] { "d1" },
+            new String[] { "idx" },
+            new float[] { 0.9f },
+            List.of(nested)
+        );
 
         java.util.Map<String, org.opensearch.index.query.InnerHitContextBuilder> innerHits = new java.util.HashMap<>();
         query.extractInnerHitBuilders(innerHits);

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -705,9 +705,32 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     }
 
     @SneakyThrows
+    public void testDoRewriteFused_whenRequestShapeIsUnsupported_thenRefusesBeforeTheFanOut() {
+        // A refusal must cost less than the search it replaces: CandidateScope validates before registerAsyncAction, so
+        // an unsupported request shape never burns a leg MultiSearch. terminate_after stands in for the whole
+        // REJECTED set; the per-field messages are covered in CandidateScopeTests.
+        initClusterUtilWithMaxResultWindow(10000);
+        HybridQueryBuilder builder = fusedBuilder(new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"))));
+        SearchRequest searchRequest = new SearchRequest("test-index").source(new SearchSourceBuilder().query(builder).terminateAfter(100));
+        QueryCoordinatorContext ctx = mock(QueryCoordinatorContext.class);
+        when(ctx.convertToCoordinatorContext()).thenReturn(ctx);
+        when(ctx.getSearchRequest()).thenReturn(searchRequest);
+        java.util.concurrent.atomic.AtomicInteger asyncRegistered = new java.util.concurrent.atomic.AtomicInteger();
+        doAnswer(invocation -> {
+            asyncRegistered.incrementAndGet();
+            return null;
+        }).when(ctx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> builder.doRewrite(ctx));
+
+        assertThat(e.getMessage(), containsString("does not support [terminate_after]"));
+        assertEquals("the refusal must precede the leg fan-out", 0, asyncRegistered.get());
+    }
+
+    @SneakyThrows
     public void testDoRewriteFused_whenWindowSizeInFusion_thenSupportedAndRegisters() {
         // A fusion block carrying window_size + supported techniques resolves and registers without error (the leg
-        // size wiring itself is asserted in HybridFusionOrchestratorTests#testBuildLegMultiSearch_perLegSourceShape).
+        // request shape itself is asserted in CandidateScopeTests).
         initClusterUtilWithMaxResultWindow(10000);
         HybridQueryBuilder withWindow = fusedBuilder(
             new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"), "window_size", 25))
@@ -798,7 +821,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         FusionSpec resolved = new FusionSpec(FusionSpec.TECHNIQUE_ARITHMETIC_MEAN, FusionSpec.NORMALIZATION_MIN_MAX, 60, new float[0]);
 
         org.opensearch.action.search.MultiSearchRequest fannedOut = HybridFusionOrchestrator.buildLegMultiSearch(
-            userRequest,
+            CandidateScope.from(userRequest),
             HybridQueryBuilder.projectResolvedConfigOntoLegs(outer.queries(), resolved),
             10
         );
@@ -821,7 +844,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
 
         // Negative control: the same nested leg WITHOUT the projected config still cannot resolve, and now says why.
         org.opensearch.action.search.MultiSearchRequest unprojected = HybridFusionOrchestrator.buildLegMultiSearch(
-            userRequest,
+            CandidateScope.from(userRequest),
             outer.queries(),
             10
         );

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -749,6 +749,93 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertThat(e.getMessage(), containsString("requires a normalization or score-ranker processor"));
     }
 
+    /** An outer fused hybrid whose first leg is itself a fused hybrid taking its config from the pipeline. */
+    private HybridQueryBuilder outerWithNestedFusedLeg() {
+        HybridQueryBuilder nested = new HybridQueryBuilder();
+        nested.add(new MatchQueryBuilder(TEXT_FIELD_NAME, "inner-a"));
+        nested.add(new MatchQueryBuilder(TEXT_FIELD_NAME, "inner-b"));
+        nested.fusion(new HashMap<>()); // fusion:{} → no inline config, must come from the pipeline
+        HybridQueryBuilder outer = new HybridQueryBuilder();
+        outer.add(nested);
+        outer.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
+        outer.fusion(new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"))));
+        return outer;
+    }
+
+    @SneakyThrows
+    public void testProjectResolvedConfigOntoLegs_projectsOnlyFusedLegsWithoutInlineConfig() {
+        FusionSpec resolved = new FusionSpec(FusionSpec.TECHNIQUE_ARITHMETIC_MEAN, FusionSpec.NORMALIZATION_MIN_MAX, 60, new float[0]);
+
+        // A fused leg with no inline config is substituted by an equal-but-distinct copy carrying the resolved config.
+        List<QueryBuilder> legs = outerWithNestedFusedLeg().queries();
+        List<QueryBuilder> projected = HybridQueryBuilder.projectResolvedConfigOntoLegs(legs, resolved);
+        assertNotSame("a projectable leg forces a new list", legs, projected);
+        assertNotSame("the fused leg is replaced by a copy", legs.get(0), projected.get(0));
+        assertEquals("the copy is wire/equality-identical to the original leg", legs.get(0), projected.get(0));
+        assertSame("non-hybrid legs are left alone", legs.get(1), projected.get(1));
+
+        // Nothing to project: an inline-config fused leg and a plain leg both stay put, and the list is not copied.
+        HybridQueryBuilder inlineNested = new HybridQueryBuilder();
+        inlineNested.add(new MatchQueryBuilder(TEXT_FIELD_NAME, "inner"));
+        inlineNested.fusion(new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"))));
+        List<QueryBuilder> noneProjectable = List.of(inlineNested, QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
+        assertSame(
+            "no projectable leg → the original list is reused",
+            noneProjectable,
+            HybridQueryBuilder.projectResolvedConfigOntoLegs(noneProjectable, resolved)
+        );
+    }
+
+    @SneakyThrows
+    public void testDoRewriteFused_whenNestedFusedLegOnPipelineDisabledLegRequest_thenInheritsResolvedConfig() {
+        // The blocker: legs are fanned out with pipeline=_none so per-leg processors do not run, so a nested fused
+        // hybrid could resolve no config from its own leg request and failed claiming the user had no pipeline.
+        // Drive the REAL leg-request builder, then rewrite the nested leg exactly as the leg sub-search would.
+        initClusterUtilWithNoPipeline();
+        HybridQueryBuilder outer = outerWithNestedFusedLeg();
+        SearchRequest userRequest = new SearchRequest("test-index").source(new SearchSourceBuilder().query(outer))
+            .pipeline("norm-pipeline");
+        FusionSpec resolved = new FusionSpec(FusionSpec.TECHNIQUE_ARITHMETIC_MEAN, FusionSpec.NORMALIZATION_MIN_MAX, 60, new float[0]);
+
+        org.opensearch.action.search.MultiSearchRequest fannedOut = HybridFusionOrchestrator.buildLegMultiSearch(
+            userRequest,
+            HybridQueryBuilder.projectResolvedConfigOntoLegs(outer.queries(), resolved),
+            10
+        );
+        SearchRequest legRequest = fannedOut.requests().get(0);
+        assertEquals("leg sub-searches run with the search pipeline disabled", "_none", legRequest.pipeline());
+
+        QueryCoordinatorContext legCtx = mock(QueryCoordinatorContext.class);
+        when(legCtx.convertToCoordinatorContext()).thenReturn(legCtx);
+        when(legCtx.getSearchRequest()).thenReturn(legRequest);
+        java.util.concurrent.atomic.AtomicInteger asyncRegistered = new java.util.concurrent.atomic.AtomicInteger();
+        doAnswer(invocation -> {
+            asyncRegistered.incrementAndGet();
+            return null;
+        }).when(legCtx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
+
+        QueryBuilder rewritten = legRequest.source().query().rewrite(legCtx);
+
+        assertEquals("the nested fused leg fans out its own legs instead of failing", 1, asyncRegistered.get());
+        assertTrue(rewritten instanceof HybridQueryBuilder);
+
+        // Negative control: the same nested leg WITHOUT the projected config still cannot resolve, and now says why.
+        org.opensearch.action.search.MultiSearchRequest unprojected = HybridFusionOrchestrator.buildLegMultiSearch(
+            userRequest,
+            outer.queries(),
+            10
+        );
+        QueryCoordinatorContext bareCtx = mock(QueryCoordinatorContext.class);
+        when(bareCtx.convertToCoordinatorContext()).thenReturn(bareCtx);
+        when(bareCtx.getSearchRequest()).thenReturn(unprojected.requests().get(0));
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> unprojected.requests().get(0).source().query().rewrite(bareCtx)
+        );
+        assertThat(e.getMessage(), containsString("must carry an inline [fusion] config"));
+        assertThat(e.getMessage(), containsString("leg sub-search runs with the search pipeline disabled"));
+    }
+
     @SneakyThrows
     public void testDoRewriteFused_whenSearchRequestNotResolvable_thenReturnsThis() {
         // If the coordinator context's request is not a SearchRequest, doRewriteFused is a no-op (returns itself).

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -882,13 +882,25 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertSame(builder, builder.doRewrite(ctx));
     }
 
-    /** A MultiSearch item wrapping a SearchResponse whose hits carry the given (_id -> score) pairs. */
+    /**
+     * A MultiSearch item wrapping a SearchResponse whose hits carry the given (_id -> score) pairs. Each hit is given a
+     * shard target, which is how a real coordinator-side hit gets its {@code _index} — fusion identifies a document by
+     * {@code _index} plus {@code _id} and rejects a hit that carries no index.
+     */
     private org.opensearch.action.search.MultiSearchResponse.Item legItem(Map<String, Float> idToScore) {
         org.opensearch.search.SearchHit[] hits = new org.opensearch.search.SearchHit[idToScore.size()];
         int i = 0;
         for (Map.Entry<String, Float> e : idToScore.entrySet()) {
             org.opensearch.search.SearchHit hit = new org.opensearch.search.SearchHit(i, e.getKey(), Map.of(), Map.of());
             hit.score(e.getValue());
+            hit.shard(
+                new org.opensearch.search.SearchShardTarget(
+                    "node-1",
+                    new org.opensearch.core.index.shard.ShardId(new Index("test-index", "test-index-uuid"), 0),
+                    null,
+                    org.opensearch.action.OriginalIndices.NONE
+                )
+            );
             hits[i++] = hit;
         }
         org.opensearch.search.SearchHits searchHits = new org.opensearch.search.SearchHits(

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -746,6 +746,16 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertEquals(1, asyncRegistered.get());
     }
 
+    /**
+     * The cluster's minimum node version, which the fused rewrite reads before anything else about the request. Every
+     * helper below stubs it: without it {@code getMinNodeVersion()} answers null on a mock and the guardrail NPEs.
+     */
+    private static void stubClusterMinVersion(final org.opensearch.cluster.ClusterState clusterState, final Version minNodeVersion) {
+        org.opensearch.cluster.node.DiscoveryNodes nodes = mock(org.opensearch.cluster.node.DiscoveryNodes.class);
+        when(clusterState.getNodes()).thenReturn(nodes);
+        when(nodes.getMinNodeVersion()).thenReturn(minNodeVersion);
+    }
+
     /** Initialize NeuralSearchClusterUtil with a cluster state that resolves NO pipeline (empty metadata, no default). */
     private void initClusterUtilWithNoPipeline() {
         org.opensearch.cluster.metadata.Metadata metadata = mock(org.opensearch.cluster.metadata.Metadata.class);
@@ -754,6 +764,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         when(clusterState.metadata()).thenReturn(metadata);
         when(clusterState.getMetadata()).thenReturn(metadata);
+        stubClusterMinVersion(clusterState, Version.CURRENT);
         org.opensearch.cluster.metadata.IndexNameExpressionResolver resolver = mock(
             org.opensearch.cluster.metadata.IndexNameExpressionResolver.class
         );
@@ -1021,6 +1032,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         when(clusterState.metadata()).thenReturn(metadata);
         when(clusterState.getMetadata()).thenReturn(metadata);
+        stubClusterMinVersion(clusterState, Version.CURRENT);
         when(metadata.custom(org.opensearch.search.pipeline.SearchPipelineMetadata.TYPE)).thenReturn(
             new org.opensearch.search.pipeline.SearchPipelineMetadata(Map.of())
         );
@@ -1052,6 +1064,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         when(clusterState.metadata()).thenReturn(metadata);
         when(clusterState.getMetadata()).thenReturn(metadata);
+        stubClusterMinVersion(clusterState, Version.CURRENT);
         when(metadata.custom(org.opensearch.search.pipeline.SearchPipelineMetadata.TYPE)).thenReturn(
             new org.opensearch.search.pipeline.SearchPipelineMetadata(Map.of())
         );

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -975,9 +975,10 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     }
 
     @SneakyThrows
-    public void testDoRewriteFused_whenMultiSearchTransportFails_thenErrorIsHybridFramed() {
+    public void testDoRewriteFused_whenMultiSearchTransportFails_thenErrorIsHybridFramedAndKeepsStatus() {
         // Whole-MultiSearch transport failure (not a per-leg Item failure) is reframed as the user's hybrid/fused query
-        // instead of surfacing a bare multiSearch error.
+        // instead of surfacing a bare multiSearch error — while keeping the underlying status, so a rejected fan-out is
+        // still the retryable 429 it was and not an opaque 500.
         initClusterUtilWithMaxResultWindow(10000);
         HybridQueryBuilder builder = fusedBuilder(
             new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"), "combination", Map.of("technique", "arithmetic_mean")))
@@ -996,7 +997,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         org.opensearch.transport.client.Client client = mock(org.opensearch.transport.client.Client.class);
         doAnswer(invocation -> {
             org.opensearch.core.action.ActionListener<org.opensearch.action.search.MultiSearchResponse> l = invocation.getArgument(1);
-            l.onFailure(new RuntimeException("msearch rejected"));
+            l.onFailure(new org.opensearch.core.concurrency.OpenSearchRejectedExecutionException("msearch rejected"));
             return null;
         }).when(client).multiSearch(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
 
@@ -1005,6 +1006,11 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertNotNull(failure.get());
         assertThat(failure.get().getMessage(), containsString("failed to execute fused-mode sub-queries"));
         assertThat(failure.get().getMessage(), containsString("msearch rejected"));
+        assertEquals(
+            "a rejected fan-out must stay a 429 so client retry-on-429 fires",
+            org.opensearch.core.rest.RestStatus.TOO_MANY_REQUESTS,
+            org.opensearch.ExceptionsHelper.status(failure.get())
+        );
     }
 
     /** Initialize NeuralSearchClusterUtil so getIndexMetadataList resolves the given number of concrete indices. */

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -1092,6 +1093,52 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         }).when(ctx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
         builder.doRewrite(ctx);
         assertEquals(1, asyncRegistered.get());
+    }
+
+    @SneakyThrows
+    public void testDoRewriteFused_whenWindowSizeExceedsMaxClauseCount_thenFailsFast() {
+        // The self-erased query holds one bool clause per ranked doc, so window_size is bounded by Lucene's clause ceiling
+        // as well — a much lower limit than max_result_window, and the only one that would otherwise be discovered at query
+        // time on every shard. Set to a non-default value so this also pins that the check reads the live static (which
+        // SearchService keeps in sync with the dynamic indices.query.bool.max_clause_count setting) and not a constant.
+        initClusterUtilWithMaxResultWindow(10000);
+        int savedMaxClauseCount = IndexSearcher.getMaxClauseCount();
+        IndexSearcher.setMaxClauseCount(8);
+        try {
+            // 8 clauses fit only if the Tail is absent, and Tail presence is unknown until the legs have answered.
+            HybridQueryBuilder builder = fusedBuilder(
+                new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"), "window_size", 8))
+            );
+            QueryCoordinatorContext ctx = coordinatorContextFor(builder);
+            doAnswer(invocation -> null).when(ctx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> builder.doRewrite(ctx));
+            assertThat(e.getMessage(), containsString("indices.query.bool.max_clause_count"));
+        } finally {
+            IndexSearcher.setMaxClauseCount(savedMaxClauseCount);
+        }
+    }
+
+    @SneakyThrows
+    public void testDoRewriteFused_whenWindowSizeLeavesRoomForTail_thenProceeds() {
+        // One below the ceiling: the window plus the single Tail clause exactly fills the bool, so the request proceeds.
+        initClusterUtilWithMaxResultWindow(10000);
+        int savedMaxClauseCount = IndexSearcher.getMaxClauseCount();
+        IndexSearcher.setMaxClauseCount(8);
+        try {
+            HybridQueryBuilder builder = fusedBuilder(
+                new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"), "window_size", 7))
+            );
+            QueryCoordinatorContext ctx = coordinatorContextFor(builder);
+            java.util.concurrent.atomic.AtomicInteger asyncRegistered = new java.util.concurrent.atomic.AtomicInteger();
+            doAnswer(invocation -> {
+                asyncRegistered.incrementAndGet();
+                return null;
+            }).when(ctx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
+            builder.doRewrite(ctx);
+            assertEquals(1, asyncRegistered.get());
+        } finally {
+            IndexSearcher.setMaxClauseCount(savedMaxClauseCount);
+        }
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -845,14 +845,22 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     }
 
     @SneakyThrows
-    public void testDoRewriteFused_whenMultipleIndices_thenFailsFast() {
-        // Fusion keys leg hits by _id, which is unique only within one index, so multi-index fused search is rejected
-        // until keying + the self-erase are index-aware (guards against conflated same-_id docs from different indices).
+    public void testDoRewriteFused_whenMultipleIndices_thenProceeds() {
+        // Multi-index fused search is supported now that fusion keys documents by _index + _id: the interim reject guard
+        // is gone, and the request registers its leg fan-out like any other. (That same-_id docs across indices stay
+        // distinct is asserted at the fusion/self-erase level in HybridFusionOrchestratorTests.)
         initClusterUtilWithConcreteIndexCount(2);
         HybridQueryBuilder builder = fusedBuilder(new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"))));
         QueryCoordinatorContext ctx = coordinatorContextFor(builder);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> builder.doRewrite(ctx));
-        assertThat(e.getMessage(), containsString("does not yet support searching multiple indices"));
+        java.util.concurrent.atomic.AtomicInteger asyncRegistered = new java.util.concurrent.atomic.AtomicInteger();
+        doAnswer(invocation -> {
+            asyncRegistered.incrementAndGet();
+            return null;
+        }).when(ctx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
+
+        builder.doRewrite(ctx);
+
+        assertEquals("multi-index fused query fans out normally", 1, asyncRegistered.get());
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedFanOutTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedFanOutTests.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.common.MinClusterVersionUtil.MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY;
 import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.DEFAULT_MAX_FUSION_LEG_SEARCHES;
 import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.MAX_FUSION_LEG_SEARCHES;
 
@@ -31,6 +32,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -295,6 +297,80 @@ public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
         assertEquals("both siblings fan out, each once", List.of(2, 2), fanOut.legCountPerMultiSearch());
     }
 
+    // ---------------------------------------------- version guard ----------------------------------------------
+
+    /**
+     * Fused mode on a cluster that cannot run round 2 everywhere is refused before anything is fanned out. Round 2 is a
+     * {@code hybrid_fusion} query, a type a node predating fused mode cannot resolve at all — it fails deserializing the
+     * shard request, and a shard failure under the default {@code allow_partial_search_results} is a 200 with those shards'
+     * documents silently missing. So the cost of being wrong here is a wrong answer, not an error.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenAnyNodeIsBelowTheMinimumVersion_isRejectedBeforeAnyFanOut() {
+        initClusterUtil(null, Version.V_3_7_0);
+        QueryBuilder query = nestedChain(1);
+        List<BiConsumer<Client, ActionListener<?>>> registered = new ArrayList<>();
+        QueryCoordinatorContext coordinatorContext = coordinatorContext(request(query), registered);
+
+        IllegalArgumentException error = expectThrows(IllegalArgumentException.class, () -> query.rewrite(coordinatorContext));
+
+        assertThat(
+            error.getMessage(),
+            containsString("on version [" + MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY + "] or later")
+        );
+        assertThat("the message quotes what the cluster actually is", error.getMessage(), containsString("is [" + Version.V_3_7_0 + "]"));
+        assertTrue("refused before the fan-out whose results no node could be asked to fuse", registered.isEmpty());
+    }
+
+    /**
+     * The boundary is inclusive: a cluster exactly at the minimum runs fused mode. Spelled as the literal rather than as
+     * {@code MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY} so it pins the version fused mode ships in — against
+     * the constant this assertion holds by construction and a bump would go unnoticed.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenEveryNodeIsExactlyAtTheMinimumVersion_thenItFansOut() {
+        initClusterUtil(null, Version.V_3_8_0);
+
+        FanOut fanOut = drive(request(nestedChain(1)));
+
+        assertEquals(1, fanOut.multiSearches());
+        assertEquals(List.of(2), fanOut.legCountPerMultiSearch());
+    }
+
+    /**
+     * The refusal sits above the {@code SearchRequest} cast on purpose. {@code _explain} and {@code _validate/query} rewrite
+     * on the coordinator with an {@code ExplainRequest}/{@code ValidateQueryRequest} and are then dispatched <i>still
+     * fused</i> to the node holding the document — where the {@code fusion} field is gated off the wire, so an old node
+     * answers for a classic hybrid instead. Refusing below the cast would leave that shape silently wrong.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenTheRequestIsNotASearch_thenItIsStillRefusedOnALaggingCluster() {
+        initClusterUtil(null, Version.V_3_7_0);
+        QueryBuilder query = nestedChain(1);
+        QueryCoordinatorContext coordinatorContext = mock(QueryCoordinatorContext.class);
+        when(coordinatorContext.convertToCoordinatorContext()).thenReturn(coordinatorContext);
+        when(coordinatorContext.getSearchRequest()).thenReturn(mock(org.opensearch.action.IndicesRequest.class));
+
+        IllegalArgumentException error = expectThrows(IllegalArgumentException.class, () -> query.rewrite(coordinatorContext));
+
+        assertThat(error.getMessage(), containsString("requires all nodes in the cluster to be on version"));
+    }
+
+    /** Scoped to fused mode: classic hybrid is answered by every version that can parse it, and stays version-free. */
+    @SneakyThrows
+    public void testClassicHybrid_onTheSameLaggingCluster_isUnaffected() {
+        initClusterUtil(null, Version.V_3_7_0);
+        HybridQueryBuilder classic = new HybridQueryBuilder();
+        classic.add(new MatchQueryBuilder(TEXT_FIELD_NAME, "hello"));
+        classic.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, "kw"));
+        List<BiConsumer<Client, ActionListener<?>>> registered = new ArrayList<>();
+
+        QueryBuilder rewritten = classic.rewrite(coordinatorContext(request(classic), registered));
+
+        assertNotNull(rewritten);
+        assertTrue("classic hybrid does not fan out at all", registered.isEmpty());
+    }
+
     // ------------------------------------------------ harness ------------------------------------------------
 
     /** A chain {@code depth} fused hybrids deep, each holding the level below plus one term leg: 2 legs per level. */
@@ -412,17 +488,26 @@ public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
         return hit;
     }
 
-    /**
-     * A cluster the fused rewrite can read: concrete indices for the window check, and cluster settings for the budget.
-     * {@code null} settings means nothing is configured, so the budget falls back to the setting's own default.
-     */
+    /** A cluster every node of which is on the current version — the fused rewrite's precondition. */
     private void initClusterUtil(final Settings clusterSettings) {
+        initClusterUtil(clusterSettings, Version.CURRENT);
+    }
+
+    /**
+     * A cluster the fused rewrite can read: a minimum node version, concrete indices for the window check, and cluster
+     * settings for the budget. {@code null} settings means nothing is configured, so the budget falls back to the
+     * setting's own default.
+     */
+    private void initClusterUtil(final Settings clusterSettings, final Version minNodeVersion) {
         Metadata metadata = mock(Metadata.class);
         ClusterState clusterState = mock(ClusterState.class);
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(clusterState);
         when(clusterState.metadata()).thenReturn(metadata);
         when(clusterState.getMetadata()).thenReturn(metadata);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(clusterState.getNodes()).thenReturn(nodes);
+        when(nodes.getMinNodeVersion()).thenReturn(minNodeVersion);
         when(metadata.custom(SearchPipelineMetadata.TYPE)).thenReturn(new SearchPipelineMetadata(Map.of()));
         if (clusterSettings != null) {
             when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(clusterSettings, Set.of(MAX_FUSION_LEG_SEARCHES)));

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedFanOutTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedFanOutTests.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.Version;
+import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequest;
@@ -38,6 +39,8 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -47,6 +50,7 @@ import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.Rewriteable;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.pipeline.SearchPipelineMetadata;
 import org.opensearch.transport.client.Client;
@@ -78,6 +82,9 @@ public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
 
     private static final String TEXT_FIELD_NAME = "field";
     private static final String INDEX_NAME = "test-index";
+
+    /** The cluster service the current {@link #initClusterUtil} call installed, so a test can swap only the resolver. */
+    private ClusterService clusterService;
 
     /** What a coordinator paid to rewrite one request: one entry in {@code legCountPerMultiSearch} per fan-out. */
     private record FanOut(List<Integer> legCountPerMultiSearch, QueryBuilder finalQuery) {
@@ -356,6 +363,39 @@ public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
         assertThat(error.getMessage(), containsString("requires all nodes in the cluster to be on version"));
     }
 
+    // ------------------------------------------- request-shape refusals -------------------------------------------
+
+    /**
+     * Where the request-shape refusal sits. {@code CandidateScope.from} runs ahead of everything that resolves index
+     * metadata — the fusion-config lookup reads the targeted indices' default pipelines, the window ceiling reads their
+     * {@code max_result_window} — because a literal {@code cluster:index} expression dies in that resolution with
+     * {@code no such index}, a message that says nothing about fused mode. This models resolution failing exactly there and
+     * asserts fused mode's own explanation is what the user gets.
+     */
+    @SneakyThrows
+    public void testCrossClusterRequest_isRefusedBeforeIndexMetadataIsResolved() {
+        initClusterUtilWhereIndexResolutionFails();
+        QueryBuilder query = nestedChain(1);
+        List<BiConsumer<Client, ActionListener<?>>> registered = new ArrayList<>();
+        SearchRequest crossCluster = new SearchRequest(INDEX_NAME, "remote-cluster:" + INDEX_NAME).source(
+            new SearchSourceBuilder().query(query)
+        );
+
+        IllegalArgumentException error = expectThrows(
+            IllegalArgumentException.class,
+            () -> query.rewrite(coordinatorContext(crossCluster, registered))
+        );
+
+        assertThat(error.getMessage(), containsString("does not support [cross-cluster search]"));
+        assertTrue("refused before any leg is fanned out", registered.isEmpty());
+
+        // Non-vacuity: with resolution failing the same way, a request that gets past this refusal really does reach it and
+        // die there — so the assertion above is about ordering, not about resolution being unreachable in this harness.
+        QueryBuilder localOnly = nestedChain(1);
+        SearchRequest localRequest = request(localOnly);
+        expectThrows(IndexNotFoundException.class, () -> localOnly.rewrite(coordinatorContext(localRequest, new ArrayList<>())));
+    }
+
     /** Scoped to fused mode: classic hybrid is answered by every version that can parse it, and stays version-free. */
     @SneakyThrows
     public void testClassicHybrid_onTheSameLaggingCluster_isUnaffected() {
@@ -482,9 +522,11 @@ public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
         return new MultiSearchResponse.Item(new SearchResponse(sections, null, 1, 1, 0, 10, null, null), null);
     }
 
+    /** A leg hit as the coordinator sees one: its {@code _index} comes from the shard target the response was read from. */
     private SearchHit hit(final int docId, final String id, final float score) {
         SearchHit hit = new SearchHit(docId, id, Map.of(), Map.of());
         hit.score(score);
+        hit.shard(new SearchShardTarget("node-1", new ShardId(new Index(INDEX_NAME, "uuid-1"), 0), null, OriginalIndices.NONE));
         return hit;
     }
 
@@ -501,7 +543,7 @@ public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
     private void initClusterUtil(final Settings clusterSettings, final Version minNodeVersion) {
         Metadata metadata = mock(Metadata.class);
         ClusterState clusterState = mock(ClusterState.class);
-        ClusterService clusterService = mock(ClusterService.class);
+        clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(clusterState);
         when(clusterState.metadata()).thenReturn(metadata);
         when(clusterState.getMetadata()).thenReturn(metadata);
@@ -524,5 +566,18 @@ public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
             new Index[] { index }
         );
         NeuralSearchClusterUtil.instance().initialize(clusterService, resolver);
+    }
+
+    /**
+     * The same cluster, except index resolution fails the way core's does for a literal expression it cannot look up —
+     * which is what a {@code cluster:index} expression hits when there is no such remote alias.
+     */
+    private void initClusterUtilWhereIndexResolutionFails() {
+        initClusterUtil(null);
+        IndexNameExpressionResolver failing = mock(IndexNameExpressionResolver.class);
+        when(failing.concreteIndices(any(ClusterState.class), any(org.opensearch.action.IndicesRequest.class))).thenThrow(
+            new IndexNotFoundException("cluster:index")
+        );
+        NeuralSearchClusterUtil.instance().initialize(clusterService, failing);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedFanOutTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedFanOutTests.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.DEFAULT_MAX_FUSION_LEG_SEARCHES;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.MAX_FUSION_LEG_SEARCHES;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.Version;
+import org.opensearch.action.search.MultiSearchRequest;
+import org.opensearch.action.search.MultiSearchResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryCoordinatorContext;
+import org.opensearch.index.query.QueryRewriteContext;
+import org.opensearch.index.query.Rewriteable;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.pipeline.SearchPipelineMetadata;
+import org.opensearch.transport.client.Client;
+import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
+
+import lombok.SneakyThrows;
+
+/**
+ * How much a fused ({@code fusion}) hybrid query is allowed to fan out, and how much it actually does.
+ *
+ * <p>Two properties are pinned here, and they only make sense together:
+ *
+ * <ul>
+ *   <li><b>Each fused hybrid fans out once.</b> A nested fused hybrid is reachable twice on the coordinator — as a leg of
+ *       the enclosing query, and again in the enclosing query's Tail, which keeps the original leg builders. Executing it
+ *       both times made cost {@code 2^(depth+1) - 2} leg sub-searches for a body that grows linearly, so a handful of
+ *       bytes bought an exponential fan-out (and past depth ~8, core's {@code MAX_REWRITE_ROUNDS} turned it into a 500).
+ *       The Tail now rewrites under a match-set marker, where a fused hybrid contributes {@code bool{should: legs}}
+ *       instead of firing them: cost is linear in the hybrids the body spells out, which is what makes a static count of
+ *       them meaningful.</li>
+ *   <li><b>That count is capped</b> by {@code plugins.neural_search.hybrid.fusion.max_leg_searches}, per request, over
+ *       every fused hybrid in the body — nested or side by side.</li>
+ * </ul>
+ *
+ * <p>Fan-out is measured where it is paid: the number of {@code multiSearch} calls this coordinator makes while the query
+ * is rewritten to completion, and the number of leg requests in each.
+ */
+public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
+
+    private static final String TEXT_FIELD_NAME = "field";
+    private static final String INDEX_NAME = "test-index";
+
+    /** What a coordinator paid to rewrite one request: one entry in {@code legCountPerMultiSearch} per fan-out. */
+    private record FanOut(List<Integer> legCountPerMultiSearch, QueryBuilder finalQuery) {
+        int multiSearches() {
+            return legCountPerMultiSearch.size();
+        }
+
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        initClusterUtil(null);
+    }
+
+    // ------------------------------------------------ fan-out shape ------------------------------------------------
+
+    /**
+     * The regression this class exists for: nesting must not multiply fan-out. Each depth is a chain of fused hybrids,
+     * every level holding the level below plus a term leg — a body that grows by one clause per level. Before the Tail was
+     * rewritten for its match set, this coordinator issued one MultiSearch per level (and the whole tree paid
+     * {@code 2^(depth+1) - 2} leg searches); now the root fans out once and the nested levels are executed exactly once
+     * each, as their parent's leg sub-search.
+     */
+    @SneakyThrows
+    public void testNestedFusedHybrids_whenRewrittenToCompletion_thenCoordinatorFansOutOnce() {
+        for (int depth = 1; depth <= 6; depth++) {
+            FanOut fanOut = drive(request(nestedChain(depth)));
+            assertEquals("depth " + depth + " must cost one MultiSearch on this coordinator", 1, fanOut.multiSearches());
+            assertEquals("and it carries this hybrid's own legs, nothing more", List.of(2), fanOut.legCountPerMultiSearch());
+        }
+    }
+
+    /**
+     * The same, for a fused hybrid the enclosing query cannot see through as a direct leg: it sits inside a {@code bool}
+     * inside the leg. The marker is carried by the rewrite context rather than applied to the leg list, so container depth
+     * makes no difference — which is the reason it is a context and not a substitution at Tail-build time.
+     */
+    @SneakyThrows
+    public void testNestedFusedHybridInsideAContainerLeg_thenCoordinatorStillFansOutOnce() {
+        HybridQueryBuilder inner = fused(new MatchQueryBuilder(TEXT_FIELD_NAME, "hello"), QueryBuilders.termQuery(TEXT_FIELD_NAME, "kw"));
+        QueryBuilder containerLeg = QueryBuilders.boolQuery().must(inner).filter(QueryBuilders.termQuery(TEXT_FIELD_NAME, "gate"));
+        HybridQueryBuilder outer = fused(containerLeg, QueryBuilders.termQuery(TEXT_FIELD_NAME, "kw"));
+
+        FanOut fanOut = drive(request(outer));
+
+        assertEquals(1, fanOut.multiSearches());
+        assertEquals(List.of(2), fanOut.legCountPerMultiSearch());
+    }
+
+    /**
+     * What the Tail ends up matching. The nested fused hybrid is replaced by a {@code bool} of its own legs, which is the
+     * set it matches: a fused hybrid compiles to {@code bool{should: Top, filter: Tail}} with no minimum_should_match, so
+     * its matches are its Tail's — the union of its legs. Scores are lost and must be: this only ever appears inside the
+     * enclosing Tail's non-scoring {@code filter}.
+     */
+    @SneakyThrows
+    public void testTail_whenLegIsAFusedHybrid_thenItBecomesTheUnionOfThatLegsSubQueries() {
+        MatchQueryBuilder innerMatch = new MatchQueryBuilder(TEXT_FIELD_NAME, "hello");
+        QueryBuilder innerTerm = QueryBuilders.termQuery(TEXT_FIELD_NAME, "inner");
+        HybridQueryBuilder inner = fused(innerMatch, innerTerm);
+        QueryBuilder outerTerm = QueryBuilders.termQuery(TEXT_FIELD_NAME, "outer");
+
+        FanOut fanOut = drive(request(fused(inner, outerTerm)));
+
+        assertTrue("the request self-erases into the fused query", fanOut.finalQuery() instanceof HybridFusionQueryBuilder);
+        BoolQueryBuilder selfErased = ((HybridFusionQueryBuilder) fanOut.finalQuery()).buildSelfErasedQuery();
+        assertEquals("the Tail is the single filter clause", 1, selfErased.filter().size());
+        BoolQueryBuilder tail = (BoolQueryBuilder) selfErased.filter().get(0);
+        assertEquals("one Tail clause per leg", 2, tail.should().size());
+        assertEquals("the non-hybrid leg is kept as itself", outerTerm, tail.should().get(1));
+        BoolQueryBuilder substituted = (BoolQueryBuilder) tail.should().get(0);
+        assertEquals("the nested hybrid contributes its legs", List.of(innerMatch, innerTerm), substituted.should());
+        assertNull("as a plain union — no minimum_should_match to satisfy", substituted.minimumShouldMatch());
+        assertEquals("and no fused hybrid is left to execute", 0, HybridQueryBuilder.countFusedLegSearches(fanOut.finalQuery()));
+    }
+
+    /**
+     * The mechanism on its own: under a match-set context a fused hybrid resolves to its legs' union without registering
+     * any async action. This is the assertion that fails if the early return in {@code doRewriteFused} is dropped, whether
+     * or not any Tail is built.
+     */
+    @SneakyThrows
+    public void testFusedHybrid_whenRewrittenForItsMatchSetOnly_thenNoFanOutIsRegistered() {
+        MatchQueryBuilder match = new MatchQueryBuilder(TEXT_FIELD_NAME, "hello");
+        QueryBuilder term = QueryBuilders.termQuery(TEXT_FIELD_NAME, "kw");
+        HybridQueryBuilder hybrid = fused(match, term);
+        List<BiConsumer<Client, ActionListener<?>>> registered = new ArrayList<>();
+        QueryCoordinatorContext coordinatorContext = coordinatorContext(request(hybrid), registered);
+
+        QueryBuilder rewritten = hybrid.rewrite(MatchSetRewriteContext.wrap(coordinatorContext));
+
+        assertEquals(new BoolQueryBuilder().should(match).should(term), rewritten);
+        assertTrue("a match set costs no sub-search", registered.isEmpty());
+    }
+
+    /** The marker is not applied where no fan-out can happen, and never stacks on itself. */
+    public void testMatchSetContext_whenThereIsNothingToMark_thenTheContextIsUnchanged() {
+        QueryRewriteContext plainContext = mock(QueryRewriteContext.class);
+        assertSame("a shard-side rewrite has no coordinator context to wrap", plainContext, MatchSetRewriteContext.wrap(plainContext));
+        assertFalse(MatchSetRewriteContext.isMatchSetOnly(plainContext));
+
+        QueryRewriteContext marked = MatchSetRewriteContext.wrap(coordinatorContext(request(fused()), new ArrayList<>()));
+        assertTrue(MatchSetRewriteContext.isMatchSetOnly(marked));
+        assertSame("a Tail inside a Tail is already marked", marked, MatchSetRewriteContext.wrap(marked));
+    }
+
+    // ------------------------------------------------ the budget ------------------------------------------------
+
+    /** The counted unit: declared legs, summed over every fused hybrid in the request, and nothing else. */
+    public void testCountFusedLegSearches_countsDeclaredLegsOfEveryFusedHybrid() {
+        assertEquals(0, HybridQueryBuilder.countFusedLegSearches(null));
+        assertEquals("a non-hybrid query declares none", 0, HybridQueryBuilder.countFusedLegSearches(QueryBuilders.matchAllQuery()));
+
+        HybridQueryBuilder classic = new HybridQueryBuilder();
+        classic.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, "a")).add(QueryBuilders.termQuery(TEXT_FIELD_NAME, "b"));
+        assertEquals("classic hybrid runs no leg sub-search at all", 0, HybridQueryBuilder.countFusedLegSearches(classic));
+
+        assertEquals("one level, one leg per sub-query", 2, HybridQueryBuilder.countFusedLegSearches(nestedChain(1)));
+        assertEquals("a chain of three pays for all three", 6, HybridQueryBuilder.countFusedLegSearches(nestedChain(3)));
+
+        QueryBuilder siblings = QueryBuilders.boolQuery().must(nestedChain(1)).should(nestedChain(2));
+        assertEquals(
+            "siblings in one request are summed — the request is what fans out",
+            6,
+            HybridQueryBuilder.countFusedLegSearches(siblings)
+        );
+
+        QueryBuilder insideContainer = QueryBuilders.functionScoreQuery(QueryBuilders.constantScoreQuery(nestedChain(1)));
+        assertEquals(
+            "a hybrid inside containers that expose their children is counted",
+            2,
+            HybridQueryBuilder.countFusedLegSearches(insideContainer)
+        );
+    }
+
+    /** The ceiling is derived from the per-query leg limit, not chosen independently, and cannot be set below it. */
+    public void testLegSearchBudgetSetting_isTiedToTheLegLimit() {
+        assertEquals(
+            HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES * HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES,
+            DEFAULT_MAX_FUSION_LEG_SEARCHES
+        );
+        assertEquals(Integer.valueOf(DEFAULT_MAX_FUSION_LEG_SEARCHES), MAX_FUSION_LEG_SEARCHES.getDefault(Settings.EMPTY));
+
+        Settings belowFloor = Settings.builder()
+            .put(MAX_FUSION_LEG_SEARCHES.getKey(), HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES - 1)
+            .build();
+        IllegalArgumentException error = expectThrows(IllegalArgumentException.class, () -> MAX_FUSION_LEG_SEARCHES.get(belowFloor));
+        assertThat(
+            "a ceiling under the legs a single hybrid may declare would reject a plain fused query",
+            error.getMessage(),
+            containsString("must be >= " + HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES)
+        );
+    }
+
+    /**
+     * Every shape the default budget admits is accepted, and settles inside core's rewrite-round budget. The widths span the
+     * per-query leg limit, so the depths span the shape the default is chosen to admit —
+     * {@link HybridQueryBuilder#MAX_NUMBER_OF_SUB_QUERIES} levels of full-width nesting — down to a 25-level single-leg
+     * chain.
+     *
+     * <p>Depth is what makes the round budget interesting. Rewrite descends one level per round, and core allows
+     * {@link Rewriteable#MAX_REWRITE_ROUNDS} for the whole request, so a nested fused hybrid substituted level by level
+     * would spend a round per level and the deepest chain here would fail with "too many rewrite rounds" — an internal
+     * error on a body inside its own declared budget. {@link #drive} runs core's loop, so that is a real failure here and
+     * not a soft assertion.
+     */
+    @SneakyThrows
+    public void testEveryShapeTheDefaultBudgetAdmits_isAcceptedAndSettlesInCoresRewriteRounds() {
+        for (int width = 1; width <= HybridQueryBuilder.MAX_NUMBER_OF_SUB_QUERIES; width++) {
+            int depth = DEFAULT_MAX_FUSION_LEG_SEARCHES / width;
+            String shape = width + " legs x " + depth + " levels";
+            HybridQueryBuilder query = nestedChain(depth, width);
+            assertEquals(shape, depth * width, HybridQueryBuilder.countFusedLegSearches(query));
+            assertTrue(shape + " must be within the budget", depth * width <= DEFAULT_MAX_FUSION_LEG_SEARCHES);
+
+            FanOut fanOut = drive(request(query));
+
+            assertEquals(shape + ": this coordinator fans out once", 1, fanOut.multiSearches());
+            assertEquals(shape + ": carrying this level's legs only", List.of(width), fanOut.legCountPerMultiSearch());
+        }
+    }
+
+    /** One over the budget is a 400 before anything is fanned out. */
+    @SneakyThrows
+    public void testRequestOverTheBudget_isRejectedBeforeAnyFanOut() {
+        int overBudget = DEFAULT_MAX_FUSION_LEG_SEARCHES / 2 + 1;
+        QueryBuilder query = nestedChain(overBudget);
+        List<BiConsumer<Client, ActionListener<?>>> registered = new ArrayList<>();
+        QueryCoordinatorContext coordinatorContext = coordinatorContext(request(query), registered);
+
+        IllegalArgumentException error = expectThrows(IllegalArgumentException.class, () -> query.rewrite(coordinatorContext));
+
+        assertThat(error.getMessage(), containsString("declares " + (2 * overBudget) + " leg sub-searches"));
+        assertThat(error.getMessage(), containsString(MAX_FUSION_LEG_SEARCHES.getKey()));
+        assertThat(error.getMessage(), containsString("(" + DEFAULT_MAX_FUSION_LEG_SEARCHES + ")"));
+        assertTrue("rejected before the fan-out it is meant to prevent", registered.isEmpty());
+    }
+
+    /** Sibling hybrids are one budget, and the budget is the live cluster setting. */
+    @SneakyThrows
+    public void testBudget_readsTheLiveClusterSetting() {
+        QueryBuilder siblings = QueryBuilders.boolQuery().must(nestedChain(1)).should(nestedChain(2));
+        assertEquals(6, HybridQueryBuilder.countFusedLegSearches(siblings));
+
+        initClusterUtil(Settings.builder().put(MAX_FUSION_LEG_SEARCHES.getKey(), 5).build());
+        IllegalArgumentException error = expectThrows(
+            IllegalArgumentException.class,
+            () -> siblings.rewrite(coordinatorContext(request(siblings), new ArrayList<>()))
+        );
+        assertThat(error.getMessage(), containsString("declares 6 leg sub-searches"));
+        assertThat("the message quotes the value in force, not the default", error.getMessage(), containsString("(5)"));
+
+        initClusterUtil(Settings.builder().put(MAX_FUSION_LEG_SEARCHES.getKey(), 6).build());
+        FanOut fanOut = drive(request(siblings));
+        assertEquals("raising the setting admits the same body", 2, fanOut.multiSearches());
+        assertEquals("both siblings fan out, each once", List.of(2, 2), fanOut.legCountPerMultiSearch());
+    }
+
+    // ------------------------------------------------ harness ------------------------------------------------
+
+    /** A chain {@code depth} fused hybrids deep, each holding the level below plus one term leg: 2 legs per level. */
+    private HybridQueryBuilder nestedChain(final int depth) {
+        return nestedChain(depth, 2);
+    }
+
+    /**
+     * A chain {@code depth} fused hybrids deep and {@code width} legs wide: every level holds the level below as its first
+     * leg, padded with term legs, so the body grows by {@code width} clauses per level and declares {@code depth × width}
+     * leg sub-searches in total.
+     */
+    private HybridQueryBuilder nestedChain(final int depth, final int width) {
+        HybridQueryBuilder query = null;
+        for (int level = 0; level < depth; level++) {
+            List<QueryBuilder> legs = new ArrayList<>();
+            legs.add(query == null ? new MatchQueryBuilder(TEXT_FIELD_NAME, "hello") : query);
+            for (int leg = 1; leg < width; leg++) {
+                legs.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, "kw" + leg));
+            }
+            query = fused(legs.toArray(new QueryBuilder[0]));
+        }
+        return query;
+    }
+
+    private HybridQueryBuilder fused(final QueryBuilder... legs) {
+        HybridQueryBuilder hybrid = new HybridQueryBuilder();
+        for (QueryBuilder leg : legs) {
+            hybrid.add(leg);
+        }
+        hybrid.fusion(fusionConfig());
+        return hybrid;
+    }
+
+    private Map<String, Object> fusionConfig() {
+        return new HashMap<>(
+            Map.of("normalization", Map.of("technique", "min_max"), "combination", Map.of("technique", "arithmetic_mean"))
+        );
+    }
+
+    private SearchRequest request(final QueryBuilder query) {
+        return new SearchRequest(INDEX_NAME).source(new SearchSourceBuilder().query(query));
+    }
+
+    private QueryCoordinatorContext coordinatorContext(
+        final SearchRequest searchRequest,
+        final List<BiConsumer<Client, ActionListener<?>>> registered
+    ) {
+        QueryCoordinatorContext coordinatorContext = mock(QueryCoordinatorContext.class);
+        when(coordinatorContext.convertToCoordinatorContext()).thenReturn(coordinatorContext);
+        when(coordinatorContext.getSearchRequest()).thenReturn(searchRequest);
+        doAnswer(invocation -> registered.add(invocation.getArgument(0))).when(coordinatorContext).registerAsyncAction(any());
+        return coordinatorContext;
+    }
+
+    /**
+     * Rewrite the request's query to completion through core's own {@code Rewriteable.rewriteAndFetch}, recording each
+     * MultiSearch the coordinator issues. Core drives the loop deliberately: it is what counts rewrite rounds, and a query
+     * that needs more than {@link Rewriteable#MAX_REWRITE_ROUNDS} of them fails the request with an internal error rather
+     * than running — so any test using this harness also pins that this query settles inside that budget.
+     */
+    @SneakyThrows
+    private FanOut drive(final SearchRequest searchRequest) {
+        List<BiConsumer<Client, ActionListener<?>>> registered = new ArrayList<>();
+        QueryCoordinatorContext coordinatorContext = coordinatorContext(searchRequest, registered);
+        List<Integer> legCountPerMultiSearch = new ArrayList<>();
+        Client client = multiSearchingClient(legCountPerMultiSearch);
+        when(coordinatorContext.hasAsyncActions()).thenAnswer(invocation -> registered.isEmpty() == false);
+        doAnswer(invocation -> {
+            List<BiConsumer<Client, ActionListener<?>>> thisRound = new ArrayList<>(registered);
+            registered.clear();
+            for (BiConsumer<Client, ActionListener<?>> action : thisRound) {
+                action.accept(client, ActionListener.wrap(response -> {}, e -> fail("leg fan-out failed: " + e.getMessage())));
+            }
+            ActionListener<Object> roundListener = invocation.getArgument(0);
+            roundListener.onResponse(null);
+            return null;
+        }).when(coordinatorContext).executeAsyncActions(any());
+
+        AtomicReference<QueryBuilder> settled = new AtomicReference<>();
+        Rewriteable.rewriteAndFetch(searchRequest.source().query(), coordinatorContext, ActionListener.wrap(settled::set, e -> {
+            throw new AssertionError("rewrite failed: " + e.getMessage(), e);
+        }));
+        assertNotNull("the rewrite never completed", settled.get());
+        return new FanOut(legCountPerMultiSearch, settled.get());
+    }
+
+    /** Answers every leg with the same two hits, and records how many legs each MultiSearch carried. */
+    private Client multiSearchingClient(final List<Integer> legCountPerMultiSearch) {
+        Client client = mock(Client.class);
+        doAnswer(invocation -> {
+            MultiSearchRequest multiSearchRequest = invocation.getArgument(0);
+            legCountPerMultiSearch.add(multiSearchRequest.requests().size());
+            MultiSearchResponse.Item[] items = new MultiSearchResponse.Item[multiSearchRequest.requests().size()];
+            for (int leg = 0; leg < items.length; leg++) {
+                items[leg] = legItem();
+            }
+            ActionListener<MultiSearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(new MultiSearchResponse(items, 10L));
+            return null;
+        }).when(client).multiSearch(any(), any());
+        return client;
+    }
+
+    private MultiSearchResponse.Item legItem() {
+        SearchHit[] hits = new SearchHit[] { hit(0, "1", 0.9f), hit(1, "2", 0.5f) };
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponseSections sections = new SearchResponseSections(searchHits, null, null, false, false, null, 0);
+        return new MultiSearchResponse.Item(new SearchResponse(sections, null, 1, 1, 0, 10, null, null), null);
+    }
+
+    private SearchHit hit(final int docId, final String id, final float score) {
+        SearchHit hit = new SearchHit(docId, id, Map.of(), Map.of());
+        hit.score(score);
+        return hit;
+    }
+
+    /**
+     * A cluster the fused rewrite can read: concrete indices for the window check, and cluster settings for the budget.
+     * {@code null} settings means nothing is configured, so the budget falls back to the setting's own default.
+     */
+    private void initClusterUtil(final Settings clusterSettings) {
+        Metadata metadata = mock(Metadata.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(metadata.custom(SearchPipelineMetadata.TYPE)).thenReturn(new SearchPipelineMetadata(Map.of()));
+        if (clusterSettings != null) {
+            when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(clusterSettings, Set.of(MAX_FUSION_LEG_SEARCHES)));
+        }
+        Index index = new Index(INDEX_NAME, "uuid-1");
+        Settings indexSettings = Settings.builder()
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 0)
+            .put("index.version.created", Version.CURRENT.id)
+            .build();
+        when(metadata.index(index)).thenReturn(IndexMetadata.builder(INDEX_NAME).settings(indexSettings).build());
+        IndexNameExpressionResolver resolver = mock(IndexNameExpressionResolver.class);
+        when(resolver.concreteIndices(any(ClusterState.class), any(org.opensearch.action.IndicesRequest.class))).thenReturn(
+            new Index[] { index }
+        );
+        NeuralSearchClusterUtil.instance().initialize(clusterService, resolver);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeAggregationsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeAggregationsIT.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import lombok.SneakyThrows;
+
+/**
+ * Proves that aggregations over a fused/resolver hybrid cover the full leg-union, not just the fused ranking window.
+ *
+ * <p>This is the property the Tail exists for. The scored Top clauses only carry the fused window, so if the Tail were
+ * missing (or were dropped) the aggregation collector would only ever see those window documents and every bucket outside
+ * it would silently read zero. The Tail adds the real legs as a non-scoring {@code filter}, which is what defines the
+ * aggregation match set.
+ *
+ * <p>Each test is paired against a classic-hybrid oracle so the numbers are anchored to known-correct behavior rather
+ * than to this feature's own implementation. Multi-shard on purpose (3 shards) so results are genuinely distributed.
+ *
+ * <p>Dataset (30 docs, ids 1..30), tiered so both legs rank the 5 blue docs into the window and never the red docs:
+ * <pre>
+ *   color:  ids 1-5   = "blue"  (tier 3 — always in the fused top-5 window)
+ *           ids 6-25  = "green" (tier 2 — always outside the window)
+ *           ids 26-30 = "red"   (tier 1 — lowest, guaranteed outside the window)
+ *   s = tier*1000 - id;  window_size = 5  =>  fused window = {1..5} = all blue
+ * </pre>
+ * So {@code terms(color)} covering the union must report {@code blue=5, green=20, red=5} and {@code total_hits=30}. The
+ * {@code red} bucket is the smoking gun: it can only be non-zero if aggregations see past the window.
+ */
+public class HybridQueryFusedModeAggregationsIT extends BaseNeuralSearchIT {
+
+    private static final String INDEX = "test-fused-aggs-matchset";
+    private static final String NORM_PIPELINE = "fused-aggs-norm-pipeline";
+    private static final String COLOR_FIELD = "color";
+    private static final String SCORE_FIELD = "s";
+    private static final int WINDOW_SIZE = 5;
+    private static final int BLUE_COUNT = 5;
+    private static final int GREEN_COUNT = 20;
+    private static final int RED_COUNT = 5;
+    private static final int TOTAL_DOCS = 30;
+
+    private String indexConfig() {
+        return "{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":0,"
+            + "\"index.search.default_pipeline\":\""
+            + NORM_PIPELINE
+            + "\"},"
+            + "\"mappings\":{\"properties\":{\""
+            + COLOR_FIELD
+            + "\":{\"type\":\"keyword\"},\""
+            + SCORE_FIELD
+            + "\":{\"type\":\"integer\"}}}}";
+    }
+
+    @SneakyThrows
+    private void ensureDataset() {
+        createSearchPipeline(NORM_PIPELINE, "min_max", "arithmetic_mean", Map.of());
+        if (indexExists(INDEX)) {
+            return;
+        }
+        createIndex(INDEX, indexConfig());
+        for (int id = 1; id <= TOTAL_DOCS; id++) {
+            String color = id <= 5 ? "blue" : (id <= 25 ? "green" : "red");
+            int tier = id <= 5 ? 3 : (id <= 25 ? 2 : 1);
+            int s = tier * 1000 - id;
+            Request request = new Request("PUT", "/" + INDEX + "/_doc/" + id + "?refresh=true");
+            request.setJsonEntity("{\"" + COLOR_FIELD + "\":\"" + color + "\",\"" + SCORE_FIELD + "\":" + s + "}");
+            Response response = client().performRequest(request);
+            int code = response.getStatusLine().getStatusCode();
+            assertTrue(
+                "indexing doc " + id + " failed: " + code,
+                code == RestStatus.OK.getStatus() || code == RestStatus.CREATED.getStatus()
+            );
+        }
+    }
+
+    /** A leg that matches ALL docs and scores each by the numeric field (deterministic, shard-independent). */
+    private String leg() {
+        return "{\"function_score\":{\"query\":{\"match_all\":{}},"
+            + "\"field_value_factor\":{\"field\":\""
+            + SCORE_FIELD
+            + "\",\"modifier\":\"none\",\"missing\":1}}}";
+    }
+
+    private String classicHybrid() {
+        return "{\"hybrid\":{\"queries\":[" + leg() + "," + leg() + "]}}";
+    }
+
+    private String fusedHybrid() {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
+            + "\"queries\":["
+            + leg()
+            + ","
+            + leg()
+            + "]}}";
+    }
+
+    private String termsAgg() {
+        return "\"aggregations\":{\"by_color\":{\"terms\":{\"field\":\"" + COLOR_FIELD + "\",\"size\":10}}}";
+    }
+
+    /** Oracle: classic hybrid aggregations cover the full leg-union — the baseline the fused numbers must match. */
+    @SneakyThrows
+    public void testClassicHybrid_aggregationsCoverFullUnion() {
+        ensureDataset();
+        String body = "{\"query\":" + classicHybrid() + "," + termsAgg() + ",\"track_total_hits\":true}";
+
+        Map<String, Object> resp = searchRaw(body, 10);
+        Map<String, Integer> buckets = colorBuckets(resp);
+
+        assertEquals("classic: blue", Integer.valueOf(BLUE_COUNT), buckets.getOrDefault("blue", 0));
+        assertEquals("classic: green proves aggs see beyond the window", Integer.valueOf(GREEN_COUNT), buckets.getOrDefault("green", 0));
+        assertEquals("classic: red is the bucket entirely outside the window", Integer.valueOf(RED_COUNT), buckets.getOrDefault("red", 0));
+        assertEquals("classic: total_hits", (long) TOTAL_DOCS, totalHits(resp));
+    }
+
+    /** The core guarantee: fused aggregations equal classic's — the Tail puts the full union into the self-erased query. */
+    @SneakyThrows
+    public void testFusedHybrid_aggregationsCoverFullUnion_notJustWindow() {
+        ensureDataset();
+        String body = "{\"query\":" + fusedHybrid() + "," + termsAgg() + ",\"track_total_hits\":true}";
+
+        Map<String, Object> resp = searchRaw(body, 10);
+        Map<String, Integer> buckets = colorBuckets(resp);
+
+        // Had fused windowed the aggregation, green/red would read 0 and total would be ~5.
+        assertEquals("fused: blue", Integer.valueOf(BLUE_COUNT), buckets.getOrDefault("blue", 0));
+        assertEquals(
+            "fused: green must equal classic (full union, not windowed)",
+            Integer.valueOf(GREEN_COUNT),
+            buckets.getOrDefault("green", 0)
+        );
+        assertEquals("fused: red must equal classic — the smoking gun", Integer.valueOf(RED_COUNT), buckets.getOrDefault("red", 0));
+        assertEquals("fused: total_hits is the full match set", (long) TOTAL_DOCS, totalHits(resp));
+    }
+
+    /**
+     * Aggregations outrank the totals preference: {@code track_total_hits:false} alone would allow a Top-only query, but
+     * an aggregation still requires the Tail, so buckets stay full.
+     */
+    @SneakyThrows
+    public void testFusedHybrid_trackTotalHitsFalse_aggregationsStillFull() {
+        ensureDataset();
+        String body = "{\"query\":" + fusedHybrid() + "," + termsAgg() + ",\"track_total_hits\":false}";
+
+        Map<String, Integer> buckets = colorBuckets(searchRaw(body, 10));
+
+        assertEquals("tth:false: green still full union", Integer.valueOf(GREEN_COUNT), buckets.getOrDefault("green", 0));
+        assertEquals("tth:false: red still full union", Integer.valueOf(RED_COUNT), buckets.getOrDefault("red", 0));
+    }
+
+    /**
+     * KNOWN LIMITATION (pins current behavior, not desired behavior): {@code min_score > 0} collapses the aggregation to
+     * the fused window.
+     *
+     * <p>Tail-only documents match just the non-scoring filter, so they score 0. Core applies the min-score collector
+     * <i>after</i> the aggregation collector precisely so it filters aggregations too, which drops every score-0 Tail doc
+     * before it can be counted — leaving only the scored window. Classic hybrid avoids this by unsetting min_score
+     * shard-side and re-applying it on the coordinator, but neither half of that machinery is reachable for a fused query
+     * (its shard-side guard keys on the classic query type, and its coordinator half keys on delimiter score-docs fused
+     * never emits).
+     *
+     * <p>When the fix lands — filter the fused Top by min_score on the coordinator and unset it on the outer source —
+     * this test should flip to expecting the full union, i.e. treat a failure here as the reminder that it did.
+     */
+    @SneakyThrows
+    public void testFusedHybrid_minScorePositive_thenAggregationsCollapseToWindow_knownLimitation() {
+        ensureDataset();
+        String body = "{\"query\":" + fusedHybrid() + "," + termsAgg() + ",\"min_score\":0.0005,\"track_total_hits\":true}";
+
+        Map<String, Integer> buckets = colorBuckets(searchRaw(body, 10));
+
+        assertEquals("min_score: the scored window survives", Integer.valueOf(BLUE_COUNT), buckets.getOrDefault("blue", 0));
+        assertEquals("min_score: score-0 Tail docs are filtered before aggregation", Integer.valueOf(0), buckets.getOrDefault("green", 0));
+        assertEquals("min_score: same for the loser bucket", Integer.valueOf(0), buckets.getOrDefault("red", 0));
+    }
+
+    // ------------------------------------------------ helpers ------------------------------------------------
+
+    @SneakyThrows
+    private Map<String, Object> searchRaw(String jsonBody, int size) {
+        Request request = new Request("POST", "/" + INDEX + "/_search");
+        request.setJsonEntity(jsonBody);
+        request.addParameter("size", Integer.toString(size));
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> colorBuckets(Map<String, Object> resp) {
+        Map<String, Integer> out = new LinkedHashMap<>();
+        Map<String, Object> aggs = (Map<String, Object>) resp.get("aggregations");
+        if (aggs == null) {
+            return out;
+        }
+        Map<String, Object> byColor = (Map<String, Object>) aggs.get("by_color");
+        for (Map<String, Object> bucket : (List<Map<String, Object>>) byColor.get("buckets")) {
+            out.put((String) bucket.get("key"), ((Number) bucket.get("doc_count")).intValue());
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private long totalHits(Map<String, Object> resp) {
+        Map<String, Object> hits = (Map<String, Object>) resp.get("hits");
+        Object totalObj = hits.get("total");
+        if (totalObj instanceof Map) {
+            Object value = ((Map<String, Object>) totalObj).get("value");
+            return value == null ? -1 : ((Number) value).longValue();
+        }
+        return -1;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
@@ -7,8 +7,10 @@ package org.opensearch.neuralsearch.query;
 import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getNestedHits;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
@@ -316,17 +318,20 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
     }
 
     /**
-     * With {@code collapse.inner_hits}, every expanded member carries ITS OWN fused score — the same score it receives in
-     * the ungrouped fused search, on the same scale as the group representative.
+     * With {@code collapse.inner_hits}, an expanded member that is <b>inside the fused window</b> carries ITS OWN fused
+     * score — the same score it receives in the ungrouped fused search, on the same scale as the group representative.
+     * Every document here is inside the default window, which is what makes that unconditional in this test; the
+     * out-of-window case is
+     * {@link #testFusedMode_whenCollapseInnerHitsAndMemberOutsideWindow_thenGroupStillExpandsFully}.
      *
      * <p>Core's {@code ExpandSearchPhase} re-runs {@code source().query()} once per collapse group. For a fused request
-     * that query is the self-erased Top, where each ranked document has its own {@code constant_score} clause, so each
-     * member is scored by its own clause rather than the representative's.
+     * that query is the self-erased Top (plus Tail), where each ranked document has its own {@code constant_score} clause,
+     * so each member is scored by its own clause rather than the representative's.
      *
      * <p>This differs from classic hybrid, which re-runs the real sub-queries and reports their raw, un-normalized scores
      * — putting members on a different scale from the representative (classic yields a representative at {@code 1.0}
      * beside members at {@code 198.0}). Fused is self-consistent instead, which is why this asserts the fused values
-     * rather than classic parity. Leg-level {@code inner_hits} do match classic exactly and are covered separately.
+     * rather than classic parity.
      */
     @SneakyThrows
     public void testFusedMode_whenCollapseInnerHits_thenMembersCarryTheirOwnFusedScore() {
@@ -373,6 +378,72 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
         }
     }
 
+    /**
+     * A collapse group's members are whatever share the representative's collapse key, which has nothing to do with the
+     * fused window — so expanding a group must not be limited to the window. Core's {@code ExpandSearchPhase} issues one
+     * search per returned group whose query is the self-erased fused query under a group-key filter; with Top only, a
+     * member that ranked outside the window matches no {@code constant_score} clause and silently disappears from the
+     * expansion, where classic hybrid (and any other query type) returns the whole group. That is why
+     * {@code collapse.inner_hits} forces the Tail on.
+     *
+     * <p>The probe: {@code window_size} one short of the document count, so exactly one member — the lowest-ranked, in the
+     * last group — sits outside the window, plus {@code track_total_hits:false} so nothing else would keep the Tail. Every
+     * document must still come back in its group's expansion. Without the Tail trigger the last group expands to one
+     * member instead of {@link #DOCS_PER_GROUP}.
+     *
+     * <p>Also pins the score split that remains, because it is a real difference from classic and is documented as such:
+     * an in-window member carries its own fused score, while the out-of-window member has no Top clause to score it and
+     * expands at {@code 0.0}.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenCollapseInnerHitsAndMemberOutsideWindow_thenGroupStillExpandsFully() {
+        ensureCollapseDataset();
+        int totalDocs = COLLAPSE_GROUPS * DOCS_PER_GROUP;
+        int window = totalDocs - 1;
+
+        // Ground truth: the fused score of each document that IS in the window, from the same Top-only query ungrouped.
+        Map<String, Double> fusedScoreById = new HashMap<>();
+        for (Map<String, Object> hit : getNestedHits(
+            searchRaw("/" + INDEX_FOR_COLLAPSE + "/_search", "{\"track_total_hits\":false,\"query\":" + collapseFusedQuery(window) + "}")
+        )) {
+            fusedScoreById.put((String) hit.get("_id"), ((Number) hit.get("_score")).doubleValue());
+        }
+        assertEquals("the window holds one document fewer than the corpus", window, fusedScoreById.size());
+
+        String body = "{\"track_total_hits\":false,\"query\":"
+            + collapseFusedQuery(window)
+            + ",\"collapse\":{\"field\":\""
+            + GRP_FIELD
+            + "\",\"inner_hits\":{\"name\":\"members\",\"size\":10}}}";
+
+        List<Map<String, Object>> groups = getNestedHits(searchRaw("/" + INDEX_FOR_COLLAPSE + "/_search", body));
+
+        assertEquals(COLLAPSE_GROUPS, groups.size());
+        Set<String> expanded = new HashSet<>();
+        for (Map<String, Object> group : groups) {
+            List<Map<String, Object>> members = innerHits(group, "members");
+            assertEquals("a group expands to all of its members, window membership notwithstanding", DOCS_PER_GROUP, members.size());
+            for (Map<String, Object> member : members) {
+                String memberId = (String) member.get("_id");
+                assertTrue("no document may be expanded twice", expanded.add(memberId));
+                double memberScore = ((Number) member.get("_score")).doubleValue();
+                if (fusedScoreById.containsKey(memberId)) {
+                    assertEquals(
+                        "in-window member " + memberId + " carries its own fused score",
+                        fusedScoreById.get(memberId),
+                        memberScore,
+                        1e-6
+                    );
+                } else {
+                    // Documented limitation: fusion ranked the window, so a document outside it has no fused score to
+                    // carry. It matches the Tail, which is a filter and therefore contributes nothing to the score.
+                    assertEquals("the out-of-window member matches only the non-scoring Tail", 0.0, memberScore, 1e-6);
+                }
+            }
+        }
+        assertEquals("every document is expanded into exactly one group", totalDocs, expanded.size());
+    }
+
     private String indexConfigWithGroupField() {
         return "{\"settings\":{\"number_of_shards\":2,\"number_of_replicas\":0,\"index.search.default_pipeline\":\""
             + NORM_PIPELINE
@@ -416,7 +487,14 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
     }
 
     private String collapseFusedQuery() {
-        return "{\"hybrid\":{\"fusion\":{\"normalization\":{\"technique\":\"min_max\"},"
+        return collapseFusedQuery(0);
+    }
+
+    /** The collapse-dataset fused query; {@code windowSize} of 0 leaves {@code window_size} at its default. */
+    private String collapseFusedQuery(int windowSize) {
+        return "{\"hybrid\":{\"fusion\":{"
+            + (windowSize > 0 ? "\"window_size\":" + windowSize + "," : "")
+            + "\"normalization\":{\"technique\":\"min_max\"},"
             + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
             + "\"queries\":["
             + collapseLeg()

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
@@ -9,6 +9,12 @@ import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getNestedHi
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.neuralsearch.BaseNeuralSearchIT;
@@ -27,6 +33,12 @@ import lombok.SneakyThrows;
 public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
 
     private static final String TEXT_FIELD = "text";
+    /** Own index: the PIT test mutates the doc set mid-test, which would break the exact hit counts asserted above. */
+    private static final String INDEX_FOR_PIT = "test-hybrid-fused-pit";
+    private static final String RANK_FIELD = "rank";
+    /** Documents in the PIT index. The fused window is bound to this count so a post-PIT doc can only enter it by
+     *  evicting a real one — which is what lets this test detect legs that ignore the PIT. */
+    private static final int PIT_DOCS = 3;
     private static final String INDEX_WITH_DEFAULT_NORM = "test-hybrid-fused-default-norm";
     private static final String INDEX_NO_PIPELINE = "test-hybrid-fused-inline-config";
     private static final String NORM_PIPELINE = "fused-mode-norm-pipeline";
@@ -130,5 +142,145 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
             assertTrue("fused score must be > 0 for a matched doc", score > 0.0);
             previous = score;
         }
+    }
+
+    /**
+     * A user-supplied point-in-time must be honored by the whole fused flow, legs included.
+     *
+     * <p>Fused mode opens N leg searches plus the round-2 self-erased query, so without a shared view those are N+1
+     * independent reader instants and a concurrently indexed document can appear in some of them but not others. Passing
+     * the request's PIT down to every leg makes them all read one immutable snapshot.
+     *
+     * <p>The probe: take a PIT, then index a document that ranks ABOVE everything already there. Through the PIT it must
+     * stay invisible, while a live search sees it.
+     *
+     * <p>Three details make this a real regression guard rather than a tautology:
+     * <ul>
+     *   <li>Both legs score by a numeric field via {@code function_score}, so the fused order is exactly the field order —
+     *       deterministic and shard-independent, unlike BM25 (whose min_max floor can actually sink a newly added short
+     *       document to the BOTTOM of a leg, which would hide the defect entirely).</li>
+     *   <li>{@code window_size} is bound to the existing document count, so a document that should be invisible can only
+     *       enter the window by evicting a real one.</li>
+     *   <li>The query is Top-only ({@code track_total_hits:false}); with the Tail present the legs would be re-matched
+     *       directly and return the real documents regardless of what the Top holds, masking the defect.</li>
+     * </ul>
+     * Top-only, the returned hits ARE the fused window: if the legs ignored the PIT they would rank the new document in,
+     * round-2 would read the PIT, fail to match that id, and the request would return FEWER hits than the window holds.
+     * Verified by mutation — removing the PIT passthrough from the legs makes this test fail with 2 hits instead of 3.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenPointInTimeSupplied_thenLegsAndRoundTwoShareOneSnapshot() {
+        if (indexExists(INDEX_FOR_PIT) == false) {
+            createIndex(INDEX_FOR_PIT, indexConfigWithRankField());
+            for (int id = 1; id <= PIT_DOCS; id++) {
+                indexRankedDoc(id, id * 10);
+            }
+        }
+        String pitId = createPointInTime(INDEX_FOR_PIT);
+        try {
+            assertEquals("the Top-only fused window holds every document", PIT_DOCS, getHitCount(searchWithPit(pitId)));
+
+            // A document that outranks everything present, so live legs would put it at the head of the window.
+            indexRankedDoc(PIT_DOCS + 1, 100_000);
+
+            Map<String, Object> throughPit = searchWithPit(pitId);
+            assertEquals(
+                "PIT snapshot must not see the doc indexed after it was taken, and no window slot may be lost to it",
+                PIT_DOCS,
+                getHitCount(throughPit)
+            );
+            for (Map<String, Object> hit : getNestedHits(throughPit)) {
+                assertNotEquals("the post-PIT doc must not leak into the fused window", String.valueOf(PIT_DOCS + 1), hit.get("_id"));
+            }
+
+            // Sanity: a live search does rank it first, so the assertions above are about the snapshot — not about the
+            // document failing to index or to match the legs.
+            List<Map<String, Object>> liveHits = getNestedHits(searchLive());
+            assertEquals("a live search ranks the new doc first", String.valueOf(PIT_DOCS + 1), liveHits.get(0).get("_id"));
+        } finally {
+            deletePointInTime(pitId);
+        }
+    }
+
+    private String indexConfigWithRankField() {
+        return "{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":0},\"mappings\":{\"properties\":{\""
+            + RANK_FIELD
+            + "\":{\"type\":\"integer\"}}}}";
+    }
+
+    @SneakyThrows
+    private void indexRankedDoc(int id, int rank) {
+        Request request = new Request("PUT", "/" + INDEX_FOR_PIT + "/_doc/" + id + "?refresh=true");
+        request.setJsonEntity("{\"" + RANK_FIELD + "\":" + rank + "}");
+        Response response = client().performRequest(request);
+        int code = response.getStatusLine().getStatusCode();
+        assertTrue("indexing doc " + id + " failed: " + code, code == RestStatus.OK.getStatus() || code == RestStatus.CREATED.getStatus());
+    }
+
+    /** Open a point-in-time over the index and return its id. */
+    @SneakyThrows
+    private String createPointInTime(String index) {
+        Request request = new Request("POST", "/" + index + "/_search/point_in_time?keep_alive=5m");
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        Map<String, Object> body = XContentHelper.convertToMap(
+            XContentType.JSON.xContent(),
+            EntityUtils.toString(response.getEntity()),
+            false
+        );
+        String pitId = (String) body.get("pit_id");
+        assertNotNull("pit_id must be returned", pitId);
+        return pitId;
+    }
+
+    @SneakyThrows
+    private void deletePointInTime(String pitId) {
+        Request request = new Request("DELETE", "/_search/point_in_time");
+        request.setJsonEntity("{\"pit_id\":[\"" + pitId + "\"]}");
+        client().performRequest(request);
+    }
+
+    /** Two legs that both score by the numeric rank field, so the fused order is exactly the rank order. */
+    private String rankedFusedQuery() {
+        String leg = "{\"function_score\":{\"query\":{\"match_all\":{}},\"field_value_factor\":{\"field\":\""
+            + RANK_FIELD
+            + "\",\"modifier\":\"none\",\"missing\":1}}}";
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + PIT_DOCS
+            + ",\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
+            + "\"queries\":["
+            + leg
+            + ","
+            + leg
+            + "]}}";
+    }
+
+    /**
+     * Fused search against a PIT, Top-only. The index deliberately does NOT appear in the path: a PIT already pins its own
+     * indices and core rejects a PIT request that also names them.
+     */
+    @SneakyThrows
+    private Map<String, Object> searchWithPit(String pitId) {
+        return searchRaw(
+            "/_search",
+            "{\"pit\":{\"id\":\"" + pitId + "\",\"keep_alive\":\"5m\"},\"track_total_hits\":false,\"query\":" + rankedFusedQuery() + "}"
+        );
+    }
+
+    /** The same fused query without a PIT, for the live-visibility contrast. */
+    @SneakyThrows
+    private Map<String, Object> searchLive() {
+        return searchRaw("/" + INDEX_FOR_PIT + "/_search", "{\"track_total_hits\":false,\"query\":" + rankedFusedQuery() + "}");
+    }
+
+    @SneakyThrows
+    private Map<String, Object> searchRaw(String endpoint, String jsonBody) {
+        Request request = new Request("POST", endpoint);
+        request.addParameter("size", "10");
+        request.setJsonEntity(jsonBody);
+        Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.query;
 
 import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getNestedHits;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.Set;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.rest.RestStatus;
@@ -42,6 +44,11 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
     /** Documents in the PIT index. The fused window is bound to this count so a post-PIT doc can only enter it by
      *  evicting a real one — which is what lets this test detect legs that ignore the PIT. */
     private static final int PIT_DOCS = 3;
+    /** Own index: the slice test partitions its corpus, so it must not share documents with the PIT test's mutations. */
+    private static final String INDEX_FOR_SLICE = "test-hybrid-fused-slice";
+    /** Enough documents that both of the index's shards hold some, so slicing partitions the corpus non-trivially. */
+    private static final int SLICE_DOCS = 20;
+    private static final int SLICES = 2;
     /** Own index: collapse needs a low-cardinality keyword to group on, which the text-only indices above lack. */
     private static final String INDEX_FOR_COLLAPSE = "test-hybrid-fused-collapse";
     private static final String GRP_FIELD = "grp";
@@ -211,14 +218,24 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
     }
 
     private String indexConfigWithRankField() {
-        return "{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":0},\"mappings\":{\"properties\":{\""
+        return indexConfigWithRankField(3);
+    }
+
+    private String indexConfigWithRankField(int shards) {
+        return "{\"settings\":{\"number_of_shards\":"
+            + shards
+            + ",\"number_of_replicas\":0},\"mappings\":{\"properties\":{\""
             + RANK_FIELD
             + "\":{\"type\":\"integer\"}}}}";
     }
 
-    @SneakyThrows
     private void indexRankedDoc(int id, int rank) {
-        Request request = new Request("PUT", "/" + INDEX_FOR_PIT + "/_doc/" + id + "?refresh=true");
+        indexRankedDoc(INDEX_FOR_PIT, id, rank);
+    }
+
+    @SneakyThrows
+    private void indexRankedDoc(String index, int id, int rank) {
+        Request request = new Request("PUT", "/" + index + "/_doc/" + id + "?refresh=true");
         request.setJsonEntity("{\"" + RANK_FIELD + "\":" + rank + "}");
         Response response = client().performRequest(request);
         int code = response.getStatusLine().getStatusCode();
@@ -250,11 +267,15 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
 
     /** Two legs that both score by the numeric rank field, so the fused order is exactly the rank order. */
     private String rankedFusedQuery() {
+        return rankedFusedQuery(PIT_DOCS);
+    }
+
+    private String rankedFusedQuery(int windowSize) {
         String leg = "{\"function_score\":{\"query\":{\"match_all\":{}},\"field_value_factor\":{\"field\":\""
             + RANK_FIELD
             + "\",\"modifier\":\"none\",\"missing\":1}}}";
         return "{\"hybrid\":{\"fusion\":{\"window_size\":"
-            + PIT_DOCS
+            + windowSize
             + ",\"normalization\":{\"technique\":\"min_max\"},"
             + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
             + "\"queries\":["
@@ -282,14 +303,137 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
         return searchRaw("/" + INDEX_FOR_PIT + "/_search", "{\"track_total_hits\":false,\"query\":" + rankedFusedQuery() + "}");
     }
 
-    @SneakyThrows
     private Map<String, Object> searchRaw(String endpoint, String jsonBody) {
+        return searchRaw(endpoint, jsonBody, 10);
+    }
+
+    @SneakyThrows
+    private Map<String, Object> searchRaw(String endpoint, String jsonBody, int size) {
         Request request = new Request("POST", endpoint);
-        request.addParameter("size", "10");
+        request.addParameter("size", String.valueOf(size));
         request.setJsonEntity(jsonBody);
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
         return XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
+    }
+
+    /**
+     * {@code slice} must reach every leg. A sliced request returns only its slice, so legs that ignored the slice would
+     * fill the window with documents belonging to other slices, and each slice would come back an arbitrary fraction of
+     * itself. That is why {@code CandidateScope} classifies {@code sliceBuilder} as propagated rather than ignored.
+     *
+     * <p>Slicing is legal only over a scroll or a point-in-time, and fused mode refuses scroll
+     * ({@link #testFusedMode_whenScroll_thenRejectedWithValidationError}), so two slices over one PIT is the only shape
+     * that reaches this code at all — before this test the word "slice" appeared in no fused test.
+     *
+     * <p>The probe: learn each slice's true membership from core alone with a plain {@code match_all} over the same PIT,
+     * then run the fused query per slice with a {@code window_size} that covers the largest slice but is still smaller
+     * than the corpus. With the slice propagated, each slice's window holds exactly the documents that slice owns.
+     * Without it, both legs return the global top {@code window_size} by rank and round 2's slice filter keeps only the
+     * part that happens to fall inside the slice, so the slices together return fewer than {@link #SLICE_DOCS} documents
+     * and the per-slice equality fails.
+     *
+     * <p>Two details keep it honest: {@code window_size} is asserted to be below the corpus size, since a window that
+     * covered everything would make an unsliced leg indistinguishable from a sliced one; and the query is Top-only
+     * ({@code track_total_hits:false}), because with the Tail present round 2 re-matches the legs directly under the
+     * shard's slice filter and returns the whole slice regardless of what the Top holds.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenSlicedOverPointInTime_thenEachSliceReturnsItsOwnDocuments() {
+        ensureSliceDataset();
+        String pitId = createPointInTime(INDEX_FOR_SLICE);
+        try {
+            // Ground truth, established by core with no hybrid query involved: which documents each slice owns.
+            List<Set<String>> membership = new ArrayList<>();
+            for (int slice = 0; slice < SLICES; slice++) {
+                membership.add(idsOf(searchRaw("/_search", slicedPitBody(pitId, slice, "{\"match_all\":{}}"), SLICE_DOCS * 2)));
+            }
+            Set<String> union = new HashSet<>();
+            int largestSlice = 0;
+            for (Set<String> slice : membership) {
+                for (String id : slice) {
+                    assertTrue("core's own slices must not overlap", union.add(id));
+                }
+                largestSlice = Math.max(largestSlice, slice.size());
+            }
+            assertEquals("core's slices must together cover the corpus", SLICE_DOCS, union.size());
+            assertTrue(
+                "the window must stay below the corpus size or an unsliced leg would cover every slice anyway",
+                largestSlice < SLICE_DOCS
+            );
+
+            for (int slice = 0; slice < SLICES; slice++) {
+                Set<String> fused = idsOf(
+                    searchRaw("/_search", slicedPitBody(pitId, slice, rankedFusedQuery(largestSlice)), SLICE_DOCS * 2)
+                );
+                assertEquals("slice " + slice + " must return exactly the documents it owns", membership.get(slice), fused);
+            }
+        } finally {
+            deletePointInTime(pitId);
+        }
+    }
+
+    /**
+     * Fused mode refuses {@code scroll} with a validation error instead of letting it fail deep in the shards. A scroll
+     * pages one reader snapshot and that snapshot covers round 2 alone: the legs that chose the window ran as separate
+     * one-shot searches against their own reader instants and are never re-run, so later pages would be paged out of a
+     * ranking round 1 cannot reproduce. Classic hybrid refuses scroll too.
+     *
+     * <p>What this pins is the diagnosis, not just the failure. Left unguarded, {@code scroll} plus {@code slice} reaches
+     * the shards, where slicing rejects the scroll-less leg requests and the user gets "all shards failed" naming the
+     * slice — a whole-request failure with a misleading cause. The error asserted here names {@code scroll} as the
+     * unsupported parameter and points at {@code point_in_time}, which fused mode does support
+     * ({@link #testFusedMode_whenPointInTimeSupplied_thenLegsAndRoundTwoShareOneSnapshot}).
+     */
+    @SneakyThrows
+    public void testFusedMode_whenScroll_thenRejectedWithValidationError() {
+        ensureSliceDataset();
+        Request request = new Request("POST", "/" + INDEX_FOR_SLICE + "/_search");
+        request.addParameter("scroll", "1m");
+        request.addParameter("size", "10");
+        // No track_total_hits here: core itself rejects disabling it in a scroll context, which would pre-empt the
+        // rejection under test.
+        request.setJsonEntity("{\"query\":" + rankedFusedQuery(SLICE_DOCS) + "}");
+
+        ResponseException exception = expectThrows(ResponseException.class, () -> client().performRequest(request));
+
+        assertEquals(RestStatus.BAD_REQUEST.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
+        String body = EntityUtils.toString(exception.getResponse().getEntity());
+        assertTrue("the error must name the unsupported parameter, not a shard-level symptom: " + body, body.contains("[scroll]"));
+        assertTrue("the error must point at the shape that does work: " + body, body.contains("point_in_time"));
+    }
+
+    /** A PIT-scoped search body for one slice. The index never appears in the path: a PIT already pins its own indices. */
+    private String slicedPitBody(String pitId, int slice, String query) {
+        return "{\"pit\":{\"id\":\""
+            + pitId
+            + "\",\"keep_alive\":\"5m\"},\"slice\":{\"id\":"
+            + slice
+            + ",\"max\":"
+            + SLICES
+            + "},\"track_total_hits\":false,\"query\":"
+            + query
+            + "}";
+    }
+
+    private Set<String> idsOf(Map<String, Object> response) {
+        Set<String> ids = new HashSet<>();
+        for (Map<String, Object> hit : getNestedHits(response)) {
+            ids.add((String) hit.get("_id"));
+        }
+        return ids;
+    }
+
+    @SneakyThrows
+    private void ensureSliceDataset() {
+        if (indexExists(INDEX_FOR_SLICE)) {
+            return;
+        }
+        // Two shards and two slices, so each slice maps to exactly one shard and the partition is deterministic.
+        createIndex(INDEX_FOR_SLICE, indexConfigWithRankField(SLICES));
+        for (int id = 1; id <= SLICE_DOCS; id++) {
+            indexRankedDoc(INDEX_FOR_SLICE, id, id * 10);
+        }
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
@@ -6,6 +6,7 @@ package org.opensearch.neuralsearch.query;
 
 import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getNestedHits;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +40,11 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
     /** Documents in the PIT index. The fused window is bound to this count so a post-PIT doc can only enter it by
      *  evicting a real one — which is what lets this test detect legs that ignore the PIT. */
     private static final int PIT_DOCS = 3;
+    /** Own index: collapse needs a low-cardinality keyword to group on, which the text-only indices above lack. */
+    private static final String INDEX_FOR_COLLAPSE = "test-hybrid-fused-collapse";
+    private static final String GRP_FIELD = "grp";
+    private static final int COLLAPSE_GROUPS = 2;
+    private static final int DOCS_PER_GROUP = 2;
     private static final String INDEX_WITH_DEFAULT_NORM = "test-hybrid-fused-default-norm";
     private static final String INDEX_NO_PIPELINE = "test-hybrid-fused-inline-config";
     private static final String NORM_PIPELINE = "fused-mode-norm-pipeline";
@@ -282,5 +288,159 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
         return XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
+    }
+
+    /**
+     * Collapse GROUPING over a fused query must match classic hybrid exactly — it is a plain query-phase operation over
+     * the fused ranking, with no fused-specific handling. This is a real parity guard, not a limitation pin.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenCollapse_thenGroupingMatchesClassic() {
+        ensureCollapseDataset();
+        String collapse = "\"collapse\":{\"field\":\"" + GRP_FIELD + "\"}";
+
+        List<Map<String, Object>> fusedHits = getNestedHits(
+            searchRaw("/" + INDEX_FOR_COLLAPSE + "/_search", "{\"query\":" + collapseFusedQuery() + "," + collapse + "}")
+        );
+        List<Map<String, Object>> classicHits = getNestedHits(
+            searchRaw("/" + INDEX_FOR_COLLAPSE + "/_search", "{\"query\":" + collapseClassicQuery() + "," + collapse + "}")
+        );
+
+        assertEquals("collapse yields one hit per group", COLLAPSE_GROUPS, fusedHits.size());
+        assertEquals("fused and classic collapse to the same number of groups", classicHits.size(), fusedHits.size());
+        // Same groups, in the same order, represented by the same documents.
+        for (int i = 0; i < fusedHits.size(); i++) {
+            assertEquals("group key order matches classic", collapseKey(classicHits.get(i)), collapseKey(fusedHits.get(i)));
+            assertEquals("group representative matches classic", classicHits.get(i).get("_id"), fusedHits.get(i).get("_id"));
+        }
+    }
+
+    /**
+     * With {@code collapse.inner_hits}, every expanded member carries ITS OWN fused score — the same score it receives in
+     * the ungrouped fused search, on the same scale as the group representative.
+     *
+     * <p>Core's {@code ExpandSearchPhase} re-runs {@code source().query()} once per collapse group. For a fused request
+     * that query is the self-erased Top, where each ranked document has its own {@code constant_score} clause, so each
+     * member is scored by its own clause rather than the representative's.
+     *
+     * <p>This differs from classic hybrid, which re-runs the real sub-queries and reports their raw, un-normalized scores
+     * — putting members on a different scale from the representative (classic yields a representative at {@code 1.0}
+     * beside members at {@code 198.0}). Fused is self-consistent instead, which is why this asserts the fused values
+     * rather than classic parity. Leg-level {@code inner_hits} do match classic exactly and are covered separately.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenCollapseInnerHits_thenMembersCarryTheirOwnFusedScore() {
+        ensureCollapseDataset();
+
+        // Ground truth: the fused score each document receives with no collapse applied.
+        Map<String, Double> fusedScoreById = new HashMap<>();
+        for (Map<String, Object> hit : getNestedHits(
+            searchRaw("/" + INDEX_FOR_COLLAPSE + "/_search", "{\"query\":" + collapseFusedQuery() + "}")
+        )) {
+            fusedScoreById.put((String) hit.get("_id"), ((Number) hit.get("_score")).doubleValue());
+        }
+        assertEquals("every document is fused", COLLAPSE_GROUPS * DOCS_PER_GROUP, fusedScoreById.size());
+
+        String body = "{\"query\":"
+            + collapseFusedQuery()
+            + ",\"collapse\":{\"field\":\""
+            + GRP_FIELD
+            + "\",\"inner_hits\":{\"name\":\"members\",\"size\":10}}}";
+
+        List<Map<String, Object>> groups = getNestedHits(searchRaw("/" + INDEX_FOR_COLLAPSE + "/_search", body));
+
+        assertEquals(COLLAPSE_GROUPS, groups.size());
+        for (Map<String, Object> group : groups) {
+            List<Map<String, Object>> members = innerHits(group, "members");
+            assertEquals("each group expands to all of its documents", DOCS_PER_GROUP, members.size());
+            for (Map<String, Object> member : members) {
+                String memberId = (String) member.get("_id");
+                assertEquals(
+                    "expanded member " + memberId + " must carry its own fused score, not the representative's",
+                    fusedScoreById.get(memberId),
+                    ((Number) member.get("_score")).doubleValue(),
+                    1e-6
+                );
+            }
+            // The representative is the group's best-scoring member, consistent with the fused ranking.
+            double representativeScore = ((Number) group.get("_score")).doubleValue();
+            for (Map<String, Object> member : members) {
+                assertTrue(
+                    "no member may outrank its group representative",
+                    ((Number) member.get("_score")).doubleValue() <= representativeScore + 1e-6
+                );
+            }
+        }
+    }
+
+    private String indexConfigWithGroupField() {
+        return "{\"settings\":{\"number_of_shards\":2,\"number_of_replicas\":0,\"index.search.default_pipeline\":\""
+            + NORM_PIPELINE
+            + "\"},\"mappings\":{\"properties\":{\""
+            + GRP_FIELD
+            + "\":{\"type\":\"keyword\"},\""
+            + RANK_FIELD
+            + "\":{\"type\":\"integer\"}}}}";
+    }
+
+    @SneakyThrows
+    private void ensureCollapseDataset() {
+        // Classic hybrid needs a normalization pipeline; the index default supplies it for the comparison test.
+        createSearchPipeline(NORM_PIPELINE, "min_max", "arithmetic_mean", Map.of());
+        if (indexExists(INDEX_FOR_COLLAPSE)) {
+            return;
+        }
+        createIndex(INDEX_FOR_COLLAPSE, indexConfigWithGroupField());
+        int id = 1;
+        for (int group = 0; group < COLLAPSE_GROUPS; group++) {
+            for (int member = 0; member < DOCS_PER_GROUP; member++) {
+                Request request = new Request("PUT", "/" + INDEX_FOR_COLLAPSE + "/_doc/" + id + "?refresh=true");
+                // Distinct ranks so both the fused order and the per-group representative are deterministic.
+                request.setJsonEntity("{\"" + GRP_FIELD + "\":\"g" + group + "\",\"" + RANK_FIELD + "\":" + (100 - id) + "}");
+                Response response = client().performRequest(request);
+                int code = response.getStatusLine().getStatusCode();
+                assertTrue(
+                    "indexing doc " + id + " failed: " + code,
+                    code == RestStatus.OK.getStatus() || code == RestStatus.CREATED.getStatus()
+                );
+                id++;
+            }
+        }
+    }
+
+    /** Two legs scoring by the numeric rank field, so the fused order is deterministic and shard-independent. */
+    private String collapseLeg() {
+        return "{\"function_score\":{\"query\":{\"match_all\":{}},\"field_value_factor\":{\"field\":\""
+            + RANK_FIELD
+            + "\",\"modifier\":\"none\",\"missing\":1}}}";
+    }
+
+    private String collapseFusedQuery() {
+        return "{\"hybrid\":{\"fusion\":{\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
+            + "\"queries\":["
+            + collapseLeg()
+            + ","
+            + collapseLeg()
+            + "]}}";
+    }
+
+    private String collapseClassicQuery() {
+        return "{\"hybrid\":{\"queries\":[" + collapseLeg() + "," + collapseLeg() + "]}}";
+    }
+
+    @SuppressWarnings("unchecked")
+    private String collapseKey(Map<String, Object> hit) {
+        List<Object> fields = (List<Object>) ((Map<String, Object>) hit.get("fields")).get(GRP_FIELD);
+        return String.valueOf(fields.get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> innerHits(Map<String, Object> hit, String name) {
+        Map<String, Object> inner = (Map<String, Object>) hit.get("inner_hits");
+        assertNotNull("collapse.inner_hits must be present", inner);
+        Map<String, Object> named = (Map<String, Object>) inner.get(name);
+        Map<String, Object> hits = (Map<String, Object>) named.get("hits");
+        return (List<Map<String, Object>>) hits.get("hits");
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeKnnTailIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeKnnTailIT.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import lombok.SneakyThrows;
+
+/**
+ * End-to-end coverage of how a fused/resolver hybrid renders an ANN ({@code knn}/{@code neural}) leg in the Tail.
+ *
+ * <p>An ANN leg's Lucene match set IS the top-k it returned, so re-running it in the Tail would only re-walk the HNSW
+ * graph to recount what the fan-out already retrieved. The coordinator therefore replaces such a leg with a direct address
+ * of its returned hits — and because the Tail is a {@code filter}, that address decides the match set that
+ * {@code total_hits}, every aggregation, and the score-0 region of the hit list are computed from.
+ *
+ * <p>Addressed by {@code _id} alone, that set silently grew: on a multi-index search every same-{@code _id} document in a
+ * sibling index passed the filter, so the numbers the Tail exists to make correct were the ones it inflated. This is not
+ * the Top's identity bug and was not fixed by qualifying the Top — the Tail is built from the raw leg hits, never from the
+ * ranked window's indices — so it needs its own end-to-end proof.
+ *
+ * <p>Dataset: two indices with deliberately COLLIDING ids 1..3. Only {@code index-a}'s documents carry a vector, so the
+ * ANN leg's complete match set is exactly those three documents — nothing is truncated by {@code k} or by the leg's
+ * {@code size} ({@code window_size} is 10 against 3 returned hits), which keeps this test about <i>addressing</i> and not
+ * about materialization depth. {@code index-b}'s documents exist, share the ids, and must stay out of the match set.
+ */
+public class HybridQueryFusedModeKnnTailIT extends BaseNeuralSearchIT {
+
+    private static final String INDEX_A = "test-fused-knn-tail-a";
+    private static final String INDEX_B = "test-fused-knn-tail-b";
+    private static final String NORM_PIPELINE = "fused-knn-tail-norm-pipeline";
+    private static final String OWNER_FIELD = "owner";
+    private static final String SCORE_FIELD = "s";
+    private static final String VECTOR_FIELD = "vec";
+    private static final String OWNER_A = "owner-a";
+    private static final String OWNER_B = "owner-b";
+    private static final int COLLIDING_IDS = 3;
+    private static final int WINDOW_SIZE = 10;
+
+    private String indexConfig() {
+        return "{\"settings\":{\"index\":{\"knn\":true,\"number_of_shards\":1,\"number_of_replicas\":0,"
+            + "\"search.default_pipeline\":\""
+            + NORM_PIPELINE
+            + "\"}},"
+            + "\"mappings\":{\"properties\":{\""
+            + OWNER_FIELD
+            + "\":{\"type\":\"keyword\"},\""
+            + SCORE_FIELD
+            + "\":{\"type\":\"integer\"},\""
+            + VECTOR_FIELD
+            + "\":{\"type\":\"knn_vector\",\"dimension\":2,"
+            + "\"method\":{\"name\":\"hnsw\",\"space_type\":\"l2\",\"engine\":\"lucene\"}}}}}";
+    }
+
+    /**
+     * Both indices hold ids 1..3 with the same mapping, but only index-a's documents carry a vector — so the ANN leg
+     * retrieves index-a's three documents and nothing else, while index-b's three same-{@code _id} documents are exactly
+     * the ones a bare {@code _id} address would drag in.
+     */
+    @SneakyThrows
+    private void ensureDataset() {
+        createSearchPipeline(NORM_PIPELINE, "min_max", "arithmetic_mean", Map.of());
+        if (indexExists(INDEX_A) && indexExists(INDEX_B)) {
+            return;
+        }
+        for (String index : List.of(INDEX_A, INDEX_B)) {
+            if (indexExists(index) == false) {
+                createIndex(index, indexConfig());
+            }
+            boolean withVector = INDEX_A.equals(index);
+            for (int id = 1; id <= COLLIDING_IDS; id++) {
+                String owner = withVector ? OWNER_A : OWNER_B;
+                int s = (withVector ? 100 : 50) - id;
+                String vector = withVector ? ",\"" + VECTOR_FIELD + "\":[1." + id + ",1.0]" : "";
+                Request request = new Request("PUT", "/" + index + "/_doc/" + id + "?refresh=true");
+                request.setJsonEntity("{\"" + OWNER_FIELD + "\":\"" + owner + "\",\"" + SCORE_FIELD + "\":" + s + vector + "}");
+                Response response = client().performRequest(request);
+                int code = response.getStatusLine().getStatusCode();
+                assertTrue(
+                    "indexing " + index + "/" + id + " failed: " + code,
+                    code == RestStatus.OK.getStatus() || code == RestStatus.CREATED.getStatus()
+                );
+            }
+        }
+    }
+
+    /** A materializable leg: {@code knn} is replaced in the Tail by an address of the hits it returned. */
+    private String knnLeg(String filter) {
+        return "{\"knn\":{\"" + VECTOR_FIELD + "\":{\"vector\":[1.1,1.0],\"k\":" + WINDOW_SIZE + filter + "}}}";
+    }
+
+    /** A non-materializable leg, kept as the real query in the Tail. Matches index-a's documents only. */
+    private String ownerLeg() {
+        return "{\"function_score\":{\"query\":{\"term\":{\""
+            + OWNER_FIELD
+            + "\":\""
+            + OWNER_A
+            + "\"}},\"field_value_factor\":{\"field\":\""
+            + SCORE_FIELD
+            + "\",\"modifier\":\"none\",\"missing\":1}}}";
+    }
+
+    private String fusedHybrid(String... legs) {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
+            + "\"queries\":["
+            + String.join(",", legs)
+            + "]}}";
+    }
+
+    /**
+     * The regression this class exists for. Both legs match index-a's three documents and nothing else, so the fused
+     * match set is those three. While the materialized ANN leg was addressed by {@code _id} alone, index-b's three
+     * same-{@code _id} documents also passed the Tail filter: {@code total_hits} read 6 instead of 3, the {@code owner}
+     * aggregation reported a bucket for an index no leg had matched, and the user got three score-0 hits from it.
+     */
+    @SneakyThrows
+    public void testFusedKnnTail_whenIdsCollideAcrossIndices_thenSiblingDocsStayOutOfTheMatchSet() {
+        ensureDataset();
+        String body = "{\"query\":"
+            + fusedHybrid(knnLeg(""), ownerLeg())
+            + ",\"aggregations\":{\"by_owner\":{\"terms\":{\"field\":\""
+            + OWNER_FIELD
+            + "\",\"size\":10}}},\"track_total_hits\":true}";
+
+        Map<String, Object> response = searchRaw(body, 20);
+
+        assertEquals("only the documents the legs matched are hits", COLLIDING_IDS, hits(response).size());
+        assertEquals("total_hits counts the legs' match set, not their _id twins", (long) COLLIDING_IDS, totalHits(response));
+        for (Map<String, Object> hit : hits(response)) {
+            assertEquals("a hit from an index no leg matched means the Tail was addressed by _id alone", INDEX_A, hit.get("_index"));
+        }
+        Map<String, Integer> buckets = ownerBuckets(response);
+        assertEquals("the aggregation covers index-a's documents", Integer.valueOf(COLLIDING_IDS), buckets.getOrDefault(OWNER_A, 0));
+        assertEquals("and counts nothing from index-b", Integer.valueOf(0), buckets.getOrDefault(OWNER_B, 0));
+    }
+
+    /**
+     * An ANN leg that matched nothing must keep matching nothing. Its Tail clause is an explicit {@code match_none}: a leg
+     * rendered as an empty {@code bool{should: []}} would compile to {@code MatchAllDocsQuery} and make the Tail match
+     * every document in both indices — so {@code total_hits} and the aggregation would report the whole corpus instead of
+     * the one leg that actually matched. The {@code filter} on the kNN leg matches no owner, so the leg returns zero hits
+     * while the second leg still fuses normally.
+     */
+    @SneakyThrows
+    public void testFusedKnnTail_whenAnnLegMatchesNothing_thenTailDoesNotFallBackToMatchAll() {
+        ensureDataset();
+        String noOwnerFilter = ",\"filter\":{\"term\":{\"" + OWNER_FIELD + "\":\"owner-nobody\"}}";
+        String body = "{\"query\":"
+            + fusedHybrid(knnLeg(noOwnerFilter), ownerLeg())
+            + ",\"aggregations\":{\"by_owner\":{\"terms\":{\"field\":\""
+            + OWNER_FIELD
+            + "\",\"size\":10}}},\"track_total_hits\":true}";
+
+        Map<String, Object> response = searchRaw(body, 20);
+
+        assertEquals("an empty ANN leg contributes nothing, it does not open the Tail up", COLLIDING_IDS, hits(response).size());
+        assertEquals("total_hits stays the surviving leg's match set", (long) COLLIDING_IDS, totalHits(response));
+        Map<String, Integer> buckets = ownerBuckets(response);
+        assertEquals(Integer.valueOf(COLLIDING_IDS), buckets.getOrDefault(OWNER_A, 0));
+        assertEquals("an empty ANN leg must not turn into match_all", Integer.valueOf(0), buckets.getOrDefault(OWNER_B, 0));
+    }
+
+    /**
+     * Scores must still be per-document with the ANN leg materialized: the fused window is index-a's documents, and the
+     * closest vector to the query must rank first. Guards against the qualification narrowing the Tail so far that it
+     * filters out the Top it is supposed to accompany — every window document has to survive its own Tail.
+     */
+    @SneakyThrows
+    public void testFusedKnnTail_whenAnnLegIsMaterialized_thenWindowDocsSurviveTheirOwnTail() {
+        ensureDataset();
+        String body = "{\"query\":" + fusedHybrid(knnLeg(""), ownerLeg()) + ",\"track_total_hits\":true}";
+
+        Map<String, Object> response = searchRaw(body, 20);
+
+        Map<String, Double> scoreById = new LinkedHashMap<>();
+        for (Map<String, Object> hit : hits(response)) {
+            scoreById.put((String) hit.get("_id"), ((Number) hit.get("_score")).doubleValue());
+        }
+        assertEquals("every window document is returned", COLLIDING_IDS, scoreById.size());
+        // The query vector is index-a's doc 2, so it is the nearest neighbour and the highest raw ANN score.
+        assertTrue(
+            "the document nearest the query vector must outrank the farthest, got " + scoreById,
+            scoreById.get("2") > scoreById.get("3")
+        );
+    }
+
+    // ------------------------------------------------ helpers ------------------------------------------------
+
+    @SneakyThrows
+    private Map<String, Object> searchRaw(String jsonBody, int size) {
+        Request request = new Request("POST", "/" + INDEX_A + "," + INDEX_B + "/_search");
+        request.setJsonEntity(jsonBody);
+        request.addParameter("size", Integer.toString(size));
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> hits(Map<String, Object> response) {
+        Map<String, Object> hits = (Map<String, Object>) response.get("hits");
+        List<Map<String, Object>> hitList = (List<Map<String, Object>>) hits.get("hits");
+        return hitList == null ? new ArrayList<>() : hitList;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> ownerBuckets(Map<String, Object> response) {
+        Map<String, Integer> out = new LinkedHashMap<>();
+        Map<String, Object> aggregations = (Map<String, Object>) response.get("aggregations");
+        if (aggregations == null) {
+            return out;
+        }
+        Map<String, Object> byOwner = (Map<String, Object>) aggregations.get("by_owner");
+        for (Map<String, Object> bucket : (List<Map<String, Object>>) byOwner.get("buckets")) {
+            out.put((String) bucket.get("key"), ((Number) bucket.get("doc_count")).intValue());
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private long totalHits(Map<String, Object> response) {
+        Map<String, Object> hits = (Map<String, Object>) response.get("hits");
+        Object total = hits.get("total");
+        if (total instanceof Map) {
+            Object value = ((Map<String, Object>) total).get("value");
+            return value == null ? -1 : ((Number) value).longValue();
+        }
+        return -1;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeMultiIndexIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeMultiIndexIT.java
@@ -88,8 +88,15 @@ public class HybridQueryFusedModeMultiIndexIT extends BaseNeuralSearchIT {
             + "\",\"modifier\":\"none\",\"missing\":1}}}";
     }
 
+    /** Window wide enough for every document in both indices, so the fused window itself spans both. */
     private String fusedHybrid() {
-        return "{\"hybrid\":{\"fusion\":{\"window_size\":10,"
+        return fusedHybrid(10);
+    }
+
+    private String fusedHybrid(int windowSize) {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + windowSize
+            + ","
             + "\"normalization\":{\"technique\":\"min_max\"},"
             + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
             + "\"queries\":["
@@ -166,6 +173,37 @@ public class HybridQueryFusedModeMultiIndexIT extends BaseNeuralSearchIT {
                     + " vs "
                     + fromB,
                 fromA > fromB
+            );
+        }
+    }
+
+    /**
+     * The window is not evidence about the request. With {@code window_size} below the size of the fused set, index-a's
+     * higher scores fill the whole window — yet round 2 still runs against both indices, where index-b's {@code _id} 1..3
+     * are waiting. While qualification was decided from the window (one distinct index there, so "no disambiguation
+     * needed") each index-b document matched its index-a namesake's Top clause and was handed that document's fused score.
+     * Both sides then carried an identical score, and which one a user saw came down to Lucene's tie-break.
+     */
+    @SneakyThrows
+    public void testFusedMultiIndex_whenWindowSpansOneIndex_thenSiblingIndexDoesNotInheritScores() {
+        ensureDataset();
+        // index-a's scores (99/98/97) beat index-b's (49/48/47) for every id, so a window of 3 is entirely index-a.
+        String body = "{\"query\":" + fusedHybrid(COLLIDING_IDS) + "}";
+
+        Map<String, Double> scoreByIndexAndId = new LinkedHashMap<>();
+        for (Map<String, Object> hit : hits(searchRaw(body, 20))) {
+            scoreByIndexAndId.put(hit.get("_index") + "#" + hit.get("_id"), ((Number) hit.get("_score")).doubleValue());
+        }
+
+        for (int id = 1; id <= COLLIDING_IDS; id++) {
+            double fromA = scoreByIndexAndId.get(INDEX_A + "#" + id);
+            double fromB = scoreByIndexAndId.get(INDEX_B + "#" + id);
+            assertTrue("id " + id + ": the windowed index-a doc must be scored, got " + fromA, fromA > 0.0d);
+            assertEquals(
+                "id " + id + ": index-b's doc is outside the window, so it must score 0 rather than inherit " + fromA,
+                0.0d,
+                fromB,
+                0.0d
             );
         }
     }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeMultiIndexIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeMultiIndexIT.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import lombok.SneakyThrows;
+
+/**
+ * End-to-end coverage of a fused/resolver hybrid searching MULTIPLE indices, where {@code _id} alone is not a unique
+ * document identity.
+ *
+ * <p>Fusion happens on the coordinator over the legs' returned hits, so a document has to be identified by something the
+ * coordinator can see. Keyed on {@code _id} alone, a document in {@code index-a} and a <b>different</b> document in
+ * {@code index-b} that happen to share an {@code _id} would be fused as if they were one entity — their scores combined —
+ * and the self-erased {@code _id}-only Top clause would then match both, giving both the same fused score. Keying on
+ * {@code _index} + {@code _id} keeps them distinct, and the Top clause is {@code _index}-qualified so a score lands on
+ * exactly the document it was computed for.
+ *
+ * <p>Dataset: two indices with deliberately COLLIDING ids 1..3. The {@code owner} field records which index a document
+ * came from, so the assertions can tell the two sides of a collision apart. Scores are driven by a numeric field via
+ * {@code function_score} to keep the fused window deterministic and shard-independent.
+ */
+public class HybridQueryFusedModeMultiIndexIT extends BaseNeuralSearchIT {
+
+    private static final String INDEX_A = "test-fused-multi-a";
+    private static final String INDEX_B = "test-fused-multi-b";
+    private static final String NORM_PIPELINE = "fused-multi-index-norm-pipeline";
+    private static final String OWNER_FIELD = "owner";
+    private static final String SCORE_FIELD = "s";
+    private static final int COLLIDING_IDS = 3;
+
+    private String indexConfig() {
+        return "{\"settings\":{\"number_of_shards\":2,\"number_of_replicas\":0,"
+            + "\"index.search.default_pipeline\":\""
+            + NORM_PIPELINE
+            + "\"},"
+            + "\"mappings\":{\"properties\":{\""
+            + OWNER_FIELD
+            + "\":{\"type\":\"keyword\"},\""
+            + SCORE_FIELD
+            + "\":{\"type\":\"integer\"}}}}";
+    }
+
+    @SneakyThrows
+    private void ensureDataset() {
+        createSearchPipeline(NORM_PIPELINE, "min_max", "arithmetic_mean", Map.of());
+        if (indexExists(INDEX_A) && indexExists(INDEX_B)) {
+            return;
+        }
+        // Same ids in both indices — every id 1..3 exists twice, once per index.
+        for (String index : List.of(INDEX_A, INDEX_B)) {
+            if (indexExists(index) == false) {
+                createIndex(index, indexConfig());
+            }
+            for (int id = 1; id <= COLLIDING_IDS; id++) {
+                // index-a scores higher than index-b for the same id, so the two sides are distinguishable by score too.
+                int s = (INDEX_A.equals(index) ? 100 : 50) - id;
+                Request request = new Request("PUT", "/" + index + "/_doc/" + id + "?refresh=true");
+                request.setJsonEntity("{\"" + OWNER_FIELD + "\":\"" + index + "\",\"" + SCORE_FIELD + "\":" + s + "}");
+                Response response = client().performRequest(request);
+                int code = response.getStatusLine().getStatusCode();
+                assertTrue(
+                    "indexing " + index + "/" + id + " failed: " + code,
+                    code == RestStatus.OK.getStatus() || code == RestStatus.CREATED.getStatus()
+                );
+            }
+        }
+    }
+
+    private String leg() {
+        return "{\"function_score\":{\"query\":{\"match_all\":{}},"
+            + "\"field_value_factor\":{\"field\":\""
+            + SCORE_FIELD
+            + "\",\"modifier\":\"none\",\"missing\":1}}}";
+    }
+
+    private String fusedHybrid() {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":10,"
+            + "\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\"}},"
+            + "\"queries\":["
+            + leg()
+            + ","
+            + leg()
+            + "]}}";
+    }
+
+    /**
+     * Colliding ids across indices must stay separate documents: all 6 (3 ids x 2 indices) come back, each id appearing
+     * once per index. Keyed on {@code _id} alone this collapsed to 3 fused entries.
+     */
+    @SneakyThrows
+    public void testFusedMultiIndex_whenIdsCollide_thenDocumentsStayDistinct() {
+        ensureDataset();
+        String body = "{\"query\":" + fusedHybrid() + ",\"track_total_hits\":true}";
+
+        Map<String, Object> resp = searchRaw(body, 20);
+
+        assertEquals("every id from both indices is returned as its own document", 2 * COLLIDING_IDS, hits(resp).size());
+        assertEquals("total_hits covers both indices", (long) (2 * COLLIDING_IDS), totalHits(resp));
+        Map<String, Integer> perIndex = countBy(resp, "_index");
+        assertEquals("index-a contributes all of its docs", Integer.valueOf(COLLIDING_IDS), perIndex.getOrDefault(INDEX_A, 0));
+        assertEquals("index-b contributes all of its docs", Integer.valueOf(COLLIDING_IDS), perIndex.getOrDefault(INDEX_B, 0));
+        // Each colliding id appears exactly twice — once per index — rather than being conflated into one hit.
+        Map<String, Integer> perId = countBy(resp, "_id");
+        for (int id = 1; id <= COLLIDING_IDS; id++) {
+            assertEquals("id " + id + " appears once per index", Integer.valueOf(2), perId.getOrDefault(String.valueOf(id), 0));
+        }
+    }
+
+    /**
+     * The {@code owner} field is the ground truth for "which document is this": every hit's {@code owner} must match the
+     * index it was returned from. A conflated identity would surface a hit whose {@code _index} and {@code owner} disagree.
+     */
+    @SneakyThrows
+    public void testFusedMultiIndex_whenIdsCollide_thenEachHitBelongsToItsOwnIndex() {
+        ensureDataset();
+        String body = "{\"query\":" + fusedHybrid() + "}";
+
+        for (Map<String, Object> hit : hits(searchRaw(body, 20))) {
+            String index = (String) hit.get("_index");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+            assertEquals("hit from " + index + " must carry that index's document", index, source.get(OWNER_FIELD));
+        }
+    }
+
+    /**
+     * Fused scores must be per-document, not shared across an id collision. index-a's documents score higher than
+     * index-b's for the same id, so if the two sides had been fused into one entry both would carry an identical score.
+     */
+    @SneakyThrows
+    public void testFusedMultiIndex_whenIdsCollide_thenScoresAreNotShared() {
+        ensureDataset();
+        String body = "{\"query\":" + fusedHybrid() + "}";
+
+        Map<String, Double> scoreByOwnerAndId = new LinkedHashMap<>();
+        for (Map<String, Object> hit : hits(searchRaw(body, 20))) {
+            Object score = hit.get("_score");
+            assertNotNull("every fused hit must be scored", score);
+            scoreByOwnerAndId.put(hit.get("_index") + "#" + hit.get("_id"), ((Number) score).doubleValue());
+        }
+
+        for (int id = 1; id <= COLLIDING_IDS; id++) {
+            double fromA = scoreByOwnerAndId.get(INDEX_A + "#" + id);
+            double fromB = scoreByOwnerAndId.get(INDEX_B + "#" + id);
+            assertTrue(
+                "id "
+                    + id
+                    + ": index-a doc (higher raw score) must outrank the index-b doc with the same _id, got "
+                    + fromA
+                    + " vs "
+                    + fromB,
+                fromA > fromB
+            );
+        }
+    }
+
+    /** Aggregations over a multi-index fused search cover every document, not a conflated subset. */
+    @SneakyThrows
+    public void testFusedMultiIndex_aggregationsCoverBothIndices() {
+        ensureDataset();
+        String body = "{\"query\":"
+            + fusedHybrid()
+            + ",\"aggregations\":{\"by_owner\":{\"terms\":{\"field\":\""
+            + OWNER_FIELD
+            + "\",\"size\":10}}},\"track_total_hits\":true}";
+
+        Map<String, Integer> buckets = ownerBuckets(searchRaw(body, 20));
+
+        assertEquals("agg counts index-a docs", Integer.valueOf(COLLIDING_IDS), buckets.getOrDefault(INDEX_A, 0));
+        assertEquals("agg counts index-b docs", Integer.valueOf(COLLIDING_IDS), buckets.getOrDefault(INDEX_B, 0));
+    }
+
+    // ------------------------------------------------ helpers ------------------------------------------------
+
+    @SneakyThrows
+    private Map<String, Object> searchRaw(String jsonBody, int size) {
+        Request request = new Request("POST", "/" + INDEX_A + "," + INDEX_B + "/_search");
+        request.setJsonEntity(jsonBody);
+        request.addParameter("size", Integer.toString(size));
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> hits(Map<String, Object> resp) {
+        Map<String, Object> hits = (Map<String, Object>) resp.get("hits");
+        List<Map<String, Object>> hitList = (List<Map<String, Object>>) hits.get("hits");
+        return hitList == null ? new ArrayList<>() : hitList;
+    }
+
+    private Map<String, Integer> countBy(Map<String, Object> resp, String field) {
+        Map<String, Integer> out = new LinkedHashMap<>();
+        for (Map<String, Object> hit : hits(resp)) {
+            out.merge((String) hit.get(field), 1, Integer::sum);
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> ownerBuckets(Map<String, Object> resp) {
+        Map<String, Integer> out = new LinkedHashMap<>();
+        Map<String, Object> aggs = (Map<String, Object>) resp.get("aggregations");
+        if (aggs == null) {
+            return out;
+        }
+        Map<String, Object> byOwner = (Map<String, Object>) aggs.get("by_owner");
+        for (Map<String, Object> bucket : (List<Map<String, Object>>) byOwner.get("buckets")) {
+            out.put((String) bucket.get("key"), ((Number) bucket.get("doc_count")).intValue());
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private long totalHits(Map<String, Object> resp) {
+        Map<String, Object> hits = (Map<String, Object>) resp.get("hits");
+        Object totalObj = hits.get("total");
+        if (totalObj instanceof Map) {
+            Object value = ((Map<String, Object>) totalObj).get("value");
+            return value == null ? -1 : ((Number) value).longValue();
+        }
+        return -1;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeNestedIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeNestedIT.java
@@ -219,6 +219,39 @@ public class HybridQueryFusedModeNestedIT extends BaseNeuralSearchIT {
         assertFalse("fusion-of-fusion must return hits", ids.isEmpty());
     }
 
+    /**
+     * Fusion of fusion where NEITHER level carries an inline config — both read the index's default pipeline. Legs are
+     * fanned out with the search pipeline disabled (so per-leg processors do not run), so the nested fused hybrid has no
+     * pipeline of its own to read and depends on the enclosing rewrite projecting the config it already resolved.
+     * Without that projection this fails claiming no normalization processor is configured — on an index that has one.
+     */
+    @SneakyThrows
+    public void testFused_hybridNestedInHybrid_whenBothLevelsConfigFromPipeline_thenResolves() {
+        ensureDataset();
+        String pipelineConfiguredHybrid = "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + "},\"queries\":["
+            + leg()
+            + ","
+            + leg()
+            + "]}}";
+        String body = "{\"query\":{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + "},\"queries\":["
+            + pipelineConfiguredHybrid
+            + ","
+            + leg()
+            + "]}}}";
+
+        List<String> ids = hitIds(searchRaw(body, 20));
+
+        assertFalse("a nested fused hybrid must resolve its config from the index default pipeline", ids.isEmpty());
+        assertTrue(
+            "fused window (grp A) ranks first",
+            ids.subList(0, Math.min(WINDOW_SIZE, ids.size())).stream().allMatch(id -> Integer.parseInt(id) <= WINDOW_LAST_ID)
+        );
+    }
+
     // ------------------------------------------------ helpers ------------------------------------------------
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeNestedIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeNestedIT.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.rest.RestStatus;
@@ -97,8 +98,12 @@ public class HybridQueryFusedModeNestedIT extends BaseNeuralSearchIT {
 
     /** A fused hybrid: presence of the {@code fusion} block enables the resolver; {@code window_size} lives inside it. */
     private String fusedHybrid() {
+        return fusedHybrid(WINDOW_SIZE);
+    }
+
+    private String fusedHybrid(int windowSize) {
         return "{\"hybrid\":{\"fusion\":{\"window_size\":"
-            + WINDOW_SIZE
+            + windowSize
             + ",\"normalization\":{\"technique\":\"min_max\"},"
             + "\"combination\":{\"technique\":\"arithmetic_mean\",\"parameters\":{\"weights\":[0.5,0.5]}}},"
             + "\"queries\":["
@@ -252,7 +257,48 @@ public class HybridQueryFusedModeNestedIT extends BaseNeuralSearchIT {
         );
     }
 
+    /**
+     * A nested leg's rejection must reach the user as the 400 it is. The leg runs as its own search, so its refusal
+     * arrives at the enclosing coordinator as a MultiSearch item failure; wrapping that in an {@code IllegalStateException}
+     * made every leg-side rejection a 500 with the real status reachable only under {@code caused_by} — a fused hybrid
+     * answered a plain user error the way it would answer a bug, and the same masking hit 429s and cluster blocks.
+     */
+    @SneakyThrows
+    public void testFused_whenNestedLegRejects_thenBadRequestNotServerError() {
+        ensureDataset();
+        // The inner window_size exceeds index.max_result_window, so the inner level refuses it during its own rewrite.
+        String body = "{\"query\":{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\",\"parameters\":{\"weights\":[0.5,0.5]}}},"
+            + "\"queries\":["
+            + fusedHybrid(20000)
+            + ","
+            + leg()
+            + "]}}}";
+
+        ResponseException e = expectThrows(ResponseException.class, () -> searchRawExpectingFailure(body));
+
+        assertEquals(
+            "a leg-side rejection is the user's 400, not a 500",
+            RestStatus.BAD_REQUEST.getStatus(),
+            e.getResponse().getStatusLine().getStatusCode()
+        );
+        assertTrue(
+            "and the response names the real cause rather than an illegal_state_exception",
+            EntityUtils.toString(e.getResponse().getEntity()).contains("max_result_window")
+        );
+    }
+
     // ------------------------------------------------ helpers ------------------------------------------------
+
+    @SneakyThrows
+    private void searchRawExpectingFailure(String jsonBody) {
+        Request request = new Request("POST", "/" + INDEX + "/_search");
+        request.setJsonEntity(jsonBody);
+        request.addParameter("size", "20");
+        client().performRequest(request);
+    }
 
     @SneakyThrows
     private Map<String, Object> searchRaw(String jsonBody, int size) {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeNestedIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeNestedIT.java
@@ -4,6 +4,9 @@
  */
 package org.opensearch.neuralsearch.query;
 
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.DEFAULT_MAX_FUSION_LEG_SEARCHES;
+import static org.opensearch.neuralsearch.settings.NeuralSearchSettings.MAX_FUSION_LEG_SEARCHES;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -111,6 +114,27 @@ public class HybridQueryFusedModeNestedIT extends BaseNeuralSearchIT {
             + ","
             + leg()
             + "]}}";
+    }
+
+    /**
+     * A chain of {@code levels} fused hybrids, each holding the level below as its first leg plus one plain leg — so the
+     * body grows by one clause per level and declares {@code 2 x levels} leg sub-searches. One level is exactly
+     * {@link #fusedHybrid()}.
+     */
+    private String nestedFusedChain(int levels) {
+        String query = leg();
+        for (int level = 0; level < levels; level++) {
+            query = "{\"hybrid\":{\"fusion\":{\"window_size\":"
+                + WINDOW_SIZE
+                + ",\"normalization\":{\"technique\":\"min_max\"},"
+                + "\"combination\":{\"technique\":\"arithmetic_mean\",\"parameters\":{\"weights\":[0.5,0.5]}}},"
+                + "\"queries\":["
+                + query
+                + ","
+                + leg()
+                + "]}}";
+        }
+        return query;
     }
 
     /**
@@ -255,6 +279,49 @@ public class HybridQueryFusedModeNestedIT extends BaseNeuralSearchIT {
             "fused window (grp A) ranks first",
             ids.subList(0, Math.min(WINDOW_SIZE, ids.size())).stream().allMatch(id -> Integer.parseInt(id) <= WINDOW_LAST_ID)
         );
+    }
+
+    /**
+     * Nesting costs what the body spells out, and no more. Every level of this chain adds two leg sub-searches, and the
+     * deepest chain the leg budget admits ({@code max_leg_searches / 2} levels) has to actually run: each level is executed
+     * exactly once, as its parent's leg sub-search, and the enclosing Tail contributes the nested legs' union instead of
+     * firing them again. Two failures this rules out, both of which reproduce on a body of a few hundred bytes: the fan-out
+     * doubling per level ({@code 2^(depth+1) - 2} leg searches), and one rewrite round spent per level of nesting, which
+     * exhausts core's 16 and answers a within-budget request with an internal error.
+     */
+    @SneakyThrows
+    public void testFused_deepestNestingWithinTheLegBudget_runs() {
+        ensureDataset();
+        int levels = DEFAULT_MAX_FUSION_LEG_SEARCHES / 2;
+        String body = "{\"query\":" + nestedFusedChain(levels) + ",\"track_total_hits\":true}";
+
+        Map<String, Object> resp = searchRaw(body, 20);
+
+        assertFalse(levels + " levels of fused nesting must return hits", hitIds(resp).isEmpty());
+        assertEquals("and the Tail still covers the whole union at that depth", (long) TOTAL_DOCS, totalHits(resp));
+    }
+
+    /**
+     * One leg sub-search past the budget is the user's 400 — naming the count, the ceiling and the setting that raises it —
+     * not a 500. The rejection is decided from the request body alone, before the first fan-out, so an over-budget request
+     * costs one tree walk rather than the searches it asked for.
+     */
+    @SneakyThrows
+    public void testFused_whenNestingExceedsTheLegBudget_thenBadRequestNotServerError() {
+        ensureDataset();
+        int levels = DEFAULT_MAX_FUSION_LEG_SEARCHES / 2 + 1;
+        String body = "{\"query\":" + nestedFusedChain(levels) + "}";
+
+        ResponseException e = expectThrows(ResponseException.class, () -> searchRawExpectingFailure(body));
+
+        assertEquals(
+            "an over-budget body is a user error, not a server error",
+            RestStatus.BAD_REQUEST.getStatus(),
+            e.getResponse().getStatusLine().getStatusCode()
+        );
+        String message = EntityUtils.toString(e.getResponse().getEntity());
+        assertTrue("the response states what the body declares: " + message, message.contains("declares " + (2 * levels) + " leg"));
+        assertTrue("and how to raise it: " + message, message.contains(MAX_FUSION_LEG_SEARCHES.getKey()));
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeNestedIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeNestedIT.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import lombok.SneakyThrows;
+
+/**
+ * End-to-end coverage of the NESTED fused/resolver hybrid case: a hybrid carrying a {@code fusion} block wrapped inside
+ * another compound query ({@code bool}, {@code dis_max}, or another fused hybrid). Classic hybrid cannot nest at all
+ * (its top-level-only guard throws), so these behaviors have no classic equivalent — this is capability the coordinator
+ * self-erase unlocks.
+ *
+ * <p><b>The Tail decision is depth-independent.</b> {@code HybridFusionOrchestrator#buildFusedQuery} decides the Tail
+ * from the request alone, never from whether the hybrid is top-level or nested. So a nested hybrid whose request wants
+ * totals/aggregations/highlight still keeps the Tail ({@code bool.filter: bool{should: legs}}), and {@code total_hits}
+ * plus aggregations cover the full leg-union at any depth.
+ *
+ * <p><b>Ranking stays fuse-then-filter.</b> Only the fused-window Top clauses carry a non-zero score; Tail-only docs
+ * score 0 and sort last. An enclosing {@code bool.filter} is a sibling clause and is NOT pushed into the legs before
+ * fusion, so the window is the GLOBAL fused top-K and the enclosing filter intersects it at the query phase. To narrow
+ * retrieval itself, use the hybrid's own {@code filter} field (which IS pushed into each leg). When the enclosing filter
+ * excludes the whole fused window, the Tail still surfaces the matching docs as score-0 hits, so totals/aggregations
+ * remain correct rather than collapsing.
+ *
+ * <p>Determinism: each leg is a {@code function_score} over a numeric field, so the fused window is shard-independent.
+ *
+ * <p>Dataset (30 docs, ids 1..30): {@code grp} is "A" for ids 1-5 (highest {@code s} — the global fused top-5 window)
+ * and "B" for ids 6-30 (never in the window). {@code s = tier*1000 - id}.
+ */
+public class HybridQueryFusedModeNestedIT extends BaseNeuralSearchIT {
+
+    private static final String INDEX = "test-fused-nested";
+    private static final String NORM_PIPELINE = "fused-nested-norm-pipeline";
+    private static final String GRP_FIELD = "grp";
+    private static final String SCORE_FIELD = "s";
+    private static final int WINDOW_SIZE = 5;
+    private static final int WINDOW_LAST_ID = 5;
+    private static final int TOTAL_DOCS = 30;
+
+    private String indexConfig() {
+        return "{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":0,"
+            + "\"index.search.default_pipeline\":\""
+            + NORM_PIPELINE
+            + "\"},"
+            + "\"mappings\":{\"properties\":{\""
+            + GRP_FIELD
+            + "\":{\"type\":\"keyword\"},\""
+            + SCORE_FIELD
+            + "\":{\"type\":\"integer\"}}}}";
+    }
+
+    @SneakyThrows
+    private void ensureDataset() {
+        createSearchPipeline(NORM_PIPELINE, "min_max", "arithmetic_mean", Map.of());
+        if (indexExists(INDEX)) {
+            return;
+        }
+        createIndex(INDEX, indexConfig());
+        for (int id = 1; id <= TOTAL_DOCS; id++) {
+            // grp A = ids 1..5 (highest s, own the top-5 window). grp B = ids 6..30 (never in the window).
+            String grp = id <= WINDOW_LAST_ID ? "A" : "B";
+            int tier = id <= WINDOW_LAST_ID ? 3 : (id <= 17 ? 2 : 1);
+            int s = tier * 1000 - id;
+            Request request = new Request("PUT", "/" + INDEX + "/_doc/" + id + "?refresh=true");
+            request.setJsonEntity("{\"" + GRP_FIELD + "\":\"" + grp + "\",\"" + SCORE_FIELD + "\":" + s + "}");
+            Response response = client().performRequest(request);
+            int code = response.getStatusLine().getStatusCode();
+            assertTrue(
+                "indexing doc " + id + " failed: " + code,
+                code == RestStatus.OK.getStatus() || code == RestStatus.CREATED.getStatus()
+            );
+        }
+    }
+
+    /** A leg that matches ALL docs and scores by the numeric field (deterministic, shard-independent). */
+    private String leg() {
+        return "{\"function_score\":{\"query\":{\"match_all\":{}},"
+            + "\"field_value_factor\":{\"field\":\""
+            + SCORE_FIELD
+            + "\",\"modifier\":\"none\",\"missing\":1}}}";
+    }
+
+    /** A fused hybrid: presence of the {@code fusion} block enables the resolver; {@code window_size} lives inside it. */
+    private String fusedHybrid() {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\",\"parameters\":{\"weights\":[0.5,0.5]}}},"
+            + "\"queries\":["
+            + leg()
+            + ","
+            + leg()
+            + "]}}";
+    }
+
+    /**
+     * Top-level baseline, for contrast with the nested cases: with {@code size <= window_size} the request returns
+     * exactly the fused window; with {@code size > window_size} the Tail also exposes union docs (score 0) below it.
+     */
+    @SneakyThrows
+    public void testFused_topLevel_windowThenTail() {
+        ensureDataset();
+        String body = "{\"query\":" + fusedHybrid() + "}";
+
+        List<String> windowIds = hitIds(searchRaw(body, WINDOW_SIZE));
+        assertEquals("size<=window returns exactly the fused window", WINDOW_SIZE, windowIds.size());
+        assertTrue("window is grp A (ids 1..5)", windowIds.stream().allMatch(id -> Integer.parseInt(id) <= WINDOW_LAST_ID));
+
+        List<String> allIds = hitIds(searchRaw(body, 20));
+        assertEquals("size>window: the Tail exposes union docs beyond the window", 20, allIds.size());
+        assertTrue(
+            "the fused window (grp A) still ranks first",
+            allIds.subList(0, WINDOW_SIZE).stream().allMatch(id -> Integer.parseInt(id) <= WINDOW_LAST_ID)
+        );
+    }
+
+    /**
+     * Fuse-then-filter with a compatible enclosing filter: the window is entirely grp A, so {@code filter grp:A} keeps
+     * all of it.
+     */
+    @SneakyThrows
+    public void testFused_nestedInBool_filterMatchesWindow_keepsAll() {
+        ensureDataset();
+        String body = "{\"query\":{\"bool\":{\"must\":[" + fusedHybrid() + "],\"filter\":[{\"term\":{\"" + GRP_FIELD + "\":\"A\"}}]}}}";
+
+        List<String> ids = hitIds(searchRaw(body, 20));
+
+        assertEquals("filter grp:A intersects the all-A window -> keeps 5", WINDOW_SIZE, ids.size());
+    }
+
+    /**
+     * Depth-independent Tail with a restrictive enclosing filter: the nested hybrid still matches the full leg-union, so
+     * {@code filter grp:B} intersects that union and the 25 grp-B docs survive as score-0 Tail hits (the fused window is
+     * all grp A and is filtered out). They are not lost from the result or from {@code total_hits}.
+     */
+    @SneakyThrows
+    public void testFused_nestedInBool_restrictiveFilter_tailSurfacesFullUnion() {
+        ensureDataset();
+        String body = "{\"query\":{\"bool\":{\"must\":["
+            + fusedHybrid()
+            + "],\"filter\":[{\"term\":{\""
+            + GRP_FIELD
+            + "\":\"B\"}}]}},\"track_total_hits\":true}";
+
+        Map<String, Object> resp = searchRaw(body, TOTAL_DOCS);
+
+        assertEquals("depth-independent Tail: filter(grpB) intersect full-union = 25 grp-B docs", 25, hitIds(resp).size());
+        assertEquals("all surviving hits are grp B", Integer.valueOf(25), grpCounts(resp).getOrDefault("B", 0));
+        assertEquals("total_hits counts the full filtered union", 25L, totalHits(resp));
+    }
+
+    /**
+     * Depth-independent Tail with an outer aggregation: the aggregation covers the full leg-union, not just the fused
+     * window — the case that would silently window if nesting forced Top-only.
+     */
+    @SneakyThrows
+    public void testFused_nestedInBool_outerAggregationCoversFullUnion() {
+        ensureDataset();
+        String body = "{\"query\":{\"bool\":{\"must\":["
+            + fusedHybrid()
+            + "]}},\"aggregations\":{\"by_grp\":{\"terms\":{\"field\":\""
+            + GRP_FIELD
+            + "\",\"size\":10}}},\"track_total_hits\":true}";
+
+        Map<String, Object> resp = searchRaw(body, 20);
+        Map<String, Integer> grp = grpBuckets(resp);
+
+        assertEquals("nested agg covers grp A", Integer.valueOf(WINDOW_LAST_ID), grp.getOrDefault("A", 0));
+        assertEquals("nested agg covers grp B via the depth-independent Tail", Integer.valueOf(25), grp.getOrDefault("B", 0));
+        assertEquals("nested agg total is the full union", (long) TOTAL_DOCS, totalHits(resp));
+    }
+
+    /** Self-erase composes inside a {@code dis_max}, and the fused-scored window still ranks first. */
+    @SneakyThrows
+    public void testFused_nestedInDisMax_composesWindowRanksFirst() {
+        ensureDataset();
+        String body = "{\"query\":{\"dis_max\":{\"queries\":[" + fusedHybrid() + "]}}}";
+
+        List<String> ids = hitIds(searchRaw(body, 20));
+
+        assertFalse("dis_max over fused composes (self-erase resolved)", ids.isEmpty());
+        assertTrue(
+            "fused window (grp A) ranks first",
+            ids.subList(0, Math.min(WINDOW_SIZE, ids.size())).stream().allMatch(id -> Integer.parseInt(id) <= WINDOW_LAST_ID)
+        );
+    }
+
+    /** A fused hybrid nested as a leg of another fused hybrid — the async round-trip must resolve at both levels. */
+    @SneakyThrows
+    public void testFused_hybridNestedInHybrid_fusionOfFusion() {
+        ensureDataset();
+        String body = "{\"query\":{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\",\"parameters\":{\"weights\":[0.5,0.5]}}},"
+            + "\"queries\":["
+            + fusedHybrid()
+            + ","
+            + leg()
+            + "]}}}";
+
+        List<String> ids = hitIds(searchRaw(body, 20));
+
+        assertFalse("fusion-of-fusion must return hits", ids.isEmpty());
+    }
+
+    // ------------------------------------------------ helpers ------------------------------------------------
+
+    @SneakyThrows
+    private Map<String, Object> searchRaw(String jsonBody, int size) {
+        Request request = new Request("POST", "/" + INDEX + "/_search");
+        request.setJsonEntity(jsonBody);
+        request.addParameter("size", Integer.toString(size));
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> hitIds(Map<String, Object> resp) {
+        List<String> out = new ArrayList<>();
+        Map<String, Object> hits = (Map<String, Object>) resp.get("hits");
+        List<Map<String, Object>> hitList = (List<Map<String, Object>>) hits.get("hits");
+        if (hitList != null) {
+            for (Map<String, Object> hit : hitList) {
+                out.add((String) hit.get("_id"));
+            }
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> grpBuckets(Map<String, Object> resp) {
+        Map<String, Integer> out = new LinkedHashMap<>();
+        Map<String, Object> aggs = (Map<String, Object>) resp.get("aggregations");
+        if (aggs == null) {
+            return out;
+        }
+        Map<String, Object> byGrp = (Map<String, Object>) aggs.get("by_grp");
+        List<Map<String, Object>> buckets = (List<Map<String, Object>>) byGrp.get("buckets");
+        for (Map<String, Object> bucket : buckets) {
+            out.put((String) bucket.get("key"), ((Number) bucket.get("doc_count")).intValue());
+        }
+        return out;
+    }
+
+    private Map<String, Integer> grpCounts(Map<String, Object> resp) {
+        Map<String, Integer> out = new LinkedHashMap<>();
+        for (String id : hitIds(resp)) {
+            out.merge(Integer.parseInt(id) <= WINDOW_LAST_ID ? "A" : "B", 1, Integer::sum);
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private long totalHits(Map<String, Object> resp) {
+        Map<String, Object> hits = (Map<String, Object>) resp.get("hits");
+        Object totalObj = hits.get("total");
+        if (totalObj instanceof Map) {
+            Object value = ((Map<String, Object>) totalObj).get("value");
+            return value == null ? -1 : ((Number) value).longValue();
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
### Description
Adding advanced query features carry-over follow-ups from #1933.

- New feature support/improvements:
  - nested composition, Tail decision is now depth-independent
     nested leg is dispatched with `search_pipeline=_none`, so re-resolving the fusion config from the leg request found nothing and a pipeline-configured index returned a 500 for any nested fused query. the resolved spec is now projected onto the legs instead of
  re-resolved, and the "no fusion config" message names what the user has to do
  - inner_hits decoupled from the executed Tail
    split `sourceQueries` into `tailQueries` (executed) and `innerHitsQueries` (registered only). Top-only query now returns leg inner_hits without re-running the legs, and previously dropped nested-fused inner_hits now work
  - added setting to limit depth of nested hq to prevent resource over-consumption
  - Point-in-time (PIT) passthrough
    parity with PIT support with regular queries - user PIT reaches every leg, so all legs and the round-2 query read one immutable view instead of N+1 reader instants
  - pluggable normalization abstraction (ScalarNormalizer) - new low level abstraction for scalar normalizers 
  - window_size validated against indices.query.bool.max_clause_count parse-time 400 instead of a per-shard failure
- Cary over/feedback from foundational PR #1933 
  - allow_partial_search_results properly handled
    explicit request value propagates to every leg; unset stays unset so legs resolve cluster default like a normal search. degraded leg shifts its own min/max, so adding affected legs names to `Warning` header. wholly-failed leg remains a hard failure.
  - multi-index correctness: index-aware document identity
     `_id`-collision bug, documents are now keyed by `_index` + `_id`
 
### Related Issues
Resolves #1930


### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
