### PR TITLE
[Backport 3.8] Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (neural-search)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:8.10.1"
         classpath "io.freefair.gradle:lombok-plugin:8.14"
 
         configurations.all {

--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -1,5 +1,10 @@
 allprojects {
     project.apply plugin: "com.diffplug.spotless"
+
+    // Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+    // Gradle invocations (test, assemble, JNI, BWC) don't provision the formatter at configuration time.
+    def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
+
     spotless {
         java {
             // Normally this isn't necessary, but we have Java sources in
@@ -7,7 +12,13 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            // Pin 4.29 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+            // formatter resolves from Maven Central through the mirror below instead of querying a
+            // P2 update site at configuration time. Keep withP2Mirrors so any non-lockfile fallback
+            // still hits the ci.opensearch.org mirror rather than the eclipse.org origin.
+            if (runningSpotlessTask) {
+                eclipse('4.29').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            }
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
Manual backport of #1988 to `3.8` (the auto-backport failed with a cherry-pick conflict). Guard eclipse() to spotless tasks and keep P2 mirror on pinned version.

### Issues Resolved
Backport of #1988. https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
