### PR TITLE
Deduplicate ingest inference inputs within sub-batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `model_selection` (language_option/model_type) parameter to semantic field to resolve the model id from cluster settings ([#1918](https://github.com/opensearch-project/neural-search/issues/1918))
 
 ### Bug Fixes
+* [Ingest] Deduplicate equal inference inputs within each ingest sub-batch and scatter the result to every original field position ([#1558](https://github.com/opensearch-project/neural-search/issues/1558))
 * [Hybrid Query] Fix NoSuchElementException in hybrid query with sort/search_after when a shard returns no results ([#1939](https://github.com/opensearch-project/neural-search/pull/1939))
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))
 * [Sparse ANN] Fold sparse vector tokens into the signed-short range (modulus 32768) so folded tokens are never sign-extended to a negative value when stored in short[] ([#1926](https://github.com/opensearch-project/neural-search/pull/1926))

--- a/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/InferenceProcessor.java
@@ -34,7 +34,6 @@ import org.opensearch.neuralsearch.util.prune.PruneType;
 import org.opensearch.neuralsearch.util.prune.PruneUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -246,27 +245,46 @@ public abstract class InferenceProcessor extends AbstractBatchingProcessor {
     }
 
     protected Tuple<List<String>, Map<Integer, Integer>> sortByLengthAndReturnOriginalOrder(List<String> inferenceList) {
+        Map<String, Integer> uniqueIndexByText = new LinkedHashMap<>();
+        List<Integer> uniqueIndexesInOriginalOrder = new ArrayList<>();
+        for (String inferenceText : inferenceList) {
+            int uniqueIndex = uniqueIndexByText.computeIfAbsent(inferenceText, ignored -> uniqueIndexByText.size());
+            uniqueIndexesInOriginalOrder.add(uniqueIndex);
+        }
+
         List<Tuple<Integer, String>> docsWithIndex = new ArrayList<>();
-        for (int i = 0; i < inferenceList.size(); ++i) {
-            docsWithIndex.add(Tuple.tuple(i, inferenceList.get(i)));
+        for (Map.Entry<String, Integer> entry : uniqueIndexByText.entrySet()) {
+            docsWithIndex.add(Tuple.tuple(entry.getValue(), entry.getKey()));
         }
         docsWithIndex.sort(Comparator.comparingInt(t -> t.v2().length()));
         List<String> sortedInferenceList = docsWithIndex.stream().map(Tuple::v2).collect(Collectors.toList());
-        Map<Integer, Integer> originalOrderMap = new HashMap<>();
+        Map<Integer, Integer> sortedIndexByUniqueIndex = new HashMap<>();
         for (int i = 0; i < docsWithIndex.size(); ++i) {
-            originalOrderMap.put(i, docsWithIndex.get(i).v1());
+            sortedIndexByUniqueIndex.put(docsWithIndex.get(i).v1(), i);
+        }
+        Map<Integer, Integer> originalOrderMap = new HashMap<>();
+        for (int i = 0; i < uniqueIndexesInOriginalOrder.size(); ++i) {
+            originalOrderMap.put(i, sortedIndexByUniqueIndex.get(uniqueIndexesInOriginalOrder.get(i)));
         }
         return Tuple.tuple(sortedInferenceList, originalOrderMap);
     }
 
     private List<?> restoreToOriginalOrder(List<?> results, Map<Integer, Integer> originalOrder) {
-        List<Object> sortedResults = Arrays.asList(results.toArray());
-        for (int i = 0; i < results.size(); ++i) {
-            if (!originalOrder.containsKey(i)) continue;
-            int oldIndex = originalOrder.get(i);
-            sortedResults.set(oldIndex, results.get(i));
+        List<Object> originalResults = new ArrayList<>(originalOrder.size());
+        for (int i = 0; i < originalOrder.size(); ++i) {
+            originalResults.add(copyInferenceResult(results.get(originalOrder.get(i))));
         }
-        return sortedResults;
+        return originalResults;
+    }
+
+    private Object copyInferenceResult(Object result) {
+        if (result instanceof List<?> listResult) {
+            return new ArrayList<>(listResult);
+        }
+        if (result instanceof Map<?, ?> mapResult) {
+            return new LinkedHashMap<>(mapResult);
+        }
+        return result;
     }
 
     protected List<String> constructInferenceTexts(List<DataForInference> dataForInferences) {

--- a/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/SparseEncodingProcessorTests.java
@@ -702,7 +702,7 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         Consumer resultHandler = mock(Consumer.class);
         TextInferenceRequest ingestRequest = TextInferenceRequest.builder()
             .modelId("mockModelID")
-            .inputTexts(List.of("value1", "value1", "value1", "value1", "value1"))
+            .inputTexts(List.of("value1"))
             .build();
         mockVectorCreation(ingestRequest, null);
         mockUpdateMultipleDocuments(ingestDocumentWrappers);
@@ -744,11 +744,11 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
         Consumer resultHandler = mock(Consumer.class);
         TextInferenceRequest ingestRequest = TextInferenceRequest.builder()
             .modelId("mockModelID")
-            .inputTexts(List.of("value1", "value1", "value1", "value1", "value1"))
+            .inputTexts(List.of("value1"))
             .build();
         TextInferenceRequest updateRequest = TextInferenceRequest.builder()
             .modelId("mockModelID")
-            .inputTexts(List.of("newValue", "newValue", "newValue", "newValue", "newValue"))
+            .inputTexts(List.of("newValue"))
             .build();
         mockVectorCreation(ingestRequest, updateRequest);
         mockUpdateMultipleDocuments(ingestDocumentWrappers);
@@ -943,6 +943,53 @@ public class SparseEncodingProcessorTests extends InferenceProcessorTestCase {
             assertEquals(ingestDocumentWrappers.get(i).getIngestDocument(), resultCallback.getValue().get(i).getIngestDocument());
             assertNull(resultCallback.getValue().get(i).getException());
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void test_batchExecute_deduplicatesWithinSparseFormatWithoutCombiningFormats() {
+        mockSeismic(KEY1_MAPPED);
+        List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(2, KEY1, VALUE1, KEY2, VALUE1);
+        SparseEncodingProcessor processor = createInstance(2, false);
+        doAnswer(invocation -> {
+            TextInferenceRequest request = invocation.getArgument(0);
+            ActionListener<List<Map<String, ?>>> listener = invocation.getArgument(1);
+            if (request.getMlAlgoParams() instanceof AsymmetricTextEmbeddingParameters) {
+                listener.onResponse(createMockMapResultWithIntToken(request.getInputTexts().size()));
+            } else {
+                listener.onResponse(createMockMapResultWithWordToken(request.getInputTexts().size()));
+            }
+            return null;
+        }).when(mlCommonsClientAccessor)
+            .inferenceSentencesWithMapResult(isA(TextInferenceRequest.class), isA(ActionListener.class));
+
+        List<IngestDocumentWrapper> results = new ArrayList<>();
+        processor.batchExecute(ingestDocumentWrappers, results::addAll);
+
+        verify(mlCommonsClientAccessor, times(2)).inferenceSentencesWithMapResult(
+            inferenceRequestCaptor.capture(),
+            isA(ActionListener.class)
+        );
+        List<TextInferenceRequest> requests = inferenceRequestCaptor.getAllValues();
+        assertEquals(List.of(VALUE1), requests.get(0).getInputTexts());
+        assertEquals(
+            SparseEmbeddingFormat.TOKEN_ID,
+            ((AsymmetricTextEmbeddingParameters) requests.get(0).getMlAlgoParams()).getSparseEmbeddingFormat()
+        );
+        assertEquals(List.of(VALUE1), requests.get(1).getInputTexts());
+        assertNull(requests.get(1).getMlAlgoParams());
+        for (IngestDocumentWrapper result : results) {
+            assertNull(result.getException());
+            assertTrue(((Map<String, Float>) result.getIngestDocument().getFieldValue(KEY1_MAPPED, Map.class)).containsKey("1000"));
+            assertTrue(((Map<String, Float>) result.getIngestDocument().getFieldValue(KEY2_MAPPED, Map.class)).containsKey("hello"));
+        }
+        assertNotSame(
+            results.get(0).getIngestDocument().getFieldValue(KEY1_MAPPED, Map.class),
+            results.get(1).getIngestDocument().getFieldValue(KEY1_MAPPED, Map.class)
+        );
+        assertNotSame(
+            results.get(0).getIngestDocument().getFieldValue(KEY2_MAPPED, Map.class),
+            results.get(1).getIngestDocument().getFieldValue(KEY2_MAPPED, Map.class)
+        );
     }
 
     public void test_batchExecute_mixed_seismic_exception() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/TextEmbeddingProcessorTests.java
@@ -1166,6 +1166,47 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         }
     }
 
+    public void test_batchExecute_deduplicatesInferenceInputsAndScattersResults() {
+        List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(
+            2,
+            "key1",
+            "duplicate",
+            "key2",
+            "tiny"
+        );
+        ingestDocumentWrappers.get(1).getIngestDocument().setFieldValue("key1", "lengthy input");
+        ingestDocumentWrappers.get(1).getIngestDocument().setFieldValue("key2", "duplicate");
+        TextEmbeddingProcessor processor = createInstanceWithLevel1MapConfig(2, false);
+        Map<String, List<Float>> embeddingsByInput = Map.of(
+            "tiny",
+            List.of(1.0f),
+            "duplicate",
+            List.of(2.0f),
+            "lengthy input",
+            List.of(3.0f)
+        );
+        doAnswer(invocation -> {
+            TextInferenceRequest request = invocation.getArgument(0);
+            ActionListener<List<List<Float>>> listener = invocation.getArgument(1);
+            listener.onResponse(request.getInputTexts().stream().map(embeddingsByInput::get).toList());
+            return null;
+        }).when(mlCommonsClientAccessor).inferenceSentences(isA(TextInferenceRequest.class), isA(ActionListener.class));
+
+        List<IngestDocumentWrapper> results = new ArrayList<>();
+        processor.batchExecute(ingestDocumentWrappers, results::addAll);
+
+        verify(mlCommonsClientAccessor).inferenceSentences(inferenceRequestCaptor.capture(), isA(ActionListener.class));
+        assertEquals(List.of("tiny", "duplicate", "lengthy input"), inferenceRequestCaptor.getValue().getInputTexts());
+        assertEquals(List.of(2.0f), results.get(0).getIngestDocument().getFieldValue("key1_knn", List.class));
+        assertEquals(List.of(1.0f), results.get(0).getIngestDocument().getFieldValue("key2_knn", List.class));
+        assertEquals(List.of(3.0f), results.get(1).getIngestDocument().getFieldValue("key1_knn", List.class));
+        assertEquals(List.of(2.0f), results.get(1).getIngestDocument().getFieldValue("key2_knn", List.class));
+        assertNotSame(
+            results.get(0).getIngestDocument().getFieldValue("key1_knn", List.class),
+            results.get(1).getIngestDocument().getFieldValue("key2_knn", List.class)
+        );
+    }
+
     public void test_batchExecute_exception() {
         final int docCount = 5;
         List<IngestDocumentWrapper> ingestDocumentWrappers = createIngestDocumentWrappers(docCount);
@@ -1196,7 +1237,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         ArgumentCaptor<List<IngestDocumentWrapper>> resultCallback = ArgumentCaptor.forClass(List.class);
         TextInferenceRequest ingestRequest = TextInferenceRequest.builder()
             .modelId("mockModelID")
-            .inputTexts(List.of("value1", "value1", "value1", "value1", "value1"))
+            .inputTexts(List.of("value1"))
             .build();
         mockVectorCreation(ingestRequest, ingestRequest);
         mockFailedUpdateMultipleDocuments(ingestDocumentWrappers);
@@ -2124,7 +2165,7 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Consumer resultHandler = mock(Consumer.class);
         TextInferenceRequest ingestRequest = TextInferenceRequest.builder()
             .modelId("mockModelID")
-            .inputTexts(List.of("value1", "value1", "value1", "value1", "value1"))
+            .inputTexts(List.of("value1"))
             .build();
         mockVectorCreation(ingestRequest, null);
         mockUpdateMultipleDocuments(ingestDocumentWrappers);
@@ -2153,11 +2194,11 @@ public class TextEmbeddingProcessorTests extends InferenceProcessorTestCase {
         Consumer resultHandler = mock(Consumer.class);
         TextInferenceRequest ingestRequest = TextInferenceRequest.builder()
             .modelId("mockModelID")
-            .inputTexts(List.of("value1", "value1", "value1", "value1", "value1"))
+            .inputTexts(List.of("value1"))
             .build();
         TextInferenceRequest updateRequest = TextInferenceRequest.builder()
             .modelId("mockModelID")
-            .inputTexts(List.of("newValue", "newValue", "newValue", "newValue", "newValue"))
+            .inputTexts(List.of("newValue"))
             .build();
         mockVectorCreation(ingestRequest, updateRequest);
         mockUpdateMultipleDocuments(ingestDocumentWrappers);


### PR DESCRIPTION
### Description
Deduplicates equal text inference inputs within a single ingest sub-batch, while preserving the existing document and field order. Each unique input is inferred once and its result is scattered to every original position with independent mutable result objects.

This applies only to the dense `text_embedding` and sparse `sparse_encoding` ingest batching paths. Sparse WORD and TOKEN_ID requests remain separate inference boundaries. Existing `skip_existing` filtering and batch error propagation are unchanged.

This does not add a search cache, in-flight search coalescing, cross-request cache, node-local TTL cache, or cluster-wide cache.

### Related Issues
Refs #1558

### Test evidence
- `gradle.bat test -PskipSpotlessEclipse -x spotlessApply -x buildJniLib -x cmakeJniLib --tests "org.opensearch.neuralsearch.processor.InferenceProcessorTests" --tests "org.opensearch.neuralsearch.processor.TextEmbeddingProcessorTests" --tests "org.opensearch.neuralsearch.processor.SparseEncodingProcessorTests" --no-daemon --max-workers=1` — passed: 112 tests, 0 failures (6 shared, 69 dense, 37 sparse).
- Regression tests failed before the production change with dense input `[tiny, duplicate, duplicate, lengthy input]` instead of `[tiny, duplicate, lengthy input]`, and sparse format inputs `[value1, value1]` instead of `[value1]`.

The standard `spotlessJavaCheck` could not configure locally because the Eclipse JDT formatter P2 mirror timed out; no formatter configuration change is included.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented in the changelog.
- [x] API changes companion pull request is not applicable; there is no API change.
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR is not applicable; this changes no public API or configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.