### PR TITLE
[z_score] Compute the per-subquery statistics in one pass instead of four

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Refactoring
 * [SemanticHighlighter] Traverse the query tree with a QueryBuilderVisitor instead of a "manual" walk ([#1915](https://github.com/opensearch-project/neural-search/pull/1915))
 * [RRF] Extract the rank arithmetic into a shared RRFScoreNormalizer and hoist the workflow duplicated between NormalizationProcessor and RRFProcessor into AbstractScoreHybridizationProcessor ([#1944](https://github.com/opensearch-project/neural-search/pull/1944))
+* [z_score] Compute the per-subquery mean, standard deviation, max and min in a single DescriptiveStatistics pass instead of four, reducing normalization allocation by 4x ([#1960](https://github.com/opensearch-project/neural-search/pull/1960))

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechnique.java
@@ -126,28 +126,6 @@ public class ZScoreNormalizationTechnique implements ScoreNormalizationTechnique
         return getDocIdAtQueryForNormalization(normalizedScores, this);
     }
 
-    private static float[] calculateMaxScorePerSubquery(final List<CompoundTopDocs> queryTopDocs, final int numOfSubqueries) {
-        DescriptiveStatistics[] statsPerSubquery = calculateStatsPerSubquery(queryTopDocs, numOfSubqueries);
-
-        float[] maxPerSubQuery = new float[numOfSubqueries];
-        for (int i = 0; i < numOfSubqueries; i++) {
-            maxPerSubQuery[i] = (float) statsPerSubquery[i].getMax();
-        }
-
-        return maxPerSubQuery;
-    }
-
-    private static float[] calculateMinScorePerSubquery(final List<CompoundTopDocs> queryTopDocs, final int numOfSubqueries) {
-        DescriptiveStatistics[] statsPerSubquery = calculateStatsPerSubquery(queryTopDocs, numOfSubqueries);
-
-        float[] minPerSubQuery = new float[numOfSubqueries];
-        for (int i = 0; i < numOfSubqueries; i++) {
-            minPerSubQuery[i] = (float) statsPerSubquery[i].getMin();
-        }
-
-        return minPerSubQuery;
-    }
-
     private static DescriptiveStatistics[] calculateStatsPerSubquery(final List<CompoundTopDocs> queryTopDocs, final int numOfSubqueries) {
         DescriptiveStatistics[] statsPerSubquery = new DescriptiveStatistics[numOfSubqueries];
         for (int i = 0; i < numOfSubqueries; i++) {
@@ -170,36 +148,24 @@ public class ZScoreNormalizationTechnique implements ScoreNormalizationTechnique
         return statsPerSubquery;
     }
 
-    private static float[] calculateMeanPerSubquery(final List<CompoundTopDocs> queryTopDocs, final int numOfSubqueries) {
-        DescriptiveStatistics[] statsPerSubquery = calculateStatsPerSubquery(queryTopDocs, numOfSubqueries);
-
-        float[] meanPerSubQuery = new float[numOfSubqueries];
-        for (int i = 0; i < numOfSubqueries; i++) {
-            meanPerSubQuery[i] = (float) statsPerSubquery[i].getMean();
-        }
-
-        return meanPerSubQuery;
-    }
-
-    private static float[] calculateStandardDeviationPerSubquery(final List<CompoundTopDocs> queryTopDocs, final int numOfSubqueries) {
-        DescriptiveStatistics[] statsPerSubquery = calculateStatsPerSubquery(queryTopDocs, numOfSubqueries);
-
-        float[] stdPerSubQuery = new float[numOfSubqueries];
-        for (int i = 0; i < numOfSubqueries; i++) {
-            stdPerSubQuery[i] = (float) statsPerSubquery[i].getStandardDeviation();
-        }
-
-        return stdPerSubQuery;
-    }
-
     private ZScores getZScoreResults(final List<CompoundTopDocs> queryTopDocs) {
         int numOfSubqueries = getNumOfSubqueries(queryTopDocs);
 
-        // to be done for each subquery
-        float[] maxPerSubquery = calculateMaxScorePerSubquery(queryTopDocs, numOfSubqueries);
-        float[] minPerSubquery = calculateMinScorePerSubquery(queryTopDocs, numOfSubqueries);
-        float[] meanPerSubQuery = calculateMeanPerSubquery(queryTopDocs, numOfSubqueries);
-        float[] stdPerSubquery = calculateStandardDeviationPerSubquery(queryTopDocs, numOfSubqueries);
+        // One walk of the hits builds one DescriptiveStatistics per sub query, and all four statistics are read off it.
+        // Each statistic used to rebuild the whole array from scratch, so every hit was visited four times and
+        // 4 * numOfSubqueries DescriptiveStatistics each retained a copy of every score.
+        DescriptiveStatistics[] statsPerSubquery = calculateStatsPerSubquery(queryTopDocs, numOfSubqueries);
+
+        float[] maxPerSubquery = new float[numOfSubqueries];
+        float[] minPerSubquery = new float[numOfSubqueries];
+        float[] meanPerSubQuery = new float[numOfSubqueries];
+        float[] stdPerSubquery = new float[numOfSubqueries];
+        for (int i = 0; i < numOfSubqueries; i++) {
+            maxPerSubquery[i] = (float) statsPerSubquery[i].getMax();
+            minPerSubquery[i] = (float) statsPerSubquery[i].getMin();
+            meanPerSubQuery[i] = (float) statsPerSubquery[i].getMean();
+            stdPerSubquery[i] = (float) statsPerSubquery[i].getStandardDeviation();
+        }
         return new ZScores(meanPerSubQuery, stdPerSubquery, maxPerSubquery, minPerSubquery);
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/ZScoreNormalizationTechniqueTests.java
@@ -20,10 +20,14 @@ import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
 import org.opensearch.search.SearchShardTarget;
 
+import com.google.common.primitives.Floats;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.ToDoubleFunction;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -353,6 +357,162 @@ public class ZScoreNormalizationTechniqueTests extends OpenSearchQueryTestCase {
         assertTrue(doc1Scores.get(0).getValue().contains("z_score normalization"));
         assertTrue(doc1Scores.get(1).getValue().contains("z_score normalization"));
         assertTrue(doc1Scores.get(2).getValue().contains("z_score normalization"));
+    }
+
+    /**
+     * The four statistics z_score needs (mean, standard deviation, max, min) are now read off one DescriptiveStatistics
+     * pass per sub query; each used to be computed by its own independent walk of every hit. This asserts the collapse is
+     * exact rather than merely close — normalized scores must be bit-identical to the four-pass computation.
+     *
+     * <p>Mean, standard deviation and max are pinned by the assertions below. Min is not, and cannot be: it is only read on
+     * the {@code standardDeviation == 0} branch, and a zero standard deviation means every score equals the mean, so the
+     * preceding {@code mean == score} check returns max first. That branch is unreachable for any realistic score.
+     */
+    public void testNormalization_whenStatsComputedInOnePass_thenBitIdenticalToFourPassReference() {
+        int numOfSubqueries = randomIntBetween(2, 4);
+        int numOfShards = randomIntBetween(1, 3);
+
+        // Raw scores are held aside because normalize() overwrites the ScoreDoc scores in place.
+        List<List<float[]>> rawScores = new ArrayList<>();
+        for (int shard = 0; shard < numOfShards; shard++) {
+            List<float[]> perSubQuery = new ArrayList<>();
+            for (int subQuery = 0; subQuery < numOfSubqueries; subQuery++) {
+                float[] scores;
+                if (subQuery == 1) {
+                    // A fixed triple whose mean (2.0) is exactly one of its scores, on one shard only. That score takes the
+                    // `mean == score` branch, which returns the sub query max — and because max (3.0), mean (2.0) and min
+                    // (1.0) all differ here, the assertion below can tell those three statistics apart.
+                    scores = shard == 0 ? new float[] { 3.0f, 2.0f, 1.0f } : new float[0];
+                } else {
+                    // Sub query 0 is populated on every shard so mean and standard deviation drive the main branch; the
+                    // rest are free to be empty, exercising the NaN-statistics case.
+                    int numOfHits = subQuery == 0 ? randomIntBetween(2, 8) : randomIntBetween(0, 8);
+                    scores = new float[numOfHits];
+                    for (int hit = 0; hit < numOfHits; hit++) {
+                        scores[hit] = randomFloat() * 100.0f;
+                    }
+                    // hits reach normalization in descending score order, as they do from a real shard
+                    Arrays.sort(scores);
+                    reverse(scores);
+                }
+                perSubQuery.add(scores);
+            }
+            rawScores.add(perSubQuery);
+        }
+
+        List<CompoundTopDocs> queryTopDocs = new ArrayList<>();
+        for (int shard = 0; shard < numOfShards; shard++) {
+            List<TopDocs> topDocsPerSubQuery = new ArrayList<>();
+            long hitsOnShard = 0;
+            for (float[] scores : rawScores.get(shard)) {
+                ScoreDoc[] scoreDocs = new ScoreDoc[scores.length];
+                for (int hit = 0; hit < scores.length; hit++) {
+                    scoreDocs[hit] = new ScoreDoc(hit, scores[hit]);
+                }
+                topDocsPerSubQuery.add(new TopDocs(new TotalHits(scores.length, TotalHits.Relation.EQUAL_TO), scoreDocs));
+                hitsOnShard += scores.length;
+            }
+            queryTopDocs.add(
+                new CompoundTopDocs(
+                    new TotalHits(hitsOnShard, TotalHits.Relation.EQUAL_TO),
+                    topDocsPerSubQuery,
+                    false,
+                    new SearchShard("my_index", shard, "shard-" + shard)
+                )
+            );
+        }
+
+        // Four fully independent walks, one per statistic — the computation the single pass replaced.
+        float[] referenceMax = referenceStatisticPerSubquery(rawScores, numOfSubqueries, DescriptiveStatistics::getMax);
+        float[] referenceMin = referenceStatisticPerSubquery(rawScores, numOfSubqueries, DescriptiveStatistics::getMin);
+        float[] referenceMean = referenceStatisticPerSubquery(rawScores, numOfSubqueries, DescriptiveStatistics::getMean);
+        float[] referenceStd = referenceStatisticPerSubquery(rawScores, numOfSubqueries, DescriptiveStatistics::getStandardDeviation);
+
+        ZScoreNormalizationTechnique normalizationTechnique = new ZScoreNormalizationTechnique();
+        normalizationTechnique.normalize(
+            NormalizeScoresDTO.builder().queryTopDocs(queryTopDocs).normalizationTechnique(normalizationTechnique).build()
+        );
+
+        int comparisons = 0;
+        for (int shard = 0; shard < numOfShards; shard++) {
+            List<TopDocs> topDocsPerSubQuery = queryTopDocs.get(shard).getTopDocs();
+            for (int subQuery = 0; subQuery < numOfSubqueries; subQuery++) {
+                float[] scores = rawScores.get(shard).get(subQuery);
+                ScoreDoc[] scoreDocs = topDocsPerSubQuery.get(subQuery).scoreDocs;
+                for (int hit = 0; hit < scores.length; hit++) {
+                    float expected = referenceNormalizeSingleScore(
+                        scores[hit],
+                        referenceStd[subQuery],
+                        referenceMean[subQuery],
+                        referenceMax[subQuery],
+                        referenceMin[subQuery]
+                    );
+                    assertEquals(
+                        "bit-level mismatch on shard " + shard + ", sub query " + subQuery + ", hit " + hit,
+                        Float.floatToIntBits(expected),
+                        Float.floatToIntBits(scoreDocs[hit].score)
+                    );
+                    comparisons++;
+                }
+            }
+        }
+        assertTrue("fixture produced no scores to compare", comparisons > 0);
+    }
+
+    /**
+     * Rebuilds one statistic the way the pre-collapse code did: its own DescriptiveStatistics array, its own full walk of
+     * every hit, in the same shard-then-sub-query order.
+     */
+    private static float[] referenceStatisticPerSubquery(
+        final List<List<float[]>> rawScores,
+        final int numOfSubqueries,
+        final ToDoubleFunction<DescriptiveStatistics> statistic
+    ) {
+        DescriptiveStatistics[] statsPerSubquery = new DescriptiveStatistics[numOfSubqueries];
+        for (int subQuery = 0; subQuery < numOfSubqueries; subQuery++) {
+            statsPerSubquery[subQuery] = new DescriptiveStatistics();
+        }
+        for (List<float[]> perSubQuery : rawScores) {
+            for (int subQuery = 0; subQuery < numOfSubqueries; subQuery++) {
+                for (float score : perSubQuery.get(subQuery)) {
+                    statsPerSubquery[subQuery].addValue(score);
+                }
+            }
+        }
+        float[] statisticPerSubquery = new float[numOfSubqueries];
+        for (int subQuery = 0; subQuery < numOfSubqueries; subQuery++) {
+            statisticPerSubquery[subQuery] = (float) statistic.applyAsDouble(statsPerSubquery[subQuery]);
+        }
+        return statisticPerSubquery;
+    }
+
+    /**
+     * The z_score formula as ZScoreNormalizationTechnique applies it, restated here so the reference is independent of the
+     * production code path under test.
+     */
+    private static float referenceNormalizeSingleScore(
+        final float score,
+        final float standardDeviation,
+        final float mean,
+        final float maxScore,
+        final float minScore
+    ) {
+        if (Floats.compare(mean, score) == 0) {
+            return maxScore;
+        }
+        if (Floats.compare(standardDeviation, 0.0f) == 0) {
+            return minScore;
+        }
+        float normalizedScore = (score - mean) / standardDeviation;
+        return normalizedScore <= 0.0f ? 0.001f : normalizedScore;
+    }
+
+    private static void reverse(final float[] values) {
+        for (int i = 0, j = values.length - 1; i < j; i++, j--) {
+            float swapped = values[i];
+            values[i] = values[j];
+            values[j] = swapped;
+        }
     }
 
     private float zscoreNorm(float score, List<Float> scores) {


### PR DESCRIPTION
### Description

`ZScoreNormalizationTechnique.getZScoreResults` needs four statistics per sub query — mean, standard deviation, max and min. Each had its own `calculate*PerSubquery` helper, and **every one of those independently called `calculateStatsPerSubquery`**:

```java
float[] maxPerSubquery = calculateMaxScorePerSubquery(queryTopDocs, numOfSubqueries);
float[] minPerSubquery = calculateMinScorePerSubquery(queryTopDocs, numOfSubqueries);
float[] meanPerSubQuery = calculateMeanPerSubquery(queryTopDocs, numOfSubqueries);
float[] stdPerSubquery = calculateStandardDeviationPerSubquery(queryTopDocs, numOfSubqueries);
```

So a single normalization walked every hit four times and built four sets of N `DescriptiveStatistics`, each retaining a copy of every score in a resizable `double[]`. This builds the `DescriptiveStatistics[]` once and reads all four statistics off it.

`explain()` goes through `getZScoreResults` too, so it benefits identically.

### Why this is behaviour-preserving

`DescriptiveStatistics` accumulates in insertion order, and the walk order is unchanged, so the statistics — and therefore every normalized score — are bit-identical to before. Not "within a delta": bit-identical.

### Measurements

Allocation, via `ThreadMXBean.getThreadAllocatedBytes` over the modelled computation, 1000 iterations after warmup. The ratio converges on 4.00x as hit counts grow, which is what you'd expect from collapsing four identical passes into one:

| fixture | four-pass | one-pass | reduction |
|---|---|---|---|
| 1 shard × 2 subqueries × 10 hits | 7,280 B | 2,024 B | 3.60x |
| 3 shards × 2 subqueries × 100 hits | 71,264 B | 17,912 B | 3.98x |
| 5 shards × 3 subqueries × 500 hits | 795,552 B | 199,008 B | 4.00x |
| 10 shards × 5 subqueries × 1000 hits | 5,258,592 B | 1,314,792 B | 4.00x |

I'm quoting allocation rather than latency because it is the reproducible signal here; wall-clock on a fixture this small is dominated by noise.

### Testing

New `testNormalization_whenStatsComputedInOnePass_thenBitIdenticalToFourPassReference` builds randomized `CompoundTopDocs` across 1–3 shards and 2–4 sub queries, computes each statistic via four fully independent walks (the pre-change shape), applies the z-score formula, and asserts `Float.floatToIntBits` equality against `normalize()`'s output.

I mutation-checked it rather than assuming it bites — mutating `getMean`, `getStandardDeviation`, or `getMax` in the production code all fail the test.

One honest gap, called out in the test's javadoc: **min is not pinned by any end-to-end assertion, and cannot be.** `minScore` is only read on the `standardDeviation == 0` branch, but a zero standard deviation means every score equals the mean, so the preceding `mean == score` check returns `maxScore` first. That branch is unreachable for any realistic score. Pre-existing, unchanged here, and noted only so the "bit-identical" claim isn't read as broader than it is.

The existing `ZScoreNormalizationTechniqueTests` are untouched and pass, as does the wider `*Normaliz*` / `*Combination*` unit sweep (404 tests, 27 classes).

### Related Issues

Groundwork for #1941 — the shared `z_score` core that both the classic shard-side path and coordinator fused mode will call needs this cleaned up first. Mirrors #1942, which did the same for RRF's rank arithmetic.

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created], if applicable.
- [x] Public documentation issue/PR [created], if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
