### PR TITLE
[Fusion] Refuse a non-object fusion parameters, name rrf's rank constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * In-query fusion in hybrid search. Count a kNN/neural leg's whole match set in `total_hits` and in every aggregation: such a leg is replaced in the non-scoring Tail by an address of the documents it returned only when `window_size` did not truncate it, so a leg with `k` above the window — or a `neural` leg that rewrites to `neural_sparse` over a semantic field, whose match set is data-defined — is now counted for real instead of silently under-counted ([#1986](https://github.com/opensearch-project/neural-search/pull/1986))
 * In-query fusion in hybrid search. Let a response processor read the hybrid a fused query replaced, so batch semantic highlighting and a `rerank` processor's `query_context.query_text_path` work in fused mode ([#1989](https://github.com/opensearch-project/neural-search/pull/1989))
 * In-query fusion in hybrid search. Gate fused mode behind an opt-in cluster setting ([#1993](https://github.com/opensearch-project/neural-search/pull/1993))
+* In-query fusion in hybrid search. Refuse a non-object fusion `parameters`, and name rrf's rank constant in explain ([#1995](https://github.com/opensearch-project/neural-search/pull/1995))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/src/main/java/org/opensearch/neuralsearch/fusion/RrfScalarNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/RrfScalarNormalizer.java
@@ -60,4 +60,16 @@ public final class RrfScalarNormalizer implements ScalarNormalizer {
     public String techniqueName() {
         return RRFNormalizationTechnique.TECHNIQUE_NAME;
     }
+
+    /**
+     * Overridden because rrf is the one technique here that carries a parameter, and the name alone would describe a
+     * normalization the request did not ask for: two queries differing only in {@code rank_constant} score differently and
+     * would otherwise explain identically. Rendered through the shared
+     * {@link RRFScoreNormalizer#describeWithRankConstant} so this reads exactly as {@link RRFNormalizationTechnique}'s
+     * {@code describe()} does for the same rank constant.
+     */
+    @Override
+    public String describe() {
+        return RRFScoreNormalizer.describeWithRankConstant(rankConstant);
+    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/fusion/ScalarNormalizer.java
@@ -41,4 +41,19 @@ public interface ScalarNormalizer {
 
     /** The technique name this normalizer implements, matching the name used in the {@code fusion} config. */
     String techniqueName();
+
+    /**
+     * How this normalization step names itself in an {@code explain} response, the coordinator-side counterpart of
+     * {@link org.opensearch.neuralsearch.processor.explain.ExplainableTechnique#describe()}. The name alone is the whole
+     * description for a technique that carries no parameter, which is why that is the default; a technique that does carry
+     * one overrides this to name it, so the same request explained on either path reads the same.
+     *
+     * <p>Kept separate from {@link #techniqueName()} rather than folded into it because that name is also the key
+     * {@link ScalarNormalizers} resolves a config value against, and a description is not a lookup key.
+     *
+     * @return this normalizer's description for {@code explain}
+     */
+    default String describe() {
+        return techniqueName();
+    }
 }

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechnique.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Locale;
 import java.util.PriorityQueue;
 import java.util.Set;
 
@@ -129,7 +128,7 @@ public class RRFNormalizationTechnique implements ScoreNormalizationTechnique, E
 
     @Override
     public String describe() {
-        return String.format(Locale.ROOT, "%s, rank_constant [%s]", TECHNIQUE_NAME, rankConstant);
+        return RRFScoreNormalizer.describeWithRankConstant(rankConstant);
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFScoreNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/normalization/RRFScoreNormalizer.java
@@ -101,6 +101,21 @@ public final class RRFScoreNormalizer {
     }
 
     /**
+     * How a rrf normalization step names itself in an {@code explain} response, rank constant included. Here for the same
+     * reason the arithmetic is: {@link RRFNormalizationTechnique} renders this shard side and
+     * {@link org.opensearch.neuralsearch.fusion.RrfScalarNormalizer} renders it on the coordinator, and a request explained
+     * on one path has to read the same as the same request explained on the other. The rank constant belongs in the text
+     * because it changes every score in the tree below it — a description that omitted it would not identify the
+     * normalization that actually ran.
+     *
+     * @param rankConstant the rank constant this normalization was configured with
+     * @return the description, for example {@code rrf, rank_constant [60]}
+     */
+    public static String describeWithRankConstant(final int rankConstant) {
+        return String.format(Locale.ROOT, "%s, rank_constant [%s]", RRFNormalizationTechnique.TECHNIQUE_NAME, rankConstant);
+    }
+
+    /**
      * Drain a queue of results, assigning zero based ranks in the order the queue yields them. Results the
      * queue's comparator treats as equal are ranked in the order the heap happens to surface them, which is
      * not the same order a stable sort would produce, so callers must supply the queue rather than a sorted

--- a/src/main/java/org/opensearch/neuralsearch/query/FusionSpec.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusionSpec.java
@@ -220,10 +220,7 @@ public final class FusionSpec {
         if ((config.get(NORMALIZATION_CLAUSE) instanceof Map) == false) {
             return Map.of();
         }
-        Map<String, Object> normalizationClause = (Map<String, Object>) config.get(NORMALIZATION_CLAUSE);
-        return normalizationClause.get(PARAMETERS_KEY) instanceof Map
-            ? (Map<String, Object>) normalizationClause.get(PARAMETERS_KEY)
-            : Map.of();
+        return readParameters((Map<String, Object>) config.get(NORMALIZATION_CLAUSE), NORMALIZATION_CLAUSE);
     }
 
     @SuppressWarnings("unchecked")
@@ -256,12 +253,8 @@ public final class FusionSpec {
      * score-ranker-processor rejects it there ("supported parameters are [weights]"). Fused mode rejects it too, rather
      * than silently falling back to the default 60 and mis-ranking every query for a user who put it in the wrong place.
      */
-    @SuppressWarnings("unchecked")
     private static void rejectRankConstantUnderParameters(Map<String, Object> combinationClause) {
-        if ((combinationClause.get(PARAMETERS_KEY) instanceof Map) == false) {
-            return;
-        }
-        if (((Map<String, Object>) combinationClause.get(PARAMETERS_KEY)).containsKey(RANK_CONSTANT_KEY)) {
+        if (readParameters(combinationClause, COMBINATION_CLAUSE).containsKey(RANK_CONSTANT_KEY)) {
             throw new IllegalArgumentException(
                 String.format(
                     Locale.ROOT,
@@ -365,6 +358,40 @@ public final class FusionSpec {
         throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] must be an object, got [%s]", clause, value));
     }
 
+    /**
+     * The {@code parameters} map of a {@code normalization} or {@code combination} clause, refusing a value that is present
+     * but not an object instead of reading it as absent. This is {@link #requireObjectClause}'s guard one level down, and it
+     * exists for the same reason: every reader of the map gated on {@code instanceof Map} and fell back to an empty one, so
+     * a list or a bare string put {@link #rejectUnhonoredNormalizationParameters} in front of an empty key set — nothing to
+     * report as unhonored — and the request fused with the technique's defaults at HTTP 200. That is exactly the
+     * accepted-and-ignored scoring config the guard exists to make impossible, reachable by mistyping the container rather
+     * than the parameter. An easy mistake to make, too, since the values inside are themselves lists:
+     * {@code "parameters": [{"lower_bounds": [...]}]} is one stray bracket from the honest form.
+     *
+     * <p>Reported in this file's wording rather than the one core's {@code readOptionalMap} gives the same mistake in a
+     * pipeline definition, because the two belong to different requests: a pipeline is refused at creation time, an inline
+     * {@code fusion} block at query time, and only the second can reach here. Parity of wording is worth having where one
+     * request could be answered by either path — {@link #weightsMustBeNumbers} — and not here.
+     *
+     * @param clause the {@code normalization} or {@code combination} clause to read {@code parameters} from
+     * @param clauseName that clause's name, so the error names the full path the user wrote
+     * @return the parameters map, empty when the key is absent or explicitly null
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> readParameters(Map<String, Object> clause, String clauseName) {
+        Object parameters = clause.get(PARAMETERS_KEY);
+        // Null is absent, matching requireObjectClause: an explicit "parameters": null asks for nothing, which is servable.
+        if (Objects.isNull(parameters)) {
+            return Map.of();
+        }
+        if (parameters instanceof Map) {
+            return (Map<String, Object>) parameters;
+        }
+        throw new IllegalArgumentException(
+            String.format(Locale.ROOT, "[%s.%s] must be an object, got [%s]", clauseName, PARAMETERS_KEY, parameters)
+        );
+    }
+
     @SuppressWarnings("unchecked")
     private static String readNormalizationTechnique(Map<String, Object> config, String defaultTechnique) {
         if ((config.get(NORMALIZATION_CLAUSE) instanceof Map) == false) {
@@ -391,10 +418,7 @@ public final class FusionSpec {
      */
     @SuppressWarnings("unchecked")
     private static float[] readWeights(Map<String, Object> combinationClause) {
-        if ((combinationClause.get(PARAMETERS_KEY) instanceof Map) == false) {
-            return new float[0];
-        }
-        Map<String, Object> parameters = (Map<String, Object>) combinationClause.get(PARAMETERS_KEY);
+        Map<String, Object> parameters = readParameters(combinationClause, COMBINATION_CLAUSE);
         if ((parameters.get(WEIGHTS_KEY) instanceof List) == false) {
             if (parameters.containsKey(WEIGHTS_KEY)) {
                 throw weightsMustBeNumbers();

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -396,9 +396,18 @@ final class HybridFusionOrchestrator {
      * to.
      *
      * <p>The descriptions are taken from the same two sources classic hybrid renders from — the combination technique's own
-     * {@link ExplainableTechnique#describe()} and the normalization technique's name — so an identical hit set produces
-     * identical wording on both paths. Classic's trailing {@code min_score} suffix has no counterpart here: fused mode does
-     * not propagate {@code min_score} to the legs, so there is no value to name.
+     * {@link ExplainableTechnique#describe()} and the normalizer's {@link ScalarNormalizer#describe()} — so an identical hit
+     * set produces identical wording on both paths, {@code rrf}'s trailing rank constant included. The normalization half
+     * read {@code techniqueName()} at first, which is right only for a technique that carries no parameter and was quietly
+     * dropping that rank constant; it is {@code describe()} for the same reason the combination half always was. Classic's
+     * trailing {@code min_score} suffix has no counterpart here: fused mode does not propagate {@code min_score} to the
+     * legs, so there is no value to name.
+     *
+     * <p>Parity holds for every technique fused mode can currently resolve, and for min_max it holds for a second reason
+     * worth knowing before changing either side: classic's min_max appends its {@code lower_bounds}/{@code upper_bounds}
+     * when they are configured, and fused mode's does not — but {@code FusionSpec} refuses those parameters outright, so no
+     * request that reaches here has them. Honoring bounds later means giving that normalizer a {@code describe()} at the
+     * same time, or the divergence this paragraph rules out becomes reachable.
      */
     private static void recordExplanations(
         final FusedDocExplanations explanations,
@@ -413,7 +422,7 @@ final class HybridFusionOrchestrator {
         }
         // Same format strings as classic: ScoreCombiner#explainByShard and ExplanationUtils#getDocIdAtQueryForNormalization.
         explanations.combinationDescription(String.format(Locale.ROOT, "%s combination of:", combination.describe()))
-            .normalizationDescription(String.format(Locale.ROOT, "%s normalization of:", normalizer.techniqueName()));
+            .normalizationDescription(String.format(Locale.ROOT, "%s normalization of:", normalizer.describe()));
         List<Map<String, Float>> legNormalizedScores = fused.legNormalizedScores();
         for (int doc = 0; doc < ranked.ids().length; doc++) {
             String key = FusedDocExplanations.documentKey(ranked.indices()[doc], ranked.ids()[doc]);

--- a/src/main/java/org/opensearch/neuralsearch/search/explain/FusedDocExplanations.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/explain/FusedDocExplanations.java
@@ -72,7 +72,9 @@ public final class FusedDocExplanations {
 
     /**
      * Description for each per-leg normalization node, in classic hybrid's exact wording — see
-     * {@code ExplanationUtils#getDocIdAtQueryForNormalization}, which formats {@code "%s normalization of:"}.
+     * {@code ExplanationUtils#getDocIdAtQueryForNormalization}, which formats {@code "%s normalization of:"} over the
+     * technique's own {@code describe()}, exactly as the combination node above does. {@code describe()} and not the
+     * technique's name: they differ for {@code rrf}, whose description carries the rank constant.
      */
     @Getter
     @Setter

--- a/src/test/java/org/opensearch/neuralsearch/fusion/ScalarNormalizerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/fusion/ScalarNormalizerTests.java
@@ -106,6 +106,49 @@ public class ScalarNormalizerTests extends OpenSearchTestCase {
         expectThrows(IllegalArgumentException.class, () -> ScalarNormalizers.forTechnique(null));
     }
 
+    // ---- explain descriptions ----
+
+    public void testDescribe_rendersRrfsRankConstantThroughTheSharedFormat() {
+        // Why describe() exists on this interface at all: one request explained through fused mode has to read the same as
+        // the same request explained through a pipeline, and rrf is the one technique where the name alone is not the whole
+        // description. Rendered through the format RRFNormalizationTechnique#describe() also uses, so the two cannot drift;
+        // that they agree when both are actually constructed is asserted in RRFNormalizationTechniqueTests, which sits in the
+        // package where classic's techniques are reachable, and end to end in HybridQueryFusedModeExplainIT.
+        //
+        // Swept across the range because a single value cannot tell "renders the configured constant" from "hardcodes 60".
+        for (int rankConstant : new int[] {
+            RRFScoreNormalizer.MIN_RANK_CONSTANT,
+            RRFScoreNormalizer.DEFAULT_RANK_CONSTANT,
+            25,
+            RRFScoreNormalizer.MAX_RANK_CONSTANT }) {
+            Map<String, Object> parameters = Map.of(RRFScoreNormalizer.PARAM_NAME_RANK_CONSTANT, rankConstant);
+            assertEquals(
+                String.valueOf(rankConstant),
+                RRFScoreNormalizer.describeWithRankConstant(rankConstant),
+                ScalarNormalizers.forTechnique("rrf", parameters).describe()
+            );
+            // Pinned literally as well, so a change to the shared format is a visible change here rather than a tautology.
+            assertEquals("rrf, rank_constant [" + rankConstant + "]", ScalarNormalizers.forTechnique("rrf", parameters).describe());
+        }
+    }
+
+    public void testDescribe_whenTechniqueTakesNoParameter_thenIsTheTechniqueName() {
+        // The interface default is the name, and that is right only while a technique carries nothing that changes its
+        // scores. Pinned so adding such a parameter — min_max's bounds being the pending one — cannot ship without also
+        // adding the override, which is how the rrf divergence shipped in the first place.
+        for (String technique : Set.of("min_max", "z_score", "l2")) {
+            ScalarNormalizer normalizer = ScalarNormalizers.forTechnique(technique);
+            assertEquals(technique, normalizer.describe());
+            assertEquals(technique, normalizer.techniqueName());
+        }
+        // rrf's description is deliberately not its lookup key: ScalarNormalizers is keyed by techniqueName(), so folding the
+        // two together would make "rrf" unresolvable.
+        ScalarNormalizer rrf = ScalarNormalizers.forTechnique("rrf");
+        assertEquals("rrf", rrf.techniqueName());
+        assertNotEquals(rrf.techniqueName(), rrf.describe());
+        assertTrue(rrf.describe(), rrf.describe().contains("rank_constant [" + RRFScoreNormalizer.DEFAULT_RANK_CONSTANT + "]"));
+    }
+
     // ---- min_max normalizer ----
 
     public void testMinMaxNormalizeLeg_matchesSharedScalarMath() {

--- a/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/processor/normalization/RRFNormalizationTechniqueTests.java
@@ -9,6 +9,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.neuralsearch.fusion.ScalarNormalizers;
 import org.opensearch.neuralsearch.processor.CompoundTopDocs;
 import org.opensearch.neuralsearch.processor.dto.ExplainDTO;
 import org.opensearch.neuralsearch.processor.dto.NormalizeScoresDTO;
@@ -42,6 +43,26 @@ public class RRFNormalizationTechniqueTests extends OpenSearchQueryTestCase {
         // verify when parameter values are set
         normalizationTechnique = new RRFNormalizationTechnique(Map.of("rank_constant", 25), scoreNormalizationUtil);
         assertEquals("rrf, rank_constant [25]", normalizationTechnique.describe());
+    }
+
+    public void testDescribe_matchesTheCoordinatorSideNormalizer() {
+        // rrf normalizes in two places — this technique shard-side, and ScalarNormalizers' coordinator-side normalizer for a
+        // fused hybrid query — and one request explained through either path has to read the same. The fused side reported
+        // just the technique name at first, so two queries differing only in rank_constant explained identically while
+        // scoring differently. Both sides are actually constructed here, which is what makes this parity rather than a
+        // restatement of the format they now share.
+        for (int rankConstant : new int[] {
+            RRFScoreNormalizer.MIN_RANK_CONSTANT,
+            RANK_CONSTANT,
+            25,
+            RRFScoreNormalizer.MAX_RANK_CONSTANT }) {
+            Map<String, Object> parameters = Map.of(RRFScoreNormalizer.PARAM_NAME_RANK_CONSTANT, rankConstant);
+            assertEquals(
+                String.valueOf(rankConstant),
+                new RRFNormalizationTechnique(parameters, scoreNormalizationUtil).describe(),
+                ScalarNormalizers.forTechnique(RRFNormalizationTechnique.TECHNIQUE_NAME, parameters).describe()
+            );
+        }
     }
 
     public void testNormalization_whenResultFromOneShardOneSubQuery_thenSuccessful() {

--- a/src/test/java/org/opensearch/neuralsearch/query/FusionSpecTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/FusionSpecTests.java
@@ -5,6 +5,7 @@
 package org.opensearch.neuralsearch.query;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -452,6 +453,80 @@ public class FusionSpecTests extends OpenSearchTestCase {
             () -> FusionSpec.fromInlineFusion(Map.of("normalization", "min_max"))
         );
         assertTrue(normalization.getMessage(), normalization.getMessage().contains("[normalization] must be an object"));
+    }
+
+    public void testFromInlineFusion_whenParametersIsNotAnObject_thenRejected() {
+        // The same guard one level down, and the mistake is the container rather than the parameter:
+        // `"parameters": [{"lower_bounds": [...]}]` is one stray bracket from the honest form. Every reader gated on
+        // instanceof Map and fell back to an empty one, so rejectUnhonoredNormalizationParameters was handed no keys to
+        // refuse and the request fused with min_max's defaults at HTTP 200 — bounds accepted and silently ignored, which is
+        // the exact outcome that guard exists to prevent.
+        for (Object malformed : List.<Object>of(List.of(Map.of("lower_bounds", List.of())), "lower_bounds", 0.5)) {
+            IllegalArgumentException e = assertThrows(
+                String.valueOf(malformed),
+                IllegalArgumentException.class,
+                () -> FusionSpec.fromInlineFusion(Map.of("normalization", Map.of("technique", "min_max", "parameters", malformed)))
+            );
+            assertTrue(e.getMessage(), e.getMessage().contains("[normalization.parameters] must be an object"));
+        }
+        // And on the other clause, reached through a different reader on each shape: readWeights for the
+        // normalization-processor one, rejectRankConstantUnderParameters for the score-ranker one that rrf routes to.
+        for (String combination : List.of("arithmetic_mean", "rrf")) {
+            IllegalArgumentException e = assertThrows(
+                combination,
+                IllegalArgumentException.class,
+                () -> FusionSpec.fromInlineFusion(
+                    Map.of("combination", Map.of("technique", combination, "parameters", List.of(Map.of("weights", List.of(0.3, 0.7)))))
+                )
+            );
+            assertTrue(e.getMessage(), e.getMessage().contains("[combination.parameters] must be an object"));
+        }
+    }
+
+    public void testFromInlineFusion_whenRrfParametersIsNotAnObject_thenTypeErrorNotRankConstantError() {
+        // rrf reads rank_constant out of this very map, so which of the two guards runs first decides what the user is told.
+        // The type error is the actionable one: nothing true can be said about a rank constant in a map that is not a map.
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> FusionSpec.fromInlineFusion(Map.of("normalization", Map.of("technique", "rrf", "parameters", List.of(60))))
+        );
+        assertTrue(e.getMessage(), e.getMessage().contains("[normalization.parameters] must be an object"));
+        assertFalse(e.getMessage(), e.getMessage().contains("rank constant must be in the interval"));
+    }
+
+    public void testFromInlineFusion_whenParametersIsExplicitlyNull_thenTreatedAsAbsent() {
+        // An explicit null asks for nothing, which is servable — the same tolerance requireObjectClause gives a null clause.
+        // Written through HashMap because Map.of rejects null values.
+        Map<String, Object> normalization = new HashMap<>();
+        normalization.put("technique", "min_max");
+        normalization.put("parameters", null);
+        Map<String, Object> combination = new HashMap<>();
+        combination.put("technique", "arithmetic_mean");
+        combination.put("parameters", null);
+
+        FusionSpec spec = FusionSpec.fromInlineFusion(Map.of("normalization", normalization, "combination", combination));
+        assertEquals("min_max", spec.normalizationTechnique());
+        assertEquals(FusionSpec.TECHNIQUE_ARITHMETIC_MEAN, spec.combinationTechnique());
+        assertEquals(0, spec.weights().length);
+    }
+
+    public void testFromPipelineConfig_whenParametersIsNotAnObject_thenRejected() {
+        // A stored pipeline cannot carry this — classic's factory reads the clause through core's readOptionalMap and
+        // refuses it at pipeline creation — but the same processor shape is also how an inline fusion block is spelled, and
+        // that one is only ever parsed here. Pinned on this entry point too so the guard cannot be lost to a refactor that
+        // only keeps fromInlineFusion covered.
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> FusionSpec.fromPipelineConfig(
+                Map.of(
+                    "phase_results_processors",
+                    List.of(
+                        Map.of("normalization-processor", Map.of("normalization", Map.of("technique", "rrf", "parameters", List.of(60))))
+                    )
+                )
+            )
+        );
+        assertTrue(e.getMessage(), e.getMessage().contains("[normalization.parameters] must be an object"));
     }
 
     private static Map<String, Object> normalizationProcessorWithRankConstant(int rankConstant) {

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridFusionOrchestratorTests.java
@@ -880,6 +880,47 @@ public class HybridFusionOrchestratorTests extends OpenSearchTestCase {
     }
 
     /**
+     * The normalization node's wording comes from the normalizer's {@code describe()}, not its {@code techniqueName()},
+     * which for rrf are different strings: the name alone would describe a normalization the request did not ask for,
+     * since two queries differing only in {@code rank_constant} score differently. It read the name at first, so this is
+     * the assertion that would have caught it — and the one the min_max case above structurally cannot make, min_max
+     * being the technique where the two strings coincide.
+     */
+    public void testBuildFusedQuery_whenNormalizationIsRrf_thenTheDescriptionNamesTheRankConstant() {
+        int rankConstant = 25;
+        List<QueryBuilder> legs = List.of(new MatchQueryBuilder("text", "hello"), new TermQueryBuilder("text", "place"));
+        MultiSearchResponse ms = multiSearch(
+            explainedLegItem(new LinkedHashMap<>(Map.of("1", 0.9f))),
+            explainedLegItem(new LinkedHashMap<>(Map.of("1", 0.6f)))
+        );
+        FusedDocExplanations explanations = new FusedDocExplanations();
+
+        HybridFusionOrchestrator.buildFusedQuery(
+            new SearchSourceBuilder().trackTotalHits(false).explain(true),
+            ms,
+            legs,
+            rrf(rankConstant),
+            10,
+            new FusedCoordinatorTimings(),
+            explanations
+        );
+
+        assertEquals(
+            "the configured rank constant, in classic hybrid's wording",
+            "rrf, rank_constant [" + rankConstant + "] normalization of:",
+            explanations.normalizationDescription()
+        );
+        // Pinned negatively as well, because the pre-fix string is a prefix of the correct one: a contains() assertion
+        // would have passed against it.
+        assertNotEquals("rrf normalization of:", explanations.normalizationDescription());
+
+        Explanation tree = explanations.explain(FusedDocExplanations.documentKey(INDEX, "1"), Float.NaN);
+        for (Explanation legNode : tree.getDetails()) {
+            assertEquals("rrf, rank_constant [" + rankConstant + "] normalization of:", legNode.getDescription());
+        }
+    }
+
+    /**
      * A leg that did not match a document contributes no node rather than a zero one — the same choice classic hybrid
      * makes. A zero node would read as "this leg scored it at zero" when the leg never saw it.
      */

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeExplainIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeExplainIT.java
@@ -50,8 +50,13 @@ public class HybridQueryFusedModeExplainIT extends BaseNeuralSearchIT {
 
     /** What the combination node is called, unweighted: classic's {@code ScoreCombiner} format over the technique's describe(). */
     private static final String COMBINATION_DESCRIPTION = "arithmetic_mean combination of:";
-    /** What each per-leg node is called: classic's {@code ExplanationUtils} format over the normalization technique's name. */
+    /** What each per-leg node is called: classic's {@code ExplanationUtils} format over the normalization's describe(). */
     private static final String NORMALIZATION_DESCRIPTION = "min_max normalization of:";
+    /** The same node under rrf, where describe() and the technique name diverge — the case that made describe() necessary. */
+    private static final String RANK_CONSTANT_PARAM = "rank_constant";
+    private static final int RRF_RANK_CONSTANT = 42;
+    private static final String RRF_EXPLAIN_PIPELINE = "fused-explain-classic-rrf-pipeline";
+    private static final String RRF_NORMALIZATION_DESCRIPTION = "rrf, rank_constant [" + RRF_RANK_CONSTANT + "] normalization of:";
     /** The node inserted above the combination when the score round 2 returned is not the fused score. */
     private static final String FINAL_SCORE_DESCRIPTION = "score of the fused hybrid query as round 2 returned it, computed from:";
     /** Floats survive one JSON round trip exactly; the tolerance is for the arithmetic asserted across nodes. */
@@ -303,6 +308,39 @@ public class HybridQueryFusedModeExplainIT extends BaseNeuralSearchIT {
     }
 
     /**
+     * The same parity claim on the one technique that can break it. min_max, z_score and l2 all describe themselves with just
+     * their name, so the test above passes whether the fused side renders the technique's description or merely its name —
+     * which is how a fused rrf came to explain itself as a bare {@code rrf}, dropping the rank constant classic names and
+     * every score in the tree below depends on. A non-default constant is used deliberately: 60 would pass against a
+     * hardcoded default.
+     */
+    @SneakyThrows
+    public void testExplainedRrfFusedHybrid_thenTheRankConstantIsNamedJustAsClassicNamesIt() {
+        ensureDataset();
+        // The score-ranker-processor helper, not createSearchPipeline: that one understands only min_max's bounds under
+        // normalization.parameters and emits an empty parameters object for anything else, so a rank_constant handed to it
+        // is silently dropped and classic ranks at 60 — which is exactly the kind of quiet default this test is about.
+        createRRFSearchPipeline(RRF_EXPLAIN_PIPELINE, List.of(), RRF_RANK_CONSTANT, true);
+
+        Map<String, Object> fused = search(explained(rrfFusedHybrid(knnLeg(WINDOW_SIZE), termLeg())));
+        Map<String, Object> classic = search(explained(classicHybrid()), RRF_EXPLAIN_PIPELINE);
+
+        List<String> fusedDescriptions = new ArrayList<>();
+        collectDescriptions(explanationOf(hits(fused).get(0)), fusedDescriptions);
+        List<String> classicDescriptions = new ArrayList<>();
+        collectDescriptions(explanationOf(hits(classic).get(0)), classicDescriptions);
+
+        assertTrue("classic names the rank constant: " + classicDescriptions, classicDescriptions.contains(RRF_NORMALIZATION_DESCRIPTION));
+        assertTrue("and so must fused: " + fusedDescriptions, fusedDescriptions.contains(RRF_NORMALIZATION_DESCRIPTION));
+        assertFalse(
+            "the bare technique name is what this used to render, and it describes a normalization the request did not ask "
+                + "for: "
+                + fusedDescriptions,
+            fusedDescriptions.contains("rrf normalization of:")
+        );
+    }
+
+    /**
      * A fused hybrid nested inside a container. The hit's score is the enclosing query's, not the hybrid's, so replacing the
      * whole tree with the fusion would describe the wrong number — the request keeps core's own explanation, which correctly
      * describes the query round 2 ran.
@@ -394,6 +432,23 @@ public class HybridQueryFusedModeExplainIT extends BaseNeuralSearchIT {
             + windowSize
             + ",\"normalization\":{\"technique\":\"min_max\"},\"combination\":{\"technique\":\"arithmetic_mean\"}},"
             + "\"queries\":["
+            + String.join(",", legs)
+            + "]}}";
+    }
+
+    /**
+     * rrf with a rank constant that is not the default, so the description has to come from the config. Written in the
+     * score-ranker-processor shape — {@code rank_constant} on the {@code combination} clause — which is where
+     * {@code RRFProcessorFactory} reads it, so {@link #createRRFSearchPipeline} builds classic the same config.
+     */
+    private String rrfFusedHybrid(final String... legs) {
+        return "{\"hybrid\":{\"fusion\":{\"window_size\":"
+            + WINDOW_SIZE
+            + ",\"combination\":{\"technique\":\"rrf\",\""
+            + RANK_CONSTANT_PARAM
+            + "\":"
+            + RRF_RANK_CONSTANT
+            + "}},\"queries\":["
             + String.join(",", legs)
             + "]}}";
     }


### PR DESCRIPTION
### Description
This PR fixes gaps in parsing normalization technique arguments

### Problem 1, non-object `parameters` was read as absent

`weights` from request were silently dropped if syntax is not correct

```json
GET /my-index/_search
{
  "query": {
    "hybrid": {
      "fusion": {
        "normalization": { "technique": "min_max" },
        "combination": {
          "technique": "arithmetic_mean",
          "parameters": [ { "weights": [0.9, 0.1] } ] // incorrect syntax, it should be "parameters": { "weights": [0.9, 0.1] }"
        }
      },
      "queries": [
        { "match": { "text": "wireless earbuds" } },
        { "knn": { "embedding": { "vector": [0.1, 0.2], "k": 50 } } }
      ]
    }
  }
}
```

| | |
|---|---|
| Before | **HTTP 200**, fused **equal-weighted**: `1@1.0, 2@0.9752475, 3@0.90384626, 4@0.7935781, 5@0.6551725, 6@0.5005`. Instead of 0.9/0.1 actual eights were 0.5/0.5. |
| Before, if syntax is correct | weights honored: `1@1.0, 2@0.9554456, 3@0.82692325, 4@0.62844056, 5@0.37931052, 6@0.1009` |
| After | **HTTP 400** `[combination.parameters] must be an object, got [[{weights=[0.9, 0.1]}]]` |

In this request min_max bounds silently dropped

```json
GET /my-index/_search
{
  "query": {
    "hybrid": {
      "fusion": {
        "window_size": 100,
        "normalization": {
          "technique": "min_max",
          "parameters": [ { "lower_bounds": [ { "mode": "apply", "min_score": 0.2 } ] } ]
        },
        "combination": { "technique": "arithmetic_mean" }
      },
      "queries": [
        { "match": { "text": "wireless earbuds" } },
        { "knn": { "embedding": { "vector": [0.1, 0.2], "k": 50 } } }
      ]
    }
  }
}
```

| | |
|---|---|
| Before | **HTTP 200**, scores `1@1.0, 2@0.9752475, 3@0.90384626, 4@0.7935781, 5@0.6551725, 6@0.5005` — score for score identical to plain min_max with no `parameters` at all. The `lower_bounds` never reached the normalizer and nothing said so. |
| Correctly spelled (`"parameters": {"lower_bounds": [...]}`) | **HTTP 400** — `[normalization.parameters] [lower_bounds] not supported with normalization [min_max] in fused mode; supported parameters are []` (#1985) |
| After | **HTTP 400** — `[normalization.parameters] must be an object, got [[{lower_bounds=[{mode=apply, min_score=0.2}]}]]` |

### Problem 2, fused explain tree dropped rrf's rank constant

Response without/before this change

```json
{
  "value": 0.07692308,
  "description": "arithmetic_mean combination of:",
  "details": [
    {
      "value": 0.03846154,
      "description": "rrf normalization of:",
      "details": [ { "value": 1.0, "description": "within top 10 docs" } ]
    },
    {
      "value": 0.03846154,
      "description": "rrf normalization of:",
      "details": [ { "value": 0.13353139, "description": "weight(text:hello in 0) [PerFieldSimilarity], result of:", "details": [ ... ] } ]
    }
  ]
}
```

and after the change it correctly renders the rank constant

```json
{
  "value": 0.07692308,
  "description": "arithmetic_mean combination of:",
  "details": [
    {
      "value": 0.03846154,
      "description": "rrf, rank_constant [25] normalization of:",
      "details": [ { "value": 1.0, "description": "within top 10 docs" } ]
    },
    {
      "value": 0.03846154,
      "description": "rrf, rank_constant [25] normalization of:",
      "details": [ { "value": 0.13353139, "description": "weight(text:hello in 0) [PerFieldSimilarity], result of:", "details": [ ... ] } ]
    }
  ]
}
```


### Related Issues
#1930 

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
