### PR TITLE
Pin two-phase processor IT index to a single shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [RRF] Reject a combination technique other than rrf when creating a score-ranker-processor, instead of accepting the pipeline and throwing NullPointerException on every query ([#1949](https://github.com/opensearch-project/neural-search/pull/1949))
 
 ### Infrastructure
+* [Neural Sparse] Pin the two-phase processor IT index to a single shard so its pruned-score assertions do not depend on the cluster's default shard count ([#1959](https://github.com/opensearch-project/neural-search/pull/1959))
 * [Semantic Field] Add an end-to-end remote dense model IT for the semantic field mapping transformer using the TorchServe mock model ([#1966](https://github.com/opensearch-project/neural-search/pull/1966))
 
 ### Documentation

--- a/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/NeuralSparseTwoPhaseProcessorIT.java
@@ -591,7 +591,10 @@ public class NeuralSparseTwoPhaseProcessorIT extends BaseNeuralSearchIT {
         if (TEST_TWO_PHASE_BASIC_INDEX_NAME.equals(indexName) && !indexExists(indexName)) {
             Map<String, Float> twoPhaseRandFeatures = new HashMap<>();
             Map<String, Float> normalRandFeatures = new HashMap<>();
-            prepareSparseEncodingIndex(indexName, List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1));
+            // Two-phase rescoring collects size * window_size_expansion documents per shard, so spreading these 20 documents over
+            // multiple shards lets phase one cover a whole shard and every document recovers its full score. Pin one shard to keep
+            // the pruned scores this index is built to assert on deterministic on any cluster.
+            prepareSparseEncodingIndex(indexName, List.of(TEST_NEURAL_SPARSE_FIELD_NAME_1), 1);
             // put [(5,5.0), (6,6.0)] into twoPhaseRandFeatures
             for (int i = 5; i < 7; i++) {
                 twoPhaseRandFeatures.put(String.valueOf(i), (float) i);

--- a/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/BaseNeuralSearchIT.java
@@ -1680,7 +1680,26 @@ public abstract class BaseNeuralSearchIT extends OpenSearchSecureRestTestCase {
 
     @SneakyThrows
     protected void prepareSparseEncodingIndex(final String indexName, final List<String> sparseEncodingFieldNames) {
-        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("mappings").startObject("properties");
+        prepareSparseEncodingIndex(indexName, sparseEncodingFieldNames, null);
+    }
+
+    /**
+     * @param numberOfShards explicit primary shard count, or null to inherit the cluster default. Pin this when a test
+     *                       asserts on exact scores produced by a per-shard operation, such as two-phase rescoring.
+     */
+    @SneakyThrows
+    protected void prepareSparseEncodingIndex(
+        final String indexName,
+        final List<String> sparseEncodingFieldNames,
+        final Integer numberOfShards
+    ) {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject();
+
+        if (numberOfShards != null) {
+            xContentBuilder.startObject("settings").field("number_of_shards", numberOfShards).endObject();
+        }
+
+        xContentBuilder.startObject("mappings").startObject("properties");
 
         for (String fieldName : sparseEncodingFieldNames) {
             xContentBuilder.startObject(fieldName).field("type", "rank_features").endObject();


### PR DESCRIPTION
### Description

`testNeuralSparseQuery_whenDifferentTwoPhaseParameter_thenGetDifferentResult` expects a pruned top score of 61, which only holds on one shard.

Two-phase rescoring collects `size * window_size_expansion` docs **per shard** — here 10, against 20 docs. Split across shards, each holds under 10, so phase one covers it entirely and every doc recovers its full 110:

```
AssertionError: expected:<61.0> but was:<110.0>  (assertSearchScore:643 via :278)
```

The index is created without settings, so its shard count is the cluster default: 1 in stock distributions (hence green CI), but raisable via `-Dopensearch.index.default_number_of_shards`.

This pins that index to one shard. The new nullable `numberOfShards` overload emits identical JSON when null, leaving the other 9 callers unaffected.

### Testing

With `-Dopensearch.index.default_number_of_shards=5`: `main` fails 1/18, this change passes 18/18; also 18/18 at the default, and 12/12 for `NeuralSparseQueryIT` + `NeuralQueryEnricherProcessorIT`.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.
