### PR TITLE
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (neural-search)

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -22,6 +22,7 @@ jobs:
   Restart-Upgrade-BWCTests-NeuralSearch:
     needs: Get-CI-Image-Tag
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
@@ -64,6 +65,7 @@ jobs:
   Rolling-Upgrade-BWCTests-NeuralSearch:
     needs: Get-CI-Image-Tag
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Sparse ANN] Add the JNI layer for the native sparse engine, bridging to the neural-sparse-cpp library, with a googletest suite run on Linux and Windows plus an ASan/LSan job ([#1972](https://github.com/opensearch-project/neural-search/pull/1972))
 * [Neural Sparse] Pin the two-phase processor IT index to a single shard so its pruned-score assertions do not depend on the cluster's default shard count ([#1959](https://github.com/opensearch-project/neural-search/pull/1959))
 * [Semantic Field] Add an end-to-end remote dense model IT for the semantic field mapping transformer using the TorchServe mock model ([#1966](https://github.com/opensearch-project/neural-search/pull/1966))
-* Resolve the Eclipse JDT formatter from Maven Central via spotless 8.10.1 embedded lockfiles, instead of querying a P2 update site at Gradle configuration time ([#1988](https://github.com/opensearch-project/neural-search/pull/1988))
+* Guard eclipse() to spotless tasks and keep P2 mirror on pinned version ([#1988](https://github.com/opensearch-project/neural-search/pull/1988))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Sparse ANN] Add the JNI layer for the native sparse engine, bridging to the neural-sparse-cpp library, with a googletest suite run on Linux and Windows plus an ASan/LSan job ([#1972](https://github.com/opensearch-project/neural-search/pull/1972))
 * [Neural Sparse] Pin the two-phase processor IT index to a single shard so its pruned-score assertions do not depend on the cluster's default shard count ([#1959](https://github.com/opensearch-project/neural-search/pull/1959))
 * [Semantic Field] Add an end-to-end remote dense model IT for the semantic field mapping transformer using the TorchServe mock model ([#1966](https://github.com/opensearch-project/neural-search/pull/1966))
+* Resolve the Eclipse JDT formatter from Maven Central via spotless 8.10.1 embedded lockfiles, instead of querying a P2 update site at Gradle configuration time ([#1988](https://github.com/opensearch-project/neural-search/pull/1988))
 
 ### Documentation
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:8.10.1"
         classpath "io.freefair.gradle:lombok-plugin:8.14"
 
         configurations.all {

--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -15,7 +15,10 @@ allprojects {
             targetExclude nativeExcludes
 
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            // Pin 4.29 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+            // formatter resolves from Maven Central through the mirrors configured above,
+            // instead of querying a P2 update site at configuration time.
+            eclipse('4.29').configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 

--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -1,6 +1,10 @@
 allprojects {
     project.apply plugin: "com.diffplug.spotless"
 
+    // Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+    // Gradle invocations (test, assemble, JNI, BWC) don't provision the formatter at configuration time.
+    def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
+
     // The native build tree, the vendored nsparse submodule and the dependencies its
     // CMake fetches (googletest, abseil) are not ours to format. They also collide
     // with buildJniLib, which declares jni/build as a task output: spotless reading
@@ -16,9 +20,12 @@ allprojects {
 
             removeUnusedImports()
             // Pin 4.29 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
-            // formatter resolves from Maven Central through the mirrors configured above,
-            // instead of querying a P2 update site at configuration time.
-            eclipse('4.29').configFile rootProject.file('formatter/formatterConfig.xml')
+            // formatter resolves from Maven Central through the mirror below instead of querying a
+            // P2 update site at configuration time. Keep withP2Mirrors so any non-lockfile fallback
+            // still hits the ci.opensearch.org mirror rather than the eclipse.org origin.
+            if (runningSpotlessTask) {
+                eclipse('4.29').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            }
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
`eclipse()` resolves at Gradle **configuration** time, so a slow P2 update site kills every task in the repo — including BWC, integ and JNI jobs that format nothing. Neither `-x spotlessCheck` nor `--offline` avoids it:

```
> java.io.IOException: Failed to load eclipse jdt formatter: SocketTimeoutException: timeout
```

spotless 8.10.0 added embedded lockfiles for Eclipse JDT 4.9–4.40 (diffplug/spotless#3000), so a pinned version resolves `org.eclipse.jdt:org.eclipse.jdt.core` from Maven Central through the repositories already in `buildscript`, with Gradle's caching and retry. Pinning **4.29** keeps today's formatter version, so no source files change. `withP2Mirrors` no longer participates in resolution.

Verified with the P2 cache deleted: `spotlessCheck` passes, `~/.m2/repository/dev/equo` is never recreated, and `./gradlew help` succeeds with the network blackholed (fails on `main`).

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm my contribution is made under the Apache 2.0 license.