### PR TITLE
Do not fail-fast the BWC and remote-model test matrices

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -22,6 +22,9 @@ jobs:
   Restart-Upgrade-BWCTests-NeuralSearch:
     needs: Get-CI-Image-Tag
     strategy:
+      # One transient failure (formatter download, Maven 429) must not cancel the
+      # rest of the matrix; that turns a single flake into dozens of red checks.
+      fail-fast: false
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
@@ -64,6 +67,9 @@ jobs:
   Rolling-Upgrade-BWCTests-NeuralSearch:
     needs: Get-CI-Image-Tag
     strategy:
+      # One transient failure (formatter download, Maven 429) must not cancel the
+      # rest of the matrix; that turns a single flake into dozens of red checks.
+      fail-fast: false
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]

--- a/.github/workflows/remote_model_integ_tests.yml
+++ b/.github/workflows/remote_model_integ_tests.yml
@@ -20,6 +20,9 @@ jobs:
   remote-model-single-node-integration-tests:
     runs-on: ubuntu-latest
     strategy:
+      # One transient failure (formatter download, Maven 429) must not cancel the
+      # rest of the matrix; that turns a single flake into dozens of red checks.
+      fail-fast: false
       matrix:
         java: [21, 25]
     steps:
@@ -42,6 +45,9 @@ jobs:
   remote-model-multi-node-integration-tests:
     runs-on: ubuntu-latest
     strategy:
+      # One transient failure (formatter download, Maven 429) must not cancel the
+      # rest of the matrix; that turns a single flake into dozens of red checks.
+      fail-fast: false
       matrix:
         nodes: [3]
         java: [21]

--- a/.github/workflows/test_aggregations.yml
+++ b/.github/workflows/test_aggregations.yml
@@ -24,6 +24,9 @@ jobs:
   Check-neural-search-linux:
     needs: Get-CI-Image-Tag
     strategy:
+      # One transient failure (formatter download, Maven 429) must not cancel the
+      # rest of the matrix; that turns a single flake into dozens of red checks.
+      fail-fast: false
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
@@ -63,6 +66,9 @@ jobs:
 
   Check-neural-search-windows:
     strategy:
+      # One transient failure (formatter download, Maven 429) must not cancel the
+      # rest of the matrix; that turns a single flake into dozens of red checks.
+      fail-fast: false
       matrix:
         java: [25]
         os: [windows-latest]

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -23,6 +23,9 @@ jobs:
 
   integ-test-with-security-linux:
     strategy:
+      # One transient failure (formatter download, Maven 429) must not cancel the
+      # rest of the matrix; that turns a single flake into dozens of red checks.
+      fail-fast: false
       matrix:
         java: [21, 25]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Sparse ANN] Add the JNI layer for the native sparse engine, bridging to the neural-sparse-cpp library, with a googletest suite run on Linux and Windows plus an ASan/LSan job ([#1972](https://github.com/opensearch-project/neural-search/pull/1972))
 * [Neural Sparse] Pin the two-phase processor IT index to a single shard so its pruned-score assertions do not depend on the cluster's default shard count ([#1959](https://github.com/opensearch-project/neural-search/pull/1959))
 * [Semantic Field] Add an end-to-end remote dense model IT for the semantic field mapping transformer using the TorchServe mock model ([#1966](https://github.com/opensearch-project/neural-search/pull/1966))
-* Do not fail-fast the BWC and remote-model test matrices, so one transient failure no longer cancels every sibling job ([#1987](https://github.com/opensearch-project/neural-search/pull/1987))
+* Do not fail-fast any CI test matrix, so one transient failure no longer cancels every sibling job ([#1987](https://github.com/opensearch-project/neural-search/pull/1987))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Sparse ANN] Add the JNI layer for the native sparse engine, bridging to the neural-sparse-cpp library, with a googletest suite run on Linux and Windows plus an ASan/LSan job ([#1972](https://github.com/opensearch-project/neural-search/pull/1972))
 * [Neural Sparse] Pin the two-phase processor IT index to a single shard so its pruned-score assertions do not depend on the cluster's default shard count ([#1959](https://github.com/opensearch-project/neural-search/pull/1959))
 * [Semantic Field] Add an end-to-end remote dense model IT for the semantic field mapping transformer using the TorchServe mock model ([#1966](https://github.com/opensearch-project/neural-search/pull/1966))
+* Do not fail-fast the BWC and remote-model test matrices, so one transient failure no longer cancels every sibling job ([#1987](https://github.com/opensearch-project/neural-search/pull/1987))
 
 ### Documentation
 


### PR DESCRIPTION
### Description
One transient failure currently cancels every other job in the BWC and remote-model matrices, so a single flake shows up as dozens of red checks and hides whatever else the run would have reported.

Two recurring triggers:
- Eclipse JDT formatter download timing out (`Failed to load eclipse jdt formatter: SocketTimeoutException`). Spotless resolves it at Gradle **configuration** time, so it fails any task, tracked fleet-wide in opensearch-build#6421.
- Maven Central `429 Too Many Requests` on `build-tools` metadata.

`CI.yml` already sets `fail-fast: false` on all six of its matrices; this applies the same to the four matrices that lack it. No behavior change beyond letting sibling jobs finish.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.