### PR TITLE
Skip sparse cache cleanup for a closed index's shards so reopening does not wedge the shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Sparse ANN] Fold sparse vector tokens into the signed-short range (modulus 32768) so folded tokens are never sign-extended to a negative value when stored in short[] ([#1926](https://github.com/opensearch-project/neural-search/pull/1926))
 * [Hybrid Query] Read the current document and its sub-query matches from the positioned disjunction iterator, fixing an ArrayIndexOutOfBoundsException and silently misattributed scores when a sub-query has a two-phase iterator ([#1946](https://github.com/opensearch-project/neural-search/issues/1946))
 * [RRF] Reject a combination technique other than rrf when creating a score-ranker-processor, instead of accepting the pipeline and throwing NullPointerException on every query ([#1949](https://github.com/opensearch-project/neural-search/pull/1949))
+* [Sparse ANN] Skip cache cleanup for a closed index's shards, which have no MapperService, so reopening a sparse index no longer leaks the shard lock and leaves the shard unassigned ([#1982](https://github.com/opensearch-project/neural-search/issues/1982))
 
 ### Infrastructure
 * [Sparse ANN] Add the JNI layer for the native sparse engine, bridging to the neural-sparse-cpp library, with a googletest suite run on Linux and Windows plus an ASan/LSan job ([#1972](https://github.com/opensearch-project/neural-search/pull/1972))

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -38,6 +38,14 @@ public class SparseIndexEventListener implements IndexEventListener {
         for (IndexShard shard : indexService) {
             try (GatedCloseable<SegmentInfos> snapshot = shard.getSegmentInfosSnapshot()) {
                 MapperService mapperService = shard.mapperService();
+                if (mapperService == null) {
+                    // A closed index's IndexService is built without a MapperService
+                    // (IndexService#needsMapperService), so a shard of one has no field types to
+                    // look up. Its caches were already cleared when the index was closed. Letting
+                    // the NPE out here aborts IndicesService#removeIndex before it releases the
+                    // shard lock, which leaves the reopened shard permanently unassigned.
+                    continue;
+                }
                 SegmentInfos segmentInfos = snapshot.get();
                 for (int i = 0; i < segmentInfos.size(); i++) {
                     SegmentInfo segmentInfo = segmentInfos.info(i).info;

--- a/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListener.java
@@ -36,31 +36,35 @@ public class SparseIndexEventListener implements IndexEventListener {
      */
     public void beforeIndexRemoved(IndexService indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason reason) {
         for (IndexShard shard : indexService) {
-            try (GatedCloseable<SegmentInfos> snapshot = shard.getSegmentInfosSnapshot()) {
+            try {
                 MapperService mapperService = shard.mapperService();
                 if (mapperService == null) {
                     // A closed index's IndexService is built without a MapperService
                     // (IndexService#needsMapperService), so a shard of one has no field types to
-                    // look up. Its caches were already cleared when the index was closed. Letting
-                    // the NPE out here aborts IndicesService#removeIndex before it releases the
-                    // shard lock, which leaves the reopened shard permanently unassigned.
+                    // look up, and its engine is closed so a segment snapshot would throw. Its
+                    // caches were already cleared when the index was closed.
                     continue;
                 }
-                SegmentInfos segmentInfos = snapshot.get();
-                for (int i = 0; i < segmentInfos.size(); i++) {
-                    SegmentInfo segmentInfo = segmentInfos.info(i).info;
-                    for (MappedFieldType fieldType : mapperService.fieldTypes()) {
-                        if (fieldType instanceof SparseVectorFieldType) {
-                            String fieldName = fieldType.name();
-                            CacheKey key = new CacheKey(segmentInfo, fieldName);
-                            ForwardIndexCache.getInstance().onIndexRemoval(key);
-                            ClusteredPostingCache.getInstance().onIndexRemoval(key);
+                try (GatedCloseable<SegmentInfos> snapshot = shard.getSegmentInfosSnapshot()) {
+                    SegmentInfos segmentInfos = snapshot.get();
+                    for (int i = 0; i < segmentInfos.size(); i++) {
+                        SegmentInfo segmentInfo = segmentInfos.info(i).info;
+                        for (MappedFieldType fieldType : mapperService.fieldTypes()) {
+                            if (fieldType instanceof SparseVectorFieldType) {
+                                String fieldName = fieldType.name();
+                                CacheKey key = new CacheKey(segmentInfo, fieldName);
+                                ForwardIndexCache.getInstance().onIndexRemoval(key);
+                                ClusteredPostingCache.getInstance().onIndexRemoval(key);
+                            }
                         }
                     }
                 }
             } catch (Exception e) {
+                // Never propagate: throwing here aborts IndicesService#removeIndex before it
+                // releases the shard lock, and the reopened shard then stays unassigned forever. A
+                // cache entry that outlives its index is the lesser of the two failures, and it is
+                // still evicted when its own segment closes.
                 log.error("An error occurred during remove index from cache", e);
-                throw new RuntimeException(e);
             }
         }
     }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListenerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListenerTests.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -99,6 +100,22 @@ public class SparseIndexEventListenerTests extends AbstractSparseTestBase {
         listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED);
 
         verify(gatedCloseable).close();
+    }
+
+    public void testBeforeIndexRemoved_withNullMapperService_skipsShard() throws IOException {
+        // A closed index's shards have no MapperService. Throwing here would abort
+        // IndicesService#removeIndex and leak the shard lock, wedging the reopened index.
+        GatedCloseable<SegmentInfos> gatedCloseable = mock(GatedCloseable.class);
+        when(gatedCloseable.get()).thenReturn(segmentInfos);
+
+        when(indexService.iterator()).thenReturn(Arrays.asList(indexShard).iterator());
+        when(indexShard.mapperService()).thenReturn(null);
+        when(indexShard.getSegmentInfosSnapshot()).thenReturn(gatedCloseable);
+
+        listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.REOPENED);
+
+        verify(gatedCloseable).close();
+        verify(segmentInfos, never()).size();
     }
 
     public void testBeforeIndexRemoved_withException_throwsRuntimeException() {

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListenerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexEventListenerTests.java
@@ -7,6 +7,7 @@ package org.opensearch.neuralsearch.sparse;
 import lombok.SneakyThrows;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -23,6 +24,7 @@ import java.util.Arrays;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -102,30 +104,36 @@ public class SparseIndexEventListenerTests extends AbstractSparseTestBase {
         verify(gatedCloseable).close();
     }
 
-    public void testBeforeIndexRemoved_withNullMapperService_skipsShard() throws IOException {
-        // A closed index's shards have no MapperService. Throwing here would abort
-        // IndicesService#removeIndex and leak the shard lock, wedging the reopened index.
-        GatedCloseable<SegmentInfos> gatedCloseable = mock(GatedCloseable.class);
-        when(gatedCloseable.get()).thenReturn(segmentInfos);
-
+    public void testBeforeIndexRemoved_withNullMapperService_skipsShardWithoutSnapshot() throws IOException {
+        // A closed index's shards have no MapperService, and their engine is closed, so asking for
+        // a segment snapshot would throw AlreadyClosedException.
         when(indexService.iterator()).thenReturn(Arrays.asList(indexShard).iterator());
         when(indexShard.mapperService()).thenReturn(null);
-        when(indexShard.getSegmentInfosSnapshot()).thenReturn(gatedCloseable);
 
         listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.REOPENED);
 
-        verify(gatedCloseable).close();
-        verify(segmentInfos, never()).size();
+        verify(indexShard, never()).getSegmentInfosSnapshot();
     }
 
-    public void testBeforeIndexRemoved_withException_throwsRuntimeException() {
-        when(indexService.iterator()).thenReturn(Arrays.asList(indexShard).iterator());
+    public void testBeforeIndexRemoved_withException_doesNotPropagate() throws IOException {
+        // Throwing aborts IndicesService#removeIndex before it releases the shard lock, which
+        // leaves a reopened shard unassigned. Every failure here has to stay logged and swallowed.
+        when(indexService.iterator()).thenReturn(Arrays.asList(indexShard, indexShard).iterator());
         when(indexShard.mapperService()).thenThrow(new RuntimeException("Test exception"));
 
-        RuntimeException exception = expectThrows(RuntimeException.class, () ->
-            listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED)
-        );
+        listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.DELETED);
 
-        assertTrue(exception.getMessage().contains("Test exception"));
+        // The second shard is still visited rather than skipped by an escaping exception.
+        verify(indexShard, times(2)).mapperService();
+    }
+
+    public void testBeforeIndexRemoved_withClosedEngine_doesNotPropagate() throws IOException {
+        when(indexService.iterator()).thenReturn(Arrays.asList(indexShard).iterator());
+        when(indexShard.mapperService()).thenReturn(mapperService);
+        when(indexShard.getSegmentInfosSnapshot()).thenThrow(new AlreadyClosedException("engine is closed"));
+
+        listener.beforeIndexRemoved(indexService, IndicesClusterStateService.AllocatedIndices.IndexRemovalReason.REOPENED);
+
+        verify(indexShard).getSegmentInfosSnapshot();
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexingIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseIndexingIT.java
@@ -34,6 +34,7 @@ public class SparseIndexingIT extends SparseBaseIT {
     private static final String NON_SPARSE_TEST_INDEX_NAME = TEST_INDEX_NAME + "_non_sparse";
     private static final String INVALID_PARAM_TEST_INDEX_NAME = TEST_INDEX_NAME + "_invalid";
     private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
+    private static final String TEST_TEXT_FIELD_NAME = "text";
     private static final String PIPELINE_NAME = "seismic_test_pipeline";
     private static final List<String> TEST_TOKENS = List.of("1000", "2000", "3000", "4000", "5000");
 
@@ -370,6 +371,48 @@ public class SparseIndexingIT extends SparseBaseIT {
         searchResults = search(TEST_INDEX_NAME, neuralSparseQueryBuilder, 10);
         Set<String> actualIds = new HashSet<>(getDocIDs(searchResults));
         assertEquals(Set.of("1"), actualIds);
+    }
+
+    /**
+     * A closed index's shards have no MapperService, so removing that index on reopen used to throw
+     * out of SparseIndexEventListener, abort IndicesService#removeIndex and leak the shard lock,
+     * leaving the shard unassigned and every search failing with "all shards failed".
+     */
+    public void testSeismicIndexRemainsSearchableAfterCloseAndOpen() throws Exception {
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 4, 0.4f, 0.5f, 3);
+
+        ingestDocumentsAndForceMergeForSingleShard(
+            TEST_INDEX_NAME,
+            TEST_TEXT_FIELD_NAME,
+            TEST_SPARSE_FIELD_NAME,
+            List.of(Map.of("1000", 0.1f, "2000", 0.1f), Map.of("1000", 0.2f, "2000", 0.2f), Map.of("1000", 0.3f, "2000", 0.3f))
+        );
+
+        NeuralSparseQueryBuilder neuralSparseQueryBuilder = getNeuralSparseQueryBuilder(
+            TEST_SPARSE_FIELD_NAME,
+            2,
+            1.0f,
+            10,
+            Map.of("1000", 0.1f, "2000", 0.2f)
+        );
+        assertEquals(3, getHitCount(search(TEST_INDEX_NAME, neuralSparseQueryBuilder, 10)));
+
+        assertEquals(
+            RestStatus.OK,
+            RestStatus.fromCode(
+                client().performRequest(new Request("POST", "/" + TEST_INDEX_NAME + "/_close")).getStatusLine().getStatusCode()
+            )
+        );
+        assertEquals(
+            RestStatus.OK,
+            RestStatus.fromCode(
+                client().performRequest(new Request("POST", "/" + TEST_INDEX_NAME + "/_open")).getStatusLine().getStatusCode()
+            )
+        );
+        waitForClusterHealthGreen(String.valueOf(getNodeCount()));
+
+        assertEquals(3, getDocCount(TEST_INDEX_NAME));
+        assertEquals(3, getHitCount(search(TEST_INDEX_NAME, neuralSparseQueryBuilder, 10)));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description

A closed index's `IndexService` is built without a `MapperService` (`IndexService#needsMapperService`), so its shards return null from `mapperService()`. `SparseIndexEventListener#beforeIndexRemoved` dereferenced it and rethrew the NPE, aborting `IndicesService#removeIndex` before it released the shard lock. Reopening an `index.sparse` index therefore left the shard `UNASSIGNED` forever, failing every search.

Such a shard is now skipped: its caches were already cleared when the index was closed.

Added `SparseIndexingIT#testSeismicIndexRemainsSearchableAfterCloseAndOpen`, which fails without this change.

### Related Issues
Resolves #1982

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
