### PR TITLE
[Backport 2.19] Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (neural-search)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ jobs:
   Check-neural-search-linux:
     needs: Get-CI-Image-Tag
     strategy:
+      fail-fast: false
       matrix:
         java: [21]
         os: [ubuntu-latest]
@@ -58,6 +59,7 @@ jobs:
 
   Check-neural-search-windows:
     strategy:
+      fail-fast: false
       matrix:
         java: [21]
         os: [windows-latest]
@@ -81,6 +83,7 @@ jobs:
   Precommit-neural-search-linux:
     needs: Get-CI-Image-Tag
     strategy:
+      fail-fast: false
       matrix:
         java: [21]
         os: [ubuntu-latest]
@@ -119,6 +122,7 @@ jobs:
 
   Precommit-neural-search-windows:
     strategy:
+      fail-fast: false
       matrix:
         java: [21]
         os: [windows-latest]

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   Restart-Upgrade-BWCTests-NeuralSearch:
     strategy:
+      fail-fast: false
       matrix:
         java: [ 21 ]
         os: [ubuntu-latest,windows-latest]
@@ -40,6 +41,7 @@ jobs:
 
   Rolling-Upgrade-BWCTests-NeuralSearch:
     strategy:
+      fail-fast: false
       matrix:
         java: [ 21 ]
         os: [ubuntu-latest,windows-latest]

--- a/.github/workflows/test_aggregations.yml
+++ b/.github/workflows/test_aggregations.yml
@@ -19,6 +19,7 @@ jobs:
   Check-neural-search-linux:
     needs: Get-CI-Image-Tag
     strategy:
+      fail-fast: false
       matrix:
         java: [21]
         os: [ubuntu-latest]
@@ -53,6 +54,7 @@ jobs:
 
   Check-neural-search-windows:
     strategy:
+      fail-fast: false
       matrix:
         java: [21]
         os: [windows-latest]

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -19,6 +19,7 @@ jobs:
 
   integ-test-with-security-linux:
     strategy:
+      fail-fast: false
       matrix:
         java: [11, 17, 21]
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,12 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:8.10.1"
+        // Spotless 8.10.x requires a Java 17+ runtime to resolve its plugin. Only put it on the
+        // buildscript classpath on Java 17+ so the Java 11 CI matrix doesn't fail resolving it.
+        // formatting.gradle applies it (also gated to Java 17+) only when it is available.
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+            classpath "com.diffplug.spotless:spotless-plugin-gradle:8.10.1"
+        }
         classpath "io.freefair.gradle:lombok-plugin:8.4"
 
         configurations.all {
@@ -62,7 +67,6 @@ apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: 'jacoco'
-apply plugin: "com.diffplug.spotless"
 apply plugin: 'io.freefair.lombok'
 apply from: 'gradle/formatting.gradle'
 
@@ -304,7 +308,11 @@ project.tasks.delombok.dependsOn(extractKnnJar)
 
 compileJava {
     dependsOn extractKnnJar
-    dependsOn spotlessApply
+    // spotless is only applied on Java 17+ (see gradle/formatting.gradle); guard the wiring so
+    // configuration doesn't fail on Java 11 where the task does not exist.
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+        dependsOn spotlessApply
+    }
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
 }
 compileTestJava {
@@ -450,7 +458,11 @@ jacocoTestReport {
     }
 }
 
-check.dependsOn spotlessCheck
+// spotless is only applied on Java 17+ (see gradle/formatting.gradle); guard the wiring so
+// configuration doesn't fail on Java 11 where the task does not exist.
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+    check.dependsOn spotlessCheck
+}
 check.dependsOn jacocoTestCoverageVerification
 jacocoTestCoverageVerification.dependsOn jacocoTestReport
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:8.10.1"
         classpath "io.freefair.gradle:lombok-plugin:8.4"
 
         configurations.all {

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -1,4 +1,10 @@
 allprojects {
+    // Spotless 8.10.x (the pinned Eclipse-JDT toolchain) requires a Java 17+ runtime to even
+    // resolve/apply its Gradle plugin. Skip it on older JDKs (e.g. the Java 11 CI matrix) so
+    // non-spotless builds don't fail at configuration time. Formatting still runs on Java 17+.
+    if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+        return
+    }
     project.apply plugin: "com.diffplug.spotless"
 
     // Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -1,5 +1,10 @@
 allprojects {
     project.apply plugin: "com.diffplug.spotless"
+
+    // Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+    // Gradle invocations (test, assemble, JNI, BWC) don't provision the formatter at configuration time.
+    def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
+
     spotless {
         java {
             // Normally this isn't necessary, but we have Java sources in
@@ -7,7 +12,13 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            // Pin 4.29 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+            // formatter resolves from Maven Central through the mirror below instead of querying a
+            // P2 update site at configuration time. Keep withP2Mirrors so any non-lockfile fallback
+            // still hits the ci.opensearch.org mirror rather than the eclipse.org origin.
+            if (runningSpotlessTask) {
+                eclipse('4.29').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+            }
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
Manual backport of #1988 to `2.19` (the auto-backport failed with a cherry-pick conflict). Guard eclipse() to spotless tasks and keep P2 mirror on pinned version.

### Issues Resolved
Backport of #1988. https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
