### PR TITLE
[Backport 2.19] Add Eclipse P2 mirror to avoid download.eclipse.org outages (neural-search)

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -7,7 +7,7 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
+            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
Manual backport of #1940 to the `2.19` branch. Routes the Spotless Eclipse JDT formatter provisioning through the OpenSearch CI mirror (`https://ci.opensearch.org/`) instead of `download.eclipse.org` to avoid upstream outages/timeouts. Only the Eclipse P2 mirror one-liner is backported; any unrelated changes bundled in the original PR are not included.

### Issues Resolved
Backport of #1940
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
