### PR TITLE
[Sparse ANN] [Native] Ship the native sparse engine in the distribution build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,13 +24,58 @@ jobs:
   # The JNI layer is C++ and has its own googletest suite under jni/tests. The Java
   # `test` task builds the shared library but never runs these, so without a
   # dedicated job the native code ships untested.
-  JNI-native-tests:
+  #
+  # In the container, not on a bare runner: ubuntu-latest would test against a GCC
+  # and an OpenMP runtime (LLVM libomp, via libomp-dev) that never ship.
+  # arm64 is the only config where SVE_ENABLED holds, so the only one that builds
+  # nsparse_sve.
+  JNI-native-tests-linux:
+    needs: Get-CI-Image-Tag
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    name: JNI C++ Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    container:
+      # Same image opensearch-build uses for the distribution. Multi-arch manifest,
+      # so this tag resolves to the arm64 image on an arm64 runner.
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
+
+    steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # jni/external/neural-sparse-cpp is a submodule the native build needs
+          submodules: recursive
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: 'gradle'
+
+      # No toolchain step needed: the image carries cmake, gcc-toolset-13 and libgomp.
+      # su to 1000 because gradle refuses to run as root.
+      - name: Run JNI C++ tests
+        run: |
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "./gradlew jniTest"
+
+  # No CI-runner container for Windows. init-nsparse.cmake pins it to generic
+  # nsparse, so this covers the MSVC toolchain and packaging path, not SIMD.
+  JNI-native-tests-windows:
     strategy:
       fail-fast: false
       matrix:
         # Windows builds with MSVC via the Visual Studio generator; the runner image
         # already ships VS 2022 and CMake, so no toolchain step is needed there.
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
     name: JNI C++ Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -46,12 +91,6 @@ jobs:
           distribution: temurin
           cache: 'gradle'
 
-      - name: Install native toolchain
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake build-essential libomp-dev
-
       - name: Run JNI C++ tests
         run: ./gradlew jniTest
 
@@ -59,6 +98,9 @@ jobs:
   # cannot see: the layer hands raw pointers to Java and frees them on the native
   # side. This job is the real coverage for the ownership rules. Linux only: the
   # -fsanitize flags are GCC/Clang, and MSVC's /fsanitize=address has no LSan.
+  #
+  # Stays on a bare runner unlike JNI-native-tests-linux: the CI image's
+  # gcc-toolset-13 has no libasan, so -fsanitize=address cannot link there.
   JNI-native-tests-sanitizers:
     name: JNI C++ Tests (ASan/LSan)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [RRF] Reject a combination technique other than rrf when creating a score-ranker-processor, instead of accepting the pipeline and throwing NullPointerException on every query ([#1949](https://github.com/opensearch-project/neural-search/pull/1949))
 
 ### Infrastructure
+* [Sparse ANN] Add scripts/build.sh so the distribution build ships the native sparse engine: every SIMD variant the target architecture may need is built into the plugin zip, and the variant to load is picked from the host's CPU flags at runtime ([#1978](https://github.com/opensearch-project/neural-search/pull/1978))
 * [Sparse ANN] Add the JNI layer for the native sparse engine, bridging to the neural-sparse-cpp library, with a googletest suite run on Linux and Windows plus an ASan/LSan job ([#1972](https://github.com/opensearch-project/neural-search/pull/1972))
 * [Neural Sparse] Pin the two-phase processor IT index to a single shard so its pruned-score assertions do not depend on the cluster's default shard count ([#1959](https://github.com/opensearch-project/neural-search/pull/1959))
 * [Semantic Field] Add an end-to-end remote dense model IT for the semantic field mapping transformer using the TorchServe mock model ([#1966](https://github.com/opensearch-project/neural-search/pull/1966))

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -115,6 +115,53 @@ also run Integration Tests and Unit Tests.
 ./gradlew build
 ```
 
+### Native sparse engine (JNI)
+
+The native sparse engine under `jni/` is C++ and needs its submodule checked out
+before anything builds it:
+
+```
+git submodule update --init --recursive
+```
+
+`./gradlew buildJniLib` builds the shared library into `jni/build`, and the test and
+run tasks depend on it. By default the build compiles the SIMD variant *this host*
+can execute, and bakes the variant into the filename
+(`libopensearch_neuralsearch_nsparse_avx512.so` and friends).
+
+### Distribution build
+
+`scripts/build.sh` is what [opensearch-build](https://github.com/opensearch-project/opensearch-build)
+invokes to produce the released artifact. It differs from `./gradlew assemble` in
+two ways that matter:
+
+* it builds every SIMD variant the target architecture may need (generic + avx2 +
+  avx512 on Linux x64, generic + sve on Linux arm64, generic elsewhere), by forcing
+  `-Davx2.enabled`, `-Davx512.enabled` and `-Dsve.enabled` one pass at a time, and
+* it adds those libraries, plus the OpenMP runtime they were linked against, to
+  `lib/` inside the plugin zip, which the plugin installer extracts to
+  `plugins/opensearch-neural-search/lib`.
+
+`NativeCpuFeatures` then picks a variant from `/proc/cpuinfo` at load time, so the
+node never loads a library its CPU cannot execute. Building a variant that the
+loader cannot verify would be a crash waiting to happen, which is why macOS and
+Windows stay generic-only.
+
+One piece lives outside this repo: nothing in OpenSearch puts a plugin's `lib`
+directory on `java.library.path` by itself. The release images do it explicitly —
+`docker/release/dockerfiles/opensearch.*.dockerfile` in `opensearch-build` sets
+`LD_LIBRARY_PATH` to `$OPENSEARCH_HOME/plugins/opensearch-knn/lib`, and the JVM folds
+`LD_LIBRARY_PATH` into `java.library.path` on Linux. Until
+`plugins/opensearch-neural-search/lib` is added there as well, `System.loadLibrary`
+will not find these libraries on an installed node.
+
+```
+./scripts/build.sh -v 3.9.0 -s true -o artifacts
+```
+
+Note that only the zip under `artifacts/plugins` carries the native libraries; the
+maven artifact is a plain plugin zip, matching k-NN.
+
 ## Run Unit Tests
 If you want to strictly test that your unit tests are passing
 you can run the following.

--- a/build.gradle
+++ b/build.gradle
@@ -371,6 +371,15 @@ def jniTestsRequested = gradle.startParameter.taskNames.any { it.endsWith('jniTe
 // sanitizer runtime preloaded, which aborts at load time.
 def jniSanitizers = Boolean.parseBoolean(findProperty('jniSanitizers')?.toString() ?: 'false')
 
+// init-nsparse.cmake defaults each SIMD toggle to what the build host can execute,
+// which is right for a developer build and wrong for a distribution build: the
+// artifact has to carry every variant the target architecture may need, so
+// scripts/build.sh forces one variant per pass. Only properties that are actually
+// set are forwarded -- an absent property leaves the host detection in place.
+def simdCmakeFlags = ['AVX2_ENABLED': 'avx2.enabled', 'AVX512_ENABLED': 'avx512.enabled', 'SVE_ENABLED': 'sve.enabled'].collectEntries {
+    cmakeVar, systemProperty -> [(cmakeVar): System.getProperty(systemProperty)]
+}.findAll { it.value != null }
+
 tasks.register('cmakeJniLib', Exec) {
     def args = []
     args.add("cmake")
@@ -388,6 +397,7 @@ tasks.register('cmakeJniLib', Exec) {
     }
     args.add("-DCONFIG_TEST=${jniTestsRequested ? 'ON' : 'OFF'}")
     args.add("-DENABLE_SANITIZERS=${jniSanitizers ? 'ON' : 'OFF'}")
+    simdCmakeFlags.each { cmakeVar, value -> args.add("-D${cmakeVar}=${value}") }
     def javaHome = Jvm.current().getJavaHome()
     logger.lifecycle("Java home directory used by gradle: $javaHome")
     // No -G override on Windows: cmake selects the installed Visual Studio
@@ -404,6 +414,7 @@ tasks.register('cmakeJniLib', Exec) {
     inputs.property('configTest', jniTestsRequested)
     inputs.property('sanitizers', jniSanitizers)
     inputs.property('buildType', cmakeBuildConfig)
+    inputs.property('simdFlags', simdCmakeFlags)
     outputs.file("$projectDir/jni/build/CMakeCache.txt")
 }
 

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -99,6 +99,21 @@ add_library(${TARGET_LIB_NSPARSE} SHARED $<TARGET_OBJECTS:${TARGET_OBJ_NSPARSE}>
 target_link_libraries(${TARGET_LIB_NSPARSE} PRIVATE ${TARGET_OBJ_NSPARSE})
 set_target_properties(${TARGET_LIB_NSPARSE} PROPERTIES SUFFIX ${LIB_EXT})
 set_target_properties(${TARGET_LIB_NSPARSE} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# nsparse links statically, so the OpenMP runtime is the only dependency that has to
+# travel with the plugin. scripts/build.sh puts it next to this library inside the
+# zip, but System.loadLibrary's java.library.path does not apply to a library's own
+# dependencies -- the dynamic loader resolves those, and without an rpath it would
+# only ever find a system-wide copy. Look beside ourselves first so the shipped copy
+# is the one that gets used.
+if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL Windows)
+    if (APPLE)
+        set(NSPARSE_ORIGIN "@loader_path")
+    else()
+        set(NSPARSE_ORIGIN "$ORIGIN")
+    endif()
+    set_target_properties(${TARGET_LIB_NSPARSE} PROPERTIES BUILD_RPATH "${NSPARSE_ORIGIN}" INSTALL_RPATH "${NSPARSE_ORIGIN}")
+endif()
 # ---------------------------------------------------------------------------
 
 # --------------------------------- TESTS -----------------------------------

--- a/jni/cmake/init-nsparse.cmake
+++ b/jni/cmake/init-nsparse.cmake
@@ -52,9 +52,8 @@ set(NSPARSE_ENABLE_TESTS OFF)
 set(NSPARSE_ENABLE_BENCHMARKS OFF)
 
 # AVX2_ENABLED / AVX512_ENABLED / SVE_ENABLED select which nsparse variant to
-# build. Exactly one variant is built and it is loaded unconditionally, so an
-# instruction set the running CPU lacks is not a slow path -- it is SIGILL on the
-# first vectorized call.
+# build. Exactly one variant is built per configure pass, and an instruction set the
+# running CPU lacks is not a slow path -- it is SIGILL on the first vectorized call.
 #
 # They therefore default to what THIS host can actually execute, not to true.
 # Defaulting them on assumed the build machine and the machine running the result
@@ -62,9 +61,9 @@ set(NSPARSE_ENABLE_BENCHMARKS OFF)
 # that died the moment it was called, which is what broke the Linux CI runners
 # while Windows (pinned to the generic build) passed.
 #
-# Pass them explicitly to override, which is what a distribution build wants: it
-# forces each variant in turn to produce the full set, and pairs that with
-# runtime CPU detection to choose between them on the target host.
+# Pass them explicitly to override, which is what a distribution build wants:
+# scripts/build.sh forces each variant in turn to produce the full set, and
+# NativeCpuFeatures then chooses between them from the target host's CPU flags.
 #
 # k-NN reached the same conclusion for its newest tier: init-faiss.cmake leaves
 # AVX2_ENABLED/AVX512_ENABLED defaulting to true but probes the host with `lscpu`
@@ -106,13 +105,33 @@ else()
     endif()
 endif()
 
+# __builtin_cpu_supports has no SVE query, so probe by running SVE code instead --
+# same reasoning as the tiers above, and a Graviton2 answers it with SIGILL, which
+# check_cxx_source_runs reports as a failure. Only non-Apple aarch64 has an SVE
+# branch in nsparse at all.
 if(NOT DEFINED SVE_ENABLED)
-    # __builtin_cpu_supports has no SVE query, so this stays opt-out rather than
-    # detected. nsparse only reaches the SVE branch on non-Apple aarch64.
-    set(SVE_ENABLED true)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64" AND NOT APPLE AND NOT CMAKE_CROSSCOMPILING AND NOT MSVC)
+        include(CheckCXXSourceRuns)
+        set(CMAKE_REQUIRED_FLAGS "-march=armv8-a+sve")
+        check_cxx_source_runs("#include <arm_sve.h>\nint main() { return svcntb() > 0 ? 0 : 1; }" HAS_SVE)
+        unset(CMAKE_REQUIRED_FLAGS)
+        if(HAS_SVE)
+            set(SVE_ENABLED true)
+        else()
+            set(SVE_ENABLED false)
+        endif()
+        message(STATUS "Build host supports SVE: ${HAS_SVE}")
+    else()
+        set(SVE_ENABLED false)
+    endif()
 endif()
 
 # Determine optimization level and target library.
+#
+# The branches are ordered by architecture rather than by flag, because the flags
+# are not mutually exclusive: SVE_ENABLED means nothing on x86_64 and the AVX
+# toggles mean nothing on aarch64, so a flat chain of conditions ends up letting an
+# irrelevant flag decide the variant.
 #
 # Windows is pinned to the generic build, matching k-NN ("SIMD optimization is not
 # supported on Windows" in the OpenSearch docs) -- but NOT for the same reason, so
@@ -122,21 +141,17 @@ endif()
 # compiles clean, the test suite passes, and the DLL really does contain
 # zmm-register instructions.
 #
-# The blocker is selection, not compilation. Only one variant is built, for
-# whatever machine ran the build, and the Java side finds it by probing file
-# names. An AVX-512 DLL shipped to a host without AVX-512 dies on an illegal
-# instruction. Lifting this needs the same work as the packaging story: build
-# every variant and pick one at runtime from the host's CPU features. Until then
-# the generic build is the only safe default for a Windows artifact.
-if(${CMAKE_SYSTEM_NAME} STREQUAL Windows OR ( NOT AVX2_ENABLED AND NOT AVX512_ENABLED))
+# The blocker is selection: NativeCpuFeatures reads /proc/cpuinfo to decide which
+# variant is safe to load, and there is no equivalent on Windows, so an AVX-512 DLL
+# there could only be picked by filename -- and dies on an illegal instruction on a
+# host without AVX-512. Same on macOS. Both stay generic-only until the loader can
+# verify the CPU on those platforms.
+if(${CMAKE_SYSTEM_NAME} STREQUAL Windows)
     set(NSPARSE_OPT_LEVEL generic)
     set(TARGET_LINK_NSPARSE_LIB nsparse)
-elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64" OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64")
-    if(APPLE)
-        # Apple Silicon does not support SVE
-        set(NSPARSE_OPT_LEVEL generic)
-        set(TARGET_LINK_NSPARSE_LIB nsparse)
-    elseif(SVE_ENABLED)
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64|arm64")
+    # Apple Silicon does not support SVE.
+    if(SVE_ENABLED AND NOT APPLE)
         set(NSPARSE_OPT_LEVEL sve)
         set(TARGET_LINK_NSPARSE_LIB nsparse_sve)
         string(PREPEND LIB_EXT "_sve")
@@ -144,14 +159,24 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64" OR ${CMAKE_SYSTEM_PROCESSOR} 
         set(NSPARSE_OPT_LEVEL generic)
         set(TARGET_LINK_NSPARSE_LIB nsparse)
     endif()
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL Linux AND AVX512_ENABLED)
-    set(NSPARSE_OPT_LEVEL avx512)
-    set(TARGET_LINK_NSPARSE_LIB nsparse_avx512)
-    string(PREPEND LIB_EXT "_avx512")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
+    # nsparse only has an avx512 target on Linux.
+    if(AVX512_ENABLED AND ${CMAKE_SYSTEM_NAME} STREQUAL Linux)
+        set(NSPARSE_OPT_LEVEL avx512)
+        set(TARGET_LINK_NSPARSE_LIB nsparse_avx512)
+        string(PREPEND LIB_EXT "_avx512")
+    elseif(AVX2_ENABLED)
+        set(NSPARSE_OPT_LEVEL avx2)
+        set(TARGET_LINK_NSPARSE_LIB nsparse_avx2)
+        string(PREPEND LIB_EXT "_avx2")
+    else()
+        set(NSPARSE_OPT_LEVEL generic)
+        set(TARGET_LINK_NSPARSE_LIB nsparse)
+    endif()
 else()
-    set(NSPARSE_OPT_LEVEL avx2)
-    set(TARGET_LINK_NSPARSE_LIB nsparse_avx2)
-    string(PREPEND LIB_EXT "_avx2")
+    set(NSPARSE_OPT_LEVEL generic)
+    set(TARGET_LINK_NSPARSE_LIB nsparse)
 endif()
+message(STATUS "nsparse optimization level: ${NSPARSE_OPT_LEVEL}")
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/neural-sparse-cpp EXCLUDE_FROM_ALL)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,7 +29,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:q:s:o:p:a:j:" arg; do
+while getopts ":hv:q:s:o:p:a:j:" arg; do
     case $arg in
         h)
             usage
@@ -210,10 +210,16 @@ else
     # dependency is the OpenMP runtime. Ship the copy it was linked against;
     # resolve it from the library rather than from a hard-coded name so gcc's
     # libgomp and clang's libomp are both handled.
+    #
+    # Probe the generic variant by name: every variant comes out of the same
+    # toolchain and so links the same runtime, the generic one is built on every
+    # platform, and a glob here would hand ldd/otool several libraries at once.
     if [ "$PLATFORM" = "darwin" ]; then
-        ompPath=$(otool -L $distributions/lib/libopensearch_neuralsearch_nsparse* | grep -o '\S*libomp[^ ]*\.dylib' | head -n 1)
+        probeLib=$distributions/lib/libopensearch_neuralsearch_nsparse.jnilib
+        ompPath=$(otool -L $probeLib | grep -o '\S*libomp[^ ]*\.dylib' | head -n 1)
     else
-        ompPath=$(ldd $distributions/lib/libopensearch_neuralsearch_nsparse* | grep -o '/\S*libgomp[^ ]*' | head -n 1)
+        probeLib=$distributions/lib/libopensearch_neuralsearch_nsparse.so
+        ompPath=$(ldd $probeLib | grep -o '/\S*libgomp[^ ]*' | head -n 1)
     fi
     if [ -f "$ompPath" ]; then
         cp -v $ompPath $distributions/lib

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# Builds the plugin zip with the native sparse engine (jni/) bundled in, for
+# opensearch-build. Without this script opensearch-build falls back to its default
+# plugin build, which only runs `./gradlew assemble` and so ships a zip with no
+# native library in it -- the plugin then fails to load the moment a sparse index
+# is used.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, default is the current platform."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, default is the current architecture."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-j NPROC_COUNT\t[Optional] Number of CPUs to use when building the JNI library. Default is all of them."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:q:s:o:p:a:j:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        j)
+            NPROC_COUNT=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ ! -z "$QUALIFIER" ]] && VERSION=$VERSION-$QUALIFIER
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+# opensearch-build always passes -p/-a, but the script is also run by hand.
+if [ -z "$PLATFORM" ]; then
+    case "$(uname -s)" in
+        Linux) PLATFORM=linux ;;
+        Darwin) PLATFORM=darwin ;;
+        CYGWIN*|MINGW*|MSYS*) PLATFORM=windows ;;
+        *) echo "Error: unsupported platform $(uname -s)"; exit 1 ;;
+    esac
+fi
+if [ -z "$ARCHITECTURE" ]; then
+    case "$(uname -m)" in
+        x86_64|amd64) ARCHITECTURE=x64 ;;
+        aarch64|arm64) ARCHITECTURE=arm64 ;;
+        *) echo "Error: unsupported architecture $(uname -m)"; exit 1 ;;
+    esac
+fi
+
+work_dir=$PWD
+
+# The native engine lives in a submodule. Check it out here rather than relying on
+# cmake to do it: jni/cmake/init-nsparse.cmake deliberately refuses to fetch code
+# over the network as a side effect of configure, and fails with a clear error
+# instead of a wall of missing headers.
+git submodule update --init --recursive -- jni/external/neural-sparse-cpp
+
+# cmake resolves jni.h from $JAVA_HOME (see jni/CMakeLists.txt), so an unset
+# JAVA_HOME fails late, as a missing header.
+if [ -z "$JAVA_HOME" ]; then
+    if [ "$PLATFORM" = "darwin" ]; then
+        export JAVA_HOME=`/usr/libexec/java_home`
+        echo "SET JAVA_HOME=$JAVA_HOME"
+    else
+        echo "Error: JAVA_HOME is not set and is required to build the JNI library"
+        exit 1
+    fi
+fi
+
+# Build the plugin zip and the Java artifacts. The JNI variants are built
+# separately below, so keep the native build out of this pass: `assemble` does not
+# depend on buildJniLib, and the test tasks that do are excluded.
+#
+# -Pcrypto.standard carries over from the default build script this one replaces, so
+# a FIPS distribution build keeps behaving the way it does today.
+echo "Building neural-search plugin"
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true \
+    -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER \
+    -Pcrypto.standard=FIPS-140-3
+
+# Publish before the native libraries are added to the zip, matching k-NN: the
+# maven artifact stays a plain plugin zip (see DEVELOPER_GUIDE.md), while the zip
+# copied to $OUTPUT/plugins -- the one the distribution installs -- gets the libs.
+./gradlew publishPluginZipPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
+./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
+
+# Build one JNI library per SIMD variant this architecture can use.
+#
+# Only one variant is compiled per pass -- nsparse picks its target from these
+# flags -- and the resulting file carries the variant in its name, so the passes
+# accumulate in jni/build instead of overwriting each other. NativeCpuFeatures
+# then picks between them from /proc/cpuinfo at load time; building a variant here
+# that the loader cannot verify at runtime would just be a SIGILL waiting to
+# happen, which is why macOS and Windows stay generic-only (init-nsparse.cmake
+# pins them there as well).
+#
+# The cmake cache has to go between passes: the flags below feed nsparse's target
+# selection through cached variables, and a stale cache silently rebuilds the
+# variant from the previous pass.
+function build_jni_variant() {
+    local description=$1
+    shift
+    echo "Building the native sparse engine: ${description}"
+    rm -rf jni/build/CMakeCache.txt jni/build/CMakeFiles
+    # An unset -j leaves the parallelism at build.gradle's default, the core count.
+    ./gradlew :buildJniLib "$@" ${NPROC_COUNT:+-Dnproc.count=$NPROC_COUNT} \
+        -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+}
+
+if [ "$PLATFORM" = "linux" ] && [ "$ARCHITECTURE" = "x64" ]; then
+    build_jni_variant "generic" -Davx2.enabled=false -Davx512.enabled=false
+    build_jni_variant "avx2" -Davx2.enabled=true -Davx512.enabled=false
+    build_jni_variant "avx512" -Davx2.enabled=true -Davx512.enabled=true
+elif [ "$PLATFORM" = "linux" ] && [ "$ARCHITECTURE" = "arm64" ]; then
+    build_jni_variant "generic" -Dsve.enabled=false
+    build_jni_variant "sve" -Dsve.enabled=true
+else
+    # macOS and Windows: NativeCpuFeatures cannot read CPU flags there, so a SIMD
+    # variant could never be selected safely even if it were built.
+    build_jni_variant "generic" -Davx2.enabled=false -Davx512.enabled=false -Dsve.enabled=false
+fi
+
+# Add the native libraries to the plugin zip. A top-level lib/ in the zip is
+# extracted into plugins/opensearch-neural-search/lib -- only a top-level shared/ is
+# relocated by opensearch-plugin, so this layout survives installation.
+#
+# Getting that directory onto the loader's search path is NOT part of the plugin:
+# opensearch-build's release Dockerfiles set LD_LIBRARY_PATH to
+# $OPENSEARCH_HOME/plugins/opensearch-knn/lib, and the JVM folds LD_LIBRARY_PATH into
+# java.library.path on Linux. The same entry has to be added there for
+# opensearch-neural-search, or System.loadLibrary will not find these files no matter
+# how the zip is built.
+#
+# Name the zip rather than searching for it: build/distributions keeps the output of
+# every build ever run in this workspace, so a glob there picks up the zip of some
+# older version as readily as this one. The name is what build.gradle derives from
+# -Dopensearch.version -- the OpenSearch version with a plugin patch number appended.
+distributions=$work_dir/build/distributions
+pluginVersion=${VERSION%%-*}.0
+[[ ! -z "$QUALIFIER" ]] && pluginVersion=$pluginVersion-$QUALIFIER
+[[ "$SNAPSHOT" == "true" ]] && pluginVersion=$pluginVersion-SNAPSHOT
+zipPath=$distributions/opensearch-neural-search-${pluginVersion}.zip
+
+if [ ! -f "$zipPath" ]; then
+    echo "Error: expected the plugin zip at $zipPath. build/distributions holds:"
+    ls -l $distributions
+    exit 1
+fi
+
+# A lib/ left behind by an earlier run would put its libraries in this zip too.
+rm -rf $distributions/lib
+mkdir -p $distributions/lib
+
+if [ "$PLATFORM" = "windows" ]; then
+    cp -v ./jni/build/opensearch_neuralsearch_nsparse*.dll $distributions/lib
+    # No OpenMP runtime is copied: this build uses MSVC, whose vcomp140.dll comes
+    # from the Visual C++ redistributable and is not ours to redistribute.
+else
+    cp -v ./jni/build/libopensearch_neuralsearch_nsparse* $distributions/lib
+
+    # nsparse itself is a static library, so the JNI library's only non-system
+    # dependency is the OpenMP runtime. Ship the copy it was linked against;
+    # resolve it from the library rather than from a hard-coded name so gcc's
+    # libgomp and clang's libomp are both handled.
+    if [ "$PLATFORM" = "darwin" ]; then
+        ompPath=$(otool -L $distributions/lib/libopensearch_neuralsearch_nsparse* | grep -o '\S*libomp[^ ]*\.dylib' | head -n 1)
+    else
+        ompPath=$(ldd $distributions/lib/libopensearch_neuralsearch_nsparse* | grep -o '/\S*libgomp[^ ]*' | head -n 1)
+    fi
+    if [ -f "$ompPath" ]; then
+        cp -v $ompPath $distributions/lib
+    else
+        echo "WARNING: could not resolve the OpenMP runtime; the node must provide it"
+    fi
+fi
+ls -l $distributions/lib
+
+cd $distributions
+zip -ur $zipPath lib
+cd $work_dir
+
+echo "COPY ${zipPath}"
+mkdir -p $OUTPUT/plugins
+cp -v $zipPath $OUTPUT/plugins
+
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch

--- a/src/main/java/org/opensearch/neuralsearch/jni/NativeCpuFeatures.java
+++ b/src/main/java/org/opensearch/neuralsearch/jni/NativeCpuFeatures.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.jni;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * The instruction-set extensions the running CPU actually supports.
+ * <p>
+ * A distribution build ships every SIMD variant of the native library, so the name
+ * a variant was built under is no longer proof that this host can run it. Loading
+ * one the CPU lacks is not a slow path -- it is SIGILL on the first vectorized
+ * call, which takes the node down rather than failing the load -- so the variant
+ * has to be picked from the CPU, not from what happens to be on disk.
+ * <p>
+ * Detection is Linux-only, by reading {@code /proc/cpuinfo}. There is no portable
+ * way to ask this from Java, and the alternatives are worse under the security
+ * manager: {@code sysctl} needs an exec, and {@code jdk.incubator.vector} needs
+ * module flags the plugin does not control. macOS and Windows therefore report no
+ * features at all, which is consistent with jni/cmake/init-nsparse.cmake building
+ * only the generic variant there anyway.
+ */
+@Log4j2
+final class NativeCpuFeatures {
+
+    /** Flags nsparse's avx2 variant is compiled with (see nsparse/CMakeLists.txt). */
+    private static final Set<String> AVX2_FLAGS = Set.of("avx2", "fma", "f16c", "popcnt");
+
+    /** The avx2 set plus the avx512 subsets nsparse's avx512 variant is compiled with. */
+    private static final Set<String> AVX512_FLAGS = Stream.concat(
+        AVX2_FLAGS.stream(),
+        Stream.of("avx512f", "avx512cd", "avx512vl", "avx512dq", "avx512bw")
+    ).collect(Collectors.toUnmodifiableSet());
+
+    private static final Set<String> SVE_FLAGS = Set.of("sve");
+
+    /**
+     * Read once: /proc/cpuinfo cannot change under a running process, and the read
+     * needs a privileged block that is not worth repeating per query.
+     */
+    private static final Set<String> FLAGS = readCpuFlags();
+
+    static boolean supportsAvx2() {
+        return FLAGS.containsAll(AVX2_FLAGS);
+    }
+
+    static boolean supportsAvx512() {
+        return FLAGS.containsAll(AVX512_FLAGS);
+    }
+
+    static boolean supportsSve() {
+        return FLAGS.containsAll(SVE_FLAGS);
+    }
+
+    private static Set<String> readCpuFlags() {
+        if (!System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux")) {
+            return Collections.emptySet();
+        }
+        Path cpuinfo = Path.of("/proc/cpuinfo");
+        return AccessController.doPrivileged((PrivilegedAction<Set<String>>) () -> {
+            try (Stream<String> lines = Files.lines(cpuinfo)) {
+                return parseCpuFlags(lines);
+            } catch (Exception e) {
+                // Not fatal: an unreadable /proc/cpuinfo only costs the SIMD variants,
+                // and the generic library is always a valid fallback.
+                log.warn("Could not read {}; assuming no SIMD support. [{}]", cpuinfo, e.getMessage());
+                return Collections.<String>emptySet();
+            }
+        });
+    }
+
+    /**
+     * Collects the flag names from every {@code flags} (x86) or {@code Features}
+     * (arm64) line.
+     * <p>
+     * The union across cores, rather than the first core's line, is deliberate:
+     * on a heterogeneous CPU the union would claim support the scheduler cannot
+     * guarantee -- but /proc/cpuinfo on such hosts already reports the same flags
+     * for every core, and taking the first line silently loses everything on a
+     * kernel that formats the field differently.
+     */
+    static Set<String> parseCpuFlags(Stream<String> lines) {
+        return lines.map(line -> line.split(":", 2)).filter(parts -> parts.length == 2).filter(parts -> {
+            String field = parts[0].trim();
+            return field.equals("flags") || field.equals("Features");
+        })
+            .flatMap(parts -> Arrays.stream(parts[1].trim().split("\\s+")))
+            .filter(flag -> !flag.isEmpty())
+            .map(flag -> flag.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private NativeCpuFeatures() {}
+}

--- a/src/main/java/org/opensearch/neuralsearch/jni/NativeLibraryCandidates.java
+++ b/src/main/java/org/opensearch/neuralsearch/jni/NativeLibraryCandidates.java
@@ -4,7 +4,11 @@
  */
 package org.opensearch.neuralsearch.jni;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 /**
@@ -20,18 +24,44 @@ final class NativeLibraryCandidates {
     static final String LIBRARY_NAME = "opensearch_neuralsearch_nsparse";
 
     /**
-     * jni/cmake/init-nsparse.cmake picks one SIMD variant at build time and appends it to
-     * the library name, so the file on disk is rarely the bare LIBRARY_NAME. Only one
-     * variant is ever built, so the suffixes are tried most-specific first with the
-     * unsuffixed (generic) build last.
+     * jni/cmake/init-nsparse.cmake appends the SIMD variant it built to the library
+     * name, so the file on disk is rarely the bare LIBRARY_NAME. A distribution build
+     * (scripts/build.sh) produces every variant its architecture can use, so which
+     * files exist says nothing about which ones this CPU can execute -- each suffix
+     * is paired with the check that decides whether it is safe to load. The generic
+     * build carries no requirement and stays last.
      * <p>
      * Must stay in sync with the {@code string(PREPEND LIB_EXT ...)} calls in
      * init-nsparse.cmake; NativeLibraryContractTests pins the pairing.
      */
-    static final List<String> SIMD_SUFFIXES = List.of("_avx512", "_avx2", "_sve", "");
+    private static final Map<String, BooleanSupplier> SIMD_REQUIREMENTS = requirements();
 
-    /** Library names to try, in order. */
+    /** Suffixes in load order, most specific first, regardless of what the host supports. */
+    static final List<String> SIMD_SUFFIXES = List.copyOf(SIMD_REQUIREMENTS.keySet());
+
+    private static Map<String, BooleanSupplier> requirements() {
+        Map<String, BooleanSupplier> byPriority = new LinkedHashMap<>();
+        byPriority.put("_avx512", NativeCpuFeatures::supportsAvx512);
+        byPriority.put("_avx2", NativeCpuFeatures::supportsAvx2);
+        byPriority.put("_sve", NativeCpuFeatures::supportsSve);
+        byPriority.put("", () -> true);
+        return Collections.unmodifiableMap(byPriority);
+    }
+
+    /**
+     * Library names to try, in order: the variants this CPU can execute, most
+     * specific first, ending with the generic build.
+     */
     static List<String> candidates() {
+        return SIMD_REQUIREMENTS.entrySet()
+            .stream()
+            .filter(entry -> entry.getValue().getAsBoolean())
+            .map(entry -> LIBRARY_NAME + entry.getKey())
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    /** Every name a build can produce, whether or not this CPU can run it. */
+    static List<String> allCandidates() {
         return SIMD_SUFFIXES.stream().map(suffix -> LIBRARY_NAME + suffix).collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -4,4 +4,14 @@ grant {
     permission java.lang.RuntimePermission "accessDeclaredMembers";
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.lang.RuntimePermission "setContextClassLoader";
+
+    // Native sparse engine. One name per SIMD variant scripts/build.sh can ship:
+    // System.loadLibrary checks the permission against the name it is asked for,
+    // and NativeLibraryCandidates tries each in turn.
+    permission java.lang.RuntimePermission "loadLibrary.opensearch_neuralsearch_nsparse";
+    permission java.lang.RuntimePermission "loadLibrary.opensearch_neuralsearch_nsparse_avx2";
+    permission java.lang.RuntimePermission "loadLibrary.opensearch_neuralsearch_nsparse_avx512";
+    permission java.lang.RuntimePermission "loadLibrary.opensearch_neuralsearch_nsparse_sve";
+    // NativeCpuFeatures reads this to pick the variant the CPU can execute.
+    permission java.io.FilePermission "/proc/cpuinfo", "read";
 };

--- a/src/test/java/org/opensearch/neuralsearch/jni/NativeCpuFeaturesTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/jni/NativeCpuFeaturesTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.jni;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * The parsing half of {@link NativeCpuFeatures}. The detection half depends on the
+ * host CPU, so what can be pinned here is that a real /proc/cpuinfo is read the way
+ * the flag checks assume — a parser that quietly returns nothing degrades to "no
+ * SIMD support", which is safe but silently gives up the vectorized library.
+ */
+public class NativeCpuFeaturesTests extends OpenSearchTestCase {
+
+    /** An x86_64 /proc/cpuinfo names the field "flags". */
+    public void testParsesX86FlagsField() {
+        Set<String> flags = NativeCpuFeatures.parseCpuFlags(
+            Stream.of(
+                "processor\t: 0",
+                "model name\t: Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz",
+                "flags\t\t: fpu vme de pse tsc avx avx2 fma f16c popcnt avx512f avx512dq avx512cd avx512bw avx512vl",
+                "bugs\t\t: spectre_v1"
+            )
+        );
+
+        assertTrue(flags.contains("avx2"));
+        assertTrue(flags.contains("avx512vl"));
+        assertFalse("only the flags field is parsed", flags.contains("intel(r)"));
+        assertFalse(flags.contains("sve"));
+    }
+
+    /** An aarch64 /proc/cpuinfo names the same thing "Features". */
+    public void testParsesAarch64FeaturesField() {
+        Set<String> flags = NativeCpuFeatures.parseCpuFlags(
+            Stream.of("processor\t: 0", "BogoMIPS\t: 2100.00", "Features\t: fp asimd evtstrm aes sha1 sve svebf16", "CPU architecture: 8")
+        );
+
+        assertTrue(flags.contains("sve"));
+        assertFalse(flags.contains("avx2"));
+    }
+
+    /** Flags are matched case-insensitively against the lowercase names cmake uses. */
+    public void testFlagsAreLowercased() {
+        assertTrue(NativeCpuFeatures.parseCpuFlags(Stream.of("Features\t: SVE")).contains("sve"));
+    }
+
+    /**
+     * The union across cores, not just the first core's line: a kernel that repeats
+     * the field per processor must not lose the flags of the later ones.
+     */
+    public void testCollectsFlagsFromEveryCore() {
+        Set<String> flags = NativeCpuFeatures.parseCpuFlags(
+            Stream.of("processor\t: 0", "flags\t\t: fpu avx2", "processor\t: 1", "flags\t\t: fpu avx2 avx512f")
+        );
+
+        assertEquals(Set.of("fpu", "avx2", "avx512f"), flags);
+    }
+
+    /** A cpuinfo with no flags field at all means no SIMD, not a failure. */
+    public void testMissingFieldYieldsNoFlags() {
+        assertTrue(NativeCpuFeatures.parseCpuFlags(Stream.of("processor\t: 0", "vendor_id\t: GenuineIntel")).isEmpty());
+        assertTrue(NativeCpuFeatures.parseCpuFlags(Stream.of("", "not a field at all")).isEmpty());
+    }
+
+    /**
+     * Whatever this host is, exactly one answer per tier and never a claim of two
+     * architectures at once.
+     */
+    public void testHostDetectionIsSelfConsistent() {
+        if (NativeCpuFeatures.supportsAvx512()) {
+            assertTrue("nsparse's avx512 variant is also compiled with -mavx2", NativeCpuFeatures.supportsAvx2());
+        }
+        assertFalse(
+            "no CPU has both AVX and SVE",
+            NativeCpuFeatures.supportsSve() && (NativeCpuFeatures.supportsAvx2() || NativeCpuFeatures.supportsAvx512())
+        );
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/jni/NativeLibraryContractTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/jni/NativeLibraryContractTests.java
@@ -11,8 +11,11 @@ import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.lucene.store.IndexOutput;
@@ -145,40 +148,66 @@ public class NativeLibraryContractTests extends OpenSearchTestCase {
         }
     }
 
-    /**
-     * init-nsparse.cmake bakes the chosen SIMD variant into the library filename.
-     * NativeLibrary probes a hard-coded suffix list to find it, and the two have no
-     * shared source of truth — if cmake gains a variant that the list does not
-     * know, the plugin silently fails to load on that architecture.
-     */
-    public void testSimdSuffixesCoverEveryVariantCmakeCanProduce() throws Exception {
-        String cmake = readProjectFile("jni/cmake/init-nsparse.cmake");
-
-        java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("string\\(PREPEND LIB_EXT \"(_\\w+)\"\\)").matcher(cmake);
-        Set<String> cmakeSuffixes = new java.util.HashSet<>();
-        while (matcher.find()) {
-            cmakeSuffixes.add(matcher.group(1));
+    /** The names are the library base name plus each suffix, in order. */
+    public void testCandidateNamesAreOrderedMostSpecificFirst() {
+        List<String> all = NativeLibraryCandidates.allCandidates();
+        assertEquals(NativeLibraryCandidates.SIMD_SUFFIXES.size(), all.size());
+        for (int i = 0; i < all.size(); i++) {
+            assertEquals(NativeLibraryCandidates.LIBRARY_NAME + NativeLibraryCandidates.SIMD_SUFFIXES.get(i), all.get(i));
         }
-        assertFalse("expected init-nsparse.cmake to append at least one SIMD suffix", cmakeSuffixes.isEmpty());
-
-        Set<String> probed = Set.copyOf(NativeLibraryCandidates.SIMD_SUFFIXES);
-        for (String suffix : cmakeSuffixes) {
-            assertTrue(
-                "init-nsparse.cmake can build " + suffix + " but NativeLibraryCandidates.SIMD_SUFFIXES does not probe for it",
-                probed.contains(suffix)
-            );
-        }
-        assertTrue("the generic (unsuffixed) build must remain a fallback candidate", probed.contains(""));
+        assertEquals("the generic build must be tried last", NativeLibraryCandidates.LIBRARY_NAME, all.get(all.size() - 1));
     }
 
-    /** The probed names are the library base name plus each suffix, in order. */
-    public void testCandidateNamesAreOrderedMostSpecificFirst() {
-        List<String> candidates = NativeLibraryCandidates.candidates();
-        assertEquals(NativeLibraryCandidates.SIMD_SUFFIXES.size(), candidates.size());
-        for (int i = 0; i < candidates.size(); i++) {
-            assertEquals(NativeLibraryCandidates.LIBRARY_NAME + NativeLibraryCandidates.SIMD_SUFFIXES.get(i), candidates.get(i));
+    /**
+     * A distribution build ships every variant, so what is on disk no longer proves
+     * the CPU can run it — candidates() must drop the ones it cannot, keep the rest
+     * in the same order, and always end with the generic build.
+     */
+    public void testCandidatesAreTheSupportedSubsetInOrder() {
+        List<String> supported = NativeLibraryCandidates.candidates();
+        List<String> all = NativeLibraryCandidates.allCandidates();
+
+        assertEquals("the generic build is always a candidate", NativeLibraryCandidates.LIBRARY_NAME, supported.get(supported.size() - 1));
+        assertTrue("candidates() must be a subset of the names a build can produce", all.containsAll(supported));
+        assertEquals(
+            "candidates() must preserve the most-specific-first order",
+            all.stream().filter(supported::contains).collect(Collectors.toList()),
+            supported
+        );
+    }
+
+    /**
+     * Every variant cmake can build needs a CPU check paired with it. A suffix without
+     * one would be loaded on any host that happens to have the file, which for a
+     * distribution artifact means SIGILL on the first vectorized call rather than a
+     * failed load.
+     */
+    public void testEveryCmakeVariantIsGatedOnACpuCheck() throws Exception {
+        Set<String> cmakeSuffixes = simdSuffixesInCmake();
+        List<String> gated = NativeLibraryCandidates.SIMD_SUFFIXES;
+        for (String suffix : cmakeSuffixes) {
+            assertTrue(
+                "init-nsparse.cmake can build " + suffix + " but NativeLibraryCandidates does not pair it with a CPU check",
+                gated.contains(suffix)
+            );
         }
-        assertEquals("the generic build must be tried last", NativeLibraryCandidates.LIBRARY_NAME, candidates.get(candidates.size() - 1));
+        // Only the generic build may be unconditional.
+        assertEquals("", gated.get(gated.size() - 1));
+    }
+
+    /**
+     * The SIMD suffixes init-nsparse.cmake can bake into the library filename. Parsed
+     * from the cmake source because the two sides have no shared source of truth.
+     */
+    private Set<String> simdSuffixesInCmake() throws IOException {
+        String cmake = readProjectFile("jni/cmake/init-nsparse.cmake");
+        Matcher matcher = Pattern.compile("string\\(PREPEND LIB_EXT \"(_\\w+)\"\\)").matcher(cmake);
+        Set<String> suffixes = new HashSet<>();
+        while (matcher.find()) {
+            suffixes.add(matcher.group(1));
+        }
+        assertFalse("expected init-nsparse.cmake to append at least one SIMD suffix", suffixes.isEmpty());
+        return suffixes;
     }
 
     /**


### PR DESCRIPTION
### Description

The distribution zip ships no native library today: the default build script only runs `./gradlew assemble`, which does not depend on `buildJniLib`, so a sparse index fails at library load. `scripts/build.sh` (found ahead of the default, like k-NN's) builds every SIMD variant the architecture needs (generic/avx2/avx512 on Linux x64, generic/sve on arm64, generic elsewhere) and packs them plus the linked OpenMP runtime into the zip's `lib/`.

Since several variants ship, `NativeCpuFeatures` picks one from `/proc/cpuinfo` and `NativeLibraryCandidates` gates each suffix on that check. Also: Gradle forwards the SIMD flags to CMake; `init-nsparse.cmake` selects by architecture (SVE was unreachable on aarch64); the library gets an `$ORIGIN` runpath; the policy gains missing `loadLibrary` grants.

Follow-up in opensearch-build: add this plugin's `lib` to `LD_LIBRARY_PATH`, as done for k-NN. Rationale in the commit message.

### Check List
- [x] Testing included.
- [x] Documented.
- [x] Commits signed per the DCO.
