### PR TITLE
[Fusion] Explain a fused hybrid score from its legs' explanations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * In-query fusion in hybrid search. Support `profile` in fused mode: every leg reports its own profiler tree, under a shard entry labelled `[fused:hybrid_N.leg_M]` ([#1977](https://github.com/opensearch-project/neural-search/pull/1977))
 * In-query fusion in hybrid search. Support `rrf` in fused mode as a normalizer over ranks, computing rank scores through the same code as the score-ranker-processor, and read `rank_constant` from the place each config shape's own classic factory reads it — the `combination` clause for `score-ranker-processor`, `normalization.parameters` for `normalization-processor` ([#1948](https://github.com/opensearch-project/neural-search/pull/1948))
 * In-query fusion in hybrid search. Report `timed_out` when a soft `timeout` truncated a leg's sub-search, since the fusion then ranked an incomplete candidate set ([#1980](https://github.com/opensearch-project/neural-search/pull/1980))
+* In-query fusion in hybrid search. Support `explain` in fused mode: each ranked hit reports every leg's normalized contribution under the fused score, in classic hybrid's wording ([#1979](https://github.com/opensearch-project/neural-search/pull/1979))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/src/main/java/org/opensearch/neuralsearch/fusion/CoordinatorScoreFusion.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/CoordinatorScoreFusion.java
@@ -80,6 +80,38 @@ public final class CoordinatorScoreFusion {
         final ScalarNormalizer normalizer,
         final ScoreCombinationTechnique combinationTechnique
     ) {
+        return fuseDetailed(legRawScores, normalizer, combinationTechnique).fused();
+    }
+
+    /**
+     * What fusion computed: the fused score per document, and the per-leg normalized scores it was computed from.
+     *
+     * <p>The normalized values are the only record of <i>how</i> a fused score was reached, and they exist nowhere else —
+     * a leg hit carries its raw score and round 2 carries the fused one, with the step between them entirely on the
+     * coordinator. Reporting them is what lets {@code explain} describe a fused score rather than merely restate it.
+     *
+     * @param fused               {@code key -> fused score} for the union of all legs' docs
+     * @param legNormalizedScores one entry per leg, in leg order, each a {@code key -> normalized score} map over that
+     *                            leg's own hits (a key absent from a leg's map did not match that leg)
+     */
+    public record FusionResult(Map<String, Float> fused, List<Map<String, Float>> legNormalizedScores) {
+    }
+
+    /**
+     * As {@link #fuse}, additionally reporting the per-leg normalized scores. Same arithmetic and same allocation —
+     * {@code fuse} is this method with the detail dropped — so there is no fast path to choose between and no way for the
+     * explained and unexplained paths to compute different scores.
+     *
+     * @param legRawScores         one entry per leg, each a {@code key -> raw score} map of that leg's hits
+     * @param normalizer           per-leg normalization step (e.g. {@code min_max})
+     * @param combinationTechnique cross-leg combination step (e.g. arithmetic_mean with weights)
+     * @return the fused scores and the per-leg normalized scores behind them
+     */
+    public static FusionResult fuseDetailed(
+        final List<Map<String, Float>> legRawScores,
+        final ScalarNormalizer normalizer,
+        final ScoreCombinationTechnique combinationTechnique
+    ) {
         final int legCount = legRawScores.size();
 
         // Normalize each leg independently. A leg's map is already the merged across-shard set, so the normalizer sees
@@ -107,6 +139,6 @@ public final class CoordinatorScoreFusion {
             }
             fused.put(key, combinationTechnique.combine(docScoresPerLeg));
         }
-        return fused;
+        return new FusionResult(fused, List.copyOf(legNormalizedScores));
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/NormalizationProcessorWorkflow.java
@@ -30,7 +30,6 @@ import org.opensearch.neuralsearch.processor.dto.NormalizeScoresDTO;
 import org.opensearch.neuralsearch.processor.explain.CombinedExplanationDetails;
 import org.opensearch.neuralsearch.processor.explain.DocIdAtSearchShard;
 import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
-import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
 import org.opensearch.neuralsearch.processor.explain.ExplanationPayload;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizer;
 import org.opensearch.search.SearchHit;
@@ -181,7 +180,7 @@ public class NormalizationProcessorWorkflow {
             Sort sortForQuery = evaluateSortCriteria(request.getQuerySearchResults(), queryTopDocs);
             ExplainDTO explainDTO = ExplainDTO.builder()
                 .queryTopDocs(queryTopDocs)
-                .explainableTechnique((ExplainableTechnique) request.getNormalizationTechnique())
+                .explainableTechnique(request.getNormalizationTechnique())
                 .singleShard(isSingleShard)
                 .build();
             Map<DocIdAtSearchShard, ExplanationDetails> normalizationExplain = scoreNormalizer.explain(explainDTO);

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombinationTechnique.java
@@ -4,7 +4,18 @@
  */
 package org.opensearch.neuralsearch.processor.combination;
 
-public interface ScoreCombinationTechnique {
+import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
+
+/**
+ * A way of combining a hybrid query's per-sub-query scores into one score.
+ *
+ * <p>Extends {@link ExplainableTechnique} so that every combination technique is describable by construction. Both of
+ * that interface's methods are {@code default}, so this costs an implementer nothing — and it is what lets the explain
+ * paths call {@code describe()} directly instead of casting. Before it, the classic and fused explain paths each cast to
+ * {@code ExplainableTechnique} unguarded, so a technique that omitted the interface compiled and then threw a
+ * {@code ClassCastException} at runtime, on explained requests only.
+ */
+public interface ScoreCombinationTechnique extends ExplainableTechnique {
 
     /**
      * Defines combination function specific to this technique

--- a/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/combination/ScoreCombiner.java
@@ -32,7 +32,6 @@ import org.opensearch.neuralsearch.processor.CompoundTopDocs;
 
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.neuralsearch.processor.SearchShard;
-import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
 import org.opensearch.neuralsearch.processor.explain.ExplanationDetails;
 
 /**
@@ -479,7 +478,7 @@ public class ScoreCombiner {
         String combinationDescription = String.format(
             Locale.ROOT,
             "%s combination of%s:",
-            ((ExplainableTechnique) scoreCombinationTechnique).describe(),
+            scoreCombinationTechnique.describe(),
             isMinScoreAvailable(minScore, sort) ? String.format(Locale.ROOT, " [filtered by min_score: %.4f]", minScore) : ""
         );
         for (int docId : sortedDocsIds) {

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/ScoreNormalizationTechnique.java
@@ -5,11 +5,16 @@
 package org.opensearch.neuralsearch.processor.normalization;
 
 import org.opensearch.neuralsearch.processor.dto.NormalizeScoresDTO;
+import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
 
 /**
  * Abstracts normalization of scores in query search results.
+ *
+ * <p>Extends {@link ExplainableTechnique} for the same reason the combination side does: a technique is describable by
+ * construction, at no cost to an implementer since both of that interface's methods are {@code default}, and the explain
+ * path reads {@code describe()} directly rather than casting.
  */
-public interface ScoreNormalizationTechnique {
+public interface ScoreNormalizationTechnique extends ExplainableTechnique {
 
     /**
      * Performs score normalization based on input normalization technique.

--- a/src/main/java/org/opensearch/neuralsearch/query/CandidateScope.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/CandidateScope.java
@@ -290,11 +290,12 @@ final class CandidateScope {
             table,
             SEARCH_SOURCE,
             "explain",
-            Disposition.NOT_PROPAGATED,
-            "round 2 explains the self-erased query, where a matching Top clause is a childless constant_score carrying "
-                + "the fused score — the right number with no breakdown under it. Normalization and combination run on "
-                + "the coordinator, so assembling the full tree is a response-side concern, exactly as it is for classic "
-                + "hybrid. Tracked as a fused-mode parity follow-up"
+            Disposition.OVERRIDDEN,
+            "a leg runs explained only when the fused rewrite has somewhere to keep its explanations, never by "
+                + "inheriting the outer flag. That somewhere is FusedDocExplanations, which FusedExplanationMerger "
+                + "rebuilds onto the response (see enableLegExplain). It has to be the legs that explain: round 2 "
+                + "explains the self-erased query, where a matching Top clause is a childless constant_score, and "
+                + "normalization and combination ran on the coordinator"
         );
         put(table, SEARCH_SOURCE, "version", Disposition.NOT_PROPAGATED, "fetch-phase metadata; a leg fetches nothing but ids");
         put(table, SEARCH_SOURCE, "seqNoAndPrimaryTerm", Disposition.NOT_PROPAGATED, "as version");
@@ -368,6 +369,13 @@ final class CandidateScope {
      * {@code profile} flag, not a field inherited from it.
      */
     private boolean legProfiling;
+
+    /**
+     * When set, every leg sub-search runs with {@code explain: true} so the raw score each leg contributed can be
+     * described in the user's response. As {@link #legProfiling}: not part of the captured scope, and decided by the fused
+     * rewrite from the outer request's {@code explain} flag rather than inherited from it.
+     */
+    private boolean legExplain;
 
     private CandidateScope(final SearchRequest request) {
         SearchSourceBuilder source = request.source();
@@ -496,6 +504,19 @@ final class CandidateScope {
     }
 
     /**
+     * Ask every leg built from here on to explain its hits, because the request asked to be explained and the rewrite has a
+     * {@code FusedDocExplanations} to keep the explanations in.
+     *
+     * <p>An explained leg pays explanation's own overhead — a second per-hit pass through the leg's weight — and, unlike
+     * profiling, that cost lands on the shards rather than only on the coordinator. It is bounded by the leg's window
+     * (explanations are produced during fetch, for the hits the leg returns, not for its whole match set), and it is the
+     * same cost classic hybrid pays for {@code explain} on the same sub-queries.
+     */
+    void enableLegExplain() {
+        this.legExplain = true;
+    }
+
+    /**
      * The single place a leg sub-search is constructed: the captured candidate scope, plus this leg's own query and the
      * candidate window. Every {@link Disposition#OVERRIDDEN} value is set here explicitly rather than inherited, so no
      * field of the outer request can reach a leg by accident. Legs are id-only (no {@code _source}) with totals disabled,
@@ -532,6 +553,9 @@ final class CandidateScope {
             .trackTotalHits(false);
         if (legProfiling) {
             legSource.profile(true);
+        }
+        if (legExplain) {
+            legSource.explain(true);
         }
         if (Objects.nonNull(timeout)) {
             legSource.timeout(timeout);

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.lucene.search.Explanation;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.MultiSearchRequest;
@@ -37,6 +38,8 @@ import org.opensearch.neuralsearch.processor.normalization.RRFScoreNormalizer;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationFactory;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationTechnique;
 import org.opensearch.neuralsearch.processor.combination.ScoreCombinationUtil;
+import org.opensearch.neuralsearch.processor.explain.ExplainableTechnique;
+import org.opensearch.neuralsearch.search.explain.FusedDocExplanations;
 import org.opensearch.neuralsearch.search.profile.FusedCoordinatorTimings;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -66,8 +69,6 @@ import lombok.NoArgsConstructor;
 final class HybridFusionOrchestrator {
 
     private static final ScoreCombinationFactory SCORE_COMBINATION_FACTORY = new ScoreCombinationFactory();
-    /** Separator for the composite _index+_id fusion key. Never parsed back — see computeRankedDocs. */
-    private static final String KEY_SEPARATOR = "#";
     /** The {@code _name} key as it appears in a rendered query — see {@link #anyLegNamed}. */
     private static final String QUERY_NAME_KEY = String.format(Locale.ROOT, "\"%s\":", AbstractQueryBuilder.NAME_FIELD.getPreferredName());
 
@@ -161,14 +162,23 @@ final class HybridFusionOrchestrator {
         FusionSpec fusion,
         int windowSize
     ) {
-        return buildFusedQuery(source, multiSearchResponse, legs, fusion, windowSize, new FusedCoordinatorTimings());
+        return buildFusedQuery(
+            source,
+            multiSearchResponse,
+            legs,
+            fusion,
+            windowSize,
+            new FusedCoordinatorTimings(),
+            new FusedDocExplanations()
+        );
     }
 
     /**
-     * As above, recording each fusion phase's span into {@code timings} for the coordinator profile entry. The timings
-     * instance is always present — never null-checked here — so that instrumentation costs the same handful of
-     * {@code nanoTime} calls whether or not the request asked to be profiled, and an unprofiled request simply discards
-     * what was measured. Phase boundaries are the method boundaries below, so a span is never attributed to two phases.
+     * As above, recording each fusion phase's span into {@code timings} for the coordinator profile entry and each window
+     * document's per-leg breakdown into {@code explanations} for the request's {@code explain}. Both instances are always
+     * present — never null-checked here — so that instrumentation costs the same handful of {@code nanoTime} calls whether
+     * or not the request asked to be profiled, and a request that asked for neither simply discards what was collected.
+     * Phase boundaries are the method boundaries below, so a span is never attributed to two phases.
      */
     static QueryBuilder buildFusedQuery(
         SearchSourceBuilder source,
@@ -176,13 +186,14 @@ final class HybridFusionOrchestrator {
         List<QueryBuilder> legs,
         FusionSpec fusion,
         int windowSize,
-        FusedCoordinatorTimings timings
+        FusedCoordinatorTimings timings,
+        FusedDocExplanations explanations
     ) {
         MultiSearchResponse.Item[] items = multiSearchResponse.getResponses();
         long windowMergeStart = System.nanoTime();
         SearchHit[][] legHits = groupLegHits(items, legs.size());
         timings.windowMergeNanos(System.nanoTime() - windowMergeStart);
-        RankedDocs ranked = computeRankedDocs(legHits, fusion, windowSize, timings);
+        RankedDocs ranked = computeRankedDocs(legHits, fusion, windowSize, timings, explanations);
         timings.rankedDocs(ranked.ids().length);
         if (ranked.ids().length == 0) {
             return new MatchNoneQueryBuilder();
@@ -314,18 +325,32 @@ final class HybridFusionOrchestrator {
      * may itself contain the separator, so the original identity is carried in a side map instead. To fusion and to every
      * normalizer the key stays opaque.
      */
-    private static RankedDocs computeRankedDocs(SearchHit[][] legHits, FusionSpec fusion, int windowSize, FusedCoordinatorTimings timings) {
+    private static RankedDocs computeRankedDocs(
+        SearchHit[][] legHits,
+        FusionSpec fusion,
+        int windowSize,
+        FusedCoordinatorTimings timings,
+        FusedDocExplanations explanations
+    ) {
         long fuseScoresStart = System.nanoTime();
         List<Map<String, Float>> legRawScores = new ArrayList<>(legHits.length);
+        // Parallel to legRawScores: the leg's own explanation of each hit's raw score, present only when the request asked
+        // to be explained (an unexplained leg carries none, so these stay empty and nothing is recorded below).
+        List<Map<String, Explanation>> legExplanations = new ArrayList<>(legHits.length);
         Map<String, SearchHit> identityByKey = new HashMap<>();
         for (SearchHit[] hits : legHits) {
             Map<String, Float> byKey = new LinkedHashMap<>();
+            Map<String, Explanation> explanationByKey = new HashMap<>();
             for (SearchHit hit : hits) {
                 String key = documentKey(hit);
                 byKey.put(key, hit.getScore());
+                if (Objects.nonNull(hit.getExplanation())) {
+                    explanationByKey.put(key, hit.getExplanation());
+                }
                 identityByKey.putIfAbsent(key, hit);
             }
             legRawScores.add(byKey);
+            legExplanations.add(explanationByKey);
         }
         ScoreCombinationTechnique combination = SCORE_COMBINATION_FACTORY.createCombination(
             fusion.combinationTechnique(),
@@ -335,12 +360,55 @@ final class HybridFusionOrchestrator {
         // ScalarNormalizers — no change here, rank-based rrf included. The caller already rejected out-of-scope
         // techniques at rewrite.
         ScalarNormalizer normalizer = ScalarNormalizers.forTechnique(fusion.normalizationTechnique(), normalizerParams(fusion));
-        Map<String, Float> combined = CoordinatorScoreFusion.fuse(legRawScores, normalizer, combination);
+        CoordinatorScoreFusion.FusionResult fused = CoordinatorScoreFusion.fuseDetailed(legRawScores, normalizer, combination);
         timings.fuseScoresNanos(System.nanoTime() - fuseScoresStart);
         long rankWindowStart = System.nanoTime();
-        RankedDocs ranked = toRankedDocs(combined, identityByKey, windowSize);
+        RankedDocs ranked = toRankedDocs(fused.fused(), identityByKey, windowSize);
         timings.rankWindowNanos(System.nanoTime() - rankWindowStart);
+        recordExplanations(explanations, ranked, fused, legExplanations, combination, normalizer);
         return ranked;
+    }
+
+    /**
+     * Record how each document in the window earned its fused score, for the request's {@code explain}. Runs after the
+     * window cut so only documents round 2 will actually rank are described, and is skipped entirely when no leg returned
+     * an explanation — which is every unexplained request, since a leg only explains when {@link CandidateScope} asked it
+     * to.
+     *
+     * <p>The descriptions are taken from the same two sources classic hybrid renders from — the combination technique's own
+     * {@link ExplainableTechnique#describe()} and the normalization technique's name — so an identical hit set produces
+     * identical wording on both paths. Classic's trailing {@code min_score} suffix has no counterpart here: fused mode does
+     * not propagate {@code min_score} to the legs, so there is no value to name.
+     */
+    private static void recordExplanations(
+        final FusedDocExplanations explanations,
+        final RankedDocs ranked,
+        final CoordinatorScoreFusion.FusionResult fused,
+        final List<Map<String, Explanation>> legExplanations,
+        final ScoreCombinationTechnique combination,
+        final ScalarNormalizer normalizer
+    ) {
+        if (legExplanations.stream().allMatch(Map::isEmpty)) {
+            return;
+        }
+        // Same format strings as classic: ScoreCombiner#explainByShard and ExplanationUtils#getDocIdAtQueryForNormalization.
+        explanations.combinationDescription(
+            String.format(Locale.ROOT, "%s combination of:", ((ExplainableTechnique) combination).describe())
+        ).normalizationDescription(String.format(Locale.ROOT, "%s normalization of:", normalizer.techniqueName()));
+        List<Map<String, Float>> legNormalizedScores = fused.legNormalizedScores();
+        for (int doc = 0; doc < ranked.ids().length; doc++) {
+            String key = FusedDocExplanations.documentKey(ranked.indices()[doc], ranked.ids()[doc]);
+            List<FusedDocExplanations.LegContribution> contributions = new ArrayList<>(legNormalizedScores.size());
+            for (int leg = 0; leg < legNormalizedScores.size(); leg++) {
+                Float normalizedScore = legNormalizedScores.get(leg).get(key);
+                if (Objects.isNull(normalizedScore)) {
+                    // The leg did not match this document. Classic renders no node for it either.
+                    continue;
+                }
+                contributions.add(new FusedDocExplanations.LegContribution(leg, normalizedScore, legExplanations.get(leg).get(key)));
+            }
+            explanations.addDocument(key, ranked.scores()[doc], contributions);
+        }
     }
 
     /**
@@ -358,7 +426,8 @@ final class HybridFusionOrchestrator {
      * is a limitation of how documents are addressed, not of how they are keyed.
      */
     private static String documentKey(SearchHit hit) {
-        return hit.getIndex() + KEY_SEPARATOR + hit.getId();
+        // Delegated so the rewrite and the response-side explanation attach build the same key from one definition.
+        return FusedDocExplanations.documentKey(hit.getIndex(), hit.getId());
     }
 
     /**
@@ -666,8 +735,8 @@ final class HybridFusionOrchestrator {
      *   <li>{@code explain} — the Tail cannot recover a fused explanation: the fused score is arithmetic the coordinator
      *       already did, and the clause carrying it into round 2 is a childless {@code constant_score} with nothing to
      *       descend into (the Tail explains as a non-scoring filter either way). Describing the fusion belongs on the
-     *       response side, where classic hybrid puts it too — tracked as a fused-mode parity follow-up, see
-     *       {@link CandidateScope.Disposition#NOT_PROPAGATED}.</li>
+     *       response side, where classic hybrid puts it too — the legs explain in round 1 and the fused tree is assembled
+     *       from those explanations on the response (see {@code FusedExplanationMerger}).</li>
      *   <li>{@code profile} — the legs report their own trees from round 1, where they execute as the queries the user
      *       wrote, each merged into the response under its own shard entry (see {@code FusedLegProfileMerger}); the
      *       response's own entry covers round 2, and a synthesized {@code [coordinator]} entry covers the fan-out and the

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -407,7 +407,13 @@ final class HybridFusionOrchestrator {
                 }
                 contributions.add(new FusedDocExplanations.LegContribution(leg, normalizedScore, legExplanations.get(leg).get(key)));
             }
-            explanations.addDocument(key, ranked.scores()[doc], contributions);
+            // The score fusion computed, deliberately not ranked.scores()[doc]: that one is already through
+            // scoreAboveTail, and recording the floored value would label the combination node with a number its own
+            // children do not produce — a fused 0.0 renders as MIN_RANKED_SCORE over children that combine to 0.0.
+            // Recording the raw value keeps the node honest and lets FusedDocExplanations#explain surface the floor as
+            // the final-score node instead, since the hit's score is the floored one and the two then differ.
+            // Non-null for every ranked document: toRankedDocs built the window out of this very map.
+            explanations.addDocument(key, fused.fused().get(key), contributions);
         }
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -392,9 +392,8 @@ final class HybridFusionOrchestrator {
             return;
         }
         // Same format strings as classic: ScoreCombiner#explainByShard and ExplanationUtils#getDocIdAtQueryForNormalization.
-        explanations.combinationDescription(
-            String.format(Locale.ROOT, "%s combination of:", ((ExplainableTechnique) combination).describe())
-        ).normalizationDescription(String.format(Locale.ROOT, "%s normalization of:", normalizer.techniqueName()));
+        explanations.combinationDescription(String.format(Locale.ROOT, "%s combination of:", combination.describe()))
+            .normalizationDescription(String.format(Locale.ROOT, "%s normalization of:", normalizer.techniqueName()));
         List<Map<String, Float>> legNormalizedScores = fused.legNormalizedScores();
         for (int doc = 0; doc < ranked.ids().length; doc++) {
             String key = FusedDocExplanations.documentKey(ranked.indices()[doc], ranked.ids()[doc]);

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -1209,6 +1209,12 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     /**
      * Combination techniques wired into the coordinator fusion path. Narrower than the classic compatibility matrix
      * while combination support is widened one technique at a time; widening this set is what admits a new combiner.
+     *
+     * <p>A technique added here must also implement {@code ExplainableTechnique}. The fused explain path casts to it
+     * unguarded to name the combination node ({@code HybridFusionOrchestrator#recordExplanations}), exactly as classic
+     * does in {@code ScoreCombiner#explainByShard} and {@code NormalizationProcessorWorkflow}. That cast can only ever
+     * see an admitted technique because this set gates it before the leg fan-out, so widening the set without the
+     * interface would turn explained requests into a {@code ClassCastException} while unexplained ones kept working.
      */
     private static final Set<String> FUSED_COMBINATION_TECHNIQUES = Set.of(FusionSpec.TECHNIQUE_ARITHMETIC_MEAN, FusionSpec.TECHNIQUE_RRF);
 

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -67,6 +67,8 @@ import org.opensearch.neuralsearch.fusion.ScalarNormalizer;
 import org.opensearch.neuralsearch.fusion.ScalarNormalizers;
 import org.opensearch.neuralsearch.processor.normalization.ScoreNormalizationFactory;
 import org.opensearch.neuralsearch.search.FusedLegTimeoutMerger;
+import org.opensearch.neuralsearch.search.explain.FusedDocExplanations;
+import org.opensearch.neuralsearch.search.explain.FusedExplanationMerger;
 import org.opensearch.neuralsearch.search.profile.FusedCoordinatorTimings;
 import org.opensearch.neuralsearch.search.profile.FusedLegProfileMerger;
 import org.opensearch.neuralsearch.stats.events.EventStatName;
@@ -169,6 +171,15 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
      * absent from {@link #doEquals}/{@link #doHashCode}.
      */
     private FusedLegTimeoutMerger.LegTimeoutConsumer legTimeoutConsumer;
+
+    /**
+     * Where to publish the per-leg breakdown behind each fused score. The counterpart of {@link #legProfileConsumer} for
+     * {@code explain}: attached by {@code HybridQuerySearchRequestFilter} before the rewrite when the request asks to be
+     * explained, so the legs run explained and {@code FusedExplanationMerger} can rebuild the tree on the response.
+     * {@code null} — the normal case — means the legs run unexplained and round 2's own explanation stands. Never parsed,
+     * never serialized, absent from {@link #doEquals}/{@link #doHashCode}.
+     */
+    private FusedExplanationMerger.FusedExplanationConsumer fusedExplanationConsumer;
 
     public static final int MAX_NUMBER_OF_SUB_QUERIES = 5;
     private static final int LOWER_BOUND_OF_PAGINATION_DEPTH = 0;
@@ -625,12 +636,21 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             candidateScope.enableLegProfiling();
         }
 
+        // Same contract for explain: with a consumer attached the request asked to be explained, so the legs explain their
+        // hits and the fused breakdown replaces round 2's own explanation of the substituted query.
+        if (Objects.nonNull(fusedExplanationConsumer)) {
+            candidateScope.enableLegExplain();
+        }
+
         // Always measured, published only when something asked for it. The spans are a handful of nanoTime calls against a
         // fan-out that costs milliseconds, so gating the measurement would buy nothing and would make the profiled and
         // unprofiled code paths differ in more than what they report.
         FusedCoordinatorTimings timings = new FusedCoordinatorTimings().windowSize(window)
             .normalizationTechnique(fusionSpec.normalizationTechnique())
             .combinationTechnique(fusionSpec.combinationTechnique());
+        // Always constructed, for the same reason, but filled only when the legs actually explained — an unexplained
+        // request's legs return no explanations, so this stays empty and is discarded.
+        FusedDocExplanations explanations = new FusedDocExplanations();
 
         SetOnce<QueryBuilder> fused = new SetOnce<>();
         queryRewriteContext.registerAsyncAction((client, listener) -> {
@@ -658,7 +678,8 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                         legs,
                         fusionSpec,
                         window,
-                        timings
+                        timings,
+                        explanations
                     );
                     // Hand the now-known window to the placeholders installed above. Mutates nothing the request holds:
                     // the placeholders are already in it, and core rewrites them into the window on its next pass.
@@ -670,6 +691,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                     // and fails the request, so a published entry always describes a completed fusion.
                     if (Objects.nonNull(fusionTimingConsumer)) {
                         fusionTimingConsumer.accept(timings);
+                    }
+                    // Likewise published only once the window is final: what is described has to be what round 2 will rank.
+                    if (Objects.nonNull(fusedExplanationConsumer)) {
+                        fusedExplanationConsumer.accept(explanations);
                     }
                     listener.onResponse(null);
                 } catch (Exception e) {

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -1210,11 +1210,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
      * Combination techniques wired into the coordinator fusion path. Narrower than the classic compatibility matrix
      * while combination support is widened one technique at a time; widening this set is what admits a new combiner.
      *
-     * <p>A technique added here must also implement {@code ExplainableTechnique}. The fused explain path casts to it
-     * unguarded to name the combination node ({@code HybridFusionOrchestrator#recordExplanations}), exactly as classic
-     * does in {@code ScoreCombiner#explainByShard} and {@code NormalizationProcessorWorkflow}. That cast can only ever
-     * see an admitted technique because this set gates it before the leg fan-out, so widening the set without the
-     * interface would turn explained requests into a {@code ClassCastException} while unexplained ones kept working.
+     * <p>A technique added here is describable for free: {@code ScoreCombinationTechnique} extends
+     * {@code ExplainableTechnique}, so the fused explain path reads {@code describe()} straight off the technique
+     * ({@code HybridFusionOrchestrator#recordExplanations}) with no cast, and a combiner that forgot to describe itself
+     * is a compile error rather than a {@code ClassCastException} on explained requests only.
      */
     private static final Set<String> FUSED_COMBINATION_TECHNIQUES = Set.of(FusionSpec.TECHNIQUE_ARITHMETIC_MEAN, FusionSpec.TECHNIQUE_RRF);
 

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
@@ -205,6 +205,12 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
             explanationMerger = new FusedExplanationMerger();
             finder.found.get(0).fusedExplanationConsumer(explanationMerger.consumer());
         }
+        // Passing the gate above is not the same as having something to report: an explained request whose fused hybrid is
+        // nested reaches here with no merger attached at all, since explain deliberately declines a hybrid that is not the
+        // request's own query. Hand the caller's listener back untouched rather than wrapping it to do nothing.
+        if (Objects.isNull(legProfileMerger) && Objects.isNull(timeoutMerger) && Objects.isNull(explanationMerger)) {
+            return listener;
+        }
         final FusedLegProfileMerger profiles = legProfileMerger;
         final FusedLegTimeoutMerger timeouts = timeoutMerger;
         final FusedExplanationMerger explanations = explanationMerger;

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
@@ -26,6 +26,7 @@ import org.opensearch.core.action.ActionResponse;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
+import org.opensearch.neuralsearch.search.explain.FusedExplanationMerger;
 import org.opensearch.neuralsearch.search.profile.FusedLegProfileMerger;
 import org.opensearch.neuralsearch.util.HybridQueryUtil;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -54,10 +55,10 @@ import lombok.extern.log4j.Log4j2;
  *
  * This filter works transparently without any pipeline or query configuration.
  *
- * The same seam carries fused mode's coordinator-side reporting — per-leg profiling and a leg cut short by a soft
- * {@code timeout}: a fused hybrid runs its legs as sub-searches during the coordinator rewrite, and this is the one place
- * that both sees the query as the user submitted it and still owns the response listener, so it can hand the legs somewhere
- * to publish what they know and merge it into the response on the way out. See {@link #attachFusedReporting}.
+ * The same seam carries fused mode's coordinator-side reporting — per-leg profiling, {@code explain}, and a leg cut short
+ * by a soft {@code timeout}: a fused hybrid runs its legs as sub-searches during the coordinator rewrite, and this is the
+ * one place that both sees the query as the user submitted it and still owns the response listener, so it can hand the legs
+ * somewhere to publish what they know and merge it into the response on the way out. See {@link #attachFusedReporting}.
  *
  */
 @Log4j2
@@ -121,18 +122,23 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
     /**
      * The response listener to proceed with: when a request carries at least one fused {@code hybrid} and there is something
      * for it to report, hand the relevant hybrids consumers writing into request-scoped mergers — the legs' profile trees,
-     * what the coordinator itself spent fanning them out and fusing them, and whether a soft {@code timeout} truncated a leg
-     * — and wrap the listener so what those mergers collected reaches the response. Otherwise the caller's own listener,
-     * unchanged.
+     * what the coordinator itself spent fanning them out and fusing them, the per-leg breakdown behind each fused score, and
+     * whether a soft {@code timeout} truncated a leg — and wrap the listener so what those mergers collected reaches the
+     * response. Otherwise the caller's own listener, unchanged.
      *
      * <p>No side channel is needed: the {@link HybridQueryBuilder} instances reachable from {@code source().query()} here
      * are the same instances rewrite round 1 runs on, so attaching to them directly is enough. Nothing happens when there is
      * nothing to report, and nothing happens to the response when nothing was ever collected.
      *
-     * <p>The two reports attach on different conditions, because they answer to different things:
+     * <p>The three reports attach on different conditions, because they answer to different things:
      * <ul>
      *   <li>{@code profile} — every fused hybrid the request fans out, since each gets its own labelled entry in the
      *       profile section.</li>
+     *   <li>{@code explain} — only when the fused hybrid <b>is</b> the request's top-level query, because a hit's
+     *       explanation is a single tree describing that hit's score: for a fused hybrid nested inside a container (or one of
+     *       several siblings) the fused score is an input to the enclosing query's own scoring, not the hit's score, and
+     *       replacing the tree would describe the wrong thing. Those requests keep core's own explanation, which correctly
+     *       describes the query round 2 ran.</li>
      *   <li>{@code timed_out} — every fused hybrid, and <b>not</b> conditional on the request having asked for a diagnostic:
      *       a leg the timeout truncated narrows the window every client's ranking comes out of, so it is part of the answer
      *       rather than part of the instrumentation. It is instead conditional on {@link #mayHitASoftTimeout}, so that a
@@ -140,7 +146,8 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
      * </ul>
      *
      * <p>This runs before search request processors do, so it reports the hybrids the request carries <b>as submitted, with
-     * {@code profile} and {@code timeout} as submitted</b>. A pipeline that replaces the query — or changes either — is
+     * {@code profile}, {@code explain} and {@code timeout} as submitted</b>. A pipeline that replaces the query — or changes
+     * any of them — is
      * outside that boundary: the request still answers correctly, it simply carries no fused detail.
      */
     @SuppressWarnings("unchecked")
@@ -158,7 +165,9 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
         }
         boolean profiled = source.profile();
         boolean mayTimeOut = mayHitASoftTimeout(source);
-        if (profiled == false && mayTimeOut == false) {
+        // explain() is a nullable Boolean on the source — unset means "not explained", so it cannot be unboxed.
+        boolean explained = Boolean.TRUE.equals(source.explain());
+        if (profiled == false && mayTimeOut == false && explained == false) {
             return listener;
         }
         FusedHybridFinder finder = new FusedHybridFinder();
@@ -189,8 +198,16 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
                 hybrid.legTimeoutConsumer(timeoutMerger.consumer());
             }
         }
+        FusedExplanationMerger explanationMerger = null;
+        // Identity, not instanceof: the finder stops at a fused hybrid, so a top-level one is necessarily the only one found,
+        // and the check is exactly "the hit's score is this hybrid's fused score".
+        if (explained && finder.found.get(0) == source.query()) {
+            explanationMerger = new FusedExplanationMerger();
+            finder.found.get(0).fusedExplanationConsumer(explanationMerger.consumer());
+        }
         final FusedLegProfileMerger profiles = legProfileMerger;
         final FusedLegTimeoutMerger timeouts = timeoutMerger;
+        final FusedExplanationMerger explanations = explanationMerger;
         return ActionListener.wrap(response -> {
             if ((response instanceof SearchResponse) == false) {
                 listener.onResponse(response);
@@ -206,6 +223,12 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
                 Objects.nonNull(profiles) ? profiles.mergedProfileResults(merged) : null,
                 merged.isTimedOut() || (Objects.nonNull(timeouts) && timeouts.anyLegTimedOut())
             );
+            // After the rebuild, not before: the explanation merger writes onto the hits the response carries, and the
+            // rebuild above may have replaced the response around them — so the explanations have to land on the one that is
+            // actually returned. It passes the SearchHits through by reference, so this reaches the same hit instances.
+            if (Objects.nonNull(explanations)) {
+                merged = explanations.getMergedResponse(merged);
+            }
             listener.onResponse((Response) merged);
         }, listener::onFailure);
     }

--- a/src/main/java/org/opensearch/neuralsearch/search/explain/FusedDocExplanations.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/explain/FusedDocExplanations.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.explain;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.lucene.search.Explanation;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * How each document in a fused ({@code fusion}) hybrid's window earned its fused score: per leg, that leg's own raw
+ * Lucene explanation from round 1 and the normalized value fusion derived from it.
+ *
+ * <p>Fused mode normalizes and combines on the <b>coordinator</b>, so the query round 2 runs carries the fused score as a
+ * childless {@code constant_score} clause — the right number with nothing under it. Everything needed to describe how
+ * that number was reached exists only during the rewrite, and is discarded there: the legs' explanations arrive on the
+ * leg hits and the per-leg normalized values are local to {@code CoordinatorScoreFusion}. This class is where both are
+ * kept so {@link FusedExplanationMerger} can rebuild the tree on the response.
+ *
+ * <p>Mutable and single-writer: one instance per fused hybrid per request, written on the leg MultiSearch response
+ * thread while the fused query is built, then read once when the response comes back. Always constructed, even when the
+ * request did not ask to be explained, so the orchestrator never has to null-check; an unexplained request records
+ * nothing (its legs ran without {@code explain}, so there are no explanations to record) and the instance is thrown
+ * away.
+ */
+public final class FusedDocExplanations {
+
+    /**
+     * Separator for the composite {@code _index} + {@code _id} document key. Lives here rather than in the orchestrator
+     * because the key has to be built in two places — over a leg hit during the rewrite, and over a response hit when
+     * the explanation is attached — and one definition is what keeps them the same key.
+     */
+    private static final String KEY_SEPARATOR = "#";
+
+    /**
+     * Description for the extra node inserted when the score round 2 returned is not the fused score. Naming the
+     * combination node with the final score would claim the fusion produced a number it did not.
+     */
+    private static final String FINAL_SCORE_DESCRIPTION = "score of the fused hybrid query after post-fusion scoring, computed from:";
+
+    /**
+     * What round 2 will be told, per document key, in leg order. Empty for an unexplained request, and absent for a
+     * document that fusion did not rank (one the Tail surfaced) — {@link FusedExplanationMerger} leaves those alone.
+     */
+    private final Map<String, List<LegContribution>> contributionsByKey = new LinkedHashMap<>();
+
+    /** The fused score fusion computed per document key, before a rescore moved it. */
+    private final Map<String, Float> fusedScoreByKey = new LinkedHashMap<>();
+
+    /**
+     * Description for the combination node, in classic hybrid's exact wording — see
+     * {@code ScoreCombiner#explainByShard}, which formats {@code "%s combination of:"} over the technique's own
+     * {@code describe()}.
+     */
+    @Getter
+    @Setter
+    @Accessors(chain = true, fluent = true)
+    private String combinationDescription;
+
+    /**
+     * Description for each per-leg normalization node, in classic hybrid's exact wording — see
+     * {@code ExplanationUtils#getDocIdAtQueryForNormalization}, which formats {@code "%s normalization of:"}.
+     */
+    @Getter
+    @Setter
+    @Accessors(chain = true, fluent = true)
+    private String normalizationDescription;
+
+    /**
+     * One leg's share of a document's fused score: the value fusion actually combined, and the leg's own explanation of
+     * the raw score it was derived from.
+     *
+     * @param legIndex        the leg's position in the hybrid, as written
+     * @param normalizedScore what normalization turned this leg's raw score into — the value the combiner consumed
+     * @param rawExplanation  the leg's own Lucene explanation from round 1, or {@code null} when the leg ran without
+     *                        {@code explain} or the shard returned none
+     */
+    public record LegContribution(int legIndex, float normalizedScore, Explanation rawExplanation) {
+    }
+
+    /** The fusion key for a document: its {@code _index}, the separator, and its {@code _id}. Never parsed back. */
+    public static String documentKey(final String index, final String id) {
+        return index + KEY_SEPARATOR + id;
+    }
+
+    /**
+     * Record one document's breakdown. Called once per ranked document, with one contribution per leg that matched it —
+     * a leg that did not match contributes nothing rather than a zero node, matching classic hybrid, which likewise only
+     * renders the legs whose own explanation is a match.
+     */
+    public void addDocument(final String documentKey, final float fusedScore, final List<LegContribution> contributions) {
+        fusedScoreByKey.put(documentKey, fusedScore);
+        contributionsByKey.put(documentKey, List.copyOf(contributions));
+    }
+
+    /** True when nothing was recorded, i.e. the request did not ask to be explained (or fusion ranked nothing). */
+    public boolean isEmpty() {
+        return contributionsByKey.isEmpty();
+    }
+
+    /**
+     * The tree for one document, or {@code null} when this document was not ranked by fusion. {@code hitScore} is the
+     * score round 2 actually returned: it differs from the fused score when a {@code rescore} moved it, and in that case
+     * the fused combination becomes a child of a node describing the final score rather than being relabelled as one.
+     *
+     * <p>A {@code NaN} {@code hitScore} is a request that sorts by a field without tracking scores. There is no final
+     * score to describe there, so the fusion is reported on its own — wrapping it in a node claiming a score of zero
+     * would describe a number nothing computed.
+     */
+    public Explanation explain(final String documentKey, final float hitScore) {
+        List<LegContribution> contributions = contributionsByKey.get(documentKey);
+        if (Objects.isNull(contributions)) {
+            return null;
+        }
+        List<Explanation> legDetails = new ArrayList<>(contributions.size());
+        for (LegContribution contribution : contributions) {
+            Explanation raw = contribution.rawExplanation();
+            legDetails.add(
+                Explanation.match(contribution.normalizedScore(), normalizationDescription, Objects.isNull(raw) ? List.of() : List.of(raw))
+            );
+        }
+        float fusedScore = fusedScoreByKey.get(documentKey);
+        Explanation combination = Explanation.match(fusedScore, combinationDescription, legDetails);
+        if (Float.isNaN(hitScore) || Float.compare(fusedScore, hitScore) == 0) {
+            return combination;
+        }
+        return Explanation.match(hitScore, FINAL_SCORE_DESCRIPTION, List.of(combination));
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/explain/FusedDocExplanations.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/explain/FusedDocExplanations.java
@@ -44,8 +44,12 @@ public final class FusedDocExplanations {
     /**
      * Description for the extra node inserted when the score round 2 returned is not the fused score. Naming the
      * combination node with the final score would claim the fusion produced a number it did not.
+     *
+     * <p>Worded for every reason the two can differ, not just {@code rescore}: the score is also moved when
+     * {@code HybridFusionOrchestrator#scoreAboveTail} floors a degenerate fused score away from {@code 0.0}, and when an
+     * enclosing {@code boost} scales it. So this says what round 2 returned rather than naming a cause.
      */
-    private static final String FINAL_SCORE_DESCRIPTION = "score of the fused hybrid query after post-fusion scoring, computed from:";
+    private static final String FINAL_SCORE_DESCRIPTION = "score of the fused hybrid query as round 2 returned it, computed from:";
 
     /**
      * What round 2 will be told, per document key, in leg order. Empty for an unexplained request, and absent for a

--- a/src/main/java/org/opensearch/neuralsearch/search/explain/FusedExplanationMerger.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/explain/FusedExplanationMerger.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.explain;
+
+import java.util.Objects;
+
+import org.apache.lucene.search.Explanation;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchHit;
+
+/**
+ * Coordinator-side {@code explain} for a fused ({@code fusion}) hybrid query: replaces each returned hit's explanation
+ * with the fused breakdown the rewrite collected.
+ *
+ * <p>Request-scoped, and the exact counterpart of {@code FusedLegProfileMerger}: created by
+ * {@code HybridQuerySearchRequestFilter}, handed to the fused {@code hybrid} the request asks about, filled in by the leg
+ * fan-out callback, read once when the response comes back. It needs no search pipeline and no pipeline component —
+ * {@code hybrid_score_explanation} cannot serve this path at all, because it reads its input from a
+ * {@code PipelineProcessingContext} attribute that only a phase-results processor writes, and fused mode has no
+ * phase-results processor and no handle on that context from the rewrite.
+ *
+ * <p>Round 2's own explanation is what gets replaced. It is not wrong — the {@code constant_score} clause carries the
+ * fused score, so the number matches — but it describes the query the rewrite <b>substituted</b> rather than the hybrid
+ * the user wrote, so on its own it reads as if an {@code _id} lookup had produced the ranking. A document round 2
+ * returned that fusion never ranked (one the Tail surfaced, at {@code 0.0}) keeps its own explanation untouched: it
+ * truthfully says the document matched a non-scoring clause, and there is no fused breakdown to put there.
+ *
+ * <p>Unlike classic hybrid's response processor this correlates by document identity — {@code _index} plus {@code _id},
+ * the same key fusion ranks by — rather than by position within a shard's hit list, so it needs no per-shard counter, no
+ * detail-count assertion and no descent past core-inserted wrapper queries.
+ *
+ * <p>Published on the leg MultiSearch response thread and read on the response-listener thread; the reference is
+ * {@code volatile} for that hand-off. The two are ordered anyway by the rewrite completing before the search phases
+ * start, so what is read is always what was collected.
+ */
+public final class FusedExplanationMerger {
+
+    /** What the rewrite collected, or {@code null} until it publishes (and for a request that collected nothing). */
+    private volatile FusedDocExplanations explanations;
+
+    /** A handle for the one fused hybrid this merger describes, handed to its {@code HybridQueryBuilder}. */
+    public interface FusedExplanationConsumer {
+        void accept(FusedDocExplanations collected);
+    }
+
+    /** The consumer to attach to the fused hybrid. Nothing collected means nothing published, and the response is untouched. */
+    public FusedExplanationConsumer consumer() {
+        return collected -> {
+            if (Objects.isNull(collected) || collected.isEmpty()) {
+                return;
+            }
+            explanations = collected;
+        };
+    }
+
+    public boolean isEmpty() {
+        return Objects.isNull(explanations) || explanations.isEmpty();
+    }
+
+    /**
+     * The response with every ranked hit's explanation replaced by its fused breakdown, or the response itself when
+     * nothing was collected.
+     *
+     * <p>Hits are mutated in place rather than rebuilt: {@code SearchHit#explanation(Explanation)} is a public setter
+     * that core's own fetch phase uses, and the hits reachable here are the response's own, so there is no copy to keep
+     * in sync. That is also how classic hybrid's {@code ExplanationResponseProcessor} writes its tree.
+     */
+    public SearchResponse getMergedResponse(final SearchResponse response) {
+        if (isEmpty() || Objects.isNull(response.getHits())) {
+            return response;
+        }
+        SearchHit[] hits = response.getHits().getHits();
+        if (Objects.isNull(hits)) {
+            return response;
+        }
+        FusedDocExplanations collected = explanations;
+        for (SearchHit hit : hits) {
+            if (Objects.isNull(hit.getIndex()) || Objects.isNull(hit.getId())) {
+                continue;
+            }
+            String key = FusedDocExplanations.documentKey(hit.getIndex(), hit.getId());
+            // The hit's score is handed over as it is, NaN included: a request that sorts without tracking scores has no
+            // final score for the tree to describe, and {@link FusedDocExplanations#explain} is what decides that.
+            Explanation fused = collected.explain(key, hit.getScore());
+            if (Objects.nonNull(fused)) {
+                hit.explanation(fused);
+            }
+        }
+        return response;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/CandidateScopeTests.java
@@ -251,6 +251,27 @@ public class CandidateScopeTests extends OpenSearchTestCase {
         );
     }
 
+    /**
+     * {@code explain} is the second OVERRIDDEN field fused mode decides after the scope is captured, and for the same
+     * reason as {@code profile}: the request's own flag never reaches a leg, and a leg runs explained only because the
+     * rewrite has a {@code FusedDocExplanations} to keep its explanations in. Inheriting the flag instead would make every
+     * leg of every explained request pay explanation's per-hit cost on the shards with nowhere for the result to go.
+     */
+    public void testExplainReachesALegOnlyWhenFusedModeAsksForIt() {
+        CandidateScope inherited = CandidateScope.from(new SearchRequest(INDEX).source(new SearchSourceBuilder().explain(true)));
+
+        assertNull("the outer explain flag is not inherited", inherited.newLegRequest(LEG, 50).source().explain());
+
+        CandidateScope enabled = CandidateScope.from(new SearchRequest(INDEX));
+        enabled.enableLegExplain();
+
+        assertEquals(
+            "fused mode explains the legs itself, so each one describes the raw score it contributed",
+            Boolean.TRUE,
+            enabled.newLegRequest(LEG, 50).source().explain()
+        );
+    }
+
     // ---- REJECTED: shapes fused mode cannot answer correctly, refused before the fan-out ----
 
     public void testRejectsTerminateAfter() {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
@@ -34,6 +35,8 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.neuralsearch.processor.normalization.RRFScoreNormalizer;
+import org.opensearch.neuralsearch.search.explain.FusedDocExplanations;
+import org.opensearch.neuralsearch.search.profile.FusedCoordinatorTimings;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -105,6 +108,39 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         hit.score(score);
         hit.shard(new SearchShardTarget("node-1", new ShardId(new Index(index, index + "-uuid"), 0), null, OriginalIndices.NONE));
         return hit;
+    }
+
+    /**
+     * A leg that ran with {@code explain: true}: every hit carries the leg's own explanation of its raw score, which is
+     * what the fan-out records and the response side nests under the normalized value. Insertion-ordered so the recorded
+     * leg order is deterministic.
+     */
+    private MultiSearchResponse.Item explainedLegItem(LinkedHashMap<String, Float> idToScore) {
+        SearchHit[] hits = new SearchHit[idToScore.size()];
+        int i = 0;
+        for (Map.Entry<String, Float> e : idToScore.entrySet()) {
+            hits[i] = hitFrom(i, INDEX, e.getKey(), e.getValue());
+            hits[i].explanation(Explanation.match(e.getValue(), "leg raw score"));
+            i++;
+        }
+        return successfulItem(hits);
+    }
+
+    /**
+     * The fused score each Top clause carries, keyed by the {@code _id} it addresses — read off the query rather than
+     * assumed from the input, so an assertion about "the score round 2 ranks by" is about the query round 2 will run.
+     */
+    private Map<String, Float> fusedScoresById(QueryBuilder fused) {
+        Map<String, Float> byId = new LinkedHashMap<>();
+        for (QueryBuilder clause : ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().should()) {
+            ConstantScoreQueryBuilder top = (ConstantScoreQueryBuilder) clause;
+            for (QueryBuilder filter : ((BoolQueryBuilder) top.innerQuery()).filter()) {
+                if (filter instanceof IdsQueryBuilder ids) {
+                    byId.put(ids.ids().iterator().next(), top.boost());
+                }
+            }
+        }
+        return byId;
     }
 
     /**
@@ -694,6 +730,166 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(source, ms, legs, minMaxArithmetic(), 10);
 
         assertEquals("explain alone → no Tail", 0, ((HybridFusionQueryBuilder) fused).buildSelfErasedQuery().filter().size());
+    }
+
+    // ---- buildFusedQuery: the per-leg breakdown recorded for the request's `explain` ----
+
+    /**
+     * The contract of the recorded breakdown: one entry per document fusion ranked, one node per leg that matched it,
+     * that leg's own round-1 explanation kept under its normalized value, and a top value equal to the score round 2 will
+     * actually rank the document by. The last part is what makes the tree an account of the ranking rather than a
+     * plausible-looking set of numbers beside it.
+     */
+    public void testBuildFusedQuery_whenLegsRanExplained_thenEveryRankedDocumentIsRecorded() {
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(
+            explainedLegItem(new LinkedHashMap<>(Map.of("1", 0.9f))),
+            explainedLegItem(new LinkedHashMap<>(Map.of("1", 0.6f)))
+        );
+        FusedDocExplanations explanations = new FusedDocExplanations();
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().trackTotalHits(false).explain(true),
+            ms,
+            legs,
+            minMaxArithmetic(),
+            10,
+            new FusedCoordinatorTimings(),
+            explanations
+        );
+
+        assertFalse("an explained fan-out records what it fused", explanations.isEmpty());
+        assertEquals(
+            "the wording is the combination technique's own",
+            "arithmetic_mean combination of:",
+            explanations.combinationDescription()
+        );
+        assertEquals("and the normalizer's own", "min_max normalization of:", explanations.normalizationDescription());
+
+        Explanation tree = explanations.explain(FusedDocExplanations.documentKey(INDEX, "1"), Float.NaN);
+        assertNotNull("the one ranked document is described", tree);
+        assertEquals("one node per leg that matched", 2, tree.getDetails().length);
+        for (int leg = 0; leg < 2; leg++) {
+            Explanation legNode = tree.getDetails()[leg];
+            assertEquals("min_max normalization of:", legNode.getDescription());
+            assertEquals("the leg's own explanation is kept under its normalized value", 1, legNode.getDetails().length);
+            assertEquals("leg raw score", legNode.getDetails()[0].getDescription());
+        }
+        assertEquals(
+            "the described score is the one round 2 ranks by",
+            fusedScoresById(fused).get("1"),
+            tree.getValue().floatValue(),
+            0.0f
+        );
+    }
+
+    /**
+     * A leg that did not match a document contributes no node rather than a zero one — the same choice classic hybrid
+     * makes. A zero node would read as "this leg scored it at zero" when the leg never saw it.
+     */
+    public void testBuildFusedQuery_whenALegDidNotMatchADocument_thenOnlyTheMatchingLegsAreRecorded() {
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        // Only document 2 is in both legs; 1 is leg 0's alone and 3 is leg 1's alone.
+        MultiSearchResponse ms = multiSearch(
+            explainedLegItem(new LinkedHashMap<>(Map.of("1", 0.9f, "2", 0.5f))),
+            explainedLegItem(new LinkedHashMap<>(Map.of("2", 0.8f, "3", 0.4f)))
+        );
+        FusedDocExplanations explanations = new FusedDocExplanations();
+
+        HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().trackTotalHits(false).explain(true),
+            ms,
+            legs,
+            minMaxArithmetic(),
+            10,
+            new FusedCoordinatorTimings(),
+            explanations
+        );
+
+        assertEquals(
+            "the document both legs matched keeps both nodes",
+            2,
+            explanations.explain(FusedDocExplanations.documentKey(INDEX, "2"), Float.NaN).getDetails().length
+        );
+        assertEquals(
+            "a document only leg 0 matched gets one node, not two with a zero",
+            1,
+            explanations.explain(FusedDocExplanations.documentKey(INDEX, "1"), Float.NaN).getDetails().length
+        );
+        assertEquals(
+            "and likewise for one only the last leg matched",
+            1,
+            explanations.explain(FusedDocExplanations.documentKey(INDEX, "3"), Float.NaN).getDetails().length
+        );
+    }
+
+    /**
+     * Recording happens after the window cut, so what is described is exactly what round 2 will rank. A document the
+     * window dropped has no Top clause to carry a fused score, so describing it would name a ranking that never happened.
+     */
+    public void testBuildFusedQuery_whenTheWindowDroppedADocument_thenOnlyTheWindowIsRecorded() {
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"));
+        MultiSearchResponse ms = multiSearch(explainedLegItem(new LinkedHashMap<>(Map.of("1", 0.9f, "2", 0.5f, "3", 0.1f))));
+        FusedDocExplanations explanations = new FusedDocExplanations();
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().trackTotalHits(false).explain(true),
+            ms,
+            legs,
+            minMaxArithmetic(),
+            1,
+            new FusedCoordinatorTimings(),
+            explanations
+        );
+
+        Map<String, Float> ranked = fusedScoresById(fused);
+        assertEquals("window=1 ranks one document", 1, ranked.size());
+        String rankedId = ranked.keySet().iterator().next();
+        assertNotNull(
+            "the ranked document is described",
+            explanations.explain(FusedDocExplanations.documentKey(INDEX, rankedId), Float.NaN)
+        );
+        for (String dropped : List.of("1", "2", "3")) {
+            if (dropped.equals(rankedId)) {
+                continue;
+            }
+            assertNull(
+                "a document the window dropped has no fused score to describe",
+                explanations.explain(FusedDocExplanations.documentKey(INDEX, dropped), Float.NaN)
+            );
+        }
+    }
+
+    /**
+     * The cost of the always-constructed collector on the path that never asks for it. An unexplained request's legs return
+     * hits with no explanation, so nothing is recorded and nothing about the fused query changes — which is what makes the
+     * explained and unexplained runs compute the same ranking rather than two code paths that agree by inspection.
+     */
+    public void testBuildFusedQuery_whenLegsRanUnexplained_thenNothingIsRecorded() {
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        SearchSourceBuilder source = new SearchSourceBuilder().trackTotalHits(false);
+        FusedDocExplanations explanations = new FusedDocExplanations();
+
+        QueryBuilder recorded = HybridFusionOrchestrator.buildFusedQuery(
+            source,
+            multiSearch(legItem(Map.of("1", 0.9f, "2", 0.5f)), legItem(Map.of("2", 0.8f))),
+            legs,
+            minMaxArithmetic(),
+            10,
+            new FusedCoordinatorTimings(),
+            explanations
+        );
+        QueryBuilder plain = HybridFusionOrchestrator.buildFusedQuery(
+            source,
+            multiSearch(legItem(Map.of("1", 0.9f, "2", 0.5f)), legItem(Map.of("2", 0.8f))),
+            legs,
+            minMaxArithmetic(),
+            10
+        );
+
+        assertTrue("legs that ran unexplained have nothing to record", explanations.isEmpty());
+        assertNull("so no document gets a tree", explanations.combinationDescription());
+        assertEquals("and the fused query is the one the overload without a collector builds", plain, recorded);
     }
 
     public void testBuildFusedQuery_profileDoesNotTriggerTail() {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -776,7 +776,8 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
             assertEquals("leg raw score", legNode.getDetails()[0].getDescription());
         }
         assertEquals(
-            "the described score is the one round 2 ranks by",
+            "the described score is the one fusion computed, which for an undegenerate document is also the one round 2 "
+                + "ranks by (see the floored case below, where the two differ)",
             fusedScoresById(fused).get("1"),
             tree.getValue().floatValue(),
             0.0f
@@ -1228,6 +1229,56 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
         assertAddressedTo(((ConstantScoreQueryBuilder) self.should().get(3)).innerQuery(), INDEX, "4");
         assertEquals(HybridFusionOrchestrator.MIN_RANKED_SCORE, topClause(fused, 2).boost(), 0.0f);
         assertEquals(HybridFusionOrchestrator.MIN_RANKED_SCORE, topClause(fused, 3).boost(), 0.0f);
+    }
+
+    /**
+     * The combination node has to report the score fusion computed, not the floored score round 2 ranks by. Same input as
+     * the test above, run explained: documents 3 and 4 matched only the zero-weighted leg, so fusion produced exactly
+     * {@code 0.0} for them while their Top clause carries {@link HybridFusionOrchestrator#MIN_RANKED_SCORE}. Recording the
+     * floored value instead would label the combination node {@code 1e-30} over children that combine to {@code 0.0}, and
+     * because the hit's score is that same {@code 1e-30} the wrapper naming the floor would be suppressed
+     * ({@code FusedDocExplanations#explain} returns the combination node bare when the two agree) — so the tree would
+     * claim a number its own children do not produce, with nothing pointing at the floor.
+     *
+     * <p>The single rendered child is the caveat the fix does not remove: the zero-weighted leg's slot still counted its
+     * weight into the combiner's divisor while rendering no node, so the parent is deliberately not the mean of what is
+     * shown. Classic renders a partially-matched document the same way.
+     */
+    public void testBuildFusedQuery_whenAZeroFusedScoreIsFloored_thenTheCombinationNodeKeepsTheComputedScore() {
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(
+            explainedLegItem(new LinkedHashMap<>(Map.of("1", 5.0f, "2", 3.0f))),
+            explainedLegItem(new LinkedHashMap<>(Map.of("3", 7.0f, "4", 2.0f)))
+        );
+        FusedDocExplanations explanations = new FusedDocExplanations();
+
+        QueryBuilder fused = HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().explain(true),
+            ms,
+            legs,
+            minMaxWeighted(1.0f, 0.0f),
+            10,
+            new FusedCoordinatorTimings(),
+            explanations
+        );
+
+        // Round 2 ranks document 3 by the floored score: that is what its Top clause boost carries.
+        assertEquals(HybridFusionOrchestrator.MIN_RANKED_SCORE, fusedScoresById(fused).get("3"), 0.0f);
+
+        Explanation tree = explanations.explain(FusedDocExplanations.documentKey(INDEX, "3"), HybridFusionOrchestrator.MIN_RANKED_SCORE);
+        assertNotNull("the document is in the window, so it is described", tree);
+        assertEquals(
+            "the floor moved the score, so the top node names what round 2 returned rather than relabelling the combination",
+            "score of the fused hybrid query as round 2 returned it, computed from:",
+            tree.getDescription()
+        );
+        assertEquals(HybridFusionOrchestrator.MIN_RANKED_SCORE, tree.getValue().floatValue(), 0.0f);
+
+        assertEquals("the combination is its only child", 1, tree.getDetails().length);
+        Explanation combination = tree.getDetails()[0];
+        assertEquals(explanations.combinationDescription(), combination.getDescription());
+        assertEquals("the combination node reports what fusion computed, not the floor", 0.0f, combination.getValue().floatValue(), 0.0f);
+        assertEquals("only the leg that matched is rendered", 1, combination.getDetails().length);
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -1013,6 +1013,15 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         return legItem(idToScore, null);
     }
 
+    /** The same, with every hit carrying the leg's own explanation, as a leg run with {@code explain: true} returns. */
+    private org.opensearch.action.search.MultiSearchResponse.Item explainedLegItem(Map<String, Float> idToScore) {
+        org.opensearch.action.search.MultiSearchResponse.Item item = legItem(idToScore, null);
+        for (org.opensearch.search.SearchHit hit : item.getResponse().getHits().getHits()) {
+            hit.explanation(org.apache.lucene.search.Explanation.match(hit.getScore(), "leg raw score"));
+        }
+        return item;
+    }
+
     /** The same, carrying a profile section, as a leg run with {@code profile: true} does. */
     private org.opensearch.action.search.MultiSearchResponse.Item legItem(
         Map<String, Float> idToScore,
@@ -1158,6 +1167,106 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertEquals("every leg that answered publishes, keyed by its own index", Set.of(0, 1), published.keySet());
         assertEquals(Set.of("leg-0-node"), published.get(0).keySet());
         assertEquals(Set.of("leg-1-node"), published.get(1).keySet());
+    }
+
+    /**
+     * The {@code explain} counterpart, and the same two obligations: with a consumer attached the legs have to run
+     * explained, and what the fan-out collected has to be published — but only once the fused query is built, since what
+     * the tree describes has to be what round 2 will rank.
+     */
+    @SneakyThrows
+    public void testDoRewriteFused_whenExplanationConsumerAttached_thenLegsRunExplainedAndPublishTheirBreakdowns() {
+        initClusterUtilWithMaxResultWindow(10000);
+        HybridQueryBuilder builder = fusedBuilder(
+            new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"), "combination", Map.of("technique", "arithmetic_mean")))
+        );
+        java.util.concurrent.atomic.AtomicReference<org.opensearch.neuralsearch.search.explain.FusedDocExplanations> published =
+            new java.util.concurrent.atomic.AtomicReference<>();
+        builder.fusedExplanationConsumer(published::set);
+        QueryCoordinatorContext ctx = coordinatorContextFor(builder);
+
+        java.util.concurrent.atomic.AtomicReference<
+            java.util.function.BiConsumer<org.opensearch.transport.client.Client, org.opensearch.core.action.ActionListener<?>>> captured =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        doAnswer(invocation -> {
+            captured.set(invocation.getArgument(0));
+            return null;
+        }).when(ctx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
+
+        builder.doRewrite(ctx);
+
+        org.opensearch.transport.client.Client client = mock(org.opensearch.transport.client.Client.class);
+        org.opensearch.action.search.MultiSearchResponse msResponse = new org.opensearch.action.search.MultiSearchResponse(
+            new org.opensearch.action.search.MultiSearchResponse.Item[] {
+                explainedLegItem(Map.of("1", 0.9f, "2", 0.5f)),
+                explainedLegItem(Map.of("2", 0.8f, "3", 0.4f)) },
+            10L
+        );
+        java.util.concurrent.atomic.AtomicReference<org.opensearch.action.search.MultiSearchRequest> legRequests =
+            new java.util.concurrent.atomic.AtomicReference<>();
+        doAnswer(invocation -> {
+            legRequests.set(invocation.getArgument(0));
+            org.opensearch.core.action.ActionListener<org.opensearch.action.search.MultiSearchResponse> l = invocation.getArgument(1);
+            l.onResponse(msResponse);
+            return null;
+        }).when(client).multiSearch(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+        java.util.concurrent.atomic.AtomicBoolean done = new java.util.concurrent.atomic.AtomicBoolean();
+        captured.get().accept(client, org.opensearch.core.action.ActionListener.wrap(r -> done.set(true), e -> fail(e.getMessage())));
+        assertTrue("async action should complete", done.get());
+
+        for (SearchRequest legRequest : legRequests.get().requests()) {
+            assertEquals("a leg has to run explained for there to be a breakdown to publish", Boolean.TRUE, legRequest.source().explain());
+        }
+        assertNotNull("the collector is published once the window is final", published.get());
+        assertFalse(published.get().isEmpty());
+        assertNotNull(
+            "and it describes a document the legs actually ranked",
+            published.get()
+                .explain(org.opensearch.neuralsearch.search.explain.FusedDocExplanations.documentKey("test-index", "2"), Float.NaN)
+        );
+    }
+
+    /**
+     * With no consumer attached — every request that did not ask to be explained — the legs stay unexplained and nothing is
+     * published, so the collector the rewrite always constructs is simply discarded.
+     */
+    @SneakyThrows
+    public void testDoRewriteFused_whenNoExplanationConsumerAttached_thenLegsRunUnexplained() {
+        initClusterUtilWithMaxResultWindow(10000);
+        HybridQueryBuilder builder = fusedBuilder(new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"))));
+        QueryCoordinatorContext ctx = coordinatorContextFor(builder);
+
+        java.util.concurrent.atomic.AtomicReference<
+            java.util.function.BiConsumer<org.opensearch.transport.client.Client, org.opensearch.core.action.ActionListener<?>>> captured =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        doAnswer(invocation -> {
+            captured.set(invocation.getArgument(0));
+            return null;
+        }).when(ctx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
+
+        builder.doRewrite(ctx);
+
+        org.opensearch.transport.client.Client client = mock(org.opensearch.transport.client.Client.class);
+        java.util.concurrent.atomic.AtomicReference<org.opensearch.action.search.MultiSearchRequest> legRequests =
+            new java.util.concurrent.atomic.AtomicReference<>();
+        doAnswer(invocation -> {
+            legRequests.set(invocation.getArgument(0));
+            org.opensearch.core.action.ActionListener<org.opensearch.action.search.MultiSearchResponse> l = invocation.getArgument(1);
+            l.onResponse(
+                new org.opensearch.action.search.MultiSearchResponse(
+                    new org.opensearch.action.search.MultiSearchResponse.Item[] { legItem(Map.of("1", 0.9f)), legItem(Map.of("2", 0.8f)) },
+                    10L
+                )
+            );
+            return null;
+        }).when(client).multiSearch(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+        java.util.concurrent.atomic.AtomicBoolean done = new java.util.concurrent.atomic.AtomicBoolean();
+        captured.get().accept(client, org.opensearch.core.action.ActionListener.wrap(r -> done.set(true), e -> fail(e.getMessage())));
+
+        assertTrue(done.get());
+        assertNull("no consumer, so no leg pays explanation's per-hit cost", legRequests.get().requests().get(0).source().explain());
     }
 
     /**

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeExplainIT.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.neuralsearch.BaseNeuralSearchIT;
+
+import lombok.SneakyThrows;
+
+/**
+ * End-to-end coverage of what {@code explain: true} reports for a fused ({@code fusion}) {@code hybrid} query.
+ *
+ * <p>A fused hybrid normalizes and combines on the coordinator and replaces itself with a {@code bool} over the fused
+ * window's {@code _id}s, so round 2's own explanation of a ranked hit is a childless {@code constant_score} carrying the
+ * fused score — the right number with nothing under it, and describing the query the rewrite substituted rather than the
+ * hybrid the user wrote. {@code FusedDocExplanations} keeps each leg's own round-1 explanation and the normalized value
+ * fusion derived from it, and {@code FusedExplanationMerger} rebuilds the tree on the response, correlating by
+ * {@code _index} plus {@code _id}.
+ *
+ * <p>Needs a live cluster for all of it: which nodes the tree has, what they are called, that the numbers agree with the
+ * scores the same request returns, that a document fusion never ranked is left alone, and that asking to be explained does
+ * not change the answer. The wording is asserted verbatim against classic hybrid's, since matching classic is the point —
+ * see the parity test.
+ *
+ * <p>Dataset: 6 documents, ids 1..6, each with the same text and a 2-dimensional vector, queried by two legs — a
+ * {@code knn} leg and a {@code term} leg that matches all six.
+ *
+ * <p>Run: {@code ./gradlew integTest --tests "*HybridQueryFusedModeExplainIT*"}.
+ */
+public class HybridQueryFusedModeExplainIT extends BaseNeuralSearchIT {
+
+    private static final String INDEX = "test-fused-explain";
+    private static final String NORM_PIPELINE = "fused-explain-norm-pipeline";
+    private static final String TEXT_FIELD = "text";
+    private static final String VECTOR_FIELD = "vec";
+    private static final int TOTAL_DOCS = 6;
+    private static final int WINDOW_SIZE = 10;
+
+    /** What the combination node is called, unweighted: classic's {@code ScoreCombiner} format over the technique's describe(). */
+    private static final String COMBINATION_DESCRIPTION = "arithmetic_mean combination of:";
+    /** What each per-leg node is called: classic's {@code ExplanationUtils} format over the normalization technique's name. */
+    private static final String NORMALIZATION_DESCRIPTION = "min_max normalization of:";
+    /** The node inserted above the combination when the score round 2 returned is not the fused score. */
+    private static final String FINAL_SCORE_DESCRIPTION = "score of the fused hybrid query after post-fusion scoring, computed from:";
+    /** Floats survive one JSON round trip exactly; the tolerance is for the arithmetic asserted across nodes. */
+    private static final double DELTA = 1e-5;
+
+    /**
+     * The shape of the tree on the flat case: one node per leg that matched, under one combination node whose value is the
+     * hit's score, with each leg's own round-1 explanation kept underneath it.
+     */
+    @SneakyThrows
+    public void testExplainedFusedHybrid_thenEveryLegIsDescribedUnderTheFusedScore() {
+        ensureDataset();
+
+        Map<String, Object> response = search(explained(fusedHybrid(knnLeg(WINDOW_SIZE), termLeg())));
+        List<Map<String, Object>> hits = hits(response);
+
+        assertEquals("both legs match every document", TOTAL_DOCS, hits.size());
+        for (Map<String, Object> hit : hits) {
+            Map<String, Object> explanation = explanationOf(hit);
+            assertEquals("the top node describes the fusion, not the substituted query", COMBINATION_DESCRIPTION, description(explanation));
+            assertEquals("and it carries the score the same request returned for this hit", score(hit), value(explanation), DELTA);
+            List<Map<String, Object>> legs = details(explanation);
+            assertEquals("one node per leg that matched: " + descriptions(legs), 2, legs.size());
+            for (Map<String, Object> leg : legs) {
+                assertEquals("each leg reports what normalization made of its score", NORMALIZATION_DESCRIPTION, description(leg));
+                assertTrue("min_max normalizes into [0, 1]: " + value(leg), value(leg) >= 0.0 && value(leg) <= 1.0);
+                List<Map<String, Object>> raw = details(leg);
+                assertEquals("and keeps the leg's own explanation of the raw score under it: " + descriptions(raw), 1, raw.size());
+            }
+            // The fused score is the mean of the two normalized values, which is what makes the tree an account of the
+            // number above it rather than a list of unrelated scores.
+            double mean = legs.stream().mapToDouble(this::value).average().orElseThrow();
+            assertEquals("the combination node is the combination of its children", mean, value(explanation), DELTA);
+        }
+    }
+
+    /**
+     * The one node of the tree the legs cannot describe: each leg's own explanation is the query the user wrote. A
+     * {@code term} leg names the field and term it scored, which is what the classic path shows too.
+     */
+    @SneakyThrows
+    public void testExplainedFusedHybrid_thenALegsOwnExplanationIsTheQueryTheUserWrote() {
+        ensureDataset();
+
+        Map<String, Object> response = search(explained(fusedHybrid(knnLeg(WINDOW_SIZE), termLeg())));
+        List<String> rawDescriptions = new ArrayList<>();
+        for (Map<String, Object> leg : details(explanationOf(hits(response).get(0)))) {
+            rawDescriptions.add(description(details(leg).get(0)));
+        }
+
+        assertEquals("one raw explanation per leg: " + rawDescriptions, 2, rawDescriptions.size());
+        assertTrue(
+            "one leg must be explained as the term query it is: " + rawDescriptions,
+            rawDescriptions.stream().anyMatch(description -> description.contains(TEXT_FIELD + ":hello"))
+        );
+        // Lucene explains an ANN match as the candidate set it came from ("within top N docs") rather than as a scored
+        // clause — a vector query has no term to attribute the score to. Asserted loosely for that reason: what matters is
+        // that the leg's own account of its raw score is what the tree carries, not which words Lucene chose for it.
+        assertTrue(
+            "and the other as the vector-candidate set it came from: " + rawDescriptions,
+            rawDescriptions.stream().anyMatch(description -> description.contains("docs"))
+        );
+    }
+
+    /**
+     * Weights are part of how the score was reached, so they belong in the description — same as classic, which renders them
+     * from the combination technique's own {@code describe()}.
+     */
+    @SneakyThrows
+    public void testExplainedWeightedFusedHybrid_thenTheWeightsAreNamed() {
+        ensureDataset();
+
+        Map<String, Object> response = search(explained(weightedFusedHybrid(knnLeg(WINDOW_SIZE), termLeg())));
+        Map<String, Object> explanation = explanationOf(hits(response).get(0));
+
+        assertEquals("arithmetic_mean, weights [0.7, 0.3] combination of:", description(explanation));
+        List<Map<String, Object>> legs = details(explanation);
+        assertEquals(
+            "the weights are applied to the values the children report, not folded into them",
+            0.7 * value(legs.get(0)) + 0.3 * value(legs.get(1)),
+            value(explanation),
+            DELTA
+        );
+    }
+
+    /**
+     * A document only one leg matched. {@code k=2} bounds the ANN leg to two candidates, so the other four documents reach
+     * fusion through the {@code term} leg alone — and the tree names one leg, exactly as classic does for a document only
+     * one sub-query matched.
+     */
+    @SneakyThrows
+    public void testExplainedFusedHybrid_whenALegDidNotMatch_thenOnlyTheMatchingLegsAreNamed() {
+        ensureDataset();
+
+        Map<String, Object> response = search(explained(fusedHybrid(knnLeg(2), termLeg())));
+        List<Integer> legCounts = new ArrayList<>();
+        for (Map<String, Object> hit : hits(response)) {
+            legCounts.add(details(explanationOf(hit)).size());
+        }
+
+        assertEquals("every document is still ranked and described", TOTAL_DOCS, legCounts.size());
+        assertEquals("the two ANN candidates are described by both legs", 2, legCounts.stream().filter(count -> count == 2).count());
+        assertEquals("the other four by the term leg alone", 4, legCounts.stream().filter(count -> count == 1).count());
+    }
+
+    /**
+     * A {@code rescore} moves the score after fusion — the one way a fused hit's score can differ from its fused score, since
+     * the {@code hybrid} query rejects {@code boost} at parse time. The fused combination can then no longer be the top node:
+     * relabelling it with the final score would claim the fusion produced a number it did not. It becomes a child of a node
+     * that names the final score instead.
+     */
+    @SneakyThrows
+    public void testExplainedRescoredFusedHybrid_thenTheFusedScoreIsNestedUnderTheFinalScore() {
+        ensureDataset();
+
+        Map<String, Object> response = search(rescored(fusedHybrid(knnLeg(WINDOW_SIZE), termLeg())));
+        Map<String, Object> hit = hits(response).get(0);
+        Map<String, Object> explanation = explanationOf(hit);
+
+        assertEquals("the top node describes the score the hit actually has", FINAL_SCORE_DESCRIPTION, description(explanation));
+        assertEquals(score(hit), value(explanation), DELTA);
+        List<Map<String, Object>> children = details(explanation);
+        assertEquals("with the fusion underneath it: " + descriptions(children), 1, children.size());
+        assertEquals(COMBINATION_DESCRIPTION, description(children.get(0)));
+        assertTrue(
+            "the rescore is what stands between them: " + value(children.get(0)) + " -> " + value(explanation),
+            value(explanation) > value(children.get(0))
+        );
+    }
+
+    /**
+     * A request that sorts without tracking scores: the hits come back with no score at all, so there is no final score for
+     * the tree to describe and the fusion is reported on its own. The fused score is still the fused score — a node claiming
+     * a final score of zero would describe a number nothing computed.
+     */
+    @SneakyThrows
+    public void testExplainedFusedHybrid_whenScoresAreNotTracked_thenTheFusionIsReportedOnItsOwn() {
+        ensureDataset();
+
+        Map<String, Object> response = search(
+            "{\"query\":"
+                + fusedHybrid(knnLeg(WINDOW_SIZE), termLeg())
+                + ",\"explain\":true,\"sort\":[\"_doc\"],\"size\":"
+                + (TOTAL_DOCS + 1)
+                + "}"
+        );
+        List<Map<String, Object>> hits = hits(response);
+
+        assertEquals(TOTAL_DOCS, hits.size());
+        for (Map<String, Object> hit : hits) {
+            assertNull("sorting without track_scores leaves the hit unscored", hit.get("_score"));
+            Map<String, Object> explanation = explanationOf(hit);
+            assertEquals(
+                "the fusion is the whole tree, with nothing above it: " + description(explanation),
+                COMBINATION_DESCRIPTION,
+                description(explanation)
+            );
+            assertTrue("and it still reports what fusion computed", value(explanation) > 0.0);
+        }
+    }
+
+    /**
+     * A document round 2 returned that fusion never ranked — one the Tail surfaced beyond the window. There is no fused
+     * breakdown to put there, and round 2's own explanation is truthful: the document matched a non-scoring clause. So it is
+     * left alone, which is also what makes "explained" a property of the window rather than of the response.
+     */
+    @SneakyThrows
+    public void testExplainedFusedHybrid_whenTheTailSurfacesADocumentBeyondTheWindow_thenItKeepsItsOwnExplanation() {
+        ensureDataset();
+
+        Map<String, Object> response = search(explained(fusedHybridWithWindow(2, knnLeg(WINDOW_SIZE), termLeg())));
+        List<Map<String, Object>> hits = hits(response);
+
+        assertEquals("the Tail surfaces the whole match set", TOTAL_DOCS, hits.size());
+        List<String> fused = new ArrayList<>();
+        List<String> untouched = new ArrayList<>();
+        for (Map<String, Object> hit : hits) {
+            String id = String.valueOf(hit.get("_id"));
+            if (COMBINATION_DESCRIPTION.equals(description(explanationOf(hit)))) {
+                fused.add(id);
+            } else {
+                untouched.add(id);
+            }
+        }
+
+        assertEquals("only the window is described as fused: " + fused, 2, fused.size());
+        assertEquals("and the rest keep round 2's own explanation: " + untouched, TOTAL_DOCS - 2, untouched.size());
+        for (Map<String, Object> hit : hits) {
+            if (untouched.contains(String.valueOf(hit.get("_id")))) {
+                assertEquals("a document the Tail alone surfaced scores zero", 0.0, score(hit), DELTA);
+            }
+        }
+    }
+
+    /**
+     * Parity with classic hybrid, which is the reason the wording is not ours to choose: a fused hybrid and a classic hybrid
+     * over the same two sub-queries, with the same normalization and combination, must describe the fusion in the same words.
+     * Classic renders it from a search pipeline ({@code hybrid_score_explanation}); fused renders it with no pipeline at all.
+     */
+    @SneakyThrows
+    public void testExplainedFusedHybrid_thenTheWordingMatchesClassicHybrid() {
+        ensureDataset();
+
+        Map<String, Object> fused = search(explained(fusedHybrid(knnLeg(WINDOW_SIZE), termLeg())));
+        Map<String, Object> classic = search(explained(classicHybrid()), EXPLAIN_PIPELINE);
+
+        List<String> classicDescriptions = new ArrayList<>();
+        collectDescriptions(explanationOf(hits(classic).get(0)), classicDescriptions);
+        assertTrue(
+            "classic must describe the combination the same way: " + classicDescriptions,
+            classicDescriptions.contains(COMBINATION_DESCRIPTION)
+        );
+        assertTrue("and the normalization the same way: " + classicDescriptions, classicDescriptions.contains(NORMALIZATION_DESCRIPTION));
+        assertEquals("which is what the fused tree is built from", COMBINATION_DESCRIPTION, description(explanationOf(hits(fused).get(0))));
+    }
+
+    /**
+     * A fused hybrid nested inside a container. The hit's score is the enclosing query's, not the hybrid's, so replacing the
+     * whole tree with the fusion would describe the wrong number — the request keeps core's own explanation, which correctly
+     * describes the query round 2 ran.
+     */
+    @SneakyThrows
+    public void testExplainedNestedFusedHybrid_thenCoreExplanationIsKept() {
+        ensureDataset();
+
+        String nested = "{\"bool\":{\"must\":[" + fusedHybrid(knnLeg(WINDOW_SIZE), termLeg()) + "]}}";
+        Map<String, Object> response = search(explained(nested));
+
+        List<String> descriptions = new ArrayList<>();
+        for (Map<String, Object> hit : hits(response)) {
+            collectDescriptions(explanationOf(hit), descriptions);
+        }
+        assertFalse("no hit may be described as if the hybrid were its whole score: " + descriptions, descriptions.isEmpty());
+        assertFalse(
+            "a nested fused hybrid contributes to the score rather than being it: " + descriptions,
+            descriptions.contains(COMBINATION_DESCRIPTION)
+        );
+    }
+
+    /**
+     * The control, and the claim that matters most: explaining a fused hybrid runs its legs explained, which is a different
+     * execution — so the answer is measured with and without it. An unexplained request also gets no explanations at all.
+     */
+    @SneakyThrows
+    public void testFusedHybrid_whenExplained_thenRankingAndTotalsAreUnchanged() {
+        ensureDataset();
+        String query = fusedHybrid(knnLeg(WINDOW_SIZE), termLeg());
+
+        Map<String, Object> plain = search("{\"query\":" + query + ",\"track_total_hits\":true}");
+        Map<String, Object> explained = search(explained(query));
+
+        assertTrue(
+            "an unexplained request carries no explanations",
+            hits(plain).stream().noneMatch(hit -> Objects.nonNull(hit.get("_explanation")))
+        );
+        assertTrue(
+            "an explained one carries them on every ranked hit",
+            hits(explained).stream().allMatch(hit -> Objects.nonNull(hit.get("_explanation")))
+        );
+        assertEquals("explaining the legs must not change the fused ranking or the scores", rankedHits(plain), rankedHits(explained));
+        assertEquals("explaining the legs must not change the totals", totalHits(plain), totalHits(explained));
+    }
+
+    // ------------------------------------------------ request bodies ------------------------------------------------
+
+    private String knnLeg(final int k) {
+        return "{\"knn\":{\"" + VECTOR_FIELD + "\":{\"vector\":[1.1,1.0],\"k\":" + k + "}}}";
+    }
+
+    private String termLeg() {
+        return "{\"term\":{\"" + TEXT_FIELD + "\":\"hello\"}}";
+    }
+
+    private String fusedHybrid(final String... legs) {
+        return fusedHybridWithWindow(WINDOW_SIZE, legs);
+    }
+
+    private String fusedHybridWithWindow(final int windowSize, final String... legs) {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + windowSize
+            + ",\"normalization\":{\"technique\":\"min_max\"},\"combination\":{\"technique\":\"arithmetic_mean\"}},"
+            + "\"queries\":["
+            + String.join(",", legs)
+            + "]}}";
+    }
+
+    private String weightedFusedHybrid(final String... legs) {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\",\"parameters\":{\"weights\":[0.7,0.3]}}},"
+            + "\"queries\":["
+            + String.join(",", legs)
+            + "]}}";
+    }
+
+    /** The fused hybrid, then a rescore that adds a term score on top of the fused one — so the hit's score is not the fused score. */
+    private String rescored(final String query) {
+        return "{\"query\":"
+            + query
+            + ",\"explain\":true,\"track_total_hits\":true,\"size\":"
+            + (TOTAL_DOCS + 1)
+            + ",\"rescore\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"query\":{\"rescore_query\":"
+            + termLeg()
+            + ",\"query_weight\":1.0,\"rescore_query_weight\":2.0}}}";
+    }
+
+    /** The same two legs with no {@code fusion} block: classic hybrid, normalized and explained by a search pipeline. */
+    private String classicHybrid() {
+        return "{\"hybrid\":{\"queries\":[" + knnLeg(WINDOW_SIZE) + "," + termLeg() + "]}}";
+    }
+
+    private String explained(final String query) {
+        return "{\"query\":" + query + ",\"explain\":true,\"track_total_hits\":true,\"size\":" + (TOTAL_DOCS + 1) + "}";
+    }
+
+    // --------------------------------------------- explanation parsing ----------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> explanationOf(final Map<String, Object> hit) {
+        Map<String, Object> explanation = (Map<String, Object>) hit.get("_explanation");
+        assertNotNull("the request asked to be explained and hit " + hit.get("_id") + " carries no explanation", explanation);
+        return explanation;
+    }
+
+    private String description(final Map<String, Object> node) {
+        return String.valueOf(node.get("description"));
+    }
+
+    private double value(final Map<String, Object> node) {
+        return ((Number) node.get("value")).doubleValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> details(final Map<String, Object> node) {
+        List<Map<String, Object>> details = (List<Map<String, Object>>) node.get("details");
+        return Objects.isNull(details) ? List.of() : details;
+    }
+
+    private List<String> descriptions(final List<Map<String, Object>> nodes) {
+        return nodes.stream().map(this::description).toList();
+    }
+
+    /** Every description in a tree, depth first — for asserting that a wording appears (or does not) at any depth. */
+    private void collectDescriptions(final Map<String, Object> node, final List<String> into) {
+        into.add(description(node));
+        for (Map<String, Object> child : details(node)) {
+            collectDescriptions(child, into);
+        }
+    }
+
+    // -------------------------------------------------- dataset -----------------------------------------------------
+
+    /** The classic hybrid's pipeline: the same normalization and combination, plus the response processor that explains it. */
+    private static final String EXPLAIN_PIPELINE = "fused-explain-classic-pipeline";
+
+    private String indexConfig() {
+        return "{\"settings\":{\"index\":{\"knn\":true,\"number_of_shards\":1,\"number_of_replicas\":0,"
+            + "\"search.default_pipeline\":\""
+            + NORM_PIPELINE
+            + "\"}},\"mappings\":{\"properties\":{\""
+            + TEXT_FIELD
+            + "\":{\"type\":\"text\"},\""
+            + VECTOR_FIELD
+            + "\":{\"type\":\"knn_vector\",\"dimension\":2,"
+            + "\"method\":{\"name\":\"hnsw\",\"space_type\":\"l2\",\"engine\":\"lucene\"}}}}}";
+    }
+
+    @SneakyThrows
+    private void ensureDataset() {
+        createSearchPipeline(NORM_PIPELINE, "min_max", "arithmetic_mean", Map.of());
+        createSearchPipeline(EXPLAIN_PIPELINE, "min_max", Map.of(), "arithmetic_mean", Map.of(), true);
+        if (indexExists(INDEX)) {
+            return;
+        }
+        createIndex(INDEX, indexConfig());
+        for (int id = 1; id <= TOTAL_DOCS; id++) {
+            Request request = new Request("PUT", "/" + INDEX + "/_doc/" + id + "?refresh=true");
+            request.setJsonEntity(
+                "{\"" + TEXT_FIELD + "\":\"hello world document " + id + "\",\"" + VECTOR_FIELD + "\":[1." + id + ",1.0]}"
+            );
+            Response response = client().performRequest(request);
+            int code = response.getStatusLine().getStatusCode();
+            assertTrue(
+                "indexing " + INDEX + "/" + id + " failed: " + code,
+                code == RestStatus.OK.getStatus() || code == RestStatus.CREATED.getStatus()
+            );
+        }
+    }
+
+    private Map<String, Object> search(final String jsonBody) {
+        return search(jsonBody, null);
+    }
+
+    @SneakyThrows
+    private Map<String, Object> search(final String jsonBody, final String pipeline) {
+        String endpoint = "/" + INDEX + "/_search" + (Objects.isNull(pipeline) ? "" : "?search_pipeline=" + pipeline);
+        Request request = new Request("POST", endpoint);
+        request.setJsonEntity(jsonBody);
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        return XContentHelper.convertToMap(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()), false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> hits(final Map<String, Object> response) {
+        Map<String, Object> hits = (Map<String, Object>) response.get("hits");
+        List<Map<String, Object>> hitList = (List<Map<String, Object>>) hits.get("hits");
+        return Objects.isNull(hitList) ? List.of() : hitList;
+    }
+
+    private double score(final Map<String, Object> hit) {
+        return ((Number) hit.get("_score")).doubleValue();
+    }
+
+    /** The hit list as {@code _id@_score}, which is both the ranking and the scores in one comparable value. */
+    private List<String> rankedHits(final Map<String, Object> response) {
+        List<String> ranked = new ArrayList<>();
+        for (Map<String, Object> hit : hits(response)) {
+            ranked.add(hit.get("_id") + "@" + hit.get("_score"));
+        }
+        return ranked;
+    }
+
+    @SuppressWarnings("unchecked")
+    private long totalHits(final Map<String, Object> response) {
+        Map<String, Object> hits = (Map<String, Object>) response.get("hits");
+        Map<String, Object> total = (Map<String, Object>) hits.get("total");
+        assertNotNull("track_total_hits was asked for", total);
+        return ((Number) total.get("value")).longValue();
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeExplainIT.java
@@ -53,7 +53,7 @@ public class HybridQueryFusedModeExplainIT extends BaseNeuralSearchIT {
     /** What each per-leg node is called: classic's {@code ExplanationUtils} format over the normalization technique's name. */
     private static final String NORMALIZATION_DESCRIPTION = "min_max normalization of:";
     /** The node inserted above the combination when the score round 2 returned is not the fused score. */
-    private static final String FINAL_SCORE_DESCRIPTION = "score of the fused hybrid query after post-fusion scoring, computed from:";
+    private static final String FINAL_SCORE_DESCRIPTION = "score of the fused hybrid query as round 2 returned it, computed from:";
     /** Floats survive one JSON round trip exactly; the tolerance is for the arithmetic asserted across nodes. */
     private static final double DELTA = 1e-5;
 
@@ -135,6 +135,40 @@ public class HybridQueryFusedModeExplainIT extends BaseNeuralSearchIT {
             value(explanation),
             DELTA
         );
+    }
+
+    /**
+     * A weight of {@code 0.0} zeroes its leg's contribution, so a document that reached fusion through that leg alone fuses
+     * to exactly {@code 0.0} and is floored away from the Tail before round 2 ranks it. The tree must then name what round 2
+     * returned and keep the score fusion computed underneath it — labelling the combination node with the floor would claim
+     * a number its own children do not produce.
+     *
+     * <p>{@code k=2} is load-bearing: on a dataset where every leg matches every document, min_max maps a zero-range leg to
+     * {@code 1.0} and no document fuses to {@code 0.0} at all, so the case would not arise. Bounding the ANN leg leaves four
+     * documents reaching fusion through the zero-weighted {@code term} leg alone. {@code size} covers them because they sort
+     * last, being the lowest-scored documents in the window.
+     */
+    @SneakyThrows
+    public void testExplainedFusedHybrid_whenALegWeightIsZero_thenTheFlooredScoreIsNamedAboveTheComputedOne() {
+        ensureDataset();
+
+        Map<String, Object> response = search(explained(zeroWeightedFusedHybrid(knnLeg(2), termLeg())));
+
+        List<Map<String, Object>> floored = new ArrayList<>();
+        for (Map<String, Object> hit : hits(response)) {
+            Map<String, Object> explanation = explanationOf(hit);
+            if (FINAL_SCORE_DESCRIPTION.equals(description(explanation))) {
+                floored.add(explanation);
+            }
+        }
+
+        assertEquals("the four documents the zero-weighted leg alone surfaced fused to 0.0 and were floored", 4, floored.size());
+        for (Map<String, Object> explanation : floored) {
+            List<Map<String, Object>> children = details(explanation);
+            assertEquals("the combination is the only child", 1, children.size());
+            assertEquals("the child reports what fusion computed, which is exactly zero", 0.0, value(children.get(0)), DELTA);
+            assertTrue("and the parent reports the floored score round 2 ranked by, which is above it", value(explanation) > 0.0);
+        }
     }
 
     /**
@@ -315,6 +349,32 @@ public class HybridQueryFusedModeExplainIT extends BaseNeuralSearchIT {
         assertEquals("explaining the legs must not change the totals", totalHits(plain), totalHits(explained));
     }
 
+    /**
+     * Both reports at once, over the wire. The two are merged by one listener and by different means — {@code profile}
+     * rebuilds the response around the hits while {@code explain} writes onto the hits themselves — so asking for both is
+     * the case where one could drop the other. Covered only through mocked consumers in a unit test until now.
+     */
+    @SneakyThrows
+    public void testFusedHybrid_whenExplainedAndProfiled_thenTheResponseCarriesBoth() {
+        ensureDataset();
+        String query = fusedHybrid(knnLeg(WINDOW_SIZE), termLeg());
+
+        Map<String, Object> response = search(
+            "{\"query\":" + query + ",\"explain\":true,\"profile\":true,\"track_total_hits\":true,\"size\":" + (TOTAL_DOCS + 1) + "}"
+        );
+
+        assertTrue(
+            "every ranked hit still carries its fused explanation",
+            hits(response).stream().allMatch(hit -> Objects.nonNull(hit.get("_explanation")))
+        );
+        assertEquals(
+            "and the fusion is still what the top node describes",
+            COMBINATION_DESCRIPTION,
+            description(explanationOf(hits(response).get(0)))
+        );
+        assertNotNull("while the profile section the rebuild carried is present too", response.get("profile"));
+    }
+
     // ------------------------------------------------ request bodies ------------------------------------------------
 
     private String knnLeg(final int k) {
@@ -333,6 +393,17 @@ public class HybridQueryFusedModeExplainIT extends BaseNeuralSearchIT {
         return "{\"hybrid\":{\"fusion\":{\"window_size\":"
             + windowSize
             + ",\"normalization\":{\"technique\":\"min_max\"},\"combination\":{\"technique\":\"arithmetic_mean\"}},"
+            + "\"queries\":["
+            + String.join(",", legs)
+            + "]}}";
+    }
+
+    /** Weights that zero the second leg entirely, so a document only that leg surfaced fuses to exactly {@code 0.0}. */
+    private String zeroWeightedFusedHybrid(final String... legs) {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"normalization\":{\"technique\":\"min_max\"},"
+            + "\"combination\":{\"technique\":\"arithmetic_mean\",\"parameters\":{\"weights\":[1.0,0.0]}}},"
             + "\"queries\":["
             + String.join(",", legs)
             + "]}}";

--- a/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.TotalHits;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequest;
@@ -25,17 +27,22 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.OpenSearchQueryTestCase;
+import org.opensearch.neuralsearch.search.explain.FusedDocExplanations;
 import org.opensearch.neuralsearch.search.profile.FusedCoordinatorTimings;
+import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.internal.InternalSearchResponse;
@@ -355,6 +362,93 @@ public class HybridQuerySearchRequestFilterTests extends OpenSearchQueryTestCase
         assertNull(hybridQuery.fusionTimingConsumer());
         assertNull("and a request that cannot time out has no timeout to watch for either", hybridQuery.legTimeoutConsumer());
         assertSame(listener, proceedListener(searchRequest, listener));
+    }
+
+    /** The per-leg breakdown attaches when the request asks to be explained and the fused hybrid is its own query. */
+    @SuppressWarnings("unchecked")
+    public void testApply_whenAnExplainedFusedHybridIsTheRequestQuery_thenTheBreakdownIsAttached() {
+        HybridQueryBuilder hybridQuery = fusedHybrid();
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        searchRequest.source(new SearchSourceBuilder().query(hybridQuery).explain(true));
+
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionListener<ActionResponse> proceeded = proceedListener(searchRequest, listener);
+
+        assertNotNull("the legs have to have somewhere to publish what they explained", hybridQuery.fusedExplanationConsumer());
+        assertNull("explain alone collects no leg trees", hybridQuery.legProfileConsumer());
+        assertNotSame("and the listener has to be wrapped for the tree to reach the response", listener, proceeded);
+    }
+
+    /**
+     * A hit's explanation is one tree describing that hit's score. For a fused hybrid nested inside a container the fused
+     * score is an input to the enclosing query's scoring rather than the hit's score, so replacing the tree would describe
+     * the wrong thing — the request keeps core's own explanation of the query round 2 ran.
+     */
+    @SuppressWarnings("unchecked")
+    public void testApply_whenAnExplainedFusedHybridIsNestedInTheRequestQuery_thenNothingIsAttached() {
+        HybridQueryBuilder hybridQuery = fusedHybrid();
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        searchRequest.source(
+            new SearchSourceBuilder().query(new BoolQueryBuilder().must(hybridQuery).filter(new MatchAllQueryBuilder())).explain(true)
+        );
+
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        assertNull("this hybrid's fused score is not the hit's score", hybridQuery.fusedExplanationConsumer());
+        assertSame("and with nothing to report the listener is handed on as it came", listener, proceedListener(searchRequest, listener));
+    }
+
+    /**
+     * The same reasoning, on the shape the identity check is actually written against: the finder stops at a fused hybrid,
+     * so two of them found means neither can be the request's own query, and neither may claim the hit's score.
+     */
+    @SuppressWarnings("unchecked")
+    public void testApply_whenTwoExplainedFusedHybridsAreSiblings_thenNothingIsAttached() {
+        HybridQueryBuilder first = fusedHybrid();
+        HybridQueryBuilder second = fusedHybrid();
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        searchRequest.source(new SearchSourceBuilder().query(new BoolQueryBuilder().should(first).should(second)).explain(true));
+
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        proceedListener(searchRequest, listener);
+
+        assertNull(first.fusedExplanationConsumer());
+        assertNull("neither sibling's fused score is the hit's score", second.fusedExplanationConsumer());
+    }
+
+    /**
+     * {@code explain} writes onto the response's hits while {@code profile} replaces the response around them, so asking for
+     * both has to yield both. What this pins is that the one rebuild carries the very {@code SearchHit} instances over: a
+     * rebuild that copied them would drop the explanation written afterwards, silently and only for requests asking for both.
+     */
+    @SuppressWarnings("unchecked")
+    public void testWrappedListener_whenExplainedAndProfiled_thenTheResponseCarriesBoth() {
+        HybridQueryBuilder hybridQuery = fusedHybrid();
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        searchRequest.source(new SearchSourceBuilder().query(hybridQuery).profile(true).explain(true));
+
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionListener<ActionResponse> proceeded = proceedListener(searchRequest, listener);
+        hybridQuery.legProfileConsumer().accept(0, Map.of(SHARD_KEY, legProfile()));
+
+        FusedDocExplanations collected = new FusedDocExplanations();
+        collected.combinationDescription("arithmetic_mean combination of:").normalizationDescription("min_max normalization of:");
+        collected.addDocument(
+            FusedDocExplanations.documentKey("test_index", "1"),
+            0.75f,
+            List.of(new FusedDocExplanations.LegContribution(0, 0.5f, Explanation.match(2.0f, "leg")))
+        );
+        hybridQuery.fusedExplanationConsumer().accept(collected);
+
+        SearchResponse merged = merge(proceeded, listener, responseWithRankedHit());
+
+        assertEquals(Set.of(SHARD_KEY + "[fused:hybrid_0.leg_0]"), merged.getProfileResults().keySet());
+        Explanation explanation = merged.getHits().getHits()[0].getExplanation();
+        assertNotNull("the breakdown must survive the rebuild the profile section needed", explanation);
+        assertEquals("arithmetic_mean combination of:", explanation.getDescription());
     }
 
     /**
@@ -740,6 +834,25 @@ public class HybridQuerySearchRequestFilterTests extends OpenSearchQueryTestCase
             null,
             Objects.isNull(profiles) ? null : new SearchProfileShardResults(profiles),
             timedOut,
+            null,
+            1
+        );
+        return new SearchResponse(sections, null, 1, 1, 0, 3L, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    }
+
+    /** A profiled response carrying one hit, for the reports that write onto the hits rather than around them. */
+    private static SearchResponse responseWithRankedHit() {
+        SearchHit hit = new SearchHit(0, "1", null, null);
+        // The shard target is what gives a hit its _index, which is half of the key the breakdown is correlated by.
+        hit.shard(new SearchShardTarget("node", new ShardId("test_index", "test_index-uuid", 0), null, OriginalIndices.NONE));
+        hit.score(0.75f);
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 0.75f);
+        InternalSearchResponse sections = new InternalSearchResponse(
+            hits,
+            InternalAggregations.EMPTY,
+            null,
+            new SearchProfileShardResults(Map.of()),
+            false,
             null,
             1
         );

--- a/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
@@ -421,8 +421,12 @@ public class HybridQuerySearchRequestFilterTests extends OpenSearchQueryTestCase
 
     /**
      * {@code explain} writes onto the response's hits while {@code profile} replaces the response around them, so asking for
-     * both has to yield both. What this pins is that the one rebuild carries the very {@code SearchHit} instances over: a
-     * rebuild that copied them would drop the explanation written afterwards, silently and only for requests asking for both.
+     * both has to yield both — that outcome is what this pins.
+     *
+     * <p>It does not pin the order, and cannot: the mergers run profile-first, so the explanation is written onto whatever
+     * hits the rebuilt response carries, and a rebuild that copied them would receive the write on the copies and still
+     * pass here. What makes the order safe is that the profile rebuild passes {@code SearchHits} through by reference,
+     * which is pinned where it belongs, by the {@code assertSame} in {@code FusedLegProfileMergerTests}.
      */
     @SuppressWarnings("unchecked")
     public void testWrappedListener_whenExplainedAndProfiled_thenTheResponseCarriesBoth() {

--- a/src/test/java/org/opensearch/neuralsearch/search/explain/FusedExplanationMergerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/explain/FusedExplanationMergerTests.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search.explain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.OriginalIndices;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchShardTarget;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit coverage for the shapes the fused {@code explain} path has to survive without a cluster: nothing collected, a hit
+ * fusion never ranked, a score a post-fusion step moved, and a leg that returned no explanation of its own. What the tree
+ * looks like for a real query is pinned end-to-end in {@code HybridQueryFusedModeExplainIT}.
+ */
+public class FusedExplanationMergerTests extends OpenSearchTestCase {
+
+    private static final String INDEX = "test-index";
+    private static final String COMBINATION = "arithmetic_mean combination of:";
+    private static final String NORMALIZATION = "min_max normalization of:";
+    private static final String FINAL_SCORE = "score of the fused hybrid query after post-fusion scoring, computed from:";
+
+    public void testGetMergedResponse_whenNothingCollected_thenResponseReturnedUntouched() {
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        SearchResponse response = responseWithHits(hit("1", 0.5f));
+
+        assertTrue("nothing was collected", merger.isEmpty());
+        assertSame("an unexplained response must not be rebuilt", response, merger.getMergedResponse(response));
+        assertNull("and no hit may gain an explanation", response.getHits().getHits()[0].getExplanation());
+    }
+
+    public void testGetMergedResponse_whenEmptyCollectionPublished_thenNothingIsAttached() {
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        merger.consumer().accept(new FusedDocExplanations());
+        SearchResponse response = responseWithHits(hit("1", 0.5f));
+
+        assertTrue("an explained request whose legs ranked nothing publishes an empty collection", merger.isEmpty());
+        assertNull(merger.getMergedResponse(response).getHits().getHits()[0].getExplanation());
+    }
+
+    public void testGetMergedResponse_whenDocumentWasRanked_thenTheFusedTreeReplacesRoundTwos() {
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        merger.consumer().accept(collected("1", 0.6f, 0.4f, 0.8f));
+        SearchHit ranked = hit("1", 0.6f);
+        ranked.explanation(Explanation.match(0.6f, "ConstantScore(_id:[1])"));
+
+        SearchResponse merged = merger.getMergedResponse(responseWithHits(ranked));
+        Explanation explanation = merged.getHits().getHits()[0].getExplanation();
+
+        assertEquals(COMBINATION, explanation.getDescription());
+        assertEquals(0.6f, explanation.getValue().floatValue(), 0.0f);
+        assertEquals("one node per leg", 2, explanation.getDetails().length);
+        assertEquals(NORMALIZATION, explanation.getDetails()[0].getDescription());
+        assertEquals(0.4f, explanation.getDetails()[0].getValue().floatValue(), 0.0f);
+        assertEquals("the leg's own explanation is kept under it", 1, explanation.getDetails()[0].getDetails().length);
+        assertEquals("leg 0 raw", explanation.getDetails()[0].getDetails()[0].getDescription());
+    }
+
+    public void testGetMergedResponse_whenDocumentWasNotRanked_thenItsOwnExplanationIsKept() {
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        merger.consumer().accept(collected("1", 0.6f, 0.4f, 0.8f));
+        SearchHit tailOnly = hit("2", 0.0f);
+        tailOnly.explanation(Explanation.match(0.0f, "the Tail matched this document"));
+
+        SearchResponse merged = merger.getMergedResponse(responseWithHits(tailOnly));
+
+        assertEquals(
+            "a document fusion never ranked has no fused breakdown to show",
+            "the Tail matched this document",
+            merged.getHits().getHits()[0].getExplanation().getDescription()
+        );
+    }
+
+    public void testGetMergedResponse_whenScoreMovedAfterFusion_thenTheFusionIsNestedUnderTheFinalScore() {
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        merger.consumer().accept(collected("1", 0.6f, 0.4f, 0.8f));
+
+        SearchResponse merged = merger.getMergedResponse(responseWithHits(hit("1", 1.9f)));
+        Explanation explanation = merged.getHits().getHits()[0].getExplanation();
+
+        assertEquals("the top node must describe the score the hit has", FINAL_SCORE, explanation.getDescription());
+        assertEquals(1.9f, explanation.getValue().floatValue(), 0.0f);
+        assertEquals(1, explanation.getDetails().length);
+        assertEquals("and the fusion keeps the number it actually produced", COMBINATION, explanation.getDetails()[0].getDescription());
+        assertEquals(0.6f, explanation.getDetails()[0].getValue().floatValue(), 0.0f);
+    }
+
+    public void testGetMergedResponse_whenALegReturnedNoExplanation_thenItsNodeIsALeaf() {
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        FusedDocExplanations collected = new FusedDocExplanations().combinationDescription(COMBINATION)
+            .normalizationDescription(NORMALIZATION);
+        collected.addDocument(
+            FusedDocExplanations.documentKey(INDEX, "1"),
+            0.4f,
+            List.of(new FusedDocExplanations.LegContribution(0, 0.4f, null))
+        );
+        merger.consumer().accept(collected);
+
+        Explanation explanation = merger.getMergedResponse(responseWithHits(hit("1", 0.4f))).getHits().getHits()[0].getExplanation();
+
+        assertEquals("the normalized value is still reported", 0.4f, explanation.getDetails()[0].getValue().floatValue(), 0.0f);
+        assertEquals("with nothing invented under it", 0, explanation.getDetails()[0].getDetails().length);
+    }
+
+    public void testGetMergedResponse_whenScoresAreNotTracked_thenTheFusedScoreIsReported() {
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        merger.consumer().accept(collected("1", 0.6f, 0.4f, 0.8f));
+
+        // A hit of a request that did not track scores carries NaN, so there is no final score to describe — the fused
+        // score is the only number there is, and comparing against NaN must not nest it under one that does not exist.
+        Explanation explanation = merger.getMergedResponse(responseWithHits(hit("1", Float.NaN))).getHits().getHits()[0].getExplanation();
+
+        assertEquals(COMBINATION, explanation.getDescription());
+        assertEquals(0.6f, explanation.getValue().floatValue(), 0.0f);
+    }
+
+    public void testGetMergedResponse_whenTheResponseCarriesNoHitsArray_thenItIsReturnedUntouched() {
+        // A response section with no hits array at all — the shape a request that asked for nothing back leaves behind.
+        // There is nothing to correlate against, and reaching for the array would fail rather than report anything.
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        merger.consumer().accept(collected("1", 0.6f, 0.4f, 0.8f));
+        SearchHits noHits = new SearchHits(null, new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        InternalSearchResponse internal = new InternalSearchResponse(noHits, InternalAggregations.EMPTY, null, null, false, null, 1);
+        SearchResponse response = new SearchResponse(
+            internal,
+            null,
+            1,
+            1,
+            0,
+            1L,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
+
+        assertFalse("something was collected, so the guard is the array and not the collection", merger.isEmpty());
+        assertSame(response, merger.getMergedResponse(response));
+    }
+
+    public void testGetMergedResponse_whenAHitCannotBeCorrelated_thenItIsSkippedAndTheRestAreStillAttached() {
+        // Correlation is by _index + _id, so a hit missing either cannot be looked up. It is skipped rather than keyed on
+        // what is left, which would collide with a real document of another index that happens to share the _id.
+        FusedExplanationMerger merger = new FusedExplanationMerger();
+        merger.consumer().accept(collected("1", 0.6f, 0.4f, 0.8f));
+        SearchHit indexless = new SearchHit(0, "1", null, null);
+        indexless.score(0.6f);
+        SearchHit idless = new SearchHit(0, null, null, null);
+        idless.shard(new SearchShardTarget("node", new ShardId(INDEX, INDEX + "-uuid", 0), null, OriginalIndices.NONE));
+        idless.score(0.6f);
+
+        SearchResponse merged = merger.getMergedResponse(responseWithHits(indexless, idless, hit("1", 0.6f)));
+
+        assertNull("a hit with no _index is left exactly as it came back", merged.getHits().getHits()[0].getExplanation());
+        assertNull("and so is one with no _id", merged.getHits().getHits()[1].getExplanation());
+        assertEquals(
+            "and skipping them does not stop the hits that can be correlated",
+            COMBINATION,
+            merged.getHits().getHits()[2].getExplanation().getDescription()
+        );
+    }
+
+    public void testDocumentKey_thenDistinctDocumentsGetDistinctKeys() {
+        // The key is never parsed back, so it only has to separate documents and be built the same way in the rewrite and
+        // on the response. An _id may contain the separator; an index name may not (OpenSearch rejects '#' in one), so the
+        // pair cannot be re-split ambiguously into a different (index, id) that is also a real document.
+        assertEquals(FusedDocExplanations.documentKey(INDEX, "a#b"), FusedDocExplanations.documentKey(INDEX, "a#b"));
+        assertNotEquals(FusedDocExplanations.documentKey(INDEX, "1"), FusedDocExplanations.documentKey(INDEX, "2"));
+        assertNotEquals(FusedDocExplanations.documentKey(INDEX, "1"), FusedDocExplanations.documentKey("other-index", "1"));
+    }
+
+    /** One document, two legs, with a raw explanation under each. */
+    private FusedDocExplanations collected(final String id, final float fusedScore, final float... normalizedScores) {
+        FusedDocExplanations collected = new FusedDocExplanations().combinationDescription(COMBINATION)
+            .normalizationDescription(NORMALIZATION);
+        List<FusedDocExplanations.LegContribution> contributions = new ArrayList<>();
+        for (int leg = 0; leg < normalizedScores.length; leg++) {
+            contributions.add(
+                new FusedDocExplanations.LegContribution(
+                    leg,
+                    normalizedScores[leg],
+                    Explanation.match(normalizedScores[leg], "leg " + leg + " raw")
+                )
+            );
+        }
+        collected.addDocument(FusedDocExplanations.documentKey(INDEX, id), fusedScore, contributions);
+        return collected;
+    }
+
+    /** A response hit as the fetch phase leaves it: the shard target is what gives it an {@code _index}. */
+    private SearchHit hit(final String id, final float score) {
+        SearchHit hit = new SearchHit(0, id, null, null);
+        hit.shard(new SearchShardTarget("node", new ShardId(INDEX, INDEX + "-uuid", 0), null, OriginalIndices.NONE));
+        hit.score(score);
+        return hit;
+    }
+
+    private SearchResponse responseWithHits(final SearchHit... hits) {
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        InternalSearchResponse internal = new InternalSearchResponse(searchHits, InternalAggregations.EMPTY, null, null, false, null, 1);
+        return new SearchResponse(internal, null, 1, 1, 0, 1L, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/search/explain/FusedExplanationMergerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/explain/FusedExplanationMergerTests.java
@@ -30,7 +30,7 @@ public class FusedExplanationMergerTests extends OpenSearchTestCase {
     private static final String INDEX = "test-index";
     private static final String COMBINATION = "arithmetic_mean combination of:";
     private static final String NORMALIZATION = "min_max normalization of:";
-    private static final String FINAL_SCORE = "score of the fused hybrid query after post-fusion scoring, computed from:";
+    private static final String FINAL_SCORE = "score of the fused hybrid query as round 2 returned it, computed from:";
 
     public void testGetMergedResponse_whenNothingCollected_thenResponseReturnedUntouched() {
         FusedExplanationMerger merger = new FusedExplanationMerger();


### PR DESCRIPTION
### Description

Adding `explain` for fused `hybrid` query. Structurally this is the `profile` mechanism of #1977 a second time, on the same approach and with the same hook: filter attaches a collector before the rewrite, fan-out fills it, filter's response listener reads from it. New DTO class FusedDocExplanations carry the report. 

Where we attach new explain classes, and where it deliberately do not

| Report | Attaches to | Why not more |
|---|---|---|
| `profile` (#1977) | every fused hybrid in the request | a profile section is a list, so N hybrids can each contribute |
| `explain` (this PR) | **only** the fused hybrid that *is* the request's own `query`, by reference identity | a hit's explanation is one tree describing that hit's score; nested, the fused score is an input to the enclosing query's scoring, so replacing the tree would describe the wrong thing |

It follows same main fusion/resolver paradigm - no pipeline or processor is required, specifically existing [explanation response processor](https://docs.opensearch.org/latest/search-plugins/search-pipelines/explanation-processor/). One more advantage over existing logic for explain - with this change we run actual query once and explain part only processes scores differently, so it's faster. Today explain in hybrid query runs query phase twice to get raw queries scores. 

---

#### Query examples

Index used by the ITs: 6 documents, ids `1`–`6`, each with the same `text` and a 2-dimensional `vec`, queried by a
`knn` leg and a `term` leg that matches all six.

#### 1. The flat case — every leg described under the fused score

```json
GET test-fused-explain/_search
{
  "explain": true,
  "track_total_hits": true,
  "size": 7,
  "query": {
    "hybrid": {
      "fusion": {
        "window_size": 10,
        "normalization": { "technique": "min_max" },
        "combination": { "technique": "arithmetic_mean" }
      },
      "queries": [
        { "knn":  { "vec": { "vector": [1.1, 1.0], "k": 10 } } },
        { "term": { "text": "hello" } }
      ]
    }
  }
}
```

Each ranked hit carries:

```json
"_explanation": {
  "value": 0.75,
  "description": "arithmetic_mean combination of:",
  "details": [
    {
      "value": 1.0,
      "description": "min_max normalization of:",
      "details": [
        { "value": 0.98, "description": "within top 10 docs", "details": [] }
      ]
    },
    {
      "value": 0.5,
      "description": "min_max normalization of:",
      "details": [
        { "value": 0.287, "description": "weight(text:hello in 0) [PerFieldSimilarity], result of:", "details": [ "..." ] }
      ]
    }
  ]
}
```

#### 2. Weighted combination — the weights are named, not folded in

```json
"combination": { "technique": "arithmetic_mean", "parameters": { "weights": [0.7, 0.3] } }
```

```json
"_explanation": {
  "value": 0.85,
  "description": "arithmetic_mean, weights [0.7, 0.3] combination of:",
  "details": [ "…leg 0, value 1.0…", "…leg 1, value 0.5…" ]
}
```

`0.7 × 1.0 + 0.3 × 0.5 = 0.85` — the weights apply to the values the children report, so the children stay readable
as the normalized leg scores they are.

#### 3. document matching one leg

```json
{ "knn": { "vec": { "vector": [1.1, 1.0], "k": 2 } } }
```

With `k: 2` the ANN leg contributes two candidates, so the other four documents reach fusion through the `term` leg
alone. Their trees carry **one** leg node, not two with a zero — the same choice classic makes.

#### 4. `rescore` — the fused score nests under the final score

```json
{
  "explain": true,
  "query": { "hybrid": { "fusion": { "...": "..." }, "queries": [ "..." ] } },
  "rescore": {
    "window_size": 10,
    "query": {
      "rescore_query": { "term": { "text": "hello" } },
      "query_weight": 1.0,
      "rescore_query_weight": 2.0
    }
  }
}
```

When the score round 2 returned is not the fused score, an extra node is inserted above the combination:

```json
"_explanation": {
  "value": 1.324,
  "description": "score of the fused hybrid query after post-fusion scoring, computed from:",
  "details": [
    { "value": 0.75, "description": "arithmetic_mean combination of:", "details": [ "..." ] }
  ]
}
```

`rescore` is the **only** way a fused hit's score can differ from its fused score: `boost` on a `hybrid` is rejected
at parse time (`[hybrid] query does not support [boost]`, HTTP 400).

### Related Issues
https://github.com/opensearch-project/neural-search/issues/1930

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
