### PR TITLE
[Hybrid Query] Read the current doc and its sub-matches from the positioned iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Hybrid Query] Fix NoSuchElementException in hybrid query with sort/search_after when a shard returns no results ([#1939](https://github.com/opensearch-project/neural-search/pull/1939))
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))
 * [Sparse ANN] Fold sparse vector tokens into the signed-short range (modulus 32768) so folded tokens are never sign-extended to a negative value when stored in short[] ([#1926](https://github.com/opensearch-project/neural-search/pull/1926))
+* [Hybrid Query] Read the current document and its sub-query matches from the positioned disjunction iterator, fixing an ArrayIndexOutOfBoundsException and silently misattributed scores when a sub-query has a two-phase iterator ([#1946](https://github.com/opensearch-project/neural-search/issues/1946))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryScorer.java
@@ -38,7 +38,7 @@ public class HybridQueryScorer extends Scorer {
 
     private final DisiPriorityQueue subScorersPQ;
 
-    private final DocIdSetIterator approximation;
+    private final HybridSubqueriesDISIApproximation approximation;
     private final HybridScoreBlockBoundaryPropagator disjunctionBlockPropagator;
     private final TwoPhase twoPhase;
     private final int numSubqueries;
@@ -119,9 +119,28 @@ public class HybridQueryScorer extends Scorer {
         return totalScore;
     }
 
+    /**
+     * Fill an array of per sub-query scores for the document this scorer is positioned on. Scores are taken
+     * from the sub-matches of the current document, the same list {@link #score()} sums up, so a sub-query
+     * that has a two-phase iterator is confirmed to match before its score is read. Reading the sub-scorers
+     * directly instead would score a sub-query on a document it has only approximately matched.
+     * @param subQueryScores array with one element per sub-query of this hybrid query
+     */
+    public void populateSubQueryScores(final float[] subQueryScores) throws IOException {
+        for (DisiWrapper disiWrapper = getSubMatches(); disiWrapper != null; disiWrapper = disiWrapper.next) {
+            // check if this doc has match in the subQuery. If not, leave the score as 0.0 and continue
+            if (disiWrapper.scorer.docID() == DocIdSetIterator.NO_MORE_DOCS) {
+                continue;
+            }
+            if (disiWrapper instanceof HybridDisiWrapper hybridDisiWrapper) {
+                subQueryScores[hybridDisiWrapper.getSubQueryIndex()] = hybridDisiWrapper.scorer.score();
+            }
+        }
+    }
+
     DisiWrapper getSubMatches() throws IOException {
         if (twoPhase == null) {
-            return subScorersPQ.topList();
+            return approximation.topList();
         } else {
             return twoPhase.getSubMatches();
         }
@@ -181,10 +200,7 @@ public class HybridQueryScorer extends Scorer {
      */
     @Override
     public int docID() {
-        if (subScorersPQ.size() == 0) {
-            return DocIdSetIterator.NO_MORE_DOCS;
-        }
-        return subScorersPQ.top().doc;
+        return approximation.docID();
     }
 
     private List<HybridDisiWrapper> initializeSubScorersList() {
@@ -225,13 +241,18 @@ public class HybridQueryScorer extends Scorer {
         DisiWrapper verifiedMatches;
         // priority queue of approximations on the current doc that have not been verified yet
         final PriorityQueue<DisiWrapper> unverifiedMatches;
-        DisiPriorityQueue subScorers;
+        final HybridSubqueriesDISIApproximation hybridApproximation;
         boolean needsScores;
 
-        private TwoPhase(DocIdSetIterator approximation, float matchCost, DisiPriorityQueue subScorers, boolean needsScores) {
+        private TwoPhase(
+            HybridSubqueriesDISIApproximation approximation,
+            float matchCost,
+            DisiPriorityQueue subScorers,
+            boolean needsScores
+        ) {
             super(approximation);
             this.matchCost = matchCost;
-            this.subScorers = subScorers;
+            this.hybridApproximation = approximation;
             unverifiedMatches = new PriorityQueue<>(subScorers.size()) {
                 @Override
                 protected boolean lessThan(DisiWrapper a, DisiWrapper b) {
@@ -257,7 +278,7 @@ public class HybridQueryScorer extends Scorer {
             verifiedMatches = null;
             unverifiedMatches.clear();
 
-            for (DisiWrapper wrapper = subScorers.topList(); wrapper != null;) {
+            for (DisiWrapper wrapper = hybridApproximation.topList(); wrapper != null;) {
                 DisiWrapper next = wrapper.next;
 
                 if (Objects.isNull(wrapper.twoPhaseView)) {
@@ -303,7 +324,7 @@ public class HybridQueryScorer extends Scorer {
      * sub iterators that return empty results
      */
     static class HybridSubqueriesDISIApproximation extends DocIdSetIterator {
-        final DocIdSetIterator docIdSetIterator;
+        final DisjunctionDISIApproximation docIdSetIterator;
         final DisiPriorityQueue subIterators;
 
         public HybridSubqueriesDISIApproximation(
@@ -312,6 +333,10 @@ public class HybridQueryScorer extends Scorer {
         ) {
             docIdSetIterator = new DisjunctionDISIApproximation(subIterators, 0);
             this.subIterators = subIteratorsPQ;
+        }
+
+        DisiWrapper topList() {
+            return docIdSetIterator.topList();
         }
 
         @Override

--- a/src/main/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollector.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollector.java
@@ -7,7 +7,6 @@ package org.opensearch.neuralsearch.search.collector;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.Scorer;
@@ -16,7 +15,6 @@ import org.opensearch.neuralsearch.query.HybridSubQueryScorer;
 import org.opensearch.search.profile.ProfilingWrapper;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -70,15 +68,7 @@ public abstract class HybridLeafCollector implements LeafCollector {
             return;
         }
         compoundQueryScorer.resetScores();
-        float[] subQueryScores = compoundQueryScorer.getSubQueryScores();
-        int currentDoc = hybridQueryScorer.docID();
-        List<Scorer> subScorers = hybridQueryScorer.getSubScorers();
-        for (int i = 0; i < subScorers.size(); i++) {
-            Scorer subScorer = subScorers.get(i);
-            if (Objects.nonNull(subScorer) && subScorer.docID() == currentDoc && currentDoc != DocIdSetIterator.NO_MORE_DOCS) {
-                subQueryScores[i] = subScorer.score();
-            }
-        }
+        hybridQueryScorer.populateSubQueryScores(compoundQueryScorer.getSubQueryScores());
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerPathsIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerPathsIT.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregationValues;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getAggregations;
+import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getTotalHits;
+import static org.opensearch.neuralsearch.util.TestUtils.RELATION_EQUAL_TO;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.Before;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import lombok.SneakyThrows;
+
+/**
+ * Integration tests for the request shapes that score a hybrid query through {@link HybridQueryScorer}
+ * instead of the bulk scorer. The default search path never builds a {@code HybridQueryScorer} at all -
+ * {@code HybridScorerSupplier.bulkScorer()} returns a {@code HybridBulkScorer} which drives each raw
+ * sub-scorer's own iterator. A caller only gets a real {@code Scorer} when it asks the weight for one,
+ * which is what the profiler, an aggregation filter and a nested query do.
+ * <p>
+ * Every query here pairs such a caller with a sub-query that has a two-phase iterator - a bool with a
+ * partial {@code minimum_should_match} over {@code match_phrase} clauses. {@code minimum_should_match}
+ * must stay below the number of clauses: equal to it, the bool rewrites to a conjunction and the
+ * two-phase path is never taken.
+ * <p>
+ * The documents are laid out in blocks of ascending document id so that the two sub-queries match
+ * overlapping but differently placed sets: the bool sub-query matches the first 60% of the index, the
+ * match sub-query the 50% starting at 40%, and the last 10% matches neither. The bool sub-query therefore
+ * runs out of documents while the match sub-query still has 30% of the index to go, which keeps the two
+ * sub-scorers on different documents over most of the iteration. That is the fixture
+ * that surfaces <a href="https://github.com/opensearch-project/neural-search/issues/1946">#1946</a>: when
+ * both sub-queries match the same documents, or when they exhaust together, the stale queue is
+ * accidentally correct. Per-document score correctness is asserted at unit level in
+ * {@code HybridQueryScorerTests}.
+ */
+public class HybridQueryScorerPathsIT extends BaseNeuralSearchIT {
+
+    private static final String TEST_INDEX = "test-hybrid-scorer-paths-index";
+    private static final String TEST_NESTED_INDEX = "test-hybrid-scorer-paths-nested-index";
+    private static final String SEARCH_PIPELINE = "phase-results-hybrid-scorer-paths-pipeline";
+    private static final String TITLE_FIELD = "title";
+    private static final String BODY_FIELD = "body";
+    private static final String NESTED_PATH = "chapters";
+    private static final String AGGREGATION_NAME = "hybrid_filter";
+    private static final int DOC_COUNT = 1000;
+    private static final int NESTED_DOC_COUNT = 400;
+    // the last tenth of each index matches neither sub-query, see titleAndBody
+    private static final int MATCHING_DOC_COUNT = DOC_COUNT / 10 * 9;
+    private static final int MATCHING_NESTED_DOC_COUNT = NESTED_DOC_COUNT / 10 * 9;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        updateClusterSettings();
+    }
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        return true;
+    }
+
+    @SneakyThrows
+    public void testHybridQuery_whenProfileEnabledAndSubQueryIsTwoPhase_thenAllMatchingDocsReturned() {
+        initializeIndexIfNotExist();
+        createSearchPipelineWithResultsPostProcessor(SEARCH_PIPELINE);
+
+        String query = String.format(
+            Locale.ROOT,
+            "{ \"profile\": true, \"query\": %s }",
+            hybridQueryWithTwoPhaseSubQuery(TITLE_FIELD, BODY_FIELD)
+        );
+        Map<String, Object> searchResponseAsMap = searchWithRawQuery(TEST_INDEX, query, 10, SEARCH_PIPELINE);
+
+        assertEquals(MATCHING_DOC_COUNT, totalHitsValue(searchResponseAsMap));
+        assertEquals(RELATION_EQUAL_TO, getTotalHits(searchResponseAsMap).get("relation"));
+        assertTrue(getDocumentIds(searchResponseAsMap).stream().allMatch(docId -> matchesHybridQuery(docId, DOC_COUNT)));
+        assertFalse(getProfileShards(searchResponseAsMap).isEmpty());
+    }
+
+    @SneakyThrows
+    public void testHybridQuery_whenInsideAggregationFilterAndSubQueryIsTwoPhase_thenAllMatchingDocsCounted() {
+        initializeIndexIfNotExist();
+
+        // the hybrid query is not the top level query here, so it is scored by the aggregation's own weight and
+        // normalization does not apply. doc_count comes straight out of the scorer's iteration, which is what
+        // makes it a direct assertion on that iteration
+        String query = String.format(
+            Locale.ROOT,
+            "{ \"query\": { \"match_all\": {} }, \"aggs\": { \"%s\": { \"filter\": %s } } }",
+            AGGREGATION_NAME,
+            hybridQueryWithTwoPhaseSubQuery(TITLE_FIELD, BODY_FIELD)
+        );
+        Map<String, Object> searchResponseAsMap = searchWithRawQuery(TEST_INDEX, query, 0, null);
+
+        Map<String, Object> filterAggregation = getAggregationValues(getAggregations(searchResponseAsMap), AGGREGATION_NAME);
+        assertEquals(MATCHING_DOC_COUNT, ((Number) filterAggregation.get("doc_count")).intValue());
+    }
+
+    @SneakyThrows
+    public void testHybridQuery_whenInsideNestedQueryAndSubQueryIsTwoPhase_thenAllMatchingParentsReturned() {
+        initializeNestedIndexIfNotExist();
+
+        String query = String.format(
+            Locale.ROOT,
+            "{ \"query\": { \"nested\": { \"path\": \"%s\", \"query\": %s } } }",
+            NESTED_PATH,
+            hybridQueryWithTwoPhaseSubQuery(NESTED_PATH + "." + TITLE_FIELD, NESTED_PATH + "." + BODY_FIELD)
+        );
+        Map<String, Object> searchResponseAsMap = searchWithRawQuery(TEST_NESTED_INDEX, query, 10, null);
+
+        assertEquals(MATCHING_NESTED_DOC_COUNT, totalHitsValue(searchResponseAsMap));
+        assertEquals(RELATION_EQUAL_TO, getTotalHits(searchResponseAsMap).get("relation"));
+        assertTrue(getDocumentIds(searchResponseAsMap).stream().allMatch(docId -> matchesHybridQuery(docId, NESTED_DOC_COUNT)));
+    }
+
+    /**
+     * Hybrid of a bool sub-query with a partial minimum_should_match, which contributes the two-phase
+     * iterator, and a plain match sub-query.
+     */
+    private String hybridQueryWithTwoPhaseSubQuery(final String titleField, final String bodyField) {
+        return String.format(Locale.ROOT, """
+            {
+              "hybrid": {
+                "queries": [
+                  {
+                    "bool": {
+                      "should": [
+                        { "match_phrase": { "%s": "apple banana" } },
+                        { "match_phrase": { "%s": "banana elderberry" } },
+                        { "match_phrase": { "%s": "cherry banana" } }
+                      ],
+                      "minimum_should_match": 2
+                    }
+                  },
+                  { "match": { "%s": "common" } }
+                ]
+              }
+            }""", titleField, titleField, titleField, bodyField);
+    }
+
+    /**
+     * Ascending document ids fall into four blocks: the first 40% match the bool sub-query only, the next
+     * 20% match both sub-queries, the next 30% the match sub-query only, and the last 10% match neither -
+     * their title holds a single one of the three phrases, so the partial minimum_should_match of 2
+     * excludes them. The bool sub-query is exhausted by the end of the second block, the match sub-query
+     * only by the end of the third.
+     */
+    private static String[] titleAndBody(final int docId, final int docCount) {
+        int block = docId * 10 / docCount;
+        if (block < 4) {
+            return new String[] { "apple banana elderberry", "rare" };
+        }
+        if (block < 6) {
+            return new String[] { "cherry banana elderberry", "common" };
+        }
+        if (block < 9) {
+            return new String[] { "durian fig grape", "common" };
+        }
+        return new String[] { "apple banana", "rare" };
+    }
+
+    private static String documentSource(final int docId, final int docCount) {
+        String[] titleAndBody = titleAndBody(docId, docCount);
+        return String.format(Locale.ROOT, "{ \"%s\": \"%s\", \"%s\": \"%s\" }", TITLE_FIELD, titleAndBody[0], BODY_FIELD, titleAndBody[1]);
+    }
+
+    private static boolean matchesHybridQuery(final String docId, final int docCount) {
+        return Integer.parseInt(docId) * 10 / docCount < 9;
+    }
+
+    @SneakyThrows
+    private void initializeIndexIfNotExist() {
+        if (indexExists(TEST_INDEX)) {
+            return;
+        }
+        createIndex(TEST_INDEX, """
+            {
+                "settings": {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 0
+                },
+                "mappings": {
+                    "properties": {
+                        "title": { "type": "text" },
+                        "body": { "type": "text" }
+                    }
+                }
+            }""");
+
+        StringBuilder payload = new StringBuilder();
+        for (int docId = 0; docId < DOC_COUNT; docId++) {
+            payload.append(String.format(Locale.ROOT, "{ \"index\": { \"_index\": \"%s\", \"_id\": \"%d\" } }%n", TEST_INDEX, docId));
+            payload.append(documentSource(docId, DOC_COUNT)).append(System.lineSeparator());
+        }
+        bulkIngest(payload.toString(), null);
+        forceMergeToSingleSegment(TEST_INDEX);
+        assertEquals(DOC_COUNT, getDocCount(TEST_INDEX));
+    }
+
+    /**
+     * Parents fall into the same four blocks. A parent matching both sub-queries does so through two
+     * different children, so the sub-scorers are positioned on different child documents.
+     */
+    @SneakyThrows
+    private void initializeNestedIndexIfNotExist() {
+        if (indexExists(TEST_NESTED_INDEX)) {
+            return;
+        }
+        createIndex(TEST_NESTED_INDEX, """
+            {
+                "settings": {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 0
+                },
+                "mappings": {
+                    "properties": {
+                        "chapters": {
+                            "type": "nested",
+                            "properties": {
+                                "title": { "type": "text" },
+                                "body": { "type": "text" }
+                            }
+                        }
+                    }
+                }
+            }""");
+
+        StringBuilder payload = new StringBuilder();
+        for (int docId = 0; docId < NESTED_DOC_COUNT; docId++) {
+            payload.append(
+                String.format(Locale.ROOT, "{ \"index\": { \"_index\": \"%s\", \"_id\": \"%d\" } }%n", TEST_NESTED_INDEX, docId)
+            );
+            int block = docId * 10 / NESTED_DOC_COUNT;
+            // a parent in the "both sub-queries" block carries one child per sub-query rather than a single
+            // child matching both, so the two sub-scorers are positioned on different child documents
+            String chapters = block >= 4 && block < 6
+                ? documentSource(0, NESTED_DOC_COUNT) + ", " + documentSource(NESTED_DOC_COUNT * 6 / 10, NESTED_DOC_COUNT)
+                : documentSource(docId, NESTED_DOC_COUNT);
+            payload.append(String.format(Locale.ROOT, "{ \"%s\": [ %s ] }%n", NESTED_PATH, chapters));
+        }
+        bulkIngest(payload.toString(), null);
+        forceMergeToSingleSegment(TEST_NESTED_INDEX);
+        assertEquals(NESTED_DOC_COUNT, getDocCount(TEST_NESTED_INDEX));
+    }
+
+    /**
+     * A single segment holding the documents in id order is what makes the layout above, and with it the
+     * divergence between the sub-scorers, deterministic.
+     */
+    @SneakyThrows
+    private void forceMergeToSingleSegment(final String index) {
+        makeRequest(client(), "POST", String.format(Locale.ROOT, "/%s/_forcemerge?max_num_segments=1", index), null, null, null);
+    }
+
+    /**
+     * Neither an aggregation filter nor the profile flag can be expressed through the query builder based
+     * search helpers of {@link BaseNeuralSearchIT}, so these tests send the request body as it is.
+     */
+    @SneakyThrows
+    private Map<String, Object> searchWithRawQuery(
+        final String index,
+        final String query,
+        final int resultSize,
+        final String searchPipeline
+    ) {
+        Request request = new Request("POST", "/" + index + "/_search");
+        request.setJsonEntity(query);
+        request.addParameter("size", Integer.toString(resultSize));
+        request.addParameter("search_type", "query_then_fetch");
+        if (searchPipeline != null) {
+            request.addParameter("search_pipeline", searchPipeline);
+        }
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        String responseBody = EntityUtils.toString(response.getEntity());
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), responseBody, false);
+    }
+
+    private int totalHitsValue(final Map<String, Object> searchResponseAsMap) {
+        return ((Number) getTotalHits(searchResponseAsMap).get("value")).intValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getDocumentIds(final Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> hitsMap = (Map<String, Object>) searchResponseAsMap.get("hits");
+        List<Map<String, Object>> hitsList = (List<Map<String, Object>>) hitsMap.get("hits");
+        return hitsList.stream().map(hit -> (String) hit.get("_id")).collect(Collectors.toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> getProfileShards(final Map<String, Object> searchResponseAsMap) {
+        Map<String, Object> profileMap = (Map<String, Object>) searchResponseAsMap.get("profile");
+        return (List<Map<String, Object>>) profileMap.get("shards");
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryScorerTests.java
@@ -22,14 +22,28 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.DisiWrapper;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.TestUtil;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
@@ -40,6 +54,8 @@ import org.opensearch.neuralsearch.search.HybridDisiWrapper;
 public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
     private static final int NUM_SUB_QUERIES = 2;
     private static final int DOC_ID_1 = 1;
+    private static final String TITLE_FIELD = "title";
+    private static final String BODY_FIELD = "body";
 
     @SneakyThrows
     public void testWithRandomDocuments_whenOneSubScorer_thenReturnSuccessfully() {
@@ -150,6 +166,111 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
             }
             idx++;
         }
+    }
+
+    @SneakyThrows
+    public void testDocIdAndScore_whenSubScorersMatchDifferentDocs_thenReflectCurrentDoc() {
+        // sub-scorers must match partially overlapping doc sets, not identical ones. Only then do their iterators
+        // sit on different docs, which is what makes reading position and match state from an unmaintained
+        // priority queue observable
+        final int[] docsOfFirstSubQuery = new int[] { 1, 3, 6 };
+        final float[] scoresOfFirstSubQuery = new float[] { 1.0f, 3.0f, 6.0f };
+        final int[] docsOfSecondSubQuery = new int[] { 2, 3, 5 };
+        final float[] scoresOfSecondSubQuery = new float[] { 20.0f, 30.0f, 50.0f };
+
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(
+            Arrays.asList(
+                scorerWithTwoPhaseIterator(docsOfFirstSubQuery, scoresOfFirstSubQuery),
+                scorerWithTwoPhaseIterator(docsOfSecondSubQuery, scoresOfSecondSubQuery)
+            )
+        );
+
+        final int[] expectedDocs = new int[] { 1, 2, 3, 5, 6 };
+        final float[] expectedScores = new float[] { 1.0f, 20.0f, 33.0f, 50.0f, 6.0f };
+
+        DocIdSetIterator iterator = hybridQueryScorer.iterator();
+        for (int idx = 0; idx < expectedDocs.length; idx++) {
+            assertEquals(expectedDocs[idx], iterator.nextDoc());
+            assertEquals("docID must be the doc the iterator is positioned on", expectedDocs[idx], hybridQueryScorer.docID());
+            assertEquals(
+                "score must only sum sub-queries that match the current doc",
+                expectedScores[idx],
+                hybridQueryScorer.score(),
+                DELTA_FOR_SCORE_ASSERTION
+            );
+        }
+        assertEquals(NO_MORE_DOCS, iterator.nextDoc());
+        assertEquals(NO_MORE_DOCS, hybridQueryScorer.docID());
+    }
+
+    @SneakyThrows
+    public void testScorer_whenSubQueryUsesPartialMinimumShouldMatch_thenIterateAllMatchingDocs() {
+        Directory directory = newDirectory();
+        IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig());
+        final String[][] titleTermsPerDoc = { { "apple", "banana" }, { "cherry", "apple" }, { "durian" }, { "banana", "cherry" } };
+        final String[] bodyTermPerDoc = { "rare", "common", "common", "rare" };
+        for (int docId = 0; docId < titleTermsPerDoc.length; docId++) {
+            Document document = new Document();
+            for (String titleTerm : titleTermsPerDoc[docId]) {
+                document.add(new TextField(TITLE_FIELD, titleTerm, Field.Store.NO));
+            }
+            document.add(new TextField(BODY_FIELD, bodyTermPerDoc[docId], Field.Store.NO));
+            writer.addDocument(document);
+        }
+        writer.commit();
+        // keep everything in one segment so that leaf doc ids are the same as top level doc ids
+        writer.forceMerge(1);
+
+        DirectoryReader reader = DirectoryReader.open(writer);
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        // a bool sub-query with a partial minimum_should_match compiles to a Lucene WANDScorer, which is only
+        // reachable through a two-phase iterator. minimum_should_match equal to the number of clauses becomes a
+        // conjunction instead and would not exercise that path. This sub-query matches docs 0, 1 and 3
+        Query subQueryWithPartialMinimumShouldMatch = new BooleanQuery.Builder().add(
+            new TermQuery(new Term(TITLE_FIELD, "apple")),
+            BooleanClause.Occur.SHOULD
+        )
+            .add(new TermQuery(new Term(TITLE_FIELD, "banana")), BooleanClause.Occur.SHOULD)
+            .add(new TermQuery(new Term(TITLE_FIELD, "cherry")), BooleanClause.Occur.SHOULD)
+            .setMinimumNumberShouldMatch(2)
+            .build();
+        // this sub-query matches docs 1 and 2, so the two sub-queries overlap only partially
+        Query termSubQuery = new TermQuery(new Term(BODY_FIELD, "common"));
+        List<Query> subQueries = List.of(subQueryWithPartialMinimumShouldMatch, termSubQuery);
+
+        HybridQuery hybridQuery = new HybridQuery(subQueries, new HybridQueryContext(10));
+        Weight weight = searcher.createWeight(hybridQuery, ScoreMode.TOP_SCORES, 1.0f);
+        LeafReaderContext leafReaderContext = reader.leaves().get(0);
+        // the default search path uses the bulk scorer, asking the weight for a scorer is what exercises
+        // HybridQueryScorer, same as an aggregation filter, a nested query or a profiled query does
+        Scorer scorer = weight.scorer(leafReaderContext);
+        assertTrue("query must be scored by HybridQueryScorer", scorer instanceof HybridQueryScorer);
+
+        List<Integer> actualDocs = new ArrayList<>();
+        DocIdSetIterator iterator = scorer.iterator();
+        for (int doc = iterator.nextDoc(); doc != NO_MORE_DOCS; doc = iterator.nextDoc()) {
+            assertEquals("docID must be the doc the iterator is positioned on", doc, scorer.docID());
+            float expectedScore = 0.0f;
+            for (Query subQuery : subQueries) {
+                Explanation explanation = searcher.explain(subQuery, doc);
+                if (explanation.isMatch()) {
+                    expectedScore += explanation.getValue().floatValue();
+                }
+            }
+            assertEquals(
+                "score must only sum sub-queries that match the current doc",
+                expectedScore,
+                scorer.score(),
+                DELTA_FOR_SCORE_ASSERTION
+            );
+            actualDocs.add(doc);
+        }
+        assertEquals(List.of(0, 1, 2, 3), actualDocs);
+
+        reader.close();
+        writer.close();
+        directory.close();
     }
 
     @SneakyThrows
@@ -479,6 +600,53 @@ public class HybridQueryScorerTests extends OpenSearchQueryTestCase {
         float score = scorer.score();
 
         assertEquals(0.0f, score, 0.0f);
+    }
+
+    /**
+     * Scorer that only iterates over its own docs, unlike {@link #scorerWithTwoPhaseIterator(int[], float[], Weight, int)}
+     * which approximates every doc in the index. Two of these on different doc sets end up on different docs, which
+     * is what a hybrid query does in practice.
+     */
+    private static Scorer scorerWithTwoPhaseIterator(final int[] docs, final float[] scores) {
+        final DocIdSetIterator approximation = iterator(docs);
+        return new Scorer() {
+
+            @Override
+            public DocIdSetIterator iterator() {
+                return TwoPhaseIterator.asDocIdSetIterator(twoPhaseIterator());
+            }
+
+            @Override
+            public int docID() {
+                return approximation.docID();
+            }
+
+            @Override
+            public float score() {
+                return scores[Arrays.binarySearch(docs, approximation.docID())];
+            }
+
+            @Override
+            public float getMaxScore(int upTo) {
+                return Float.MAX_VALUE;
+            }
+
+            @Override
+            public TwoPhaseIterator twoPhaseIterator() {
+                return new TwoPhaseIterator(approximation) {
+
+                    @Override
+                    public boolean matches() {
+                        return Arrays.binarySearch(docs, approximation.docID()) >= 0;
+                    }
+
+                    @Override
+                    public float matchCost() {
+                        return 10;
+                    }
+                };
+            }
+        };
     }
 
     protected static Scorer scorerWithTwoPhaseIterator(final int[] docs, final float[] scores, Weight weight, int maxDoc) {

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridCollapsingTopDocsCollectorTests.java
@@ -16,9 +16,9 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.LeafCollector;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.Weight;
@@ -40,7 +40,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCase {
 
@@ -1180,29 +1179,25 @@ public class HybridCollapsingTopDocsCollectorTests extends HybridCollectorTestCa
         Weight weight = mock(Weight.class);
         collector.setWeight(weight);
 
-        // setup: simulate profiler mode by directly setting hybridQueryScorer and compoundQueryScorer
-        Scorer subScorer1 = mock(Scorer.class);
-        HybridQueryScorer mockHybridScorer = mock(HybridQueryScorer.class);
-        when(mockHybridScorer.getSubScorers()).thenReturn(java.util.Arrays.asList(subScorer1));
-
-        HybridSubQueryScorer adapter = new HybridSubQueryScorer(1);
+        // setup: profiler mode, where the leaf collector is handed a HybridQueryScorer instead of a
+        // HybridSubQueryScorer and reads the per sub-query scores off it on every collect() call
+        int[] docIds = IntStream.range(0, 20).toArray();
+        float[] subQueryScores = new float[20];
+        for (int doc = 0; doc < 20; doc++) {
+            subQueryScores[doc] = 1.0f + doc * 0.05f;
+        }
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(
+            java.util.Arrays.asList(scorer(docIds, subQueryScores, mock(Weight.class)))
+        );
 
         LeafReaderContext context = reader.leaves().getFirst();
         LeafCollector leafCollector = collector.getLeafCollector(context);
 
-        // First set the adapter via setScorer() to trigger minScoreThresholds initialization,
-        // then override with profiler-mode fields
-        leafCollector.setScorer(adapter);
-        HybridLeafCollector hybridLeaf = (HybridLeafCollector) leafCollector;
-        hybridLeaf.hybridQueryScorer = mockHybridScorer;
-        hybridLeaf.compoundQueryScorer = adapter;
+        leafCollector.setScorer(hybridQueryScorer);
 
-        // execute: collect docs
-        for (int doc = 0; doc < 20; doc++) {
-            float score = 1.0f + doc * 0.05f;
-            when(mockHybridScorer.docID()).thenReturn(doc);
-            when(subScorer1.docID()).thenReturn(doc);
-            when(subScorer1.score()).thenReturn(score);
+        // execute: collect docs while iterating the hybrid scorer, the way the default bulk scorer does
+        DocIdSetIterator iterator = hybridQueryScorer.iterator();
+        for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
             leafCollector.collect(doc);
         }
 

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridLeafCollectorTests.java
@@ -14,6 +14,8 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.opensearch.neuralsearch.query.HybridQueryScorer;
@@ -23,6 +25,7 @@ import org.opensearch.neuralsearch.search.HitsThresholdChecker;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -87,27 +90,19 @@ public class HybridLeafCollectorTests extends HybridCollectorTestCase {
         HybridTopScoreDocCollector collector = new HybridTopScoreDocCollector(NUM_DOCS, new HitsThresholdChecker(TOTAL_HITS_UP_TO));
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
 
-        // Create mock scorers positioned on doc 5
-        Scorer subScorer1 = mock(Scorer.class);
-        Scorer subScorer2 = mock(Scorer.class);
-        when(subScorer1.docID()).thenReturn(5);
-        when(subScorer2.docID()).thenReturn(5);
-        when(subScorer1.score()).thenReturn(1.5f);
-        when(subScorer2.score()).thenReturn(2.5f);
+        // both sub-queries match doc 5
+        Weight weight = mock(Weight.class);
+        Scorer subScorer1 = scorer(new int[] { 5 }, new float[] { 1.5f }, weight);
+        Scorer subScorer2 = scorer(new int[] { 5 }, new float[] { 2.5f }, weight);
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(Arrays.asList(subScorer1, subScorer2));
 
-        // Mock HybridQueryScorer to control docID and sub-scorers
-        HybridQueryScorer mockHybridScorer = mock(HybridQueryScorer.class);
-        when(mockHybridScorer.docID()).thenReturn(5);
-        when(mockHybridScorer.getSubScorers()).thenReturn(Arrays.asList(subScorer1, subScorer2));
+        leafCollector.setScorer(hybridQueryScorer);
 
         HybridTopScoreDocCollector.HybridTopScoreLeafCollector hybridLeafCollector =
             (HybridTopScoreDocCollector.HybridTopScoreLeafCollector) leafCollector;
 
-        // Directly set the profiler-mode fields
-        hybridLeafCollector.hybridQueryScorer = mockHybridScorer;
-        hybridLeafCollector.compoundQueryScorer = new HybridSubQueryScorer(2);
-
-        // Populate scores
+        // position the hybrid scorer the way the default bulk scorer of the profiler path does
+        assertEquals(5, hybridQueryScorer.iterator().nextDoc());
         hybridLeafCollector.populateScoresFromHybridQueryScorer();
 
         // Verify scores were populated
@@ -135,29 +130,84 @@ public class HybridLeafCollectorTests extends HybridCollectorTestCase {
         HybridTopScoreDocCollector collector = new HybridTopScoreDocCollector(NUM_DOCS, new HitsThresholdChecker(TOTAL_HITS_UP_TO));
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
 
-        // subScorer1 on doc 5, subScorer2 on doc 10
-        Scorer subScorer1 = mock(Scorer.class);
-        Scorer subScorer2 = mock(Scorer.class);
-        when(subScorer1.docID()).thenReturn(5);
-        when(subScorer2.docID()).thenReturn(10);
-        when(subScorer1.score()).thenReturn(1.5f);
-        when(subScorer2.score()).thenReturn(2.5f);
+        // subScorer1 matches doc 5 only, subScorer2 doc 10 only
+        Weight weight = mock(Weight.class);
+        Scorer subScorer1 = scorer(new int[] { 5 }, new float[] { 1.5f }, weight);
+        Scorer subScorer2 = scorer(new int[] { 10 }, new float[] { 2.5f }, weight);
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(Arrays.asList(subScorer1, subScorer2));
 
-        HybridQueryScorer mockHybridScorer = mock(HybridQueryScorer.class);
-        when(mockHybridScorer.docID()).thenReturn(5);
-        when(mockHybridScorer.getSubScorers()).thenReturn(Arrays.asList(subScorer1, subScorer2));
+        leafCollector.setScorer(hybridQueryScorer);
 
         HybridTopScoreDocCollector.HybridTopScoreLeafCollector hybridLeafCollector =
             (HybridTopScoreDocCollector.HybridTopScoreLeafCollector) leafCollector;
 
-        hybridLeafCollector.hybridQueryScorer = mockHybridScorer;
-        hybridLeafCollector.compoundQueryScorer = new HybridSubQueryScorer(2);
-
+        assertEquals(5, hybridQueryScorer.iterator().nextDoc());
         hybridLeafCollector.populateScoresFromHybridQueryScorer();
 
         float[] scores = hybridLeafCollector.getCompoundQueryScorer().getSubQueryScores();
         assertEquals("sub-query 1 score should be 1.5 (matching doc)", 1.5f, scores[0], 0.001f);
         assertEquals("sub-query 2 score should be 0.0 (different doc)", 0.0f, scores[1], 0.001f);
+
+        // the sub-query that matches the next document must be the only one scored there
+        assertEquals(10, hybridQueryScorer.iterator().nextDoc());
+        hybridLeafCollector.populateScoresFromHybridQueryScorer();
+
+        scores = hybridLeafCollector.getCompoundQueryScorer().getSubQueryScores();
+        assertEquals("sub-query 1 score should be 0.0 (different doc)", 0.0f, scores[0], 0.001f);
+        assertEquals("sub-query 2 score should be 2.5 (matching doc)", 2.5f, scores[1], 0.001f);
+
+        reader.close();
+        w.close();
+        directory.close();
+    }
+
+    /**
+     * A sub-query with a two-phase iterator, a bool query with a partial minimum_should_match for instance, is
+     * positioned on every document its approximation returns, including documents it does not match. Its score
+     * must only be read once the match is confirmed, which is what the sub-matches of the hybrid scorer hold.
+     */
+    @SneakyThrows
+    public void testPopulateScores_whenTwoPhaseSubQueryDoesNotMatchApproximatedDoc_thenItsScoreIsNotPopulated() {
+        final Directory directory = newDirectory();
+        final IndexWriter w = new IndexWriter(directory, newIndexWriterConfig());
+        FieldType ft = new FieldType(TextField.TYPE_NOT_STORED);
+        ft.freeze();
+        w.addDocument(getDocument(TEXT_FIELD_NAME, 1, "text1", ft));
+        w.commit();
+
+        DirectoryReader reader = DirectoryReader.open(w);
+        LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
+
+        HybridTopScoreDocCollector collector = new HybridTopScoreDocCollector(NUM_DOCS, new HitsThresholdChecker(TOTAL_HITS_UP_TO));
+        LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
+
+        // the two-phase sub-query approximates every document but only matches doc 5, the plain one matches 5 and 7
+        Weight weight = mock(Weight.class);
+        Scorer twoPhaseSubScorer = scorerWithTwoPhaseIterator(new int[] { 5 }, new float[] { 1.5f }, 8);
+        Scorer plainSubScorer = scorer(new int[] { 5, 7 }, new float[] { 2.5f, 3.5f }, weight);
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(Arrays.asList(twoPhaseSubScorer, plainSubScorer));
+
+        leafCollector.setScorer(hybridQueryScorer);
+
+        HybridTopScoreDocCollector.HybridTopScoreLeafCollector hybridLeafCollector =
+            (HybridTopScoreDocCollector.HybridTopScoreLeafCollector) leafCollector;
+
+        DocIdSetIterator iterator = hybridQueryScorer.iterator();
+        assertEquals(5, iterator.nextDoc());
+        hybridLeafCollector.populateScoresFromHybridQueryScorer();
+
+        float[] scores = hybridLeafCollector.getCompoundQueryScorer().getSubQueryScores();
+        assertEquals("two-phase sub-query score should be 1.5 on a confirmed match", 1.5f, scores[0], 0.001f);
+        assertEquals("plain sub-query score should be 2.5", 2.5f, scores[1], 0.001f);
+
+        // doc 7 is approximated but not matched by the two-phase sub-query
+        assertEquals(7, iterator.nextDoc());
+        assertEquals("two-phase sub-query is positioned on doc 7", 7, twoPhaseSubScorer.docID());
+        hybridLeafCollector.populateScoresFromHybridQueryScorer();
+
+        scores = hybridLeafCollector.getCompoundQueryScorer().getSubQueryScores();
+        assertEquals("two-phase sub-query score should be 0.0 on an unconfirmed match", 0.0f, scores[0], 0.001f);
+        assertEquals("plain sub-query score should be 3.5", 3.5f, scores[1], 0.001f);
 
         reader.close();
         w.close();
@@ -218,23 +268,21 @@ public class HybridLeafCollectorTests extends HybridCollectorTestCase {
         HybridTopScoreDocCollector collector = new HybridTopScoreDocCollector(NUM_DOCS, new HitsThresholdChecker(TOTAL_HITS_UP_TO));
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
 
-        Scorer subScorer1 = mock(Scorer.class);
-        when(subScorer1.docID()).thenReturn(5);
-        when(subScorer1.score()).thenReturn(1.5f);
+        Weight weight = mock(Weight.class);
+        Scorer subScorer1 = scorer(new int[] { 5 }, new float[] { 1.5f }, weight);
+        // a sub-query with no scorer on this segment comes in as a null element
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(Arrays.asList(subScorer1, null));
 
-        HybridQueryScorer mockHybridScorer = mock(HybridQueryScorer.class);
-        when(mockHybridScorer.docID()).thenReturn(5);
-        when(mockHybridScorer.getSubScorers()).thenReturn(Arrays.asList(subScorer1, null));
+        leafCollector.setScorer(hybridQueryScorer);
 
         HybridTopScoreDocCollector.HybridTopScoreLeafCollector hybridLeafCollector =
             (HybridTopScoreDocCollector.HybridTopScoreLeafCollector) leafCollector;
 
-        hybridLeafCollector.hybridQueryScorer = mockHybridScorer;
-        hybridLeafCollector.compoundQueryScorer = new HybridSubQueryScorer(2);
-
+        assertEquals(5, hybridQueryScorer.iterator().nextDoc());
         hybridLeafCollector.populateScoresFromHybridQueryScorer();
 
         float[] scores = hybridLeafCollector.getCompoundQueryScorer().getSubQueryScores();
+        assertEquals("scores must have one element per sub-query", 2, scores.length);
         assertEquals("sub-query 1 score should be 1.5", 1.5f, scores[0], 0.001f);
         assertEquals("sub-query 2 score should be 0.0 (null scorer)", 0.0f, scores[1], 0.001f);
 
@@ -320,6 +368,53 @@ public class HybridLeafCollectorTests extends HybridCollectorTestCase {
      */
     static abstract class ProfilingWrapperScorer extends Scorer implements ProfilingWrapper<Scorer> {}
 
+    /**
+     * Scorer that approximates every document below maxDoc but only matches docs, the shape a bool query
+     * with a partial minimum_should_match has. Calling score() on a document outside docs is a contract
+     * violation and fails the test with an {@link ArrayIndexOutOfBoundsException}.
+     */
+    private static Scorer scorerWithTwoPhaseIterator(final int[] docs, final float[] scores, final int maxDoc) {
+        final DocIdSetIterator approximation = DocIdSetIterator.all(maxDoc);
+        return new Scorer() {
+
+            @Override
+            public DocIdSetIterator iterator() {
+                return TwoPhaseIterator.asDocIdSetIterator(twoPhaseIterator());
+            }
+
+            @Override
+            public int docID() {
+                return approximation.docID();
+            }
+
+            @Override
+            public float score() {
+                return scores[Arrays.binarySearch(docs, approximation.docID())];
+            }
+
+            @Override
+            public float getMaxScore(int upTo) {
+                return Float.MAX_VALUE;
+            }
+
+            @Override
+            public TwoPhaseIterator twoPhaseIterator() {
+                return new TwoPhaseIterator(approximation) {
+
+                    @Override
+                    public boolean matches() {
+                        return Arrays.binarySearch(docs, approximation.docID()) >= 0;
+                    }
+
+                    @Override
+                    public float matchCost() {
+                        return 10;
+                    }
+                };
+            }
+        };
+    }
+
     @SneakyThrows
     public void testSetScorer_whenProfilingWrapperReturnsNullDelegate_thenFallsThrough() {
         final Directory directory = newDirectory();
@@ -363,28 +458,25 @@ public class HybridLeafCollectorTests extends HybridCollectorTestCase {
         HybridTopScoreDocCollector collector = new HybridTopScoreDocCollector(NUM_DOCS, new HitsThresholdChecker(TOTAL_HITS_UP_TO));
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
 
-        // Create mock scorers positioned on doc 0
-        Scorer subScorer1 = mock(Scorer.class);
-        when(subScorer1.docID()).thenReturn(0);
-        when(subScorer1.score()).thenReturn(2.0f);
-        when(subScorer1.iterator()).thenReturn(DocIdSetIterator.empty());
+        Weight weight = mock(Weight.class);
+        Scorer subScorer1 = scorer(new int[] { 0 }, new float[] { 2.0f }, weight);
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(Arrays.asList(subScorer1));
 
-        HybridQueryScorer mockHybridScorer = mock(HybridQueryScorer.class);
-        when(mockHybridScorer.docID()).thenReturn(0);
-        when(mockHybridScorer.getSubScorers()).thenReturn(Arrays.asList(subScorer1));
-
-        HybridTopScoreDocCollector.HybridTopScoreLeafCollector hybridLeafCollector =
-            (HybridTopScoreDocCollector.HybridTopScoreLeafCollector) leafCollector;
-
-        // Set profiler-mode fields
-        hybridLeafCollector.hybridQueryScorer = mockHybridScorer;
-        hybridLeafCollector.compoundQueryScorer = new HybridSubQueryScorer(1);
+        leafCollector.setScorer(hybridQueryScorer);
 
         // Call collect() which should internally call populateScoresFromHybridQueryScorer()
+        assertEquals(0, hybridQueryScorer.iterator().nextDoc());
         leafCollector.collect(0);
 
         // Verify that scores were collected (totalHits incremented)
         assertTrue("totalHits should be > 0 after collect", collector.getTotalHits() > 0);
+
+        // a score of 0.0 counts as no match for the sub-query, so the hit only makes it into the
+        // results when collect() has read the score of the sub-query through the hybrid scorer
+        List<TopDocs> topDocs = collector.topDocs();
+        assertEquals(1, topDocs.size());
+        assertEquals(1, topDocs.get(0).scoreDocs.length);
+        assertEquals(2.0f, topDocs.get(0).scoreDocs[0].score, 0.001f);
 
         reader.close();
         w.close();

--- a/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollectorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/collector/HybridTopFieldDocSortCollectorTests.java
@@ -21,10 +21,10 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopFieldDocs;
@@ -252,24 +252,19 @@ public class HybridTopFieldDocSortCollectorTests extends HybridCollectorTestCase
         collector.setWeight(weight);
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
 
-        // setup: simulate profiler mode by directly setting hybridQueryScorer and compoundQueryScorer
-        // on the leaf collector, matching what HybridLeafCollector.setScorer() does in the profiler path
-        Scorer subScorer1 = mock(Scorer.class);
-        HybridQueryScorer mockHybridScorer = mock(HybridQueryScorer.class);
-        when(mockHybridScorer.getSubScorers()).thenReturn(Arrays.asList(subScorer1));
-
-        HybridSubQueryScorer adapter = new HybridSubQueryScorer(1);
-        HybridTopFieldDocSortCollector.HybridTopDocSortLeafCollector hybridLeaf =
-            (HybridTopFieldDocSortCollector.HybridTopDocSortLeafCollector) leafCollector;
-        hybridLeaf.hybridQueryScorer = mockHybridScorer;
-        hybridLeaf.compoundQueryScorer = adapter;
-
-        // execute: collect docs — populateScoresFromHybridQueryScorer() populates scores from mock
+        // setup: profiler mode, where the leaf collector is handed a HybridQueryScorer instead of a
+        // HybridSubQueryScorer and reads the per sub-query scores off it on every collect() call
+        int[] docIds = IntStream.range(0, NUM_DOCS).toArray();
+        float[] subQueryScores = new float[NUM_DOCS];
         for (int doc = 0; doc < NUM_DOCS; doc++) {
-            float score = 1.0f + doc * 0.1f;
-            when(mockHybridScorer.docID()).thenReturn(doc);
-            when(subScorer1.docID()).thenReturn(doc);
-            when(subScorer1.score()).thenReturn(score);
+            subQueryScores[doc] = 1.0f + doc * 0.1f;
+        }
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(Arrays.asList(scorer(docIds, subQueryScores, weight)));
+        leafCollector.setScorer(hybridQueryScorer);
+
+        // execute: collect docs while iterating the hybrid scorer, the way the default bulk scorer does
+        DocIdSetIterator iterator = hybridQueryScorer.iterator();
+        for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
             leafCollector.collect(doc);
         }
 
@@ -317,23 +312,18 @@ public class HybridTopFieldDocSortCollectorTests extends HybridCollectorTestCase
         collector.setWeight(weight);
         LeafCollector leafCollector = collector.getLeafCollector(leafReaderContext);
 
-        // setup: simulate profiler mode
-        Scorer subScorer1 = mock(Scorer.class);
-        HybridQueryScorer mockHybridScorer = mock(HybridQueryScorer.class);
-        when(mockHybridScorer.getSubScorers()).thenReturn(Arrays.asList(subScorer1));
+        // setup: profiler mode, see testSimpleFieldCollector_whenProfilerMode_thenResultsNotEmpty
+        int[] docIds = IntStream.range(0, NUM_DOCS).toArray();
+        float[] subQueryScores = new float[NUM_DOCS];
+        for (int doc = 0; doc < NUM_DOCS; doc++) {
+            subQueryScores[doc] = 1.0f + doc * 0.1f;
+        }
+        HybridQueryScorer hybridQueryScorer = new HybridQueryScorer(Arrays.asList(scorer(docIds, subQueryScores, weight)));
+        leafCollector.setScorer(hybridQueryScorer);
 
-        HybridSubQueryScorer adapter = new HybridSubQueryScorer(1);
-        HybridTopFieldDocSortCollector.HybridTopDocSortLeafCollector hybridLeaf =
-            (HybridTopFieldDocSortCollector.HybridTopDocSortLeafCollector) leafCollector;
-        hybridLeaf.hybridQueryScorer = mockHybridScorer;
-        hybridLeaf.compoundQueryScorer = adapter;
-
-        // execute: collect docs starting after doc 0
-        for (int doc = 1; doc < NUM_DOCS; doc++) {
-            float score = 1.0f + doc * 0.1f;
-            when(mockHybridScorer.docID()).thenReturn(doc);
-            when(subScorer1.docID()).thenReturn(doc);
-            when(subScorer1.score()).thenReturn(score);
+        // execute: collect all docs, the collector itself pages past the ones on the previous page
+        DocIdSetIterator iterator = hybridQueryScorer.iterator();
+        for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
             leafCollector.collect(doc);
         }
 


### PR DESCRIPTION
### Description
`HybridQueryScorer` reads the current document and the per sub-query match state out of its own `DisiPriorityQueue`, but the order sequence may go out of sync with internal state kept in Lucene.

That queue used to be maintained by Lucene: `DisjunctionDISIApproximation(DisiPriorityQueue)` constructor took the caller's queue and called `updateTop()` on it as it advanced. Lucene 10.2.0 removed that constructor ([apache/lucene#14052](https://github.com/apache/lucene/pull/14052)) in favour of `DisjunctionDISIApproximation(Collection<? extends DisiWrapper>, long leadCost)`, which copies the wrappers into a heap it owns. neural-search adopted the new signature in `979a9fc9` and kept `subScorersPQ`.

Wrappers in `subScorersPQ` are still the live ones, so their `.doc` fields move, but the **queue's ordering is frozen at insertion time**, when every sub-iterator is still at doc `-1`, so `heap[0]` / `top()` is permanently pinned to whichever wrapper landed there first — sub-query 0 in practice. Three readers were consuming that:

```
  |-------------|----------------------------------------------------------|
  | `docID()` | reports sub-query 0's position instead of the hybrid query's |
  | `getSubMatches()` (`twoPhase == null`) | `topList()` off the stale queue: wrong set of matching sub-queries |
  | `TwoPhase#matches()` | verifies the wrong sub-query set for the current doc |
```

  All three now read from `HybridSubqueriesDISIApproximation`, which wraps the `DisjunctionDISIApproximation` that actually gets advanced, through a new `topList()` accessor. Because we construct it with `leadCost = 0`, every sub-iterator is a lead iterator and `minOtherDoc` is `Integer.MAX_VALUE`, so `topList()` is the complete and authoritative list of approximate matches on the current document.

  #### A second, independent defect with the same symptom

  `HybridLeafCollector#populateScoresFromHybridQueryScorer()` looped over the raw sub-scorers and called `score()` on any whose `docID()` equalled the current doc:

  ```java
  int currentDoc = hybridQueryScorer.docID();          // itself a stale-queue read, see above
  List<Scorer> subScorers = hybridQueryScorer.getSubScorers();
  for (int i = 0; i < subScorers.size(); i++) {
      Scorer subScorer = subScorers.get(i);
      if (Objects.nonNull(subScorer) && subScorer.docID() == currentDoc && currentDoc != DocIdSetIterator.NO_MORE_DOCS) {
          subQueryScores[i] = subScorer.score();       // no two-phase confirmation
      }
  }
  ```

  A sub-query with a two-phase iterator is positioned on every document its **approximation** returns, including documents it does not match. `docID() == currentDoc` is therefore not a match. Scoring an unconfirmed `WANDScorer` walks into `advanceAllTail()` → `ensureConsistent()` and trips. This is why the profile path stayed broken even with the queue fix applied. It now delegates to the new `HybridQueryScorer#populateSubQueryScores(float[])`, which walks the confirmed sub-matches — the same list `score()` sums — so the per sub-query array and the total always agree, including the `NO_MORE_DOCS` skip that `score(DisiWrapper)` already had.

  ### Scope and symptoms

  Only callers that pull a real `Scorer` out of `HybridQueryWeight` are affected. The default search path goes through `HybridScorerSupplier#bulkScorer()` → `HybridBulkScorer`, which drives each sub-scorer's own `iterator()` and confirms matches itself, so it is immune. Reachable shapes are:

  1. `"profile": true`
  2. `hybrid` query inside a `nested` query
  3. document level security producing sparse `liveDocs`

Sub-query has to actually expose a two-phase iterator and the sub-queries' doc sets have to diverge. A `bool` with a **partial** `minimum_should_match` (2 of 3) compiles to a `WANDScorer` reachable only via `TwoPhaseIterator`;
  `minimum_should_match` equal to the clause count becomes a conjunction and never takes that path.
  Depending on the Lucene version the outcome is an `ArrayIndexOutOfBoundsException` or a `NullPointerException` surfacing as a 500, an `AssertionError` that kills the node when assertions are on, or — when no bound happens to be violated **scores silently attributed to the wrong sub-query**, which normalization then combines incorrectly.

  Iteration itself was never wrong. `iterator()` returns the approximation (or `asDocIdSetIterator(twoPhase)`), not `this`, so hit counts and totals were correct even unpatched. Only `docID()`, `score()` and `matches()` were corrupted.

<details>
  <summary>Reproduced stack traces (unpatched, assertions enabled)</summary>

  `"profile": true` — the `HybridLeafCollector` defect:

  ```
  java.lang.AssertionError
        at org.apache.lucene.search.WANDScorer.ensureConsistent(WANDScorer.java:238)
        at org.apache.lucene.search.WANDScorer.advanceAllTail(WANDScorer.java:549)
        at org.apache.lucene.search.WANDScorer.score(WANDScorer.java:555)
        at org.opensearch.search.profile.query.ProfileScorer.score(ProfileScorer.java:99)
        at org.opensearch.neuralsearch.search.collector.HybridLeafCollector.populateScoresFromHybridQueryScorer(HybridLeafCollector.java:79)
        at org.opensearch.neuralsearch.search.collector.HybridTopScoreDocCollector$HybridTopScoreLeafCollector.collect(HybridTopScoreDocCollector.java:137)
        at org.apache.lucene.search.Weight$DefaultBulkScorer.scoreTwoPhaseIterator(Weight.java:312)
  ```

  aggregation `filter` — the stale queue:

  ```
  java.lang.AssertionError
        at org.apache.lucene.search.WANDScorer$2.matches(WANDScorer.java:330)
        at org.opensearch.neuralsearch.query.HybridQueryScorer$TwoPhase.matches(HybridQueryScorer.java:286)
        at org.opensearch.common.lucene.Lucene$2.get(Lucene.java:859)
        at org.opensearch.search.aggregations.bucket.filter.FilterAggregator$1.collect(FilterAggregator.java:82)

        at org.apache.lucene.codecs.lucene104.Lucene104PostingsReader$BlockPostingsEnum.accumulatePendingPositions(...)
        at org.apache.lucene.search.ExactPhraseMatcher.nextMatch(...)
        at org.apache.lucene.search.PhraseScorer$1.matches(...)
        at org.apache.lucene.search.ConjunctionDISI$ConjunctionTwoPhaseIterator.matches(...)
        at org.opensearch.neuralsearch.query.HybridQueryScorer$TwoPhase.matches(HybridQueryScorer.java:286)
        at org.apache.lucene.search.join.ToParentBlockJoinQuery$BlockJoinBulkScorer.score(ToParentBlockJoinQuery.java:541)
  ```
</details>

  ### Notes on issue #1946

  The issue is accurate on the mechanism but understates the blast radius, so for anyone triaging:

  - **Starts at 3.1.0, not 3.3+.** `HybridQueryScorer.java` is byte-identical from 3.1 through `main`; 3.0 and 2.19 are clean. One patch applies to every branch in that range.
  - **Not profile-only.** The aggregation-filter and nested shapes need no `profile` flag.
  - **Not only a 500.** Silent score misattribution is possible, and with assertions enabled the node dies.
  - exception type tracks the Lucene version (NPE on 10.3.1, AIOOBE on 10.3.2+), so grep for both when correlating reports.
  - exact query shape quoted in the issue does not reproduce on its own, `transform` in it rewrites the `HybridQuery` away before `HybridQueryScorer` is ever built. The three shapes above do.

### Related Issues
Resolves #1946

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
