### PR TITLE
[Sparse ANN] Report sparse vector field adoption as neural info stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 - Add `model_selection` (language_option/model_type) parameter to semantic field to resolve the model id from cluster settings ([#1918](https://github.com/opensearch-project/neural-search/issues/1918))
+- [Sparse ANN] Report sparse vector field adoption in the neural stats API, counting the indices and fields that use a sparse vector field and how many of them are on the native engine ([#1802](https://github.com/opensearch-project/neural-search/issues/1802))
 
 ### Bug Fixes
 * [Neural Query] Expose embedded filters to `QueryBuilderVisitor` traversal ([#1992](https://github.com/opensearch-project/neural-search/pull/1992))

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatName.java
@@ -102,7 +102,15 @@ public enum InfoStatName implements StatName {
         Version.V_3_2_0
     ),
     /** Counts agentic context processors */
-    AGENTIC_CONTEXT_PROCESSORS("agentic_context_processors", "processors.search.agentic", InfoStatType.INFO_COUNTER, Version.V_3_3_0);
+    AGENTIC_CONTEXT_PROCESSORS("agentic_context_processors", "processors.search.agentic", InfoStatType.INFO_COUNTER, Version.V_3_3_0),
+    /** Counts indices with at least one sparse_vector field */
+    SPARSE_VECTOR_INDICES("sparse_vector_indices", "index.sparse", InfoStatType.INFO_COUNTER, Version.V_3_9_0),
+    /** Counts sparse_vector fields across all indices */
+    SPARSE_VECTOR_FIELDS("sparse_vector_fields", "index.sparse", InfoStatType.INFO_COUNTER, Version.V_3_9_0),
+    /** Counts indices with at least one sparse_vector field on the native engine */
+    SPARSE_NATIVE_ENGINE_INDICES("sparse_native_engine_indices", "index.sparse", InfoStatType.INFO_COUNTER, Version.V_3_9_0),
+    /** Counts sparse_vector fields on the native engine across all indices */
+    SPARSE_NATIVE_ENGINE_FIELDS("sparse_native_engine_fields", "index.sparse", InfoStatType.INFO_COUNTER, Version.V_3_9_0);
 
     private final String nameString;
     private final String path;

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
@@ -280,18 +280,17 @@ public class InfoStatsManager {
         }
 
         for (Map<String, Object> mapping : indexMappings) {
-            SparseFieldCounts counts = new SparseFieldCounts();
-            countSparseVectorFields(asMap(mapping.get(PROPERTIES_KEY)), counts);
+            SparseFieldCounts counts = countSparseVectorFields(asMap(mapping.get(PROPERTIES_KEY)));
 
-            if (counts.total == 0) {
+            if (counts.total() == 0) {
                 continue;
             }
             increment(stats, InfoStatName.SPARSE_VECTOR_INDICES);
-            incrementBy(stats, InfoStatName.SPARSE_VECTOR_FIELDS, counts.total);
+            incrementBy(stats, InfoStatName.SPARSE_VECTOR_FIELDS, counts.total());
 
-            if (counts.nativeEngine > 0) {
+            if (counts.nativeEngine() > 0) {
                 increment(stats, InfoStatName.SPARSE_NATIVE_ENGINE_INDICES);
-                incrementBy(stats, InfoStatName.SPARSE_NATIVE_ENGINE_FIELDS, counts.nativeEngine);
+                incrementBy(stats, InfoStatName.SPARSE_NATIVE_ENGINE_FIELDS, counts.nativeEngine());
             }
         }
     }
@@ -300,26 +299,34 @@ public class InfoStatsManager {
      * Counts the sparse vector fields under one level of a mapping's properties, recursing into
      * object and nested fields. Multi-fields are not walked, since a sparse vector field cannot be one.
      *
+     * Recursion depth is the nesting depth of the mapping, which the mapper has already capped at
+     * {@code index.mapping.depth.limit} (20 by default) before the mapping reached cluster state.
+     *
      * @param properties the properties map of a mapping level, may be null
-     * @param counts the running counts for the index being walked, mutated
+     * @return the sparse vector fields found at this level and below
      */
-    private void countSparseVectorFields(Map<String, Object> properties, SparseFieldCounts counts) {
+    private SparseFieldCounts countSparseVectorFields(Map<String, Object> properties) {
         if (properties == null) {
-            return;
+            return SparseFieldCounts.NONE;
         }
+        long total = 0;
+        long nativeEngine = 0;
         for (Object field : properties.values()) {
             Map<String, Object> fieldConfig = asMap(field);
             if (fieldConfig == null) {
                 continue;
             }
             if (SparseVectorFieldMapper.CONTENT_TYPE.equals(asString(fieldConfig.get(TYPE_KEY)))) {
-                counts.total++;
+                total++;
                 if (isNativeEngine(fieldConfig)) {
-                    counts.nativeEngine++;
+                    nativeEngine++;
                 }
             }
-            countSparseVectorFields(asMap(fieldConfig.get(PROPERTIES_KEY)), counts);
+            SparseFieldCounts nested = countSparseVectorFields(asMap(fieldConfig.get(PROPERTIES_KEY)));
+            total += nested.total();
+            nativeEngine += nested.nativeEngine();
         }
+        return new SparseFieldCounts(total, nativeEngine);
     }
 
     /**
@@ -336,11 +343,10 @@ public class InfoStatsManager {
     }
 
     /**
-     * The sparse vector fields found in one index's mapping
+     * The sparse vector fields found in one index's mapping, and how many of them are on the native engine
      */
-    private static class SparseFieldCounts {
-        private long total;
-        private long nativeEngine;
+    private record SparseFieldCounts(long total, long nativeEngine) {
+        private static final SparseFieldCounts NONE = new SparseFieldCounts(0, 0);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/info/InfoStatsManager.java
@@ -29,6 +29,8 @@ import org.opensearch.neuralsearch.processor.chunker.FixedTokenLengthChunker;
 import org.opensearch.neuralsearch.processor.rerank.RerankProcessor;
 import org.opensearch.neuralsearch.processor.rerank.RerankType;
 import org.opensearch.neuralsearch.settings.NeuralSearchSettingsAccessor;
+import org.opensearch.neuralsearch.sparse.algorithm.SparseEngine;
+import org.opensearch.neuralsearch.sparse.mapper.SparseVectorFieldMapper;
 import org.opensearch.neuralsearch.stats.common.StatSnapshot;
 import org.opensearch.neuralsearch.util.NeuralSearchClusterUtil;
 import org.opensearch.neuralsearch.util.PipelineServiceUtil;
@@ -42,6 +44,8 @@ import java.util.function.Consumer;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.opensearch.neuralsearch.sparse.common.SparseConstants.ENGINE_FIELD;
+
 /**
  * Manager to generate stat snapshots for cluster level info stats
  */
@@ -50,6 +54,8 @@ public class InfoStatsManager {
     public static final String REQUEST_PROCESSORS_KEY = "request_processors";
     public static final String RESPONSE_PROCESSORS_KEY = "response_processors";
     public static final String PHASE_PROCESSORS_KEY = "phase_results_processors";
+    public static final String PROPERTIES_KEY = "properties";
+    public static final String TYPE_KEY = "type";
 
     private final NeuralSearchClusterUtil neuralSearchClusterUtil;
     private final NeuralSearchSettingsAccessor settingsAccessor;
@@ -140,6 +146,9 @@ public class InfoStatsManager {
 
         // Parses search pipeline processor configs for processor info
         addSearchProcessorStats(countableInfoStats);
+
+        // Parses index mappings for sparse vector field info
+        addSparseFieldStats(countableInfoStats);
 
         // Helpers to parse search pipeline processor configs for processor info would go here
         return countableInfoStats;
@@ -254,6 +263,84 @@ public class InfoStatsManager {
                 }
             }
         }
+    }
+
+    /**
+     * Adds sparse vector field info stats, mutating the input
+     *
+     * Derived from the mappings in cluster state rather than counted as fields are created, so the
+     * numbers stay correct across mapping updates, node restarts and replayed cluster state.
+     *
+     * @param stats mutable map of info stats that the result will be added to
+     */
+    private void addSparseFieldStats(Map<InfoStatName, CountableInfoStatSnapshot> stats) {
+        List<Map<String, Object>> indexMappings = neuralSearchClusterUtil.getAllIndexMappings();
+        if (indexMappings == null) {
+            return;
+        }
+
+        for (Map<String, Object> mapping : indexMappings) {
+            SparseFieldCounts counts = new SparseFieldCounts();
+            countSparseVectorFields(asMap(mapping.get(PROPERTIES_KEY)), counts);
+
+            if (counts.total == 0) {
+                continue;
+            }
+            increment(stats, InfoStatName.SPARSE_VECTOR_INDICES);
+            incrementBy(stats, InfoStatName.SPARSE_VECTOR_FIELDS, counts.total);
+
+            if (counts.nativeEngine > 0) {
+                increment(stats, InfoStatName.SPARSE_NATIVE_ENGINE_INDICES);
+                incrementBy(stats, InfoStatName.SPARSE_NATIVE_ENGINE_FIELDS, counts.nativeEngine);
+            }
+        }
+    }
+
+    /**
+     * Counts the sparse vector fields under one level of a mapping's properties, recursing into
+     * object and nested fields. Multi-fields are not walked, since a sparse vector field cannot be one.
+     *
+     * @param properties the properties map of a mapping level, may be null
+     * @param counts the running counts for the index being walked, mutated
+     */
+    private void countSparseVectorFields(Map<String, Object> properties, SparseFieldCounts counts) {
+        if (properties == null) {
+            return;
+        }
+        for (Object field : properties.values()) {
+            Map<String, Object> fieldConfig = asMap(field);
+            if (fieldConfig == null) {
+                continue;
+            }
+            if (SparseVectorFieldMapper.CONTENT_TYPE.equals(asString(fieldConfig.get(TYPE_KEY)))) {
+                counts.total++;
+                if (isNativeEngine(fieldConfig)) {
+                    counts.nativeEngine++;
+                }
+            }
+            countSparseVectorFields(asMap(fieldConfig.get(PROPERTIES_KEY)), counts);
+        }
+    }
+
+    /**
+     * Whether a sparse vector field's mapping puts it on the native engine. A field that leaves the
+     * engine out means the default, matching how {@code SparseMethodContext#parse} resolves it.
+     *
+     * @param fieldConfig the field's mapping config
+     * @return whether the field uses the native engine
+     */
+    private boolean isNativeEngine(Map<String, Object> fieldConfig) {
+        Map<String, Object> method = asMap(fieldConfig.get(SparseVectorFieldMapper.METHOD));
+        String engine = method == null ? null : asString(method.get(ENGINE_FIELD));
+        return SparseEngine.NATIVE == SparseEngine.fromName(engine);
+    }
+
+    /**
+     * The sparse vector fields found in one index's mapping
+     */
+    private static class SparseFieldCounts {
+        private long total;
+        private long nativeEngine;
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtil.java
@@ -14,10 +14,12 @@ import org.opensearch.Version;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.index.Index;
 import org.opensearch.search.pipeline.SearchPipelineService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +76,30 @@ public class NeuralSearchClusterUtil {
         return Arrays.stream(concreteIndices)
             .map(concreteIndex -> clusterService.state().metadata().index(concreteIndex))
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Mapping source of every index in the cluster state, for stats derived from field mappings.
+     *
+     * An index whose mapping is absent or unparseable is skipped rather than failing the caller: a
+     * stats call should still report what the rest of the cluster looks like.
+     *
+     * @return one mapping map per index, with the type level already stripped
+     */
+    public List<Map<String, Object>> getAllIndexMappings() {
+        List<Map<String, Object>> mappings = new ArrayList<>();
+        for (Map.Entry<String, IndexMetadata> entry : clusterService.state().metadata().indices().entrySet()) {
+            MappingMetadata mappingMetadata = entry.getValue().mapping();
+            if (mappingMetadata == null) {
+                continue;
+            }
+            try {
+                mappings.add(mappingMetadata.sourceAsMap());
+            } catch (Exception e) {
+                log.warn("Failed to parse mapping of index [{}] for stats", entry.getKey(), e);
+            }
+        }
+        return mappings;
     }
 
     public Map<String, String> getIndexMapping(String[] indices) {

--- a/src/test/java/org/opensearch/neuralsearch/stats/info/InfoStatsManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/stats/info/InfoStatsManagerTests.java
@@ -19,6 +19,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,54 @@ public class InfoStatsManagerTests extends OpenSearchTestCase {
         when(mockPipelineServiceUtil.getIngestPipelineConfigs()).thenReturn(new ArrayList<>());
         when(mockPipelineServiceUtil.getSearchPipelineConfigs()).thenReturn(new ArrayList<>());
         when(mockClusterUtil.getClusterMinVersion()).thenReturn(Version.CURRENT);
+        when(mockClusterUtil.getAllIndexMappings()).thenReturn(new ArrayList<>());
         infoStatsManager = new InfoStatsManager(mockClusterUtil, mockSettingsAccessor, mockPipelineServiceUtil);
+    }
+
+    public void test_getStats_countsSparseVectorFieldsPerIndex() {
+        when(mockClusterUtil.getAllIndexMappings()).thenReturn(
+            List.of(
+                // Two native engine fields, one of them nested under an object field
+                mappingOf(
+                    Map.of(
+                        "native_field",
+                        sparseVectorField("native"),
+                        "parent",
+                        Map.of("properties", Map.of("nested_native_field", sparseVectorField("native")))
+                    )
+                ),
+                // An explicit lucene engine field and one that defaults to lucene
+                mappingOf(Map.of("lucene_field", sparseVectorField("lucene"), "default_field", sparseVectorField(null))),
+                // No sparse vector field at all
+                mappingOf(Map.of("text_field", Map.of("type", "text")))
+            )
+        );
+
+        Map<InfoStatName, StatSnapshot<?>> stats = infoStatsManager.getStats(EnumSet.allOf(InfoStatName.class));
+
+        assertEquals(2L, getCountable(stats, InfoStatName.SPARSE_VECTOR_INDICES));
+        assertEquals(4L, getCountable(stats, InfoStatName.SPARSE_VECTOR_FIELDS));
+        assertEquals(1L, getCountable(stats, InfoStatName.SPARSE_NATIVE_ENGINE_INDICES));
+        assertEquals(2L, getCountable(stats, InfoStatName.SPARSE_NATIVE_ENGINE_FIELDS));
+    }
+
+    public void test_getStats_returnsZeroSparseFieldStats_whenNoIndexHasTheField() {
+        when(mockClusterUtil.getAllIndexMappings()).thenReturn(List.of(mappingOf(Map.of("text_field", Map.of("type", "text")))));
+
+        Map<InfoStatName, StatSnapshot<?>> stats = infoStatsManager.getStats(EnumSet.allOf(InfoStatName.class));
+
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_VECTOR_INDICES));
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_VECTOR_FIELDS));
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_NATIVE_ENGINE_INDICES));
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_NATIVE_ENGINE_FIELDS));
+    }
+
+    public void test_getStats_ignoresMappingWithoutProperties() {
+        when(mockClusterUtil.getAllIndexMappings()).thenReturn(List.of(Collections.emptyMap()));
+
+        Map<InfoStatName, StatSnapshot<?>> stats = infoStatsManager.getStats(EnumSet.allOf(InfoStatName.class));
+
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_VECTOR_FIELDS));
     }
 
     public void test_getStats_returnsAllStats() {
@@ -103,5 +151,22 @@ public class InfoStatsManagerTests extends OpenSearchTestCase {
 
         assertEquals(1, (long) stats.get(InfoStatName.NORM_TECHNIQUE_L2_PROCESSORS).getValue());
         assertEquals(0, (long) stats.get(InfoStatName.NORM_TECHNIQUE_MINMAX_PROCESSORS).getValue());
+    }
+
+    private Map<String, Object> mappingOf(Map<String, Object> properties) {
+        return Map.of("properties", properties);
+    }
+
+    private Map<String, Object> sparseVectorField(String engine) {
+        Map<String, Object> method = new HashMap<>();
+        method.put("name", "seismic");
+        if (engine != null) {
+            method.put("engine", engine);
+        }
+        return Map.of("type", "sparse_vector", "method", method);
+    }
+
+    private long getCountable(Map<InfoStatName, StatSnapshot<?>> stats, InfoStatName statName) {
+        return ((CountableInfoStatSnapshot) stats.get(statName)).getValue();
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/stats/info/InfoStatsManagerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/stats/info/InfoStatsManagerTests.java
@@ -93,6 +93,30 @@ public class InfoStatsManagerTests extends OpenSearchTestCase {
         assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_VECTOR_FIELDS));
     }
 
+    public void test_getStats_ignoresMalformedMappingEntries() {
+        // A properties value that is not a map, and a sparse vector field with no method, are both
+        // shapes the mapper rejects, so they only reach here if cluster state holds something odd
+        when(mockClusterUtil.getAllIndexMappings()).thenReturn(
+            List.of(mappingOf(Map.of("not_a_field", "text", "no_method_field", Map.of("type", "sparse_vector"))))
+        );
+
+        Map<InfoStatName, StatSnapshot<?>> stats = infoStatsManager.getStats(EnumSet.allOf(InfoStatName.class));
+
+        assertEquals(1L, getCountable(stats, InfoStatName.SPARSE_VECTOR_INDICES));
+        assertEquals(1L, getCountable(stats, InfoStatName.SPARSE_VECTOR_FIELDS));
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_NATIVE_ENGINE_INDICES));
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_NATIVE_ENGINE_FIELDS));
+    }
+
+    public void test_getStats_whenIndexMappingsUnavailable_thenNoSparseFieldStats() {
+        when(mockClusterUtil.getAllIndexMappings()).thenReturn(null);
+
+        Map<InfoStatName, StatSnapshot<?>> stats = infoStatsManager.getStats(EnumSet.allOf(InfoStatName.class));
+
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_VECTOR_INDICES));
+        assertEquals(0L, getCountable(stats, InfoStatName.SPARSE_VECTOR_FIELDS));
+    }
+
     public void test_getStats_returnsAllStats() {
         Map<InfoStatName, StatSnapshot<?>> stats = infoStatsManager.getStats(EnumSet.allOf(InfoStatName.class));
         Set<InfoStatName> allStatNames = EnumSet.allOf(InfoStatName.class);

--- a/src/test/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtilTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/util/NeuralSearchClusterUtilTests.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
 import static org.opensearch.neuralsearch.util.NeuralSearchClusterTestUtils.mockClusterService;
 
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.Version;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.cluster.ClusterState;
@@ -148,6 +149,51 @@ public class NeuralSearchClusterUtilTests extends OpenSearchTestCase {
             () -> neuralSearchClusterUtil.getIndexMapping(new String[] {})
         );
         assertEquals("No valid index found to extract mapping", exception.getMessage());
+    }
+
+    public void testGetAllIndexMappings_skipsIndicesWithoutAReadableMapping() {
+        final ClusterService clusterService = mock(ClusterService.class);
+        final ClusterState clusterState = mock(ClusterState.class);
+        final Metadata metadata = mock(Metadata.class);
+        final IndexMetadata mapped = mock(IndexMetadata.class);
+        final IndexMetadata unmapped = mock(IndexMetadata.class);
+        final IndexMetadata unparseable = mock(IndexMetadata.class);
+        final MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        final MappingMetadata brokenMappingMetadata = mock(MappingMetadata.class);
+        final Map<String, Object> mapping = Map.of("properties", Map.of("title", Map.of("type", "text")));
+
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.indices()).thenReturn(Map.of("mapped-index", mapped, "unmapped-index", unmapped, "unparseable-index", unparseable));
+        when(mapped.mapping()).thenReturn(mappingMetadata);
+        when(mappingMetadata.sourceAsMap()).thenReturn(mapping);
+        when(unmapped.mapping()).thenReturn(null);
+        when(unparseable.mapping()).thenReturn(brokenMappingMetadata);
+        when(brokenMappingMetadata.sourceAsMap()).thenThrow(new OpenSearchParseException("broken mapping"));
+
+        final NeuralSearchClusterUtil neuralSearchClusterUtil = NeuralSearchClusterUtil.instance();
+        final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
+        neuralSearchClusterUtil.initialize(clusterService, indexNameExpressionResolver);
+
+        final List<Map<String, Object>> mappings = neuralSearchClusterUtil.getAllIndexMappings();
+
+        assertEquals(List.of(mapping), mappings);
+    }
+
+    public void testGetAllIndexMappings_whenNoIndices_thenEmpty() {
+        final ClusterService clusterService = mock(ClusterService.class);
+        final ClusterState clusterState = mock(ClusterState.class);
+        final Metadata metadata = mock(Metadata.class);
+
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.indices()).thenReturn(Map.of());
+
+        final NeuralSearchClusterUtil neuralSearchClusterUtil = NeuralSearchClusterUtil.instance();
+        final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
+        neuralSearchClusterUtil.initialize(clusterService, indexNameExpressionResolver);
+
+        assertTrue(neuralSearchClusterUtil.getAllIndexMappings().isEmpty());
     }
 
     public void testGetClusterService_thenSuccess() {


### PR DESCRIPTION
### Description

Adds four info stats under `index.sparse`: `sparse_vector_indices`, `sparse_vector_fields`, `sparse_native_engine_indices`, `sparse_native_engine_fields`.

Derived from cluster-state mappings on each stats call, not event counters. No hook fires once per user-created index — a mapping is parsed on the cluster manager, on every node applying the state, on each update, and again on restart — so an event counter over-counts and drifts. Lucene counts are total minus native; an omitted `engine` counts as lucene, matching `SparseMethodContext#parse`. The walk recurses into `properties`, so nested fields count. Full rationale in the commit message.

### Testing

Unit tests cover per-index counting, nested fields, engine defaults, and mappings without properties. Verified on a local cluster: counts follow index create/delete.

### Related Issues

Related to #1802

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO.