### PR TITLE
[RRF] Extract RRF rank arithmetic into a shared helper and deduplicate the hybridization processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Refactoring
 * [SemanticHighlighter] Traverse the query tree with a QueryBuilderVisitor instead of a "manual" walk ([#1915](https://github.com/opensearch-project/neural-search/pull/1915))
+* [RRF] Extract the rank arithmetic into a shared RRFScoreNormalizer and hoist the workflow duplicated between NormalizationProcessor and RRFProcessor into AbstractScoreHybridizationProcessor ([#1944](https://github.com/opensearch-project/neural-search/pull/1944))

--- a/src/main/java/org/opensearch/neuralsearch/processor/AbstractScoreHybridizationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/AbstractScoreHybridizationProcessor.java
@@ -4,19 +4,37 @@
  */
 package org.opensearch.neuralsearch.processor;
 
+import org.opensearch.action.search.QueryPhaseResultConsumer;
 import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchPhaseName;
 import org.opensearch.action.search.SearchPhaseResults;
+import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
 import org.opensearch.search.SearchPhaseResult;
+import org.opensearch.search.fetch.FetchSearchResult;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.pipeline.PipelineProcessingContext;
 import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
+import org.opensearch.search.query.QuerySearchResult;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.log4j.Log4j2;
+
+import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;
 
 /**
  * Base class for all score hybridization processors. This class is responsible for executing the score hybridization process.
  * It is a pipeline processor that is executed after the query phase and before the fetch phase.
+ * <p>
+ * Subclasses supply the techniques to apply and the stats to record; the harvesting of query phase results and
+ * the handoff to {@link NormalizationProcessorWorkflow} are identical for all of them and are implemented here.
  */
+@Log4j2
 public abstract class AbstractScoreHybridizationProcessor implements SearchPhaseResultsProcessor {
     /**
      * Method abstracts functional aspect of score normalization and score combination. Exact methods for each processing stage
@@ -57,9 +75,105 @@ public abstract class AbstractScoreHybridizationProcessor implements SearchPhase
      * @param requestContextOptional
      * @param <Result>
      */
-    abstract <Result extends SearchPhaseResult> void hybridizeScores(
+    <Result extends SearchPhaseResult> void hybridizeScores(
         SearchPhaseResults<Result> searchPhaseResult,
         SearchPhaseContext searchPhaseContext,
         Optional<PipelineProcessingContext> requestContextOptional
-    );
+    ) {
+        if (shouldSkipProcessor(searchPhaseResult)) {
+            log.debug("Query results are not compatible with processor of type [{}]", getType());
+            return;
+        }
+        List<QuerySearchResult> querySearchResults = getQueryPhaseSearchResults(searchPhaseResult);
+        Optional<FetchSearchResult> fetchSearchResult = getFetchSearchResults(searchPhaseResult);
+        boolean explain = Objects.nonNull(searchPhaseContext.getRequest().source().explain())
+            && searchPhaseContext.getRequest().source().explain();
+        recordStats();
+        NormalizationProcessorWorkflowExecuteRequest request = NormalizationProcessorWorkflowExecuteRequest.builder()
+            .querySearchResults(querySearchResults)
+            .fetchSearchResultOptional(fetchSearchResult)
+            .normalizationTechnique(getNormalizationTechnique())
+            .combinationTechnique(getCombinationTechnique())
+            .explain(explain)
+            .pipelineProcessingContext(requestContextOptional.orElse(null))
+            .searchPhaseContext(searchPhaseContext)
+            .build();
+        getNormalizationWorkflow().execute(request);
+    }
+
+    /**
+     * @return technique used to normalize scores of individual subqueries
+     */
+    protected abstract ScoreNormalizationTechnique getNormalizationTechnique();
+
+    /**
+     * @return technique used to combine normalized scores into a single score per document
+     */
+    protected abstract ScoreCombinationTechnique getCombinationTechnique();
+
+    /**
+     * @return workflow that applies the normalization and combination techniques to the query phase results
+     */
+    protected abstract NormalizationProcessorWorkflow getNormalizationWorkflow();
+
+    /**
+     * Records that this processor executed. Called once per hybrid query, before the workflow runs.
+     */
+    protected abstract void recordStats();
+
+    @Override
+    public SearchPhaseName getBeforePhase() {
+        return SearchPhaseName.QUERY;
+    }
+
+    @Override
+    public SearchPhaseName getAfterPhase() {
+        return SearchPhaseName.FETCH;
+    }
+
+    @Override
+    public boolean isIgnoreFailure() {
+        return false;
+    }
+
+    @VisibleForTesting
+    <Result extends SearchPhaseResult> boolean shouldSkipProcessor(SearchPhaseResults<Result> searchPhaseResult) {
+        if (Objects.isNull(searchPhaseResult) || !(searchPhaseResult instanceof QueryPhaseResultConsumer queryPhaseResultConsumer)) {
+            return true;
+        }
+
+        return queryPhaseResultConsumer.getAtomicArray().asList().stream().filter(Objects::nonNull).noneMatch(this::isHybridQuery);
+    }
+
+    /**
+     * Return true if results are from hybrid query.
+     * @param searchPhaseResult
+     * @return true if results are from hybrid query
+     */
+    @VisibleForTesting
+    boolean isHybridQuery(final SearchPhaseResult searchPhaseResult) {
+        // check for delimiter at the end of the score docs.
+        return Objects.nonNull(searchPhaseResult.queryResult())
+            && Objects.nonNull(searchPhaseResult.queryResult().topDocs())
+            && Objects.nonNull(searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs)
+            && searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs.length > 0
+            && isHybridQueryStartStopElement(searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs[0]);
+    }
+
+    @VisibleForTesting
+    <Result extends SearchPhaseResult> List<QuerySearchResult> getQueryPhaseSearchResults(final SearchPhaseResults<Result> results) {
+        return results.getAtomicArray()
+            .asList()
+            .stream()
+            .map(result -> result == null ? null : result.queryResult())
+            .collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    <Result extends SearchPhaseResult> Optional<FetchSearchResult> getFetchSearchResults(
+        final SearchPhaseResults<Result> searchPhaseResults
+    ) {
+        Optional<Result> optionalFirstSearchPhaseResult = searchPhaseResults.getAtomicArray().asList().stream().findFirst();
+        return optionalFirstSearchPhaseResult.map(SearchPhaseResult::fetchResult);
+    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessor.java
@@ -4,18 +4,9 @@
  */
 package org.opensearch.neuralsearch.processor;
 
-import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;
-
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-import org.opensearch.action.search.QueryPhaseResultConsumer;
-import org.opensearch.action.search.SearchPhaseContext;
-import org.opensearch.action.search.SearchPhaseName;
-import org.opensearch.action.search.SearchPhaseResults;
 import org.opensearch.neuralsearch.processor.combination.ArithmeticMeanScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.GeometricMeanScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.HarmonicMeanScoreCombinationTechnique;
@@ -26,12 +17,10 @@ import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTec
 import org.opensearch.neuralsearch.processor.normalization.ZScoreNormalizationTechnique;
 import org.opensearch.neuralsearch.stats.events.EventStatName;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
-import org.opensearch.search.SearchPhaseResult;
-import org.opensearch.search.fetch.FetchSearchResult;
-import org.opensearch.search.pipeline.PipelineProcessingContext;
-import org.opensearch.search.query.QuerySearchResult;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
 /**
@@ -45,8 +34,11 @@ public class NormalizationProcessor extends AbstractScoreHybridizationProcessor 
 
     private final String tag;
     private final String description;
+    @Getter(AccessLevel.PROTECTED)
     private final ScoreNormalizationTechnique normalizationTechnique;
+    @Getter(AccessLevel.PROTECTED)
     private final ScoreCombinationTechnique combinationTechnique;
+    @Getter(AccessLevel.PROTECTED)
     private final NormalizationProcessorWorkflow normalizationWorkflow;
 
     private final Map<String, Runnable> normTechniqueIncrementers = Map.of(
@@ -68,43 +60,6 @@ public class NormalizationProcessor extends AbstractScoreHybridizationProcessor 
     );
 
     @Override
-    <Result extends SearchPhaseResult> void hybridizeScores(
-        SearchPhaseResults<Result> searchPhaseResult,
-        SearchPhaseContext searchPhaseContext,
-        Optional<PipelineProcessingContext> requestContextOptional
-    ) {
-        if (shouldSkipProcessor(searchPhaseResult)) {
-            log.debug("Query results are not compatible with normalization processor");
-            return;
-        }
-        List<QuerySearchResult> querySearchResults = getQueryPhaseSearchResults(searchPhaseResult);
-        Optional<FetchSearchResult> fetchSearchResult = getFetchSearchResults(searchPhaseResult);
-        boolean explain = Objects.nonNull(searchPhaseContext.getRequest().source().explain())
-            && searchPhaseContext.getRequest().source().explain();
-        recordStats(normalizationTechnique, combinationTechnique);
-        NormalizationProcessorWorkflowExecuteRequest request = NormalizationProcessorWorkflowExecuteRequest.builder()
-            .querySearchResults(querySearchResults)
-            .fetchSearchResultOptional(fetchSearchResult)
-            .normalizationTechnique(normalizationTechnique)
-            .combinationTechnique(combinationTechnique)
-            .explain(explain)
-            .pipelineProcessingContext(requestContextOptional.orElse(null))
-            .searchPhaseContext(searchPhaseContext)
-            .build();
-        normalizationWorkflow.execute(request);
-    }
-
-    @Override
-    public SearchPhaseName getBeforePhase() {
-        return SearchPhaseName.QUERY;
-    }
-
-    @Override
-    public SearchPhaseName getAfterPhase() {
-        return SearchPhaseName.FETCH;
-    }
-
-    @Override
     public String getType() {
         return TYPE;
     }
@@ -120,51 +75,7 @@ public class NormalizationProcessor extends AbstractScoreHybridizationProcessor 
     }
 
     @Override
-    public boolean isIgnoreFailure() {
-        return false;
-    }
-
-    private <Result extends SearchPhaseResult> boolean shouldSkipProcessor(SearchPhaseResults<Result> searchPhaseResult) {
-        if (Objects.isNull(searchPhaseResult) || !(searchPhaseResult instanceof QueryPhaseResultConsumer)) {
-            return true;
-        }
-
-        QueryPhaseResultConsumer queryPhaseResultConsumer = (QueryPhaseResultConsumer) searchPhaseResult;
-        return queryPhaseResultConsumer.getAtomicArray().asList().stream().filter(Objects::nonNull).noneMatch(this::isHybridQuery);
-    }
-
-    /**
-     * Return true if results are from hybrid query.
-     * @param searchPhaseResult
-     * @return true if results are from hybrid query
-     */
-    private boolean isHybridQuery(final SearchPhaseResult searchPhaseResult) {
-        // check for delimiter at the end of the score docs.
-        return Objects.nonNull(searchPhaseResult.queryResult())
-            && Objects.nonNull(searchPhaseResult.queryResult().topDocs())
-            && Objects.nonNull(searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs)
-            && searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs.length > 0
-            && isHybridQueryStartStopElement(searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs[0]);
-    }
-
-    private <Result extends SearchPhaseResult> List<QuerySearchResult> getQueryPhaseSearchResults(
-        final SearchPhaseResults<Result> results
-    ) {
-        return results.getAtomicArray()
-            .asList()
-            .stream()
-            .map(result -> result == null ? null : result.queryResult())
-            .collect(Collectors.toList());
-    }
-
-    private <Result extends SearchPhaseResult> Optional<FetchSearchResult> getFetchSearchResults(
-        final SearchPhaseResults<Result> searchPhaseResults
-    ) {
-        Optional<Result> optionalFirstSearchPhaseResult = searchPhaseResults.getAtomicArray().asList().stream().findFirst();
-        return optionalFirstSearchPhaseResult.map(SearchPhaseResult::fetchResult);
-    }
-
-    private void recordStats(ScoreNormalizationTechnique normalizationTechnique, ScoreCombinationTechnique combinationTechnique) {
+    protected void recordStats() {
         EventStatsManager.increment(EventStatName.NORMALIZATION_PROCESSOR_EXECUTIONS);
         Optional.ofNullable(normTechniqueIncrementers.get(normalizationTechnique.techniqueName())).ifPresent(Runnable::run);
         Optional.ofNullable(combTechniqueIncrementers.get(combinationTechnique.techniqueName())).ifPresent(Runnable::run);

--- a/src/main/java/org/opensearch/neuralsearch/processor/RRFProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/RRFProcessor.java
@@ -156,6 +156,8 @@ public class RRFProcessor extends AbstractScoreHybridizationProcessor {
 
     private void recordStats(ScoreCombinationTechnique combinationTechnique) {
         EventStatsManager.increment(EventStatName.RRF_PROCESSOR_EXECUTIONS);
-        Optional.of(combTechniqueIncrementers.get(combinationTechnique.techniqueName())).ifPresent(Runnable::run);
+        // ofNullable, not of: a technique with no incrementer must not fail the query. RRFProcessorFactory rejects any
+        // technique but rrf, so this is no longer reachable from a pipeline definition, but this constructor is public.
+        Optional.ofNullable(combTechniqueIncrementers.get(combinationTechnique.techniqueName())).ifPresent(Runnable::run);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/RRFProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/RRFProcessor.java
@@ -4,32 +4,16 @@
  */
 package org.opensearch.neuralsearch.processor;
 
-import static org.opensearch.neuralsearch.search.util.HybridSearchResultFormatUtil.isHybridQueryStartStopElement;
-
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
-import com.google.common.annotations.VisibleForTesting;
+import lombok.AccessLevel;
 import lombok.Getter;
 import org.opensearch.neuralsearch.processor.combination.RRFScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
 import org.opensearch.neuralsearch.stats.events.EventStatName;
 import org.opensearch.neuralsearch.stats.events.EventStatsManager;
-import org.opensearch.search.fetch.FetchSearchResult;
-import org.opensearch.search.pipeline.PipelineProcessingContext;
-import org.opensearch.search.query.QuerySearchResult;
-
-import org.opensearch.action.search.QueryPhaseResultConsumer;
-import org.opensearch.action.search.SearchPhaseContext;
-import org.opensearch.action.search.SearchPhaseName;
-import org.opensearch.action.search.SearchPhaseResults;
-import org.opensearch.search.SearchPhaseResult;
-import org.opensearch.search.internal.SearchContext;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -50,8 +34,11 @@ public class RRFProcessor extends AbstractScoreHybridizationProcessor {
     private final String tag;
     @Getter
     private final String description;
+    @Getter(AccessLevel.PROTECTED)
     private final ScoreNormalizationTechnique normalizationTechnique;
+    @Getter(AccessLevel.PROTECTED)
     private final ScoreCombinationTechnique combinationTechnique;
+    @Getter(AccessLevel.PROTECTED)
     private final NormalizationProcessorWorkflow normalizationWorkflow;
 
     private final Map<String, Runnable> combTechniqueIncrementers = Map.of(
@@ -59,102 +46,13 @@ public class RRFProcessor extends AbstractScoreHybridizationProcessor {
         () -> EventStatsManager.increment(EventStatName.COMB_TECHNIQUE_RRF_EXECUTIONS)
     );
 
-    /**
-     * Method abstracts functional aspect of score normalization and score combination. Exact methods for each processing stage
-     * are set as part of class constructor
-     * @param searchPhaseResult {@link SearchPhaseResults} DTO that has query search results. Results will be mutated as part of this method execution
-     * @param searchPhaseContext {@link SearchContext}
-     */
-    @Override
-    <Result extends SearchPhaseResult> void hybridizeScores(
-        SearchPhaseResults<Result> searchPhaseResult,
-        SearchPhaseContext searchPhaseContext,
-        Optional<PipelineProcessingContext> requestContextOptional
-    ) {
-        if (shouldSkipProcessor(searchPhaseResult)) {
-            log.debug("Query results are not compatible with RRF processor");
-            return;
-        }
-        List<QuerySearchResult> querySearchResults = getQueryPhaseSearchResults(searchPhaseResult);
-        Optional<FetchSearchResult> fetchSearchResult = getFetchSearchResults(searchPhaseResult);
-        boolean explain = Objects.nonNull(searchPhaseContext.getRequest().source().explain())
-            && searchPhaseContext.getRequest().source().explain();
-        recordStats(combinationTechnique);
-        // make data transfer object to pass in, execute will get object with 4 or 5 fields, depending
-        // on coming from NormalizationProcessor or RRFProcessor
-        NormalizationProcessorWorkflowExecuteRequest normalizationExecuteDTO = NormalizationProcessorWorkflowExecuteRequest.builder()
-            .querySearchResults(querySearchResults)
-            .fetchSearchResultOptional(fetchSearchResult)
-            .normalizationTechnique(normalizationTechnique)
-            .combinationTechnique(combinationTechnique)
-            .explain(explain)
-            .pipelineProcessingContext(requestContextOptional.orElse(null))
-            .searchPhaseContext(searchPhaseContext)
-            .build();
-        normalizationWorkflow.execute(normalizationExecuteDTO);
-    }
-
-    @Override
-    public SearchPhaseName getBeforePhase() {
-        return SearchPhaseName.QUERY;
-    }
-
-    @Override
-    public SearchPhaseName getAfterPhase() {
-        return SearchPhaseName.FETCH;
-    }
-
     @Override
     public String getType() {
         return TYPE;
     }
 
     @Override
-    public boolean isIgnoreFailure() {
-        return false;
-    }
-
-    @VisibleForTesting
-    <Result extends SearchPhaseResult> boolean shouldSkipProcessor(SearchPhaseResults<Result> searchPhaseResult) {
-        if (Objects.isNull(searchPhaseResult) || !(searchPhaseResult instanceof QueryPhaseResultConsumer queryPhaseResultConsumer)) {
-            return true;
-        }
-
-        return queryPhaseResultConsumer.getAtomicArray().asList().stream().filter(Objects::nonNull).noneMatch(this::isHybridQuery);
-    }
-
-    /**
-     * Return true if results are from hybrid query.
-     * @param searchPhaseResult
-     * @return true if results are from hybrid query
-     */
-    @VisibleForTesting
-    boolean isHybridQuery(final SearchPhaseResult searchPhaseResult) {
-        // check for delimiter at the end of the score docs.
-        return Objects.nonNull(searchPhaseResult.queryResult())
-            && Objects.nonNull(searchPhaseResult.queryResult().topDocs())
-            && Objects.nonNull(searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs)
-            && searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs.length > 0
-            && isHybridQueryStartStopElement(searchPhaseResult.queryResult().topDocs().topDocs.scoreDocs[0]);
-    }
-
-    <Result extends SearchPhaseResult> List<QuerySearchResult> getQueryPhaseSearchResults(final SearchPhaseResults<Result> results) {
-        return results.getAtomicArray()
-            .asList()
-            .stream()
-            .map(result -> result == null ? null : result.queryResult())
-            .collect(Collectors.toList());
-    }
-
-    @VisibleForTesting
-    <Result extends SearchPhaseResult> Optional<FetchSearchResult> getFetchSearchResults(
-        final SearchPhaseResults<Result> searchPhaseResults
-    ) {
-        Optional<Result> optionalFirstSearchPhaseResult = searchPhaseResults.getAtomicArray().asList().stream().findFirst();
-        return optionalFirstSearchPhaseResult.map(SearchPhaseResult::fetchResult);
-    }
-
-    private void recordStats(ScoreCombinationTechnique combinationTechnique) {
+    protected void recordStats() {
         EventStatsManager.increment(EventStatName.RRF_PROCESSOR_EXECUTIONS);
         // ofNullable, not of: a technique with no incrementer must not fail the query. RRFProcessorFactory rejects any
         // technique but rrf, so this is no longer reachable from a pipeline definition, but this constructor is public.

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.neuralsearch.processor.factory;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -63,6 +64,22 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
                 TECHNIQUE,
                 RRFScoreCombinationTechnique.TECHNIQUE_NAME
             );
+
+            // This processor normalizes by rank, so rrf is the only combination that means anything here. The other
+            // techniques registered in ScoreCombinationFactory (the means) belong to the normalization-processor, where
+            // they combine normalized scores. Accepting one here produced a pipeline that threw on every query, so
+            // reject it at pipeline creation with a 400 instead of failing at search time.
+            if (RRFScoreCombinationTechnique.TECHNIQUE_NAME.equals(combinationTechnique) == false) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "provided combination technique is not supported by [%s], supported technique is [%s], got [%s]",
+                        RRFProcessor.TYPE,
+                        RRFScoreCombinationTechnique.TECHNIQUE_NAME,
+                        combinationTechnique
+                    )
+                );
+            }
 
             String rankConstantParam = RRFNormalizationTechnique.PARAM_NAME_RANK_CONSTANT;
             if (combinationClause.containsKey(rankConstantParam)) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
@@ -4,8 +4,6 @@
  */
 package org.opensearch.neuralsearch.processor.normalization;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +47,9 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
     private static final int MIN_RANK_CONSTANT = 1;
     private static final int MAX_RANK_CONSTANT = 10_000;
     private static final Range<Integer> RANK_CONSTANT_RANGE = Range.of(MIN_RANK_CONSTANT, MAX_RANK_CONSTANT);
+    // Rank scores are quantized to 10 decimal places, i.e. expressed as an integer numerator over 10^10.
+    private static final long SCORE_SCALE_L = 10_000_000_000L;
+    private static final double SCORE_SCALE_D = 1.0e10;
     @ToString.Include
     private final int rankConstant;
     // Comparator to compare ShardResultPerSubQuery
@@ -218,8 +219,29 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
         }
     }
 
+    /**
+     * Computes the rank score of a result, {@code 1 / (rankConstant + position + 1)} rounded HALF_UP to 10
+     * decimal places. This is an allocation-free integer equivalent of the original implementation:
+     * <pre>{@code
+     * BigDecimal.ONE.divide(BigDecimal.valueOf(rankConstant + position + 1), 10, RoundingMode.HALF_UP).floatValue()
+     * }</pre>
+     * Because 10^10 and 2 * 10^10 both fit in a {@code long}, rounding HALF_UP to scale 10 is exactly expressible
+     * as the integer division {@code (2 * 10^10 + d) / (2 * d)}. That quotient is at most 5 * 10^9, well inside
+     * the range a {@code double} represents exactly, as is 10^10 itself, so the single narrowing to {@code float}
+     * reproduces what {@code BigDecimal.floatValue()} produced. Verified bit-identical for every reachable
+     * denominator in [2, Integer.MAX_VALUE].
+     * <p>
+     * The final division is deliberately performed in {@code double}. Narrowing the numerator to {@code float}
+     * first and dividing by {@code 1.0e10f} rounds twice and is <em>not</em> bit-identical: it differs for 167
+     * denominators, starting at 3.
+     *
+     * @param position zero-based rank of the result within its subquery
+     * @return the rank score, to be summed across subqueries in the combination step
+     */
     private float calculateNormalizedScore(int position) {
-        return BigDecimal.ONE.divide(BigDecimal.valueOf(rankConstant + position + 1), 10, RoundingMode.HALF_UP).floatValue();
+        long denominator = (long) rankConstant + position + 1;
+        long numerator = (2 * SCORE_SCALE_L + denominator) / (2 * denominator);
+        return (float) (numerator / SCORE_SCALE_D);
     }
 
     private int getRankConstant(final Map<String, Object> params) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
@@ -15,8 +15,6 @@ import java.util.Set;
 
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.lang3.Range;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.opensearch.common.TriConsumer;
@@ -35,21 +33,18 @@ import static org.opensearch.neuralsearch.processor.explain.ExplanationUtils.get
 /**
  * Abstracts calculation of rank scores for each document returned as part of
  * reciprocal rank fusion. Rank scores are summed across subqueries in combination classes.
+ * <p>
+ * This class owns the traversal of shard side {@link CompoundTopDocs}; the RRF arithmetic itself lives in
+ * {@link RRFScoreNormalizer} so that coordinator side fusion can apply identical logic to its own result shape.
  */
 @ToString(onlyExplicitlyIncluded = true)
 @Log4j2
 public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, ExplainableTechnique {
     @ToString.Include
     public static final String TECHNIQUE_NAME = "rrf";
-    public static final int DEFAULT_RANK_CONSTANT = 60;
-    public static final String PARAM_NAME_RANK_CONSTANT = "rank_constant";
+    public static final int DEFAULT_RANK_CONSTANT = RRFScoreNormalizer.DEFAULT_RANK_CONSTANT;
+    public static final String PARAM_NAME_RANK_CONSTANT = RRFScoreNormalizer.PARAM_NAME_RANK_CONSTANT;
     private static final Set<String> SUPPORTED_PARAMS = Set.of(PARAM_NAME_RANK_CONSTANT);
-    private static final int MIN_RANK_CONSTANT = 1;
-    private static final int MAX_RANK_CONSTANT = 10_000;
-    private static final Range<Integer> RANK_CONSTANT_RANGE = Range.of(MIN_RANK_CONSTANT, MAX_RANK_CONSTANT);
-    // Rank scores are quantized to 10 decimal places, i.e. expressed as an integer numerator over 10^10.
-    private static final long SCORE_SCALE_L = 10_000_000_000L;
-    private static final double SCORE_SCALE_D = 1.0e10;
     @ToString.Include
     private final int rankConstant;
     // Comparator to compare ShardResultPerSubQuery
@@ -60,7 +55,7 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
 
     public RRFNormalizationTechnique(final Map<String, Object> params, final ScoreNormalizationUtil scoreNormalizationUtil) {
         scoreNormalizationUtil.validateParameters(params, SUPPORTED_PARAMS, Map.of());
-        rankConstant = getRankConstant(params);
+        rankConstant = RRFScoreNormalizer.resolveRankConstant(params);
     }
 
     /**
@@ -120,16 +115,14 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
         // We created docId-shardId format because docId can be same across different shards but the combination is unique.
         for (Map.Entry<Integer, PriorityQueue<ShardResultPerSubQuery>> entry : scoreDocsPerSubquery.entrySet()) {
             int subQueryNumber = entry.getKey();
-            globallySortedDocIdMap.putIfAbsent(subQueryNumber, new HashMap<>());
-
             PriorityQueue<ShardResultPerSubQuery> sortedScoreDocsAcrossAllShards = entry.getValue();
-            // first rank
-            int rank = 0;
-            while (!sortedScoreDocsAcrossAllShards.isEmpty()) {
-                ShardResultPerSubQuery shardResultPerSubQuery = sortedScoreDocsAcrossAllShards.poll();
-                globallySortedDocIdMap.get(subQueryNumber)
-                    .put(shardResultPerSubQuery.scoreDoc.doc + "_" + shardResultPerSubQuery.referenceShardId, rank++);
-            }
+            globallySortedDocIdMap.putIfAbsent(
+                subQueryNumber,
+                RRFScoreNormalizer.drainToRanks(
+                    sortedScoreDocsAcrossAllShards,
+                    shardResultPerSubQuery -> shardResultPerSubQuery.scoreDoc.doc + "_" + shardResultPerSubQuery.referenceShardId
+                )
+            );
         }
         return globallySortedDocIdMap;
     }
@@ -212,64 +205,10 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
                     "Document not found in global ranking map: doc=" + scoreDoc.doc + ", shard=" + referenceShardId
                 );
             }
-            float normalizedScore = calculateNormalizedScore(rank);
+            float normalizedScore = RRFScoreNormalizer.scoreForRank(rank, rankConstant);
             DocIdAtSearchShard docIdAtSearchShard = new DocIdAtSearchShard(scoreDoc.doc, searchShard);
             scoreProcessor.apply(docIdAtSearchShard, normalizedScore, topDocsIndex);
             scoreDoc.score = normalizedScore;
-        }
-    }
-
-    /**
-     * Computes the rank score of a result, {@code 1 / (rankConstant + position + 1)} rounded HALF_UP to 10
-     * decimal places. This is an allocation-free integer equivalent of the original implementation:
-     * <pre>{@code
-     * BigDecimal.ONE.divide(BigDecimal.valueOf(rankConstant + position + 1), 10, RoundingMode.HALF_UP).floatValue()
-     * }</pre>
-     * Because 10^10 and 2 * 10^10 both fit in a {@code long}, rounding HALF_UP to scale 10 is exactly expressible
-     * as the integer division {@code (2 * 10^10 + d) / (2 * d)}. That quotient is at most 5 * 10^9, well inside
-     * the range a {@code double} represents exactly, as is 10^10 itself, so the single narrowing to {@code float}
-     * reproduces what {@code BigDecimal.floatValue()} produced. Verified bit-identical for every reachable
-     * denominator in [2, Integer.MAX_VALUE].
-     * <p>
-     * The final division is deliberately performed in {@code double}. Narrowing the numerator to {@code float}
-     * first and dividing by {@code 1.0e10f} rounds twice and is <em>not</em> bit-identical: it differs for 167
-     * denominators, starting at 3.
-     *
-     * @param position zero-based rank of the result within its subquery
-     * @return the rank score, to be summed across subqueries in the combination step
-     */
-    private float calculateNormalizedScore(int position) {
-        long denominator = (long) rankConstant + position + 1;
-        long numerator = (2 * SCORE_SCALE_L + denominator) / (2 * denominator);
-        return (float) (numerator / SCORE_SCALE_D);
-    }
-
-    private int getRankConstant(final Map<String, Object> params) {
-        if (Objects.isNull(params) || !params.containsKey(PARAM_NAME_RANK_CONSTANT)) {
-            return DEFAULT_RANK_CONSTANT;
-        }
-        int rankConstant = getParamAsInteger(params, PARAM_NAME_RANK_CONSTANT);
-        validateRankConstant(rankConstant);
-        return rankConstant;
-    }
-
-    private void validateRankConstant(final int rankConstant) {
-        if (!RANK_CONSTANT_RANGE.contains(rankConstant)) {
-            throw new IllegalArgumentException(
-                String.format(
-                    Locale.ROOT,
-                    "rank constant must be in the interval between 1 and 10000, submitted rank constant: %d",
-                    rankConstant
-                )
-            );
-        }
-    }
-
-    private static int getParamAsInteger(final Map<String, Object> parameters, final String fieldName) {
-        try {
-            return NumberUtils.createInteger(String.valueOf(parameters.get(fieldName)));
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "parameter [%s] must be an integer", fieldName));
         }
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFScoreNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFScoreNormalizer.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.normalization;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.Range;
+import org.apache.commons.lang3.math.NumberUtils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Stateless reciprocal rank fusion arithmetic: the rank score formula, rank constant parsing and
+ * validation, and derivation of zero based ranks from an ordered queue of results.
+ * <p>
+ * RRF is applied from more than one place. The shard side {@link RRFNormalizationTechnique} works on
+ * {@link org.opensearch.neuralsearch.processor.CompoundTopDocs}, while coordinator side fusion works on
+ * per sub-query maps of document id to score. The shapes differ but the arithmetic must not, so it is
+ * defined here once instead of being re-derived per call site.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RRFScoreNormalizer {
+    public static final int DEFAULT_RANK_CONSTANT = 60;
+    public static final String PARAM_NAME_RANK_CONSTANT = "rank_constant";
+    public static final int MIN_RANK_CONSTANT = 1;
+    public static final int MAX_RANK_CONSTANT = 10_000;
+
+    private static final Range<Integer> RANK_CONSTANT_RANGE = Range.of(MIN_RANK_CONSTANT, MAX_RANK_CONSTANT);
+    // Rank scores are quantized to 10 decimal places, i.e. expressed as an integer numerator over 10^10.
+    private static final long SCORE_SCALE_L = 10_000_000_000L;
+    private static final double SCORE_SCALE_D = 1.0e10;
+
+    /**
+     * Rank score for a single document within a single sub-query, {@code 1 / (rankConstant + rank + 1)} rounded
+     * HALF_UP to 10 decimal places. Scores are summed across sub-queries in the combination step.
+     * <p>
+     * This is an allocation-free integer equivalent of the original implementation:
+     * <pre>{@code
+     * BigDecimal.ONE.divide(BigDecimal.valueOf(rankConstant + rank + 1), 10, RoundingMode.HALF_UP).floatValue()
+     * }</pre>
+     * Because 10^10 and 2 * 10^10 both fit in a {@code long}, rounding HALF_UP to scale 10 is exactly expressible
+     * as the integer division {@code (2 * 10^10 + d) / (2 * d)}. That quotient is at most 5 * 10^9, well inside
+     * the range a {@code double} represents exactly, as is 10^10 itself, so the single narrowing to {@code float}
+     * reproduces what {@code BigDecimal.floatValue()} produced. Verified bit-identical for every reachable
+     * denominator in [2, Integer.MAX_VALUE].
+     * <p>
+     * The final division is deliberately performed in {@code double}. Narrowing the numerator to {@code float}
+     * first and dividing by {@code 1.0e10f} rounds twice and is <em>not</em> bit-identical: it differs for 167
+     * denominators, starting at 3.
+     *
+     * @param rank zero based rank of the document within the sub-query
+     * @param rankConstant RRF rank constant
+     * @return the rank score
+     */
+    public static float scoreForRank(final int rank, final int rankConstant) {
+        long denominator = (long) rankConstant + rank + 1;
+        long numerator = (2 * SCORE_SCALE_L + denominator) / (2 * denominator);
+        return (float) (numerator / SCORE_SCALE_D);
+    }
+
+    /**
+     * Read the rank constant from user provided parameters, falling back to {@link #DEFAULT_RANK_CONSTANT}
+     * when it is absent.
+     *
+     * @param params user provided technique parameters, may be null
+     * @return a validated rank constant
+     * @throws IllegalArgumentException if the value is not an integer or is out of range
+     */
+    public static int resolveRankConstant(final Map<String, Object> params) {
+        if (Objects.isNull(params) || !params.containsKey(PARAM_NAME_RANK_CONSTANT)) {
+            return DEFAULT_RANK_CONSTANT;
+        }
+        int rankConstant = getParamAsInteger(params, PARAM_NAME_RANK_CONSTANT);
+        validateRankConstant(rankConstant);
+        return rankConstant;
+    }
+
+    /**
+     * @param rankConstant rank constant to check
+     * @throws IllegalArgumentException if the rank constant is outside the supported range
+     */
+    public static void validateRankConstant(final int rankConstant) {
+        if (!RANK_CONSTANT_RANGE.contains(rankConstant)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "rank constant must be in the interval between 1 and 10000, submitted rank constant: %d",
+                    rankConstant
+                )
+            );
+        }
+    }
+
+    /**
+     * Drain a queue of results, assigning zero based ranks in the order the queue yields them. Results the
+     * queue's comparator treats as equal are ranked in the order the heap happens to surface them, which is
+     * not the same order a stable sort would produce, so callers must supply the queue rather than a sorted
+     * collection if they need to reproduce this exactly.
+     *
+     * @param queue results for a single sub-query, best first; drained by this call
+     * @param keyFunction maps a result to the key its rank is recorded under
+     * @return map of result key to zero based rank
+     */
+    public static <T, K> Map<K, Integer> drainToRanks(final PriorityQueue<T> queue, final Function<T, K> keyFunction) {
+        Map<K, Integer> ranks = new HashMap<>();
+        // first rank
+        int rank = 0;
+        while (!queue.isEmpty()) {
+            ranks.put(keyFunction.apply(queue.poll()), rank++);
+        }
+        return ranks;
+    }
+
+    /**
+     * Assign zero based ranks to documents held as a map of document id to score, ordered by descending
+     * score with ascending document id as tie break. This is the shape coordinator side fusion works in,
+     * where results for a sub-query have already been merged across shards.
+     *
+     * @param scoresById document id to score for a single sub-query
+     * @return map of document id to zero based rank
+     */
+    public static Map<String, Integer> assignRanksByScoreDescending(final Map<String, Float> scoresById) {
+        Comparator<Map.Entry<String, Float>> byScoreDescendingThenId = Comparator.<Map.Entry<String, Float>, Float>comparing(
+            Map.Entry::getValue
+        ).reversed().thenComparing(Map.Entry::getKey);
+        PriorityQueue<Map.Entry<String, Float>> queue = new PriorityQueue<>(byScoreDescendingThenId);
+        queue.addAll(scoresById.entrySet());
+        return drainToRanks(queue, Map.Entry::getKey);
+    }
+
+    private static int getParamAsInteger(final Map<String, Object> parameters, final String fieldName) {
+        try {
+            return NumberUtils.createInteger(String.valueOf(parameters.get(fieldName)));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "parameter [%s] must be an integer", fieldName));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/processor/AbstractScoreHybridizationProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/AbstractScoreHybridizationProcessorTests.java
@@ -16,6 +16,8 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.common.util.concurrent.AtomicArray;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchPhaseResult;
 import org.opensearch.search.SearchShardTarget;
@@ -61,6 +63,26 @@ public class AbstractScoreHybridizationProcessorTests extends OpenSearchTestCase
                 .pipelineProcessingContext(requestContextOptional.orElse(null))
                 .build();
             normalizationWorkflow1.execute(normalizationExecuteDTO);
+        }
+
+        @Override
+        protected ScoreNormalizationTechnique getNormalizationTechnique() {
+            return null;
+        }
+
+        @Override
+        protected ScoreCombinationTechnique getCombinationTechnique() {
+            return null;
+        }
+
+        @Override
+        protected NormalizationProcessorWorkflow getNormalizationWorkflow() {
+            return normalizationWorkflow1;
+        }
+
+        @Override
+        protected void recordStats() {
+            // no stats for this test processor
         }
 
         @Override

--- a/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorIT.java
@@ -4,10 +4,17 @@
  */
 package org.opensearch.neuralsearch.processor;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.Before;
+import org.opensearch.client.ResponseException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
@@ -27,6 +34,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_USER_AGENT;
 import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
 import static org.opensearch.neuralsearch.util.TestUtils.TEST_SPACE_TYPE;
 import static org.opensearch.neuralsearch.util.TestUtils.createRandomVector;
@@ -55,6 +63,49 @@ public class RRFProcessorIT extends BaseNeuralSearchIT {
         );
         addDocuments();
         createDefaultRRFSearchPipeline();
+    }
+
+    /**
+     * The score-ranker-processor normalizes by rank, so rrf is the only combination technique that applies. The mean
+     * techniques are registered in ScoreCombinationFactory and used to be accepted here, producing a pipeline that
+     * threw NullPointerException on every query. Creating such a pipeline must fail with 400 instead.
+     */
+    @SneakyThrows
+    public void testRRFPipelineCreation_whenCombinationTechniqueIsNotRrf_thenBadRequest() {
+        String body = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("description", "score-ranker-processor with a combination technique it does not support")
+            .startArray("phase_results_processors")
+            .startObject()
+            .startObject("score-ranker-processor")
+            .startObject("combination")
+            .field("technique", "arithmetic_mean")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject()
+            .toString();
+
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> makeRequest(
+                client(),
+                "PUT",
+                "/_search/pipeline/rrf-unsupported-combination",
+                null,
+                toHttpEntity(body),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            )
+        );
+
+        assertEquals(RestStatus.BAD_REQUEST.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
+        String message = EntityUtils.toString(exception.getResponse().getEntity());
+        assertTrue(
+            message,
+            message.contains("provided combination technique is not supported by [score-ranker-processor], supported technique is [rrf]")
+        );
+        assertTrue(message, message.contains("arithmetic_mean"));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorTests.java
@@ -23,6 +23,7 @@ import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.common.util.concurrent.AtomicArray;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.neuralsearch.processor.combination.ArithmeticMeanScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.RRFScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
@@ -136,6 +137,26 @@ public class RRFProcessorTests extends OpenSearchTestCase {
         rrfProcessor.process(mockQueryPhaseResultConsumer, mockSearchPhaseContext);
 
         verify(mockNormalizationWorkflow, never()).execute(any(NormalizationProcessorWorkflowExecuteRequest.class));
+    }
+
+    @SneakyThrows
+    public void testProcess_whenCombinationTechniqueHasNoStatsIncrementer_thenSucceed() {
+        // RRFProcessorFactory now rejects any combination technique but rrf, so this is unreachable from a pipeline
+        // definition. It stays reachable by direct construction, and a stats lookup miss must not fail the query.
+        when(mockCombinationTechnique.techniqueName()).thenReturn(ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME);
+        QuerySearchResult result = createQuerySearchResult(true);
+        AtomicArray<SearchPhaseResult> atomicArray = new AtomicArray<>(1);
+        atomicArray.set(0, result);
+
+        when(mockQueryPhaseResultConsumer.getAtomicArray()).thenReturn(atomicArray);
+
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(new SearchSourceBuilder());
+        when(mockSearchPhaseContext.getRequest()).thenReturn(searchRequest);
+
+        rrfProcessor.process(mockQueryPhaseResultConsumer, mockSearchPhaseContext);
+
+        verify(mockNormalizationWorkflow).execute(any(NormalizationProcessorWorkflowExecuteRequest.class));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactoryTests.java
@@ -9,6 +9,9 @@ import lombok.SneakyThrows;
 import org.opensearch.neuralsearch.processor.NormalizationProcessorWorkflow;
 import org.opensearch.neuralsearch.processor.RRFProcessor;
 import org.opensearch.neuralsearch.processor.combination.ArithmeticMeanScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.combination.GeometricMeanScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.combination.HarmonicMeanScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.combination.RRFScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationFactory;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombiner;
 import org.opensearch.neuralsearch.processor.normalization.RRFNormalizationTechnique;
@@ -20,6 +23,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -190,6 +194,55 @@ public class RRFProcessorFactoryTests extends OpenSearchTestCase {
             () -> rrfProcessorFactory.create(processorFactories, tag, description, ignoreFailure, config, pipelineContext)
         );
         assertTrue(exception.getMessage().contains("provided combination technique is not supported"));
+    }
+
+    @SneakyThrows
+    public void testInvalidCombinationName_whenTechniqueBelongsToNormalizationProcessor_thenFail() {
+        // These three are registered in ScoreCombinationFactory, so they used to be accepted here and then threw
+        // NullPointerException on every query. They combine normalized scores and belong to the normalization-processor;
+        // this processor normalizes by rank, so rrf is the only combination that applies.
+        for (String technique : List.of(
+            ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME,
+            HarmonicMeanScoreCombinationTechnique.TECHNIQUE_NAME,
+            GeometricMeanScoreCombinationTechnique.TECHNIQUE_NAME
+        )) {
+            RRFProcessorFactory rrfProcessorFactory = new RRFProcessorFactory(
+                new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
+                new ScoreNormalizationFactory(),
+                new ScoreCombinationFactory()
+            );
+            final Map<String, Processor.Factory<SearchPhaseResultsProcessor>> processorFactories = new HashMap<>();
+            Map<String, Object> config = new HashMap<>();
+            config.put(COMBINATION_CLAUSE, new HashMap<>(Map.of(TECHNIQUE, technique)));
+            Processor.PipelineContext pipelineContext = mock(Processor.PipelineContext.class);
+
+            IllegalArgumentException exception = expectThrows(
+                IllegalArgumentException.class,
+                () -> rrfProcessorFactory.create(processorFactories, "tag", "description", false, config, pipelineContext)
+            );
+            assertTrue(
+                "unexpected message for [" + technique + "]: " + exception.getMessage(),
+                exception.getMessage()
+                    .contains("provided combination technique is not supported by [score-ranker-processor], supported technique is [rrf]")
+            );
+            assertTrue("message should name the rejected technique: " + exception.getMessage(), exception.getMessage().contains(technique));
+        }
+    }
+
+    @SneakyThrows
+    public void testCombinationName_whenRrfExplicitlyRequested_thenSuccessful() {
+        // The counterpart to the rejection above: rrf stated explicitly is still accepted, so the guard rejects only
+        // the techniques that never worked.
+        RRFProcessorFactory rrfProcessorFactory = new RRFProcessorFactory(
+            new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
+            new ScoreNormalizationFactory(),
+            new ScoreCombinationFactory()
+        );
+        final Map<String, Processor.Factory<SearchPhaseResultsProcessor>> processorFactories = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(COMBINATION_CLAUSE, new HashMap<>(Map.of(TECHNIQUE, RRFScoreCombinationTechnique.TECHNIQUE_NAME)));
+        Processor.PipelineContext pipelineContext = mock(Processor.PipelineContext.class);
+        assertRRFProcessor(rrfProcessorFactory.create(processorFactories, "tag", "description", false, config, pipelineContext));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -354,9 +354,56 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
         assertTrue(explanation.containsKey(new DocIdAtSearchShard(0, new SearchShard("test_index", 0, "uuid"))));
     }
 
+    /**
+     * Rank scores are computed in integer arithmetic rather than with {@link BigDecimal}. That is only a safe
+     * substitution if it is exactly equal to the BigDecimal form it replaced, so this asserts on raw float bits
+     * rather than within a delta - a change that rounded even one ULP differently would pass a delta comparison.
+     * The ranks covered span the point where a scale-10 numerator crosses 2^24, where BigDecimal's conversion to
+     * float changes behavior, and rank constants at both ends of the permitted range.
+     */
+    public void testNormalize_whenScoresComputed_thenBitIdenticalToBigDecimalReference() {
+        int numDocs = 1200;
+        float[] scores = new float[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            scores[i] = 1.0f - i / (float) numDocs;
+        }
+
+        for (int rankConstant : new int[] { 1, RANK_CONSTANT, 10_000 }) {
+            CompoundTopDocs compoundTopDocs = createCompoundTopDocs(scores, numDocs);
+            RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(
+                Map.of("rank_constant", rankConstant),
+                scoreNormalizationUtil
+            );
+            normalizationTechnique.normalize(
+                NormalizeScoresDTO.builder()
+                    .queryTopDocs(List.of(compoundTopDocs))
+                    .normalizationTechnique(normalizationTechnique)
+                    .singleShard(true)
+                    .build()
+            );
+
+            ScoreDoc[] scoreDocs = compoundTopDocs.getTopDocs().get(0).scoreDocs;
+            for (int rank = 0; rank < numDocs; rank++) {
+                assertEquals(
+                    "rank_constant [" + rankConstant + "], rank [" + rank + "]",
+                    Float.floatToIntBits(rrfNorm(rank, rankConstant)),
+                    Float.floatToIntBits(scoreDocs[rank].score)
+                );
+            }
+        }
+    }
+
     private float rrfNorm(int rank) {
-        // 1.0f / (float) (rank + RANK_CONSTANT + 1);
-        return BigDecimal.ONE.divide(BigDecimal.valueOf(rank + RANK_CONSTANT + 1), 10, RoundingMode.HALF_UP).floatValue();
+        return rrfNorm(rank, RANK_CONSTANT);
+    }
+
+    /**
+     * The BigDecimal implementation that {@code RRFNormalizationTechnique#calculateNormalizedScore} replaced,
+     * retained here as an independent reference for what the rank score must be.
+     */
+    private float rrfNorm(int rank, int rankConstant) {
+        // 1.0f / (float) (rank + rankConstant + 1);
+        return BigDecimal.ONE.divide(BigDecimal.valueOf(rank + rankConstant + 1), 10, RoundingMode.HALF_UP).floatValue();
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -19,8 +19,6 @@ import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 import org.opensearch.search.SearchShardTarget;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -245,6 +243,52 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
         }
     }
 
+    /**
+     * Pins the multi shard ranking contract with exact score equality. Ranks for a subquery are assigned
+     * globally across all shards, ordered by descending original score with ascending docId as tie break
+     * (the ordering of {@link ScoreDoc#COMPARATOR}), and only then by ascending shard. This is the contract
+     * that any other RRF implementation has to reproduce to stay score compatible, and the assertion
+     * deltas used elsewhere in this class are too loose to detect a regression in it.
+     */
+    public void testNormalization_whenResultFromMultipleShards_thenRanksAreGlobalAcrossShards() {
+        RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(Map.of(), scoreNormalizationUtil);
+        TopDocs shard1TopDocs = new TopDocs(
+            new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+            new ScoreDoc[] { new ScoreDoc(3, 0.9f), new ScoreDoc(4, 0.7f), new ScoreDoc(2, 0.1f) }
+        );
+        TopDocs shard2TopDocs = new TopDocs(
+            new TotalHits(4, TotalHits.Relation.EQUAL_TO),
+            new ScoreDoc[] { new ScoreDoc(3, 0.8f), new ScoreDoc(9, 0.7f), new ScoreDoc(10, 0.6f), new ScoreDoc(15, 0.5f) }
+        );
+        List<CompoundTopDocs> compoundTopDocs = List.of(
+            new CompoundTopDocs(
+                new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                List.of(shard1TopDocs),
+                false,
+                new SearchShard("my_index", 0, "shard-uuid-1")
+            ),
+            new CompoundTopDocs(
+                new TotalHits(4, TotalHits.Relation.EQUAL_TO),
+                List.of(shard2TopDocs),
+                false,
+                new SearchShard("my_index", 1, "shard-uuid-2")
+            )
+        );
+
+        normalizationTechnique.normalize(
+            NormalizeScoresDTO.builder().queryTopDocs(compoundTopDocs).normalizationTechnique(normalizationTechnique).build()
+        );
+
+        // global order by descending score: 0.9, 0.8, then 0.7 tied and broken by docId 4 before 9, then 0.6, 0.5, 0.1
+        assertEquals(rrfNorm(0), shard1TopDocs.scoreDocs[0].score, 0.0f); // doc 3, score 0.9
+        assertEquals(rrfNorm(2), shard1TopDocs.scoreDocs[1].score, 0.0f); // doc 4, score 0.7
+        assertEquals(rrfNorm(6), shard1TopDocs.scoreDocs[2].score, 0.0f); // doc 2, score 0.1
+        assertEquals(rrfNorm(1), shard2TopDocs.scoreDocs[0].score, 0.0f); // doc 3, score 0.8
+        assertEquals(rrfNorm(3), shard2TopDocs.scoreDocs[1].score, 0.0f); // doc 9, score 0.7
+        assertEquals(rrfNorm(4), shard2TopDocs.scoreDocs[2].score, 0.0f); // doc 10, score 0.6
+        assertEquals(rrfNorm(5), shard2TopDocs.scoreDocs[3].score, 0.0f); // doc 15, score 0.5
+    }
+
     public void testNormalizedScoresAreSetAtCorrectIndices() {
         // Setup test data
         SearchShardTarget shardTarget = new SearchShardTarget("node1", new ShardId("index", "_na_", 0), null, null);
@@ -355,55 +399,12 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
     }
 
     /**
-     * Rank scores are computed in integer arithmetic rather than with {@link BigDecimal}. That is only a safe
-     * substitution if it is exactly equal to the BigDecimal form it replaced, so this asserts on raw float bits
-     * rather than within a delta - a change that rounded even one ULP differently would pass a delta comparison.
-     * The ranks covered span the point where a scale-10 numerator crosses 2^24, where BigDecimal's conversion to
-     * float changes behavior, and rank constants at both ends of the permitted range.
+     * Expected scores come from the shared normalizer rather than a local copy of the formula, so this asserts
+     * that the technique delegates to it. That the formula itself is correct, and bit-identical to the BigDecimal
+     * implementation it replaced, is pinned separately in {@link RRFScoreNormalizerTests}.
      */
-    public void testNormalize_whenScoresComputed_thenBitIdenticalToBigDecimalReference() {
-        int numDocs = 1200;
-        float[] scores = new float[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            scores[i] = 1.0f - i / (float) numDocs;
-        }
-
-        for (int rankConstant : new int[] { 1, RANK_CONSTANT, 10_000 }) {
-            CompoundTopDocs compoundTopDocs = createCompoundTopDocs(scores, numDocs);
-            RRFNormalizationTechnique normalizationTechnique = new RRFNormalizationTechnique(
-                Map.of("rank_constant", rankConstant),
-                scoreNormalizationUtil
-            );
-            normalizationTechnique.normalize(
-                NormalizeScoresDTO.builder()
-                    .queryTopDocs(List.of(compoundTopDocs))
-                    .normalizationTechnique(normalizationTechnique)
-                    .singleShard(true)
-                    .build()
-            );
-
-            ScoreDoc[] scoreDocs = compoundTopDocs.getTopDocs().get(0).scoreDocs;
-            for (int rank = 0; rank < numDocs; rank++) {
-                assertEquals(
-                    "rank_constant [" + rankConstant + "], rank [" + rank + "]",
-                    Float.floatToIntBits(rrfNorm(rank, rankConstant)),
-                    Float.floatToIntBits(scoreDocs[rank].score)
-                );
-            }
-        }
-    }
-
     private float rrfNorm(int rank) {
-        return rrfNorm(rank, RANK_CONSTANT);
-    }
-
-    /**
-     * The BigDecimal implementation that {@code RRFNormalizationTechnique#calculateNormalizedScore} replaced,
-     * retained here as an independent reference for what the rank score must be.
-     */
-    private float rrfNorm(int rank, int rankConstant) {
-        // 1.0f / (float) (rank + rankConstant + 1);
-        return BigDecimal.ONE.divide(BigDecimal.valueOf(rank + rankConstant + 1), 10, RoundingMode.HALF_UP).floatValue();
+        return RRFScoreNormalizer.scoreForRank(rank, RANK_CONSTANT);
     }
 
     private void assertCompoundTopDocs(TopDocs expected, TopDocs actual) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFScoreNormalizerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFScoreNormalizerTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.processor.normalization;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * Tests the shared RRF arithmetic in isolation from the {@link org.opensearch.neuralsearch.processor.CompoundTopDocs}
+ * traversal that {@link RRFNormalizationTechnique} wraps around it.
+ */
+public class RRFScoreNormalizerTests extends OpenSearchTestCase {
+    private static final float DELTA = 1e-6f;
+
+    public void testScoreForRank_whenDefaultRankConstant_thenReciprocalOfOneBasedRank() {
+        assertEquals(1.0f / 61.0f, RRFScoreNormalizer.scoreForRank(0, RRFScoreNormalizer.DEFAULT_RANK_CONSTANT), DELTA);
+        assertEquals(1.0f / 62.0f, RRFScoreNormalizer.scoreForRank(1, RRFScoreNormalizer.DEFAULT_RANK_CONSTANT), DELTA);
+        assertEquals(1.0f / 70.0f, RRFScoreNormalizer.scoreForRank(9, RRFScoreNormalizer.DEFAULT_RANK_CONSTANT), DELTA);
+    }
+
+    public void testScoreForRank_whenCustomRankConstant_thenUsesIt() {
+        assertEquals(1.0f / 26.0f, RRFScoreNormalizer.scoreForRank(0, 25), DELTA);
+        assertEquals(1.0f / 2.0f, RRFScoreNormalizer.scoreForRank(0, 1), DELTA);
+    }
+
+    public void testScoreForRank_whenScoresDecrease_thenStrictlyMonotonic() {
+        float previous = Float.MAX_VALUE;
+        for (int rank = 0; rank < 100; rank++) {
+            float score = RRFScoreNormalizer.scoreForRank(rank, RRFScoreNormalizer.DEFAULT_RANK_CONSTANT);
+            assertTrue("score must decrease as rank grows", score < previous);
+            previous = score;
+        }
+    }
+
+    /**
+     * The score is computed in integer arithmetic rather than with {@link BigDecimal}. That is only a safe
+     * substitution if it is exactly equal to the BigDecimal form it replaced, so assert on raw float bits rather
+     * than within a delta - a change that rounded even one ULP differently would pass a delta comparison. The
+     * denominators covered span the point where a scale-10 numerator crosses 2^24, where BigDecimal's conversion
+     * to float changes behavior, and the point past which scale 10 is coarser than float itself.
+     */
+    public void testScoreForRank_whenComputed_thenBitIdenticalToBigDecimalReference() {
+        for (int rankConstant : new int[] {
+            RRFScoreNormalizer.MIN_RANK_CONSTANT,
+            RRFScoreNormalizer.DEFAULT_RANK_CONSTANT,
+            RRFScoreNormalizer.MAX_RANK_CONSTANT }) {
+            for (int rank = 0; rank <= 5000; rank++) {
+                assertEquals(
+                    "rank_constant [" + rankConstant + "], rank [" + rank + "]",
+                    Float.floatToIntBits(bigDecimalScoreForRank(rank, rankConstant)),
+                    Float.floatToIntBits(RRFScoreNormalizer.scoreForRank(rank, rankConstant))
+                );
+            }
+        }
+    }
+
+    /**
+     * The BigDecimal implementation that {@link RRFScoreNormalizer#scoreForRank} replaced, retained as an
+     * independent reference for what the rank score must be. Deliberately does not delegate to the production
+     * code: an oracle that calls the implementation cannot detect a change in the implementation.
+     */
+    private static float bigDecimalScoreForRank(final int rank, final int rankConstant) {
+        return BigDecimal.ONE.divide(BigDecimal.valueOf(rankConstant + rank + 1), 10, RoundingMode.HALF_UP).floatValue();
+    }
+
+    public void testResolveRankConstant_whenParamAbsent_thenDefault() {
+        assertEquals(RRFScoreNormalizer.DEFAULT_RANK_CONSTANT, RRFScoreNormalizer.resolveRankConstant(null));
+        assertEquals(RRFScoreNormalizer.DEFAULT_RANK_CONSTANT, RRFScoreNormalizer.resolveRankConstant(Map.of()));
+        assertEquals(RRFScoreNormalizer.DEFAULT_RANK_CONSTANT, RRFScoreNormalizer.resolveRankConstant(Map.of("other_param", 5)));
+    }
+
+    public void testResolveRankConstant_whenParamPresent_thenParsed() {
+        assertEquals(25, RRFScoreNormalizer.resolveRankConstant(Map.of(RRFScoreNormalizer.PARAM_NAME_RANK_CONSTANT, 25)));
+        // values arrive from parsed JSON, so a string representation must parse too
+        assertEquals(25, RRFScoreNormalizer.resolveRankConstant(Map.of(RRFScoreNormalizer.PARAM_NAME_RANK_CONSTANT, "25")));
+    }
+
+    public void testResolveRankConstant_whenParamNotNumeric_thenFail() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> RRFScoreNormalizer.resolveRankConstant(Map.of(RRFScoreNormalizer.PARAM_NAME_RANK_CONSTANT, "not_a_number"))
+        );
+        assertEquals("parameter [rank_constant] must be an integer", exception.getMessage());
+    }
+
+    public void testResolveRankConstant_whenParamOutOfRange_thenFail() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> RRFScoreNormalizer.resolveRankConstant(Map.of(RRFScoreNormalizer.PARAM_NAME_RANK_CONSTANT, 0))
+        );
+        assertEquals("rank constant must be in the interval between 1 and 10000, submitted rank constant: 0", exception.getMessage());
+    }
+
+    public void testValidateRankConstant_whenAtBounds_thenAccepted() {
+        RRFScoreNormalizer.validateRankConstant(RRFScoreNormalizer.MIN_RANK_CONSTANT);
+        RRFScoreNormalizer.validateRankConstant(RRFScoreNormalizer.MAX_RANK_CONSTANT);
+    }
+
+    public void testValidateRankConstant_whenOutsideBounds_thenFail() {
+        expectThrows(IllegalArgumentException.class, () -> RRFScoreNormalizer.validateRankConstant(0));
+        expectThrows(IllegalArgumentException.class, () -> RRFScoreNormalizer.validateRankConstant(-1));
+        expectThrows(IllegalArgumentException.class, () -> RRFScoreNormalizer.validateRankConstant(10_001));
+    }
+
+    public void testDrainToRanks_whenOrderedByComparator_thenZeroBasedRanks() {
+        PriorityQueue<String> queue = new PriorityQueue<>(Comparator.<String>naturalOrder());
+        queue.addAll(List.of("c", "a", "b"));
+
+        assertEquals(Map.of("a", 0, "b", 1, "c", 2), RRFScoreNormalizer.drainToRanks(queue, item -> item));
+    }
+
+    public void testDrainToRanks_whenEmpty_thenEmptyMap() {
+        PriorityQueue<String> queue = new PriorityQueue<>(Comparator.<String>naturalOrder());
+
+        assertTrue(RRFScoreNormalizer.drainToRanks(queue, item -> item).isEmpty());
+    }
+
+    public void testDrainToRanks_whenKeyFunctionDiffersFromItem_thenKeyedByFunction() {
+        PriorityQueue<Integer> queue = new PriorityQueue<>(Comparator.<Integer>naturalOrder());
+        queue.addAll(List.of(30, 10, 20));
+
+        assertEquals(Map.of("doc_10", 0, "doc_20", 1, "doc_30", 2), RRFScoreNormalizer.drainToRanks(queue, item -> "doc_" + item));
+    }
+
+    public void testDrainToRanks_whenCalled_thenQueueIsDrained() {
+        PriorityQueue<String> queue = new PriorityQueue<>(Comparator.<String>naturalOrder());
+        queue.addAll(List.of("b", "a"));
+
+        RRFScoreNormalizer.drainToRanks(queue, item -> item);
+
+        assertTrue("drainToRanks consumes the queue it is given", queue.isEmpty());
+    }
+
+    public void testAssignRanksByScoreDescending_whenDistinctScores_thenHighestScoreRanksFirst() {
+        Map<String, Integer> ranks = RRFScoreNormalizer.assignRanksByScoreDescending(Map.of("d1", 0.2f, "d2", 0.9f, "d3", 0.5f));
+
+        assertEquals(Map.of("d2", 0, "d3", 1, "d1", 2), ranks);
+    }
+
+    public void testAssignRanksByScoreDescending_whenScoresTie_thenBrokenByAscendingId() {
+        Map<String, Integer> ranks = RRFScoreNormalizer.assignRanksByScoreDescending(Map.of("b", 0.5f, "a", 0.5f, "c", 0.9f));
+
+        assertEquals(Map.of("c", 0, "a", 1, "b", 2), ranks);
+    }
+
+    public void testAssignRanksByScoreDescending_whenEmpty_thenEmptyMap() {
+        assertTrue(RRFScoreNormalizer.assignRanksByScoreDescending(Map.of()).isEmpty());
+    }
+}


### PR DESCRIPTION
### Description

Prep work for replicating RRF under the coordinator-side "fusion" path introduced by #1933, plus a
duplication cleanup that fell out of reading the two hybridization processors side by side. Every
pre-existing test passes unmodified.

**Now behavior-preserving throughout.** An earlier revision hoisted `RRFProcessor.recordStats` *and*
fixed the `Optional.of` NPE lurking in it in the same commit. Per review feedback, that fix — plus the
validation that makes the bad config a 400 at pipeline creation instead of a 500 on every query — is
now a **separate commit of its own** (`80ce5f91`), a straight port of #1949 against `main`. The
refactor commit on top of it moves code and nothing else. Once #1949 merges and `main` is forward-merged
into this feature branch, that ported commit drops out as already-applied.

#### 1. Extract `RRFScoreNormalizer`

#1933 established the pattern: it lifted the scalar min-max arithmetic out of
`MinMaxScoreNormalizationTechnique` into a stateless `MinMaxScoreNormalizer` so the shard-side and
coordinator-side paths call one implementation of the formula. This does the same for RRF, in the same
style (`public final`, static-only, private constructor, same package).

Moved out of `RRFNormalizationTechnique`:

| New member | Was |
|---|---|
| `DEFAULT_RANK_CONSTANT`, `PARAM_NAME_RANK_CONSTANT`, `MIN_RANK_CONSTANT`, `MAX_RANK_CONSTANT` | constants on the technique |
| `scoreForRank(rank, rankConstant)` | `private float calculateNormalizedScore(int)` |
| `resolveRankConstant(params)` | `private int getRankConstant(Map)` + `getParamAsInteger` |
| `validateRankConstant(int)` | `private void validateRankConstant(int)` |
| `drainToRanks(queue, keyFunction)` | the priority-queue drain inside `sortDocumentsAsPerGlobalRankInIndividualQuery` |
| `assignRanksByScoreDescending(scoresById)` | new — the coordinator-side entry point |

`drainToRanks` takes the `PriorityQueue` rather than building one from a collection, and the queue
construction stays in `RRFNormalizationTechnique` unchanged. The reason is only that this is a move:
restructuring the caller's queue assembly is a rewrite reviewers would have to re-verify, for no
functional gain.

To be precise about what the heap does and does not buy, since an earlier revision of this description
overstated it: ranks here do not depend on using a heap. Heap-drain order and stable-sort order diverge
only for elements a comparator treats as equal, and the classic comparator (`ScoreDoc.COMPARATOR` then
`referenceShardId`) is a *total* order over results — measured, it returns `0` only for identical
`(docId, shardId)`, which cannot occur across two distinct results. Sorting a list with the same
comparator would therefore yield identical ranks. The `PriorityQueue` is kept because it is what the code
already did, not because the semantics require it.

`RRFNormalizationTechnique` keeps only what is `CompoundTopDocs`-shaped — the traversal, the
`ShardResultPerSubQuery` record, the comparator, `describe()`. `DEFAULT_RANK_CONSTANT` and
`PARAM_NAME_RANK_CONSTANT` remain as public aliases sourced from the normalizer, since
`RRFProcessorFactory` and several tests reach for them through the technique (same as #1933 did for
`MIN_SCORE`/`MAX_SCORE`).

`RRFScoreCombinationTechnique` is **not** extracted, on purpose: coordinator-side fusion builds a real
`ScoreCombinationTechnique` from `ScoreCombinationFactory` and calls `combine(float[])` on it directly,
so the combination side is already shared. Nothing to do there.

#### 2. Deduplicate the two hybridization processors

`NormalizationProcessor` and `RRFProcessor` were byte-for-byte identical across ~70 lines
(`hybridizeScores`, `shouldSkipProcessor`, `isHybridQuery`, `getQueryPhaseSearchResults`,
`getFetchSearchResults`, `getBeforePhase`, `getAfterPhase`, `isIgnoreFailure`). That is now implemented
once in `AbstractScoreHybridizationProcessor`, driven by four hooks — `getNormalizationTechnique()`,
`getCombinationTechnique()`, `getNormalizationWorkflow()` (all satisfied by Lombok `@Getter`) and
`recordStats()`. Each subclass is now just its `TYPE`, its fields, and its stats incrementers. The log
message uses `getType()` instead of a hard-coded name.

#### Preparatory commits ported from `main`

The base commit here mirrors #1942 (opened against `main`) so the extracted `scoreForRank` doesn't
land in its old allocating form and immediately need rewriting. It replaces the per-document
`BigDecimal` with the exact integer equivalent — `HALF_UP` rounding to scale 10 is expressible as
`(2 * 10^10 + d) / (2 * d)`, verified **bit-identical for all 2,147,483,646 reachable denominators** on
three JDKs. Kept as a separate commit so it can be swapped for the merged form of #1942 if that lands
differently.

The second, `80ce5f91`, ports #1949: `RRFProcessorFactory` rejects any `combination.technique` but `rrf`
(HTTP 400 at `PUT _search/pipeline/...`), and `recordStats` uses `Optional.ofNullable`. Both are
pre-existing bugs on `main`, not artifacts of this refactor, which is why they are fixed there and merely
carried here so the refactor commit stays a move.

#### One finding worth flagging before RRF is wired into fusion

Multi-shard ranks **are** globally score-ordered and interleave across shards; the existing
`testNormalization_whenResultFromMultipleShardsMultipleSubQueries_thenSuccessful` looks like it asserts
shard-grouped ranks but cannot distinguish them — it compares within `DELTA_FOR_ASSERTION = 0.001f`
while adjacent RRF scores at `rank_constant = 60` differ by roughly `0.00026`. A new test pins the real
contract with exact equality.

This matters for fusion: classic multi-shard ranking breaks score ties by **Lucene docId**, which does
not exist on the coordinator, so `assignRanksByScoreDescending` uses ascending `_id` as the closest
analogue. Any tie will therefore rank differently between the two paths.

That has now been measured rather than left open, because it decides whether fused-mode RRF should chase
bit-exact parity with classic on ties. It should not. Taking three docs all tied at score `1.0` — which is
not exotic; a `constant_score`, `match_all` or filter-context leg ties *every* doc by construction — and
laying the same logical hit set out differently:

| Layout | Resulting rank order |
|---|---|
| 1 shard, Lucene docIds 5, 3, 9 | `doc3` → `doc5` → `doc9` |
| 3 shards, each with local docId 0 | `shard0` → `shard1` → `shard2` |
| 1 shard, docIds 9, 5, 3 (post-merge renumbering) | `doc3` → `doc5` → `doc9` |

Classic's tie order is `docId` ascending then `shardId` ascending, and both are physical storage
artifacts: docId is reassigned by segment merges and reindexing, shardId by re-sharding. So the same tied
documents can change relative order without any change to the data or the query. It is deterministic for
a fixed index state, but it is not a contract.

Coordinator-side `_id` ascending is deterministic *and* independent of segment layout, shard count and
insertion order (verified: scrambled insertion orders produce identical ranks). Fused-mode RRF will
therefore define `_id` ascending as its tie contract, and the parity tests will assert the arithmetic over
tie-free score sets plus one explicit test pinning the tie divergence as intended — rather than trying to
reproduce a Lucene internal that is not present in `SearchHit` in order to match an order that is not
stable anyway.

#### Follow-up not in this PR

`HybridQueryBuilder.requireSupportedTechniques(...)` still gates out `rrf`; `CoordinatorScoreFusion`
needs `fuseRrf(...)`; `HybridFusionOrchestrator.computeRankedDocs(...)` ignores `fusion.rankConstant()`;
`FusionSpec` carries its own `DEFAULT_RANK_CONSTANT = 60` / `RANK_CONSTANT_KEY` literals and accepts any
`Number` where `RRFProcessorFactoryTests` requires negative/too-large/non-numeric to be rejected; and
`BaseNeuralSearchIT.createRRFSearchPipeline` takes `weights` but no `rank_constant`.

### Related Issues

Related to #1933 (this targets its feature branch). Preparatory commits mirror #1942 (merged) and #1949 (open against `main`).

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



