### PR TITLE
Fix CI: resolve Eclipse JDT formatter without the ci.opensearch.org P2 mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [RRF] Reject a combination technique other than rrf when creating a score-ranker-processor, instead of accepting the pipeline and throwing NullPointerException on every query ([#1949](https://github.com/opensearch-project/neural-search/pull/1949))
 
 ### Infrastructure
+* Resolve the Eclipse JDT formatter directly from download.eclipse.org instead of the ci.opensearch.org P2 mirror, which was timing out at configuration time and failing CI ([#20826](https://github.com/opensearch-project/OpenSearch/issues/20826))
 
 
 ### Documentation

--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -7,7 +7,11 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            // Resolve the Eclipse JDT formatter directly from download.eclipse.org. The prior
+            // withP2Mirrors(... -> https://ci.opensearch.org/) mirror (added in #1940) started timing
+            // out at configuration time (SocketTimeoutException), failing every task on affected
+            // runners. This aligns with the OpenSearch 3.x resolution in opensearch-project/OpenSearch#20826.
+            eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description

CI on `main` and open PRs is failing because Spotless cannot load the Eclipse JDT formatter at project-configuration time:

```
A problem occurred configuring root project 'neural-search'.
> java.io.IOException: Failed to load eclipse jdt formatter:
      java.lang.RuntimeException: java.net.SocketTimeoutException: timeout
BUILD FAILED in ~30s
```

The formatter is resolved through the P2 mirror configured in `formatter/formatting.gradle`:

```groovy
eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/"))
```

That `ci.opensearch.org` mirror (added in #1940) is currently timing out from most GitHub-hosted runners. Because Spotless resolves the formatter **during configuration**, this fails *every* Gradle task — integTest, BWC, pre-commit, etc. — before any test runs, regardless of the change under test. It presents as a per-runner lottery (some jobs pass, most fail on the same commit).

### Fix

Drop `withP2Mirrors` and resolve the Eclipse JDT formatter directly from `download.eclipse.org`. This matches the resolution documented for the 3.x branches in opensearch-project/OpenSearch#20826 ("The 3.x branches have since removed `withP2Mirrors`") and this repo's own prior toggle (#1543).

### Related

- Tracking issue: opensearch-project/OpenSearch#20826
- Mirror history in this repo: #1079 (added umd.edu mirror) → #1543 (removed mirror) → #1940 (added ci.opensearch.org mirror, now failing)

### Check List
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
