### PR TITLE
[Fusion] Search the fusion config parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * In-query fusion in hybrid search. Support `rrf` in fused mode as a normalizer over ranks, computing rank scores through the same code as the score-ranker-processor, and read `rank_constant` from the place each config shape's own classic factory reads it — the `combination` clause for `score-ranker-processor`, `normalization.parameters` for `normalization-processor` ([#1948](https://github.com/opensearch-project/neural-search/pull/1948))
 * In-query fusion in hybrid search. Report `timed_out` when a soft `timeout` truncated a leg's sub-search, since the fusion then ranked an incomplete candidate set ([#1980](https://github.com/opensearch-project/neural-search/pull/1980))
 * In-query fusion in hybrid search. Support `explain` in fused mode: each ranked hit reports every leg's normalized contribution under the fused score, in classic hybrid's wording ([#1979](https://github.com/opensearch-project/neural-search/pull/1979))
+* In-query fusion in hybrid search. Search the fusion config parameters: read `rank_constant` from either the `combination` clause or `normalization.parameters`, and refuse min_max `lower_bounds`/`upper_bounds` with a validation error ([#1985](https://github.com/opensearch-project/neural-search/pull/1985))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/src/main/java/org/opensearch/neuralsearch/query/FusedRescoreScope.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusedRescoreScope.java
@@ -154,7 +154,7 @@ final class FusedRescoreScope {
                         "[%s] query [%s] cannot confine the request's [rescore] to the fused window: the [rescore] this "
                             + "coordinator rewrote is not the one being executed, so a rescore query could lift a document the "
                             + "fusion never ranked. Failing the request rather than answering it — remove the [rescore], or run "
-                            + "the query without an inline [%s] config",
+                            + "the query without a [%s] block",
                         HybridQueryBuilder.NAME,
                         FUSION,
                         FUSION

--- a/src/main/java/org/opensearch/neuralsearch/query/FusionSpec.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusionSpec.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,7 +43,8 @@ import org.opensearch.neuralsearch.processor.normalization.RRFScoreNormalizer;
  *       combination clause itself, NOT under {@code parameters} — that is where {@code RRFProcessorFactory} reads it) +
  *       optional {@code combination.parameters.weights}. RRF is rank-based, so this shape carries no normalization
  *       clause; it still resolves to {@code normalization = rrf}, because that is the normalization classic applies for
- *       it — see {@link #readNormalizationTechnique}.</li>
+ *       it — see {@link #readNormalizationTechnique}. An inline block may also spell {@code rank_constant} the other
+ *       shape's way, under {@code normalization.parameters} — see {@link #resolveScoreRankerRankConstant}.</li>
  * </ul>
  *
  * <p>Note that {@code rrf} appears in both, and means different things: under a {@code normalization-processor} it is
@@ -85,6 +88,14 @@ public final class FusionSpec {
     private static final String PARAMETERS_KEY = "parameters";
     private static final String WEIGHTS_KEY = "weights";
     private static final String RANK_CONSTANT_KEY = RRFScoreNormalizer.PARAM_NAME_RANK_CONSTANT;
+
+    /**
+     * The only {@code normalization.parameters} key fused mode honors, and only where {@code rrf} is the normalization
+     * technique. Every other parameter classic reads from that clause — min_max's {@code lower_bounds} and
+     * {@code upper_bounds} — has no coordinator-side implementation, so it is refused rather than accepted and dropped;
+     * see {@link #rejectUnhonoredNormalizationParameters}.
+     */
+    private static final Set<String> RRF_NORMALIZATION_PARAMETERS = Set.of(RANK_CONSTANT_KEY);
 
     private final Shape shape; // which processor shape this was read as
     private final String combinationTechnique; // rrf | arithmetic_mean
@@ -150,6 +161,8 @@ public final class FusionSpec {
         if (Objects.isNull(fusionConfig)) {
             return null;
         }
+        requireObjectClause(fusionConfig, NORMALIZATION_CLAUSE);
+        requireObjectClause(fusionConfig, COMBINATION_CLAUSE);
         if (fusionConfig.get(COMBINATION_CLAUSE) instanceof Map) {
             Object technique = ((Map<String, Object>) fusionConfig.get(COMBINATION_CLAUSE)).get(TECHNIQUE_KEY);
             if (Objects.nonNull(technique) && TECHNIQUE_RRF.equals(technique.toString().toLowerCase(Locale.ROOT))) {
@@ -162,6 +175,13 @@ public final class FusionSpec {
     @SuppressWarnings("unchecked")
     private static FusionSpec fromNormalizationProcessor(Map<String, Object> config) {
         String normalization = readNormalizationTechnique(config, NORMALIZATION_MIN_MAX);
+        // Before anything reads a value out of `normalization.parameters`, so that whichever parameters this shape does
+        // not honor are named in the error instead of being dropped on the floor.
+        rejectUnhonoredNormalizationParameters(
+            config,
+            normalization,
+            NORMALIZATION_RRF.equals(normalization) ? RRF_NORMALIZATION_PARAMETERS : Set.of()
+        );
         String combination = TECHNIQUE_ARITHMETIC_MEAN;
         float[] weights = new float[0];
         if (config.get(COMBINATION_CLAUSE) instanceof Map) {
@@ -184,7 +204,7 @@ public final class FusionSpec {
      *
      * <p>Only read for {@code rrf}, because it is an rrf parameter: resolving it for a score-based technique would answer
      * a stray {@code rank_constant} under {@code min_max} with a rank-constant range error instead of the unsupported-
-     * parameter error {@code ScoreNormalizationUtil} raises for it.
+     * parameter error {@link #rejectUnhonoredNormalizationParameters} raises for it first.
      */
     private static int readRankConstant(Map<String, Object> config, String normalization) {
         if (NORMALIZATION_RRF.equals(normalization) == false) {
@@ -208,32 +228,27 @@ public final class FusionSpec {
 
     @SuppressWarnings("unchecked")
     private static FusionSpec fromScoreRankerProcessor(Map<String, Object> config) {
-        int rankConstant = DEFAULT_RANK_CONSTANT;
+        String normalization = readNormalizationTechnique(config, NORMALIZATION_RRF);
+        rejectUnhonoredNormalizationParameters(
+            config,
+            normalization,
+            NORMALIZATION_RRF.equals(normalization) ? RRF_NORMALIZATION_PARAMETERS : Set.of()
+        );
+        Map<String, Object> combinationClause = Map.of();
         float[] weights = new float[0];
         if (config.get(COMBINATION_CLAUSE) instanceof Map) {
-            Map<String, Object> combinationClause = (Map<String, Object>) config.get(COMBINATION_CLAUSE);
+            combinationClause = (Map<String, Object>) config.get(COMBINATION_CLAUSE);
             rejectRankConstantUnderParameters(combinationClause);
-            // rank_constant sits on the combination clause itself, which is where RRFProcessorFactory reads it — NOT
-            // under `parameters`, whose only supported key is `weights`. Delegating to the shared resolver makes fused
-            // mode accept, reject and report exactly what classic does: absent -> default, non-integer -> "must be an
-            // integer", outside [1, 10000] -> the range error. Reading the value directly here would silently accept a
-            // negative, oversized or fractional rank constant that the score-ranker-processor rejects.
-            rankConstant = RRFScoreNormalizer.resolveRankConstant(combinationClause);
             weights = readWeights(combinationClause);
         }
+        int rankConstant = resolveScoreRankerRankConstant(combinationClause, readNormalizationParameters(config));
         // The score-ranker-processor has no normalization clause, so the default is what this shape almost always
         // resolves to. It is "rrf", not "none", because rank scoring IS this shape's normalization step — classic says so
         // itself: RRFProcessorFactory builds an RRFNormalizationTechnique for a processor with no normalization clause.
         // Naming it lets the coordinator resolve rrf through the same ScalarNormalizers lookup as every other technique.
         // An inline fusion block can still carry a normalization clause, and it is reported rather than dropped so the
         // caller's technique check rejects the contradictory pairing instead of silently ignoring what the user asked for.
-        return new FusionSpec(
-            Shape.SCORE_RANKER_PROCESSOR,
-            TECHNIQUE_RRF,
-            readNormalizationTechnique(config, NORMALIZATION_RRF),
-            rankConstant,
-            weights
-        );
+        return new FusionSpec(Shape.SCORE_RANKER_PROCESSOR, TECHNIQUE_RRF, normalization, rankConstant, weights);
     }
 
     /**
@@ -260,6 +275,96 @@ public final class FusionSpec {
         }
     }
 
+    /**
+     * Refuse a {@code normalization.parameters} key fused mode does not honor, rather than parsing the config as if it
+     * were not there. Every parameter classic reads from that clause changes the scores it produces, so accepting one and
+     * ignoring it answers the request with a different ranking at HTTP 200 — min_max's {@code lower_bounds}/
+     * {@code upper_bounds} being the case that matters, since they are the documented way to bound a score-based
+     * normalization and there is no coordinator-side implementation of them yet: {@code ScalarNormalizers} resolves
+     * min_max to a parameterless singleton, and the only parameter map the orchestrator ever builds carries
+     * {@code rank_constant}. Refusing is what leaves that honoring for later without a behavior change; a config classic
+     * accepts then fails fast in fused mode, which is a 400 the user can act on rather than silent divergence.
+     *
+     * <p>The honored set is the caller's, not this method's, because it is technique-dependent: {@code rank_constant} is
+     * an rrf parameter, so it is honored wherever rrf is the normalization and refused under a score-based one — which is
+     * also what keeps a stray {@code rank_constant} under {@code min_max} from being answered with a rank-constant range
+     * error instead of an unsupported-parameter one.
+     */
+    private static void rejectUnhonoredNormalizationParameters(
+        Map<String, Object> config,
+        String normalization,
+        Set<String> honoredParameters
+    ) {
+        Set<String> unhonored = new TreeSet<>(readNormalizationParameters(config).keySet());
+        unhonored.removeAll(honoredParameters);
+        if (unhonored.isEmpty()) {
+            return;
+        }
+        throw new IllegalArgumentException(
+            String.format(
+                Locale.ROOT,
+                "[%s.%s] %s not supported with normalization [%s] in fused mode; supported parameters are %s",
+                NORMALIZATION_CLAUSE,
+                PARAMETERS_KEY,
+                unhonored,
+                normalization,
+                new TreeSet<>(honoredParameters)
+            )
+        );
+    }
+
+    /**
+     * {@code rank_constant} for the {@code score-ranker-processor} shape, read from either place a user may reasonably
+     * spell it: the combination clause itself, which is where {@code RRFProcessorFactory} reads it, or
+     * {@code normalization.parameters}, which is where the {@code normalization-processor} shape keeps the very same
+     * parameter. Both name one rank constant for one rrf normalization, so honoring either is unambiguous — and the
+     * second spelling can only reach here from an inline {@code fusion} block, never from a pipeline: classic's
+     * {@code RRFProcessorFactory} reads no normalization clause at all, so a {@code score-ranker-processor} carrying one
+     * is rejected at pipeline creation. Honoring it therefore cannot make fused mode fuse a *pipeline* differently than
+     * classic would.
+     *
+     * <p>Given in both places with different values it is a contradiction, not a precedence question, so it is refused
+     * rather than resolved by a rule the user cannot see. Each location is resolved through the shared resolver, so a
+     * non-integer or out-of-range value is reported exactly as classic reports it whichever place it was written.
+     */
+    private static int resolveScoreRankerRankConstant(Map<String, Object> combinationClause, Map<String, Object> normalizationParameters) {
+        // Absent from the combination clause this is the default, which is also the right answer when neither place has it.
+        int fromCombination = RRFScoreNormalizer.resolveRankConstant(combinationClause);
+        if (normalizationParameters.containsKey(RANK_CONSTANT_KEY) == false) {
+            return fromCombination;
+        }
+        int fromNormalization = RRFScoreNormalizer.resolveRankConstant(normalizationParameters);
+        if (combinationClause.containsKey(RANK_CONSTANT_KEY) && fromCombination != fromNormalization) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] is set to [%d] on the [%s] clause and to [%d] under [%s.%s]; set it in one place only",
+                    RANK_CONSTANT_KEY,
+                    fromCombination,
+                    COMBINATION_CLAUSE,
+                    fromNormalization,
+                    NORMALIZATION_CLAUSE,
+                    PARAMETERS_KEY
+                )
+            );
+        }
+        return fromNormalization;
+    }
+
+    /**
+     * Refuse a {@code normalization}/{@code combination} value that is not an object. Every reader below gates on
+     * {@code instanceof Map}, so a bare string would fall through to the min_max + arithmetic_mean defaults and fuse by a
+     * technique the user did not ask for, at HTTP 200. The mistake is an easy one to make, because one level up the
+     * shorthand {@code "fusion": "pipeline"} <em>is</em> a bare string.
+     */
+    private static void requireObjectClause(Map<String, Object> fusionConfig, String clause) {
+        Object value = fusionConfig.get(clause);
+        if (Objects.isNull(value) || value instanceof Map) {
+            return;
+        }
+        throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] must be an object, got [%s]", clause, value));
+    }
+
     @SuppressWarnings("unchecked")
     private static String readNormalizationTechnique(Map<String, Object> config, String defaultTechnique) {
         if ((config.get(NORMALIZATION_CLAUSE) instanceof Map) == false) {
@@ -269,6 +374,15 @@ public final class FusionSpec {
         return Objects.isNull(technique) ? defaultTechnique : technique.toString().toLowerCase(Locale.ROOT);
     }
 
+    /**
+     * {@code combination.parameters.weights}, read the same way for both shapes — weights sit on the combination clause,
+     * so the normalization technique has no bearing on them.
+     *
+     * <p>A {@code weights} that is present but not a list is refused rather than read as absent. The orchestrator hands
+     * {@link org.opensearch.neuralsearch.processor.combination.ScoreCombinationUtil} a list it rebuilds from the parsed
+     * array, so classic's own type check ("must be a collection of numbers") can never see the malformed value and a
+     * scalar or string {@code weights} was fusing unweighted at HTTP 200 — the same request classic answers with a 400.
+     */
     @SuppressWarnings("unchecked")
     private static float[] readWeights(Map<String, Object> combinationClause) {
         if ((combinationClause.get(PARAMETERS_KEY) instanceof Map) == false) {
@@ -276,6 +390,11 @@ public final class FusionSpec {
         }
         Map<String, Object> parameters = (Map<String, Object>) combinationClause.get(PARAMETERS_KEY);
         if ((parameters.get(WEIGHTS_KEY) instanceof List) == false) {
+            if (parameters.containsKey(WEIGHTS_KEY)) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "parameter [%s] must be a collection of numbers", WEIGHTS_KEY)
+                );
+            }
             return new float[0];
         }
         List<Object> raw = (List<Object>) parameters.get(WEIGHTS_KEY);

--- a/src/main/java/org/opensearch/neuralsearch/query/FusionSpec.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusionSpec.java
@@ -382,6 +382,12 @@ public final class FusionSpec {
      * {@link org.opensearch.neuralsearch.processor.combination.ScoreCombinationUtil} a list it rebuilds from the parsed
      * array, so classic's own type check ("must be a collection of numbers") can never see the malformed value and a
      * scalar or string {@code weights} was fusing unweighted at HTTP 200 — the same request classic answers with a 400.
+     *
+     * <p>The elements are checked too, and that half is <em>stricter</em> than classic rather than parity with it: the list
+     * check is the only one classic makes either ({@code ScoreCombinationUtil#validateParams}), and it then streams the
+     * elements through {@code Double::floatValue}, so a list holding a non-numeric or null element fails classic and fused
+     * mode alike with a cast failure at HTTP 500. Refused here with the reason instead — a request that cannot be served
+     * should say what to fix.
      */
     @SuppressWarnings("unchecked")
     private static float[] readWeights(Map<String, Object> combinationClause) {
@@ -391,17 +397,25 @@ public final class FusionSpec {
         Map<String, Object> parameters = (Map<String, Object>) combinationClause.get(PARAMETERS_KEY);
         if ((parameters.get(WEIGHTS_KEY) instanceof List) == false) {
             if (parameters.containsKey(WEIGHTS_KEY)) {
-                throw new IllegalArgumentException(
-                    String.format(Locale.ROOT, "parameter [%s] must be a collection of numbers", WEIGHTS_KEY)
-                );
+                throw weightsMustBeNumbers();
             }
             return new float[0];
         }
         List<Object> raw = (List<Object>) parameters.get(WEIGHTS_KEY);
         float[] weights = new float[raw.size()];
         for (int i = 0; i < raw.size(); i++) {
+            // Checked per element, because the cast is unchecked: a non-numeric or null element would otherwise fail the
+            // request with a ClassCastException or a NullPointerException, at HTTP 500, saying nothing about what to fix.
+            if ((raw.get(i) instanceof Number) == false) {
+                throw weightsMustBeNumbers();
+            }
             weights[i] = ((Number) raw.get(i)).floatValue();
         }
         return weights;
+    }
+
+    /** Classic's own wording for a malformed {@code weights}, so one request reads the same however it was refused. */
+    private static IllegalArgumentException weightsMustBeNumbers() {
+        return new IllegalArgumentException(String.format(Locale.ROOT, "parameter [%s] must be a collection of numbers", WEIGHTS_KEY));
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridQueryBuilder.java
@@ -586,16 +586,18 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
             throw new IllegalArgumentException(
                 String.format(
                     Locale.ROOT,
-                    "[%s] query [%s] requires a normalization or score-ranker processor: the resolved search pipeline "
-                        + "(from ?search_pipeline= or index.search.default_pipeline) has none, and no inline fusion block "
-                        + "was provided (a missing pipeline id is rejected earlier by core). A fused [%s] nested inside "
-                        + "another compound query (for example [bool] or [dis_max]) within a leg of an enclosing fused [%s] "
-                        + "must carry an inline [%s] config, because a leg sub-search runs with the search pipeline disabled",
+                    "[%s] query [%s: %s] requires a normalization or score-ranker processor: the resolved search pipeline "
+                        + "(from ?search_pipeline= or index.search.default_pipeline) has none (a missing pipeline id is "
+                        + "rejected earlier by core). Drop [%s] to fuse with the built-in defaults, or name the techniques "
+                        + "inline. A fused [%s] nested inside another compound query (for example [bool] or [dis_max]) "
+                        + "within a leg of an enclosing fused [%s] must not read from the pipeline, because a leg "
+                        + "sub-search runs with the search pipeline disabled",
                     NAME,
-                    FUSION_FIELD.getPreferredName(),
+                    FUSION_KEY_SOURCE,
+                    FUSION_SOURCE_PIPELINE,
+                    FUSION_KEY_SOURCE,
                     NAME,
-                    NAME,
-                    FUSION_FIELD.getPreferredName()
+                    NAME
                 )
             );
         }
@@ -1127,12 +1129,14 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     /**
      * Resolve the fusion config for this rewrite, in precedence order:
      * <ol>
-     *   <li>an inline {@code fusion} block on this query body (explicit user intent, wins outright);</li>
+     *   <li>the {@code fusion} block on this query body, unless it delegates with {@code source: pipeline} — the block
+     *       configures the fusion (technique keys, or the built-in defaults when it names none), and wins outright;</li>
      *   <li>a config projected down by an enclosing fused hybrid ({@link #resolvedFusionSpec}) — this builder is one of
      *       its legs, and the leg request has no pipeline to read;</li>
      *   <li>the search pipeline attached to the request (inline body / {@code ?search_pipeline=} / index default).</li>
      * </ol>
-     * {@code null} when none of the three yields a config; the caller fails fast rather than emitting unfused scores.
+     * {@code null} when none of the three yields a config, which now means only a {@code source: pipeline} block with no
+     * pipeline carrying a phase-results processor; the caller fails fast rather than emitting unfused scores.
      */
     private FusionSpec resolveFusionSpec(final SearchRequest searchRequest) {
         if (Objects.nonNull(this.fusion) && hasInlineConfig(this.fusion)) {
@@ -1145,7 +1149,7 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
     }
 
     /**
-     * Hand the already-resolved fusion config down to any leg that is itself a fused hybrid without an inline config.
+     * Hand the already-resolved fusion config down to any leg that is itself a fused hybrid delegating to the pipeline.
      *
      * <p>Legs are fanned out with {@code pipeline=_none} so that per-leg request/response processors do not run
      * ({@link HybridFusionOrchestrator#buildLegMultiSearch}); a nested fused hybrid would therefore resolve no config
@@ -1154,9 +1158,9 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
      * and it is the same request and therefore the same pipeline.
      *
      * <p>Reaches direct legs only, at any nesting depth (each level projects onto its own legs). A fused hybrid buried
-     * inside a container query within a leg (e.g. {@code bool{must: hybrid{fusion}}}) is not reachable —
-     * {@link QueryBuilder} exposes no generic child accessor — and still fails, now with a message that names the real
-     * cause and the inline-config workaround.
+     * inside a container query within a leg (e.g. {@code bool{must: hybrid{fusion: {source: pipeline}}}}) is not
+     * reachable — {@link QueryBuilder} exposes no generic child accessor — and still fails, now with a message that names
+     * the real cause and the two workarounds (drop {@code source}, or name the techniques inline).
      *
      * @return the original list when nothing needed projecting (the common case), else a copy with legs substituted
      */
@@ -1201,9 +1205,17 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
         return copy;
     }
 
-    /** True when the inline {@code fusion} block carries an actual config (not just {@code source: pipeline} / empty). */
+    /**
+     * True when the {@code fusion} block configures the fusion itself rather than delegating to the attached pipeline.
+     *
+     * <p>Keys on the absence of {@code source: pipeline}, not on the presence of a technique key: a block that names
+     * neither a technique nor a source ({@code fusion: {}}, {@code fusion: {"window_size": N}}) is the built-in-defaults
+     * form, and {@link FusionSpec#fromInlineFusion} fills in min_max + arithmetic_mean with equal weights. Reading the
+     * pipeline instead would depend on request context the query body does not show — which pipeline the request or the
+     * index happens to attach — so it is only ever done when the body asks for it.
+     */
     private static boolean hasInlineConfig(final Map<String, Object> fusion) {
-        return fusion.containsKey(FUSION_KEY_NORMALIZATION) || fusion.containsKey(FUSION_KEY_COMBINATION);
+        return fusion.containsKey(FUSION_KEY_SOURCE) == false;
     }
 
     /**
@@ -1430,6 +1442,10 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
      *   <li>{@code source: "pipeline"} alongside inline {@code normalization}/{@code combination} → 400 (contradiction:
      *       read-from-pipeline vs inline config);</li>
      *   <li>{@code source} present but not {@code "pipeline"} → 400;</li>
+     *   <li>{@code normalization}/{@code combination} present but not an object → 400 (a bare string would otherwise fall
+     *       through every {@code instanceof Map} gate in {@link FusionSpec} to the min_max + arithmetic_mean defaults, and
+     *       fuse by a technique the user did not ask for — the shorthand {@code "fusion": "pipeline"} one level up makes
+     *       {@code "combination": "rrf"} an easy thing to write);</li>
      *   <li>{@code window_size} non-positive → 400 (upper bound vs {@code index.max_result_window} is shard-side);</li>
      *   <li>{@code pagination_depth} co-set with {@code fusion} → 400 (fused pages over {@code window_size}).</li>
      * </ul>
@@ -1474,6 +1490,23 @@ public final class HybridQueryBuilder extends AbstractQueryBuilder<HybridQueryBu
                         FUSION_SOURCE_PIPELINE,
                         FUSION_KEY_NORMALIZATION,
                         FUSION_KEY_COMBINATION
+                    )
+                );
+            }
+        }
+
+        for (String clause : List.of(FUSION_KEY_NORMALIZATION, FUSION_KEY_COMBINATION)) {
+            Object value = fusion.get(clause);
+            if (Objects.nonNull(value) && (value instanceof Map) == false) {
+                throw new ParsingException(
+                    parser.getTokenLocation(),
+                    String.format(
+                        Locale.ROOT,
+                        "[%s] query [%s.%s] must be an object, got [%s]",
+                        NAME,
+                        FUSION_FIELD.getPreferredName(),
+                        clause,
+                        value
                     )
                 );
             }

--- a/src/test/java/org/opensearch/neuralsearch/query/FusionSpecTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/FusionSpecTests.java
@@ -194,6 +194,235 @@ public class FusionSpecTests extends OpenSearchTestCase {
         assertEquals(FusionSpec.Shape.NORMALIZATION_PROCESSOR, FusionSpec.fromInlineFusion(Map.of()).shape());
     }
 
+    public void testFromInlineFusion_whenMinMaxBounds_thenRejected() {
+        // lower_bounds/upper_bounds are the documented way to bound min_max in classic, and fused mode has no
+        // coordinator-side implementation of them. Refused, because accepting them and normalizing without them answers
+        // the request with a different ranking at HTTP 200 — silent divergence on the zero-migration path.
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> FusionSpec.fromInlineFusion(
+                Map.of(
+                    "normalization",
+                    Map.of("technique", "min_max", "parameters", Map.of("lower_bounds", List.of(Map.of("mode", "apply", "min_score", 0.1))))
+                )
+            )
+        );
+        assertTrue(e.getMessage(), e.getMessage().contains("[lower_bounds] not supported with normalization [min_max] in fused mode"));
+    }
+
+    public void testFromPipelineConfig_whenMinMaxBounds_thenRejected() {
+        // Same refusal through the other entry point: a classic normalization-processor pipeline read at rewrite. This is
+        // the migration path a user takes without editing their query at all, so it must not fuse on unbounded scores.
+        Map<String, Object> pipelineConfig = Map.of(
+            "phase_results_processors",
+            List.of(
+                Map.of(
+                    "normalization-processor",
+                    Map.of(
+                        "normalization",
+                        Map.of(
+                            "technique",
+                            "min_max",
+                            "parameters",
+                            Map.of(
+                                "lower_bounds",
+                                List.of(Map.of("mode", "apply", "min_score", 0.1)),
+                                "upper_bounds",
+                                List.of(Map.of("mode", "apply", "max_score", 0.9))
+                            )
+                        ),
+                        "combination",
+                        Map.of("technique", "arithmetic_mean")
+                    )
+                )
+            )
+        );
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> FusionSpec.fromPipelineConfig(pipelineConfig));
+        // Both offenders named, in a stable order, and the honored set reported as empty for a score-based technique.
+        assertTrue(e.getMessage(), e.getMessage().contains("[normalization.parameters] [lower_bounds, upper_bounds] not supported"));
+        assertTrue(e.getMessage(), e.getMessage().contains("supported parameters are []"));
+    }
+
+    public void testFromInlineFusion_whenScoreNormalizationHasAnyParameter_thenRejected() {
+        // l2 and z_score take no parameters at all in classic either, so anything under the clause is a config error
+        // rather than something fused mode is behind on.
+        for (String technique : List.of("l2", "z_score")) {
+            IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> FusionSpec.fromInlineFusion(Map.of("normalization", Map.of("technique", technique, "parameters", Map.of("bogus", 1))))
+            );
+            assertTrue(e.getMessage(), e.getMessage().contains("[bogus] not supported with normalization [" + technique + "]"));
+        }
+    }
+
+    public void testFromInlineFusion_whenRrfNormalizationUnknownParameter_thenRejected() {
+        // rrf-as-normalization honors rank_constant and nothing else — the unknown key is named, the honored one is not.
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> FusionSpec.fromInlineFusion(
+                Map.of(
+                    "normalization",
+                    Map.of("technique", "rrf", "parameters", Map.of("rank_constant", 100, "bogus", 1)),
+                    "combination",
+                    Map.of("technique", "arithmetic_mean")
+                )
+            )
+        );
+        assertTrue(e.getMessage(), e.getMessage().contains("[bogus] not supported"));
+        assertTrue(e.getMessage(), e.getMessage().contains("supported parameters are [rank_constant]"));
+    }
+
+    public void testFromInlineFusion_whenRrfNormalizationWithArithmeticMean_thenRankConstantHonored() {
+        // The honored case, inline: rrf as the normalization step with a mean doing the combining. Guards the refusal
+        // above from over-reaching, and is the only unit coverage of this pairing through the inline entry point.
+        FusionSpec spec = FusionSpec.fromInlineFusion(
+            Map.of(
+                "normalization",
+                Map.of("technique", "rrf", "parameters", Map.of("rank_constant", 100)),
+                "combination",
+                Map.of("technique", "arithmetic_mean")
+            )
+        );
+        assertNotNull(spec);
+        assertEquals(FusionSpec.Shape.NORMALIZATION_PROCESSOR, spec.shape());
+        assertEquals(FusionSpec.NORMALIZATION_RRF, spec.normalizationTechnique());
+        assertEquals(FusionSpec.TECHNIQUE_ARITHMETIC_MEAN, spec.combinationTechnique());
+        assertEquals(100, spec.rankConstant());
+    }
+
+    public void testFromInlineFusion_whenScoreRankerRankConstantUnderNormalizationParameters_thenHonored() {
+        // The other shape's spelling of the same rrf parameter. Honored rather than refused: it names one rank constant
+        // for one rrf normalization, so there is nothing ambiguous to resolve, and 100 must reach the spec — resolving to
+        // the default 60 here is exactly the silent mis-ranking the refusal was written to avoid.
+        FusionSpec spec = FusionSpec.fromInlineFusion(
+            Map.of(
+                "normalization",
+                Map.of("technique", "rrf", "parameters", Map.of("rank_constant", 100)),
+                "combination",
+                Map.of("technique", "rrf")
+            )
+        );
+        assertEquals(FusionSpec.Shape.SCORE_RANKER_PROCESSOR, spec.shape());
+        assertEquals(FusionSpec.NORMALIZATION_RRF, spec.normalizationTechnique());
+        assertEquals(FusionSpec.TECHNIQUE_RRF, spec.combinationTechnique());
+        assertEquals(100, spec.rankConstant());
+    }
+
+    public void testFromInlineFusion_whenScoreRankerRankConstantInBothPlacesAndAgree_thenHonored() {
+        FusionSpec spec = FusionSpec.fromInlineFusion(
+            Map.of(
+                "normalization",
+                Map.of("technique", "rrf", "parameters", Map.of("rank_constant", 100)),
+                "combination",
+                Map.of("technique", "rrf", "rank_constant", 100)
+            )
+        );
+        assertEquals(100, spec.rankConstant());
+    }
+
+    public void testFromInlineFusion_whenScoreRankerRankConstantInBothPlacesAndConflict_thenRejected() {
+        // A contradiction, not a precedence question: picking one silently would rank by a constant the user did not ask
+        // for, whichever side the rule favored.
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> FusionSpec.fromInlineFusion(
+                Map.of(
+                    "normalization",
+                    Map.of("technique", "rrf", "parameters", Map.of("rank_constant", 100)),
+                    "combination",
+                    Map.of("technique", "rrf", "rank_constant", 10)
+                )
+            )
+        );
+        assertTrue(e.getMessage(), e.getMessage().contains("[rank_constant] is set to [10] on the [combination] clause"));
+        assertTrue(e.getMessage(), e.getMessage().contains("to [100] under [normalization.parameters]"));
+        assertTrue(e.getMessage(), e.getMessage().contains("set it in one place only"));
+    }
+
+    public void testFromInlineFusion_whenScoreRankerRankConstantUnderNormalizationParametersInvalid_thenRejected() {
+        // Range and type checks have to hold at the alternate spelling too, or it becomes the lenient way in.
+        for (Object invalid : List.of(0, 10001, "not-a-number")) {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> FusionSpec.fromInlineFusion(
+                    Map.of(
+                        "normalization",
+                        Map.of("technique", "rrf", "parameters", Map.of("rank_constant", invalid)),
+                        "combination",
+                        Map.of("technique", "rrf")
+                    )
+                )
+            );
+        }
+    }
+
+    public void testFromInlineFusion_whenWeights_thenParsedForEveryTechnique() {
+        // weights live on the combination clause, which both shapes read the same way, so the normalization technique is
+        // irrelevant to whether they parse. Pinned across all four so a future per-technique parameter check cannot start
+        // dropping them for one of them.
+        for (String normalization : List.of("min_max", "z_score", "l2", "rrf")) {
+            FusionSpec spec = FusionSpec.fromInlineFusion(
+                Map.of(
+                    "normalization",
+                    Map.of("technique", normalization),
+                    "combination",
+                    Map.of("technique", "arithmetic_mean", "parameters", Map.of("weights", List.of(0.4, 0.6)))
+                )
+            );
+            assertEquals(normalization, FusionSpec.Shape.NORMALIZATION_PROCESSOR, spec.shape());
+            assertArrayEquals(normalization, new float[] { 0.4f, 0.6f }, spec.weights(), 0.0001f);
+        }
+        // ...and on the score-ranker shape, alongside a rank_constant in either place.
+        FusionSpec scoreRanker = FusionSpec.fromInlineFusion(
+            Map.of("combination", Map.of("technique", "rrf", "rank_constant", 10, "parameters", Map.of("weights", List.of(0.4, 0.6))))
+        );
+        assertEquals(FusionSpec.Shape.SCORE_RANKER_PROCESSOR, scoreRanker.shape());
+        assertEquals(10, scoreRanker.rankConstant());
+        assertArrayEquals(new float[] { 0.4f, 0.6f }, scoreRanker.weights(), 0.0001f);
+    }
+
+    public void testFromInlineFusion_whenWeightsIsNotAList_thenRejected() {
+        // Classic answers this with a 400 from ScoreCombinationUtil.validateParams. Fused mode never let that check see the
+        // value — it rebuilds the list from the parsed array — so a scalar or string weights fused unweighted at HTTP 200.
+        for (Object malformed : List.of(0.5, "0.3,0.7", Map.of("0", 0.3))) {
+            IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> FusionSpec.fromInlineFusion(
+                    Map.of(
+                        "normalization",
+                        Map.of("technique", "min_max"),
+                        "combination",
+                        Map.of("technique", "arithmetic_mean", "parameters", Map.of("weights", malformed))
+                    )
+                )
+            );
+            assertTrue(e.getMessage(), e.getMessage().contains("parameter [weights] must be a collection of numbers"));
+        }
+        // Absent is still absent, not malformed.
+        assertEquals(
+            0,
+            FusionSpec.fromInlineFusion(
+                Map.of("normalization", Map.of("technique", "min_max"), "combination", Map.of("technique", "arithmetic_mean"))
+            ).weights().length
+        );
+    }
+
+    public void testFromInlineFusion_whenClauseIsNotAnObject_thenRejected() {
+        // `"combination": "rrf"` copies the shape of the supported one-level-up shorthand `"fusion": "pipeline"`. Every
+        // reader gates on instanceof Map, so without this it resolved to min_max + arithmetic_mean at HTTP 200.
+        IllegalArgumentException combination = assertThrows(
+            IllegalArgumentException.class,
+            () -> FusionSpec.fromInlineFusion(Map.of("combination", "rrf"))
+        );
+        assertTrue(combination.getMessage(), combination.getMessage().contains("[combination] must be an object"));
+
+        IllegalArgumentException normalization = assertThrows(
+            IllegalArgumentException.class,
+            () -> FusionSpec.fromInlineFusion(Map.of("normalization", "min_max"))
+        );
+        assertTrue(normalization.getMessage(), normalization.getMessage().contains("[normalization] must be an object"));
+    }
+
     private static Map<String, Object> normalizationProcessorWithRankConstant(int rankConstant) {
         return Map.of(
             "phase_results_processors",

--- a/src/test/java/org/opensearch/neuralsearch/query/FusionSpecTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/FusionSpecTests.java
@@ -4,6 +4,7 @@
  */
 package org.opensearch.neuralsearch.query;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -404,6 +405,36 @@ public class FusionSpecTests extends OpenSearchTestCase {
             FusionSpec.fromInlineFusion(
                 Map.of("normalization", Map.of("technique", "min_max"), "combination", Map.of("technique", "arithmetic_mean"))
             ).weights().length
+        );
+    }
+
+    public void testFromInlineFusion_whenWeightsHasNonNumericElement_thenRejected() {
+        // The list check one level up cannot see this, and the element read is an unchecked cast — so before this guard a
+        // non-numeric element was a ClassCastException and a null one a NullPointerException, both HTTP 500. Stricter than
+        // classic, which casts the elements just as unguardedly, rather than parity with it.
+        List<Object> withNull = new ArrayList<>();
+        withNull.add(0.5);
+        withNull.add(null);
+        for (Object malformed : List.<Object>of(List.of("a"), List.of("a", 0.5), List.of(0.5, "b"), List.of(0.5, Map.of()), withNull)) {
+            // Both shapes read weights through the same method, so both are pinned: rrf routes to the score-ranker shape.
+            for (String combination : List.of("arithmetic_mean", "rrf")) {
+                IllegalArgumentException e = assertThrows(
+                    combination + " " + malformed,
+                    IllegalArgumentException.class,
+                    () -> FusionSpec.fromInlineFusion(
+                        Map.of("combination", Map.of("technique", combination, "parameters", Map.of("weights", malformed)))
+                    )
+                );
+                assertTrue(e.getMessage(), e.getMessage().contains("parameter [weights] must be a collection of numbers"));
+            }
+        }
+        // An integer is a Number too — the guard must not reject a weights list a user wrote without decimal points.
+        assertArrayEquals(
+            new float[] { 1.0f, 0.0f },
+            FusionSpec.fromInlineFusion(
+                Map.of("combination", Map.of("technique", "arithmetic_mean", "parameters", Map.of("weights", List.of(1, 0))))
+            ).weights(),
+            0.0001f
         );
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryBuilderTests.java
@@ -458,6 +458,31 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     }
 
     @SneakyThrows
+    public void testFromXContent_whenFusionCombinationIsAString_then400() {
+        // `"combination": "rrf"` reads like the supported shorthand one level up (`"fusion": "pipeline"`), and every reader
+        // in FusionSpec gates on instanceof Map — so before this check it parsed to the min_max + arithmetic_mean defaults
+        // and fused by a technique the user did not ask for, at HTTP 200.
+        setUpClusterService();
+        XContentBuilder xContentBuilder = hybridWithOneTermQuery().startObject("fusion")
+            .field("combination", "rrf")
+            .endObject()
+            .endObject();
+        ParsingException e = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(fusionTestParser(xContentBuilder)));
+        assertThat(e.getMessage(), containsString("[fusion.combination] must be an object"));
+    }
+
+    @SneakyThrows
+    public void testFromXContent_whenFusionNormalizationIsAString_then400() {
+        setUpClusterService();
+        XContentBuilder xContentBuilder = hybridWithOneTermQuery().startObject("fusion")
+            .field("normalization", "min_max")
+            .endObject()
+            .endObject();
+        ParsingException e = expectThrows(ParsingException.class, () -> HybridQueryBuilder.fromXContent(fusionTestParser(xContentBuilder)));
+        assertThat(e.getMessage(), containsString("[fusion.normalization] must be an object"));
+    }
+
+    @SneakyThrows
     public void testFromXContent_whenFusionWindowSizeNonPositive_then400() {
         setUpClusterService();
         XContentBuilder xContentBuilder = hybridWithOneTermQuery().startObject("fusion").field("window_size", 0).endObject().endObject();
@@ -724,8 +749,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         // normalization technique and lists the three means — it describes the normalization-processor and cannot speak to
         // this pairing. The exemption has to stop there: a normalization-processor combining rrf-normalized scores by rrf
         // resolves to the same two technique names, but is a pairing classic rejects through that very matrix, so admitting
-        // it would leave fused mode looser than classic (and, since that shape keeps rank_constant under
-        // `normalization.parameters`, would silently fuse at the default 60).
+        // it would leave fused mode looser than classic.
         HybridQueryBuilder.requireSupportedTechniques(
             new FusionSpec(
                 FusionSpec.Shape.SCORE_RANKER_PROCESSOR,
@@ -892,6 +916,30 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         QueryCoordinatorContext ctx = coordinatorContextFor(builder);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> builder.doRewrite(ctx));
         assertThat(e.getMessage(), containsString("requires a normalization or score-ranker processor"));
+        assertThat("the message must name the two ways out", e.getMessage(), containsString("Drop [source]"));
+    }
+
+    @SneakyThrows
+    public void testDoRewriteFused_whenNoTechniqueKeysAndNoPipeline_thenFusesWithBuiltInDefaults() {
+        // A fusion block naming neither a technique nor a source is the built-in-defaults form, not a pipeline read:
+        // with no pipeline resolvable at all it still fans out, rather than failing fast. `window_size` is a neutral key
+        // and does not turn the block into a delegation.
+        for (Map<String, Object> fusion : List.<Map<String, Object>>of(Map.of(), Map.of("window_size", 25))) {
+            initClusterUtilWithNoPipeline();
+            HybridQueryBuilder builder = fusedBuilder(new HashMap<>(fusion));
+            QueryCoordinatorContext ctx = coordinatorContextFor(builder);
+            java.util.concurrent.atomic.AtomicInteger asyncRegistered = new java.util.concurrent.atomic.AtomicInteger();
+            doAnswer(invocation -> {
+                asyncRegistered.incrementAndGet();
+                return null;
+            }).when(ctx).registerAsyncAction(org.mockito.ArgumentMatchers.any());
+
+            QueryBuilder rewritten = builder.doRewrite(ctx);
+
+            assertEquals("fusion " + fusion + " must fuse by the defaults, not resolve a pipeline", 1, asyncRegistered.get());
+            assertTrue(rewritten instanceof HybridQueryBuilder);
+            assertNotSame("round 1 returns a marker, not the original", builder, rewritten);
+        }
     }
 
     /** An outer fused hybrid whose first leg is itself a fused hybrid taking its config from the pipeline. */
@@ -899,7 +947,8 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         HybridQueryBuilder nested = new HybridQueryBuilder();
         nested.add(new MatchQueryBuilder(TEXT_FIELD_NAME, "inner-a"));
         nested.add(new MatchQueryBuilder(TEXT_FIELD_NAME, "inner-b"));
-        nested.fusion(new HashMap<>()); // fusion:{} → no inline config, must come from the pipeline
+        // fusion:{source: pipeline} → the one form that delegates, so the one form that needs projecting
+        nested.fusion(new HashMap<>(Map.of("source", "pipeline")));
         HybridQueryBuilder outer = new HybridQueryBuilder();
         outer.add(nested);
         outer.add(QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
@@ -908,7 +957,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
     }
 
     @SneakyThrows
-    public void testProjectResolvedConfigOntoLegs_projectsOnlyFusedLegsWithoutInlineConfig() {
+    public void testProjectResolvedConfigOntoLegs_projectsOnlyPipelineDelegatingFusedLegs() {
         FusionSpec resolved = new FusionSpec(
             FusionSpec.Shape.NORMALIZATION_PROCESSOR,
             FusionSpec.TECHNIQUE_ARITHMETIC_MEAN,
@@ -917,7 +966,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
             new float[0]
         );
 
-        // A fused leg with no inline config is substituted by an equal-but-distinct copy carrying the resolved config.
+        // A fused leg that delegates to the pipeline is substituted by an equal-but-distinct copy carrying the config.
         List<QueryBuilder> legs = outerWithNestedFusedLeg().queries();
         List<QueryBuilder> projected = HybridQueryBuilder.projectResolvedConfigOntoLegs(legs, resolved);
         assertNotSame("a projectable leg forces a new list", legs, projected);
@@ -925,11 +974,19 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
         assertEquals("the copy is wire/equality-identical to the original leg", legs.get(0), projected.get(0));
         assertSame("non-hybrid legs are left alone", legs.get(1), projected.get(1));
 
-        // Nothing to project: an inline-config fused leg and a plain leg both stay put, and the list is not copied.
+        // Nothing to project: a technique-naming leg, a defaults-form (`fusion:{}`) leg — which configures itself, so it
+        // must not inherit — and a plain leg all stay put, and the list is not copied.
         HybridQueryBuilder inlineNested = new HybridQueryBuilder();
         inlineNested.add(new MatchQueryBuilder(TEXT_FIELD_NAME, "inner"));
         inlineNested.fusion(new HashMap<>(Map.of("normalization", Map.of("technique", "min_max"))));
-        List<QueryBuilder> noneProjectable = List.of(inlineNested, QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT));
+        HybridQueryBuilder defaultsNested = new HybridQueryBuilder();
+        defaultsNested.add(new MatchQueryBuilder(TEXT_FIELD_NAME, "inner"));
+        defaultsNested.fusion(new HashMap<>());
+        List<QueryBuilder> noneProjectable = List.of(
+            inlineNested,
+            defaultsNested,
+            QueryBuilders.termQuery(TEXT_FIELD_NAME, TERM_QUERY_TEXT)
+        );
         assertSame(
             "no projectable leg → the original list is reused",
             noneProjectable,
@@ -989,7 +1046,7 @@ public class HybridQueryBuilderTests extends OpenSearchQueryTestCase {
             IllegalArgumentException.class,
             () -> unprojected.requests().get(0).source().query().rewrite(bareCtx)
         );
-        assertThat(e.getMessage(), containsString("must carry an inline [fusion] config"));
+        assertThat(e.getMessage(), containsString("must not read from the pipeline"));
         assertThat(e.getMessage(), containsString("leg sub-search runs with the search pipeline disabled"));
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
@@ -68,8 +68,10 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
     private static final String INDEX_NO_PIPELINE = "test-hybrid-fused-inline-config";
     private static final String INDEX_WITH_DEFAULT_RRF = "test-hybrid-fused-default-rrf";
     private static final String INDEX_RRF_PARITY = "test-hybrid-fused-rrf-parity";
+    private static final String INDEX_WITH_BOUNDED_NORM = "test-hybrid-fused-bounded-norm";
     private static final String NORM_PIPELINE = "fused-mode-norm-pipeline";
     private static final String RRF_PIPELINE = "fused-mode-rrf-pipeline";
+    private static final String BOUNDED_NORM_PIPELINE = "fused-mode-bounded-norm-pipeline";
     /** Candidate window for the parity test, comfortably above the match count so neither path truncates. */
     private static final int WINDOW = 50;
 
@@ -178,6 +180,106 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
             assertTrue("fused score must be > 0 for a matched doc", score > 0.0);
             previous = score;
         }
+    }
+
+    /**
+     * Every way of asking for the fused defaults without a pipeline: a bare {@code fusion:{}}, a window-only block, and a
+     * technique-less clause (mirroring classic hybrid's min_max + arithmetic_mean when a processor names no technique).
+     * Each must fuse identically to spelling both techniques out — a "does not throw" assertion would pass even if one of
+     * them silently resolved to something else.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenNoTechniqueNamed_thenDefaultsToMinMaxArithmeticMean() {
+        if (indexExists(INDEX_NO_PIPELINE) == false) {
+            createIndex(INDEX_NO_PIPELINE, indexConfigWithoutPipeline());
+            addFourDocs(INDEX_NO_PIPELINE);
+        }
+        List<Map<String, Object>> explicitHits = getNestedHits(search(INDEX_NO_PIPELINE, fusedTwoLegInlineConfigQuery(), 10));
+
+        for (Map<String, Object> fusion : List.<Map<String, Object>>of(
+            Map.of(),
+            Map.of("window_size", 10),
+            Map.of("normalization", Map.of())
+        )) {
+            HybridQueryBuilder defaulted = new HybridQueryBuilder().fusion(fusion);
+            defaulted.add(new MatchQueryBuilder(TEXT_FIELD, "hello"));
+            defaulted.add(new TermQueryBuilder(TEXT_FIELD, "place"));
+
+            List<Map<String, Object>> defaultedHits = getNestedHits(search(INDEX_NO_PIPELINE, defaulted, 10));
+
+            assertEquals("fusion " + fusion + " hit count", explicitHits.size(), defaultedHits.size());
+            for (int i = 0; i < explicitHits.size(); i++) {
+                assertEquals("fusion " + fusion + " hit " + i + " id", explicitHits.get(i).get("_id"), defaultedHits.get(i).get("_id"));
+                assertEquals(
+                    "fusion " + fusion + " hit " + i + " score",
+                    ((Number) explicitHits.get(i).get("_score")).floatValue(),
+                    ((Number) defaultedHits.get(i).get("_score")).floatValue(),
+                    0.0f
+                );
+            }
+        }
+    }
+
+    /**
+     * A {@code fusion} block naming neither a technique nor {@code source} is the built-in-defaults form: it fuses by
+     * min_max + arithmetic_mean, and does <b>not</b> read the attached pipeline. Reading the pipeline depends on request
+     * context the body does not show, so it is only ever done when the body says {@code source: pipeline}.
+     *
+     * <p>Pinned on an index whose default pipeline is rrf, which makes the two answers tell each other apart: the same
+     * query with {@code source: pipeline} fuses by rrf rank sums on this very index (asserted below), so scores equal to
+     * the inline min_max run are proof the defaults were applied rather than the pipeline silently chosen.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenNoTechniqueKeysButPipelineAttached_thenFusesByTheDefaultsNotThePipeline() {
+        createRRFSearchPipeline(RRF_PIPELINE, List.of(), RRFScoreNormalizer.DEFAULT_RANK_CONSTANT, false);
+        if (indexExists(INDEX_WITH_DEFAULT_RRF) == false) {
+            createIndex(INDEX_WITH_DEFAULT_RRF, indexConfigWithDefaultPipeline(RRF_PIPELINE));
+            addFourDocs(INDEX_WITH_DEFAULT_RRF);
+        }
+        // `window_size` is a neutral key: it tunes the candidate window without making the block a delegation.
+        HybridQueryBuilder windowOnly = new HybridQueryBuilder().fusion(Map.of("window_size", 10));
+        windowOnly.add(new MatchQueryBuilder(TEXT_FIELD, "hello"));
+        windowOnly.add(new TermQueryBuilder(TEXT_FIELD, "place"));
+
+        List<Map<String, Object>> hits = getNestedHits(search(INDEX_WITH_DEFAULT_RRF, windowOnly, 10));
+        List<Map<String, Object>> inlineMinMaxHits = getNestedHits(search(INDEX_WITH_DEFAULT_RRF, fusedTwoLegInlineConfigQuery(), 10));
+
+        assertEquals(3, hits.size());
+        assertEquals(inlineMinMaxHits.size(), hits.size());
+        for (int i = 0; i < inlineMinMaxHits.size(); i++) {
+            assertEquals("hit " + i + " id", inlineMinMaxHits.get(i).get("_id"), hits.get(i).get("_id"));
+            assertEquals(
+                "hit " + i + " score",
+                ((Number) inlineMinMaxHits.get(i).get("_score")).floatValue(),
+                ((Number) hits.get(i).get("_score")).floatValue(),
+                0.0f
+            );
+        }
+    }
+
+    /**
+     * The delegating form on the same rrf index: {@code source: pipeline} is what reads the attached pipeline, and it must
+     * still do so. Paired with the defaults test above — together they pin that the two forms resolve differently on one
+     * index, so neither assertion can pass by accident.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenSourcePipelineAndDefaultRrfPipeline_thenFusesByThePipeline() {
+        createRRFSearchPipeline(RRF_PIPELINE, List.of(), RRFScoreNormalizer.DEFAULT_RANK_CONSTANT, false);
+        if (indexExists(INDEX_WITH_DEFAULT_RRF) == false) {
+            createIndex(INDEX_WITH_DEFAULT_RRF, indexConfigWithDefaultPipeline(RRF_PIPELINE));
+            addFourDocs(INDEX_WITH_DEFAULT_RRF);
+        }
+        HybridQueryBuilder delegating = new HybridQueryBuilder().fusion(Map.of("source", "pipeline", "window_size", 10));
+        delegating.add(new MatchQueryBuilder(TEXT_FIELD, "hello"));
+        delegating.add(new TermQueryBuilder(TEXT_FIELD, "place"));
+
+        Map<String, Object> response = search(INDEX_WITH_DEFAULT_RRF, delegating, 10);
+
+        assertEquals(3, getHitCount(response));
+        List<Map<String, Object>> hits = getNestedHits(response);
+        assertEquals("2", hits.get(0).get("_id"));
+        // Exact rank-score sums: min_max + arithmetic_mean cannot produce these, so the pipeline's rrf is what ran.
+        assertScoresAreRrfRankSums(hits, RRFScoreNormalizer.DEFAULT_RANK_CONSTANT);
     }
 
     /**
@@ -978,6 +1080,55 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
     }
 
     @SneakyThrows
+    public void testFusedMode_whenInlineRrfRankConstantUnderNormalizationParameters_thenHonored() {
+        // The normalization-processor spelling of rank_constant, on a query whose combination technique makes it the
+        // score-ranker shape. Asserting against the k=1 formulas is what makes this a behavior test rather than a parse
+        // test: the k=60 scores are orders of magnitude smaller, so falling back to the default cannot pass.
+        if (indexExists(INDEX_NO_PIPELINE) == false) {
+            createIndex(INDEX_NO_PIPELINE, indexConfigWithoutPipeline());
+            addFourDocs(INDEX_NO_PIPELINE);
+        }
+        HybridQueryBuilder alternateSpelling = new HybridQueryBuilder().fusion(
+            Map.of(
+                "normalization",
+                Map.of("technique", "rrf", "parameters", Map.of("rank_constant", 1)),
+                "combination",
+                Map.of("technique", "rrf")
+            )
+        );
+        alternateSpelling.add(new MatchQueryBuilder(TEXT_FIELD, "hello"));
+        alternateSpelling.add(new TermQueryBuilder(TEXT_FIELD, "place"));
+
+        Map<String, Object> response = search(INDEX_NO_PIPELINE, alternateSpelling, 10);
+
+        assertEquals(3, getHitCount(response));
+        List<Map<String, Object>> hits = getNestedHits(response);
+        assertEquals("2", hits.get(0).get("_id"));
+        assertScoresAreRrfRankSums(hits, 1);
+    }
+
+    @SneakyThrows
+    public void testFusedMode_whenInlineRrfRankConstantInBothPlacesAndConflict_thenRejected() {
+        if (indexExists(INDEX_NO_PIPELINE) == false) {
+            createIndex(INDEX_NO_PIPELINE, indexConfigWithoutPipeline());
+            addFourDocs(INDEX_NO_PIPELINE);
+        }
+        HybridQueryBuilder conflicting = new HybridQueryBuilder().fusion(
+            Map.of(
+                "normalization",
+                Map.of("technique", "rrf", "parameters", Map.of("rank_constant", 1)),
+                "combination",
+                Map.of("technique", "rrf", "rank_constant", 60)
+            )
+        );
+        conflicting.add(new MatchQueryBuilder(TEXT_FIELD, "hello"));
+        conflicting.add(new TermQueryBuilder(TEXT_FIELD, "place"));
+
+        ResponseException e = expectThrows(ResponseException.class, () -> search(INDEX_NO_PIPELINE, conflicting, 10));
+        assertTrue(e.getMessage(), e.getMessage().contains("set it in one place only"));
+    }
+
+    @SneakyThrows
     public void testFusedMode_whenInlineRrfWithNormalizationTechnique_thenRejected() {
         // rrf is rank based; pairing it with a normalization technique is contradictory and must be rejected rather than
         // silently dropping the normalization clause.
@@ -995,5 +1146,41 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
         // Rejected by the classic compatibility matrix, not by a fused-mode-specific rule: classic maps min_max to the three
         // means, never to rrf. Only rrf + rrf short circuits ahead of that matrix.
         assertTrue(e.getMessage(), e.getMessage().contains("does not support combination [rrf] with normalization [min_max]"));
+    }
+
+    /**
+     * The zero-migration path carrying a config fused mode cannot honor. {@code min_max}'s {@code lower_bounds} live under
+     * {@code normalization.parameters}, and there is no coordinator-side implementation of them — so fusing this pipeline
+     * would answer the request at HTTP 200 with a ranking that differs from what the very same pipeline produces
+     * classically. Refused instead, at the pipeline entry point a user reaches without editing their query at all.
+     *
+     * <p>The second half is what makes this fused-mode-specific rather than a regression: the same pipeline, run
+     * classically over the same index, must still serve the query with its bounds honored shard-side.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenPipelineNormalizationCarriesBounds_thenRejectedWhileClassicStillServes() {
+        createSearchPipeline(
+            BOUNDED_NORM_PIPELINE,
+            "min_max",
+            // One bound per sub-query, which is what the classic technique validates against.
+            Map.of("lower_bounds", List.of(Map.of("mode", "apply", "min_score", "0.1"), Map.of("mode", "apply", "min_score", "0.1"))),
+            "arithmetic_mean",
+            Map.of(),
+            false
+        );
+        if (indexExists(INDEX_WITH_BOUNDED_NORM) == false) {
+            createIndex(INDEX_WITH_BOUNDED_NORM, indexConfigWithDefaultPipeline(BOUNDED_NORM_PIPELINE));
+            addFourDocs(INDEX_WITH_BOUNDED_NORM);
+        }
+
+        ResponseException e = expectThrows(ResponseException.class, () -> search(INDEX_WITH_BOUNDED_NORM, fusedTwoLegQuery(), 10));
+        assertTrue(e.getMessage(), e.getMessage().contains("[normalization.parameters] [lower_bounds] not supported"));
+        assertTrue(e.getMessage(), e.getMessage().contains("normalization [min_max] in fused mode"));
+
+        HybridQueryBuilder classic = new HybridQueryBuilder();
+        classic.add(new MatchQueryBuilder(TEXT_FIELD, "hello"));
+        classic.add(new TermQueryBuilder(TEXT_FIELD, "place"));
+        Map<String, Object> response = search(INDEX_WITH_BOUNDED_NORM, classic, 10);
+        assertEquals(3, getHitCount(response));
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeIT.java
@@ -7,6 +7,7 @@ package org.opensearch.neuralsearch.query;
 import static org.opensearch.neuralsearch.util.AggregationsTestUtils.getNestedHits;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1146,6 +1147,39 @@ public class HybridQueryFusedModeIT extends BaseNeuralSearchIT {
         // Rejected by the classic compatibility matrix, not by a fused-mode-specific rule: classic maps min_max to the three
         // means, never to rrf. Only rrf + rrf short circuits ahead of that matrix.
         assertTrue(e.getMessage(), e.getMessage().contains("does not support combination [rrf] with normalization [min_max]"));
+    }
+
+    /**
+     * A {@code weights} list whose <em>elements</em> are not numbers. The type check one level up only sees whether the
+     * value is a list, so this reaches the element read — where an unchecked cast would answer a malformed request with an
+     * HTTP 500 instead of a validation error. Asserted on the status code, not only the message, because that is the whole
+     * difference: the request is refused either way, but only one of the two ways tells the caller what to fix.
+     *
+     * <p>Not a divergence from classic — classic casts the elements just as unguardedly ({@code ScoreCombinationUtil}
+     * checks the list and then streams it through {@code Double::floatValue}), so this is stricter than classic rather
+     * than restoring parity with it.
+     */
+    @SneakyThrows
+    public void testFusedMode_whenInlineWeightsHasNonNumericElement_thenRejectedWithValidationError() {
+        if (indexExists(INDEX_NO_PIPELINE) == false) {
+            createIndex(INDEX_NO_PIPELINE, indexConfigWithoutPipeline());
+            addFourDocs(INDEX_NO_PIPELINE);
+        }
+        for (List<Object> weights : List.of(List.<Object>of("a", 0.5), Arrays.<Object>asList(0.5, null))) {
+            HybridQueryBuilder malformed = new HybridQueryBuilder().fusion(
+                Map.of("combination", Map.of("technique", "arithmetic_mean", "parameters", Map.of("weights", weights)))
+            );
+            malformed.add(new MatchQueryBuilder(TEXT_FIELD, "hello"));
+            malformed.add(new TermQueryBuilder(TEXT_FIELD, "place"));
+
+            ResponseException e = expectThrows(ResponseException.class, () -> search(INDEX_NO_PIPELINE, malformed, 10));
+            assertEquals(
+                "weights " + weights + " must be refused as a bad request, not fail the request",
+                RestStatus.BAD_REQUEST.getStatus(),
+                e.getResponse().getStatusLine().getStatusCode()
+            );
+            assertTrue(e.getMessage(), e.getMessage().contains("parameter [weights] must be a collection of numbers"));
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Improved handling for search configs in fusion hybrid query:
- read and apply rank_constant for RRF technique
- block lower and upper bounds for min_max, currently they are silently ignored. Adding proper support for those techniques should be in a separate PR
- default is min_max+arithmetic_mean, same as in existing HQ: `fusion: {}` and `fusion: {"window_size": N}` are the defaults form (min_max + arithmetic_mean, equal weights), not a pipeline read

### Related Issues
#1930 

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
