### PR TITLE
[RRF] Reject combination techniques the score-ranker-processor cannot use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Hybrid Query] Fix NoSuchElementException in hybrid query with sort/search_after when a shard returns no results ([#1939](https://github.com/opensearch-project/neural-search/pull/1939))
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))
 * [Sparse ANN] Fold sparse vector tokens into the signed-short range (modulus 32768) so folded tokens are never sign-extended to a negative value when stored in short[] ([#1926](https://github.com/opensearch-project/neural-search/pull/1926))
+* [RRF] Reject a combination technique other than rrf when creating a score-ranker-processor, instead of accepting the pipeline and throwing NullPointerException on every query ([#1949](https://github.com/opensearch-project/neural-search/pull/1949))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/processor/RRFProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/RRFProcessor.java
@@ -156,6 +156,8 @@ public class RRFProcessor extends AbstractScoreHybridizationProcessor {
 
     private void recordStats(ScoreCombinationTechnique combinationTechnique) {
         EventStatsManager.increment(EventStatName.RRF_PROCESSOR_EXECUTIONS);
-        Optional.of(combTechniqueIncrementers.get(combinationTechnique.techniqueName())).ifPresent(Runnable::run);
+        // ofNullable, not of: a technique with no incrementer must not fail the query. RRFProcessorFactory rejects any
+        // technique but rrf, so this is no longer reachable from a pipeline definition, but this constructor is public.
+        Optional.ofNullable(combTechniqueIncrementers.get(combinationTechnique.techniqueName())).ifPresent(Runnable::run);
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactory.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.neuralsearch.processor.factory;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -63,6 +64,22 @@ public class RRFProcessorFactory implements Processor.Factory<SearchPhaseResults
                 TECHNIQUE,
                 RRFScoreCombinationTechnique.TECHNIQUE_NAME
             );
+
+            // This processor normalizes by rank, so rrf is the only combination that means anything here. The other
+            // techniques registered in ScoreCombinationFactory (the means) belong to the normalization-processor, where
+            // they combine normalized scores. Accepting one here produced a pipeline that threw on every query, so
+            // reject it at pipeline creation with a 400 instead of failing at search time.
+            if (RRFScoreCombinationTechnique.TECHNIQUE_NAME.equals(combinationTechnique) == false) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "provided combination technique is not supported by [%s], supported technique is [%s], got [%s]",
+                        RRFProcessor.TYPE,
+                        RRFScoreCombinationTechnique.TECHNIQUE_NAME,
+                        combinationTechnique
+                    )
+                );
+            }
 
             String rankConstantParam = RRFNormalizationTechnique.PARAM_NAME_RANK_CONSTANT;
             if (combinationClause.containsKey(rankConstantParam)) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorIT.java
@@ -4,10 +4,17 @@
  */
 package org.opensearch.neuralsearch.processor;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.Before;
+import org.opensearch.client.ResponseException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
@@ -27,6 +34,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opensearch.neuralsearch.util.TestUtils.DEFAULT_USER_AGENT;
 import static org.opensearch.neuralsearch.util.TestUtils.DELTA_FOR_SCORE_ASSERTION;
 import static org.opensearch.neuralsearch.util.TestUtils.TEST_SPACE_TYPE;
 import static org.opensearch.neuralsearch.util.TestUtils.createRandomVector;
@@ -55,6 +63,49 @@ public class RRFProcessorIT extends BaseNeuralSearchIT {
         );
         addDocuments();
         createDefaultRRFSearchPipeline();
+    }
+
+    /**
+     * The score-ranker-processor normalizes by rank, so rrf is the only combination technique that applies. The mean
+     * techniques are registered in ScoreCombinationFactory and used to be accepted here, producing a pipeline that
+     * threw NullPointerException on every query. Creating such a pipeline must fail with 400 instead.
+     */
+    @SneakyThrows
+    public void testRRFPipelineCreation_whenCombinationTechniqueIsNotRrf_thenBadRequest() {
+        String body = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("description", "score-ranker-processor with a combination technique it does not support")
+            .startArray("phase_results_processors")
+            .startObject()
+            .startObject("score-ranker-processor")
+            .startObject("combination")
+            .field("technique", "arithmetic_mean")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject()
+            .toString();
+
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> makeRequest(
+                client(),
+                "PUT",
+                "/_search/pipeline/rrf-unsupported-combination",
+                null,
+                toHttpEntity(body),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            )
+        );
+
+        assertEquals(RestStatus.BAD_REQUEST.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
+        String message = EntityUtils.toString(exception.getResponse().getEntity());
+        assertTrue(
+            message,
+            message.contains("provided combination technique is not supported by [score-ranker-processor], supported technique is [rrf]")
+        );
+        assertTrue(message, message.contains("arithmetic_mean"));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/RRFProcessorTests.java
@@ -23,6 +23,7 @@ import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.common.util.concurrent.AtomicArray;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.neuralsearch.processor.combination.ArithmeticMeanScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.RRFScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationTechnique;
@@ -136,6 +137,26 @@ public class RRFProcessorTests extends OpenSearchTestCase {
         rrfProcessor.process(mockQueryPhaseResultConsumer, mockSearchPhaseContext);
 
         verify(mockNormalizationWorkflow, never()).execute(any(NormalizationProcessorWorkflowExecuteRequest.class));
+    }
+
+    @SneakyThrows
+    public void testProcess_whenCombinationTechniqueHasNoStatsIncrementer_thenSucceed() {
+        // RRFProcessorFactory now rejects any combination technique but rrf, so this is unreachable from a pipeline
+        // definition. It stays reachable by direct construction, and a stats lookup miss must not fail the query.
+        when(mockCombinationTechnique.techniqueName()).thenReturn(ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME);
+        QuerySearchResult result = createQuerySearchResult(true);
+        AtomicArray<SearchPhaseResult> atomicArray = new AtomicArray<>(1);
+        atomicArray.set(0, result);
+
+        when(mockQueryPhaseResultConsumer.getAtomicArray()).thenReturn(atomicArray);
+
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(new SearchSourceBuilder());
+        when(mockSearchPhaseContext.getRequest()).thenReturn(searchRequest);
+
+        rrfProcessor.process(mockQueryPhaseResultConsumer, mockSearchPhaseContext);
+
+        verify(mockNormalizationWorkflow).execute(any(NormalizationProcessorWorkflowExecuteRequest.class));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactoryTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/factory/RRFProcessorFactoryTests.java
@@ -9,6 +9,9 @@ import lombok.SneakyThrows;
 import org.opensearch.neuralsearch.processor.NormalizationProcessorWorkflow;
 import org.opensearch.neuralsearch.processor.RRFProcessor;
 import org.opensearch.neuralsearch.processor.combination.ArithmeticMeanScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.combination.GeometricMeanScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.combination.HarmonicMeanScoreCombinationTechnique;
+import org.opensearch.neuralsearch.processor.combination.RRFScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationFactory;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombiner;
 import org.opensearch.neuralsearch.processor.normalization.RRFNormalizationTechnique;
@@ -20,6 +23,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -190,6 +194,55 @@ public class RRFProcessorFactoryTests extends OpenSearchTestCase {
             () -> rrfProcessorFactory.create(processorFactories, tag, description, ignoreFailure, config, pipelineContext)
         );
         assertTrue(exception.getMessage().contains("provided combination technique is not supported"));
+    }
+
+    @SneakyThrows
+    public void testInvalidCombinationName_whenTechniqueBelongsToNormalizationProcessor_thenFail() {
+        // These three are registered in ScoreCombinationFactory, so they used to be accepted here and then threw
+        // NullPointerException on every query. They combine normalized scores and belong to the normalization-processor;
+        // this processor normalizes by rank, so rrf is the only combination that applies.
+        for (String technique : List.of(
+            ArithmeticMeanScoreCombinationTechnique.TECHNIQUE_NAME,
+            HarmonicMeanScoreCombinationTechnique.TECHNIQUE_NAME,
+            GeometricMeanScoreCombinationTechnique.TECHNIQUE_NAME
+        )) {
+            RRFProcessorFactory rrfProcessorFactory = new RRFProcessorFactory(
+                new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
+                new ScoreNormalizationFactory(),
+                new ScoreCombinationFactory()
+            );
+            final Map<String, Processor.Factory<SearchPhaseResultsProcessor>> processorFactories = new HashMap<>();
+            Map<String, Object> config = new HashMap<>();
+            config.put(COMBINATION_CLAUSE, new HashMap<>(Map.of(TECHNIQUE, technique)));
+            Processor.PipelineContext pipelineContext = mock(Processor.PipelineContext.class);
+
+            IllegalArgumentException exception = expectThrows(
+                IllegalArgumentException.class,
+                () -> rrfProcessorFactory.create(processorFactories, "tag", "description", false, config, pipelineContext)
+            );
+            assertTrue(
+                "unexpected message for [" + technique + "]: " + exception.getMessage(),
+                exception.getMessage()
+                    .contains("provided combination technique is not supported by [score-ranker-processor], supported technique is [rrf]")
+            );
+            assertTrue("message should name the rejected technique: " + exception.getMessage(), exception.getMessage().contains(technique));
+        }
+    }
+
+    @SneakyThrows
+    public void testCombinationName_whenRrfExplicitlyRequested_thenSuccessful() {
+        // The counterpart to the rejection above: rrf stated explicitly is still accepted, so the guard rejects only
+        // the techniques that never worked.
+        RRFProcessorFactory rrfProcessorFactory = new RRFProcessorFactory(
+            new NormalizationProcessorWorkflow(new ScoreNormalizer(), new ScoreCombiner()),
+            new ScoreNormalizationFactory(),
+            new ScoreCombinationFactory()
+        );
+        final Map<String, Processor.Factory<SearchPhaseResultsProcessor>> processorFactories = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(COMBINATION_CLAUSE, new HashMap<>(Map.of(TECHNIQUE, RRFScoreCombinationTechnique.TECHNIQUE_NAME)));
+        Processor.PipelineContext pipelineContext = mock(Processor.PipelineContext.class);
+        assertRRFProcessor(rrfProcessorFactory.create(processorFactories, "tag", "description", false, config, pipelineContext));
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description

`score-ranker-processor` normalizes by rank, so `rrf` is the only combination technique that means anything to it. `RRFProcessorFactory` nonetheless accepted any technique registered in `ScoreCombinationFactory` — including the three means (`arithmetic_mean`, `harmonic_mean`, `geometric_mean`), which belong to `normalization-processor`, where they combine already-normalized scores.

Such a pipeline was accepted at creation and then **threw `NullPointerException` on every query**:

```java
// RRFProcessor
private final Map<String, Runnable> combTechniqueIncrementers = Map.of(
    RRFScoreCombinationTechnique.TECHNIQUE_NAME, ...   // rrf and nothing else
);

private void recordStats(ScoreCombinationTechnique combinationTechnique) {
    EventStatsManager.increment(EventStatName.RRF_PROCESSOR_EXECUTIONS);
    Optional.of(combTechniqueIncrementers.get(combinationTechnique.techniqueName()))  // NPE on a miss
        .ifPresent(Runnable::run);
}
```

`recordStats` runs unconditionally, before any normalization or combination work, so **no such pipeline could ever serve a query**. There is no working configuration to preserve, which is what makes rejecting the config strictly an improvement rather than a breaking change.

This came out of review feedback on #1944, but the bug predates that PR, so it is fixed here against `main`.

### Changes

1. **`RRFProcessorFactory` rejects any combination technique but `rrf`** → `IllegalArgumentException` from a processor factory, which OpenSearch surfaces as **HTTP 400 at `PUT _search/pipeline/...`** instead of HTTP 500 on every subsequent search. The guard sits before `createCombination`, and the message is a *superset* of the previous string:

   ```
   provided combination technique is not supported by [score-ranker-processor], supported technique is [rrf], got [arithmetic_mean]
   ```

   Because it still contains `provided combination technique is not supported`, the existing assertion in `testInvalidCombinationName_whenUnsupportedFunction_thenFail` holds unchanged — and an unregistered name like `my_function` now gets the more informative message too. One code path, no test churn.

2. **`recordStats` uses `Optional.ofNullable`.** With (1) in place the miss is unreachable from a pipeline definition, but `RRFProcessor`'s constructor is public, and stats bookkeeping should never fail a query. Defence in depth, not the primary fix.

### Verification

**The NPE was reproduced on unmodified `main` first**, so the claim above isn't inferred from reading the code:

```
RRFProcessorTests > testProcess_whenCombinationTechniqueHasNoStatsIncrementer_thenSucceed FAILED
    java.lang.NullPointerException
        at java.base/java.util.Optional.of(Optional.java:117)
        at org.opensearch.neuralsearch.processor.RRFProcessor.recordStats(RRFProcessor.java:159)
15 tests completed, 1 failed
```

Added tests:

| Test | What it pins down |
|---|---|
| `RRFProcessorFactoryTests.testInvalidCombinationName_whenTechniqueBelongsToNormalizationProcessor_thenFail` | Each of the three means is rejected, and the message names the rejected technique |
| `RRFProcessorFactoryTests.testCombinationName_whenRrfExplicitlyRequested_thenSuccessful` | The counterpart — an explicit `rrf` is still accepted, so the guard rejects only what never worked |
| `RRFProcessorTests.testProcess_whenCombinationTechniqueHasNoStatsIncrementer_thenSucceed` | The `ofNullable` path via direct construction (the reproduction above) |
| `RRFProcessorIT.testRRFPipelineCreation_whenCombinationTechniqueIsNotRrf_thenBadRequest` | **Asserts the 400 against a live cluster** rather than assuming the status code |

The IT was mutation-checked — with the guard disabled it fails for the right reason, so it is not vacuously green:

```
junit.framework.AssertionFailedError: Expected exception ResponseException but no exception was thrown
    at org.opensearch.neuralsearch.processor.RRFProcessorIT
       .testRRFPipelineCreation_whenCombinationTechniqueIsNotRrf_thenBadRequest(RRFProcessorIT.java:90)
```

With the guard in place, `RRFProcessorIT` is `tests="2" failures="0" errors="0"`, and the full unit suite is `BUILD SUCCESSFUL`.

### Deliberately not changed

`RRFProcessorFactory` also **silently ignores a `normalization` clause** (enshrined by the existing `testInvalidTechniqueType_whenPassingNormalization_thenSuccessful`). That is a second flavour of improper config, but unlike this one those pipelines *work correctly today* — the ignored clause defaults to `rrf` anyway — so rejecting them would break working configurations on upgrade. Worth a separate discussion rather than a drive-by change here.

### Related Issues

Follows up on review feedback in #1944.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-project.github.io/blob/main/_community_members/DEVELOPER_CERTIFICATE_OF_ORIGIN.md).
