### PR TITLE
Re-add Eclipse P2 mirror to avoid download.eclipse.org outages (neural-search)

### DIFF
--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -7,11 +7,7 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            // Resolve the Eclipse JDT formatter directly from download.eclipse.org. The prior
-            // withP2Mirrors(... -> https://ci.opensearch.org/) mirror (added in #1940) started timing
-            // out at configuration time (SocketTimeoutException), failing every task on affected
-            // runners. This aligns with the OpenSearch 3.x resolution in opensearch-project/OpenSearch#20826.
-            eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
+            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
Re-applies the Eclipse JDT formatter P2 mirror (`withP2Mirrors` -> `https://ci.opensearch.org/`) on `main`, which was removed in #1919. The direct `download.eclipse.org` path is the throttled upstream that caused the original `SocketTimeoutException` failures; the CloudFront mirror at `ci.opensearch.org/eclipse/` has been hardened (Origin Shield + long cache TTL) to serve these P2 artifacts reliably. This also realigns `main` with the `3.8` and `2.19` branches, which still use the mirror.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
