### PR TITLE
[Sparse ANN] [Native] Add conversion from heap_factor to k_prime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 * [Sparse ANN] Add scripts/build.sh so the distribution build ships the native sparse engine: every SIMD variant the target architecture may need is built into the plugin zip, and the variant to load is picked from the host's CPU flags at runtime ([#1978](https://github.com/opensearch-project/neural-search/pull/1978))
 * [Sparse ANN] Add the JNI layer for the native sparse engine, bridging to the neural-sparse-cpp library, with a googletest suite run on Linux and Windows plus an ASan/LSan job ([#1972](https://github.com/opensearch-project/neural-search/pull/1972))
+* [Sparse ANN] Add the conversion mechanism from `heap_factor` in sparse ann to `k_prime` in DiskSeismic in native engine ([#1997](https://github.com/opensearch-project/neural-search/pull/1997))
 * [Neural Sparse] Pin the two-phase processor IT index to a single shard so its pruned-score assertions do not depend on the cluster's default shard count ([#1959](https://github.com/opensearch-project/neural-search/pull/1959))
 * [Semantic Field] Add an end-to-end remote dense model IT for the semantic field mapping transformer using the TorchServe mock model ([#1966](https://github.com/opensearch-project/neural-search/pull/1966))
 * Guard eclipse() to spotless tasks and keep P2 mirror on pinned version ([#1988](https://github.com/opensearch-project/neural-search/pull/1988))

--- a/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseConstants.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/common/SparseConstants.java
@@ -44,9 +44,5 @@ public final class SparseConstants {
         public static final int MAX_CLUSTERING_BATCH_SIZE = 10000;
         public static final float DEFAULT_QUANTIZATION_CEILING_INGEST = 3.0f;
         public static final float DEFAULT_QUANTIZATION_CEILING_SEARCH = 16.0f;
-        // Mirrors nsparse's kDefaultBlockBudget: how many blocks a per_block forward index reads
-        // per query. Sent explicitly only so the query's quantization range reaches the index --
-        // there is no query parameter for it yet.
-        public static final int DEFAULT_BLOCK_BUDGET = 50;
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/DiskSeismicKPrime.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/DiskSeismicKPrime.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.query;
+
+/**
+ * Converts the user-facing {@code heap_factor} recall/latency knob into the {@code k'} (k-prime)
+ * block budget that the native disk-resident index ({@code disk_seismic_sq}, i.e. a {@code per_block}
+ * forward index) takes.
+ *
+ * <p>Plain SEISMIC prunes with a <em>relative</em> threshold ({@code summary * heap_factor <
+ * kth_score}); the disk-resident index instead scores the globally best {@code k'} block summaries
+ * and reads exactly those, which keeps the per-query block-read count flat (good for a disk index's
+ * tail latency). So the native disk path takes a {@code k'}, not a {@code heap_factor}. Rather than
+ * force users onto a second knob, {@link NativeIndexScorer} keeps exposing {@code heap_factor} and
+ * maps it here before putting {@code k_prime} into the native {@code methodParameters}, leaving the
+ * native library's {@code k'} interface untouched for callers that use it directly.
+ *
+ * <p>The mapping is a deliberately simple, predictable linear convention (not a per-corpus
+ * calibration): {@code heap_factor = 1.0} reads {@value #K_PRIME_AT_UNIT_HEAP_FACTOR} blocks, and
+ * every {@code 0.01} step in {@code heap_factor} moves the budget by one block. It is monotone
+ * non-decreasing, so raising {@code heap_factor} never reads fewer blocks.
+ *
+ * <ul>
+ *   <li><b>Floor:</b> {@code k'} is clamped to {@value #MIN_K_PRIME}; the native side rejects a
+ *       non-positive budget.
+ *   <li><b>No ceiling:</b> an oversized budget is harmless — the native {@code block_budget_query}
+ *       takes {@code std::min(k', candidate_pool)}, so a budget above the per-query pool just means
+ *       "score every candidate block" (an exhaustive search within the cut lists). The result is
+ *       only saturated to {@link Integer#MAX_VALUE} to avoid {@code int} overflow at extreme inputs.
+ * </ul>
+ */
+public final class DiskSeismicKPrime {
+
+    /** Block budget when {@code heap_factor == 1.0} (also the default, since heap_factor defaults to 1.0). */
+    static final int K_PRIME_AT_UNIT_HEAP_FACTOR = 20;
+
+    /** Blocks added per unit of {@code heap_factor} (i.e. one block per 0.01 step). */
+    static final double K_PRIME_PER_HEAP_FACTOR_UNIT = 100.0d;
+
+    /** Smallest budget the native side accepts (it requires {@code k' > 0}). */
+    static final int MIN_K_PRIME = 1;
+
+    private DiskSeismicKPrime() {}
+
+    /**
+     * Maps {@code heap_factor} to the disk block budget {@code k'}.
+     *
+     * @param heapFactor the query's heap factor (validated positive upstream; any non-positive,
+     *                   {@code NaN}, or otherwise tiny value simply clamps to {@link #MIN_K_PRIME})
+     * @return {@code k'} in {@code [MIN_K_PRIME, Integer.MAX_VALUE]}
+     */
+    public static int fromHeapFactor(float heapFactor) {
+        double kPrime = K_PRIME_AT_UNIT_HEAP_FACTOR + K_PRIME_PER_HEAP_FACTOR_UNIT * ((double) heapFactor - 1.0d);
+        long rounded = Math.round(kPrime);
+        if (rounded < MIN_K_PRIME) {
+            return MIN_K_PRIME;
+        }
+        if (rounded > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) rounded;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/query/NativeIndexScorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/query/NativeIndexScorer.java
@@ -36,8 +36,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.opensearch.neuralsearch.sparse.common.SparseConstants.Seismic.DEFAULT_BLOCK_BUDGET;
-
 /**
  * Scores one segment against the native engine index.
  *
@@ -259,11 +257,12 @@ public class NativeIndexScorer extends Scorer {
             searchParameters.put("vmin", 0.0f);
             searchParameters.put("vmax", ByteQuantizationUtil.getCeilingValueSearch(fieldInfo));
             if (SparseFieldUtils.getSparseForwardIndex(fieldInfo) == SparseForwardIndex.PER_BLOCK) {
-                // k_prime is what makes the range above land on DiskSeismicSQSearchParameters,
-                // the only subtype a disk_seismic_sq index reads a query range from. Pinned to
-                // nsparse's own default until it is exposed as a query parameter, so a per_block
-                // field quantizes like a shared one instead of at its ingest ceiling.
-                searchParameters.put("k_prime", DEFAULT_BLOCK_BUDGET);
+                // k_prime is what makes the range above land on DiskSeismicSQSearchParameters, the
+                // only subtype a disk_seismic_sq index reads a query range from, so it must always
+                // be present for a per_block field. It is also the recall/latency budget: derive it
+                // from the query's heap_factor so a single user-facing knob drives both the disk and
+                // the in-memory paths, instead of the native default that ignored heap_factor.
+                searchParameters.put("k_prime", DiskSeismicKPrime.fromHeapFactor(sparseQueryContext.getHeapFactor()));
             }
         }
         return searchParameters;

--- a/src/test/java/org/opensearch/neuralsearch/sparse/query/DiskSeismicKPrimeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/query/DiskSeismicKPrimeTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse.query;
+
+import org.opensearch.neuralsearch.sparse.AbstractSparseTestBase;
+
+import static org.opensearch.neuralsearch.sparse.query.DiskSeismicKPrime.K_PRIME_AT_UNIT_HEAP_FACTOR;
+import static org.opensearch.neuralsearch.sparse.query.DiskSeismicKPrime.MIN_K_PRIME;
+
+public class DiskSeismicKPrimeTests extends AbstractSparseTestBase {
+
+    public void testUnitHeapFactor_mapsToBaseBudget() {
+        assertEquals(K_PRIME_AT_UNIT_HEAP_FACTOR, DiskSeismicKPrime.fromHeapFactor(1.0f));
+    }
+
+    public void testStepsAboveUnit_addOneBlockPerHundredth() {
+        assertEquals(21, DiskSeismicKPrime.fromHeapFactor(1.01f));
+        assertEquals(22, DiskSeismicKPrime.fromHeapFactor(1.02f));
+        assertEquals(30, DiskSeismicKPrime.fromHeapFactor(1.1f));
+        assertEquals(70, DiskSeismicKPrime.fromHeapFactor(1.5f));
+        assertEquals(120, DiskSeismicKPrime.fromHeapFactor(2.0f));
+    }
+
+    public void testStepsBelowUnit_removeOneBlockPerHundredth() {
+        assertEquals(19, DiskSeismicKPrime.fromHeapFactor(0.99f));
+        assertEquals(15, DiskSeismicKPrime.fromHeapFactor(0.95f));
+        assertEquals(12, DiskSeismicKPrime.fromHeapFactor(0.92f));
+    }
+
+    public void testFloor_clampsToMinKPrime() {
+        // heap_factor <= 0.80 would compute k' <= 0; the floor protects the native "k' > 0" rule.
+        assertEquals(MIN_K_PRIME, DiskSeismicKPrime.fromHeapFactor(0.81f)); // exactly 1 at the boundary
+        assertEquals(MIN_K_PRIME, DiskSeismicKPrime.fromHeapFactor(0.8f));  // 0 -> clamp
+        assertEquals(MIN_K_PRIME, DiskSeismicKPrime.fromHeapFactor(0.5f));  // negative -> clamp
+        assertEquals(MIN_K_PRIME, DiskSeismicKPrime.fromHeapFactor(0.01f));
+    }
+
+    public void testDefensiveInputs_clampToMinKPrime() {
+        // heap_factor is validated positive upstream; the converter must still never
+        // return a non-positive or garbage budget that the native side would reject.
+        assertEquals(MIN_K_PRIME, DiskSeismicKPrime.fromHeapFactor(0.0f));
+        assertEquals(MIN_K_PRIME, DiskSeismicKPrime.fromHeapFactor(-3.0f));
+        assertEquals(MIN_K_PRIME, DiskSeismicKPrime.fromHeapFactor(Float.NaN));
+        assertEquals(MIN_K_PRIME, DiskSeismicKPrime.fromHeapFactor(Float.NEGATIVE_INFINITY));
+    }
+
+    public void testNoCeiling_saturatesWithoutOverflow() {
+        // A huge heap_factor must saturate to Integer.MAX_VALUE, never overflow to a
+        // negative int (which the native side would reject). Native clamps k' to the pool.
+        assertEquals(Integer.MAX_VALUE, DiskSeismicKPrime.fromHeapFactor(1.0e9f));
+        assertEquals(Integer.MAX_VALUE, DiskSeismicKPrime.fromHeapFactor(Float.MAX_VALUE));
+        assertEquals(Integer.MAX_VALUE, DiskSeismicKPrime.fromHeapFactor(Float.POSITIVE_INFINITY));
+    }
+
+    public void testMonotoneNonDecreasing_acrossOperatingRange() {
+        int previous = Integer.MIN_VALUE;
+        // 0.50 .. 3.00 in 0.01 steps, the region users actually operate in.
+        for (int hundredths = 50; hundredths <= 300; hundredths++) {
+            int current = DiskSeismicKPrime.fromHeapFactor(hundredths / 100.0f);
+            assertTrue(
+                "k' must be non-decreasing in heap_factor at hf=" + (hundredths / 100.0f) + " (prev=" + previous + ", cur=" + current + ")",
+                current >= previous
+            );
+            assertTrue("k' must always be at least MIN_K_PRIME", current >= MIN_K_PRIME);
+            previous = current;
+        }
+    }
+}


### PR DESCRIPTION
### Description
The `disk_seismic_sq` (forward_index: per_block) query path takes a `k_prime` block budget, not the `heap_factor` that drives the in-memory SEISMIC path. #1974 pinned it to the native default (`DEFAULT_BLOCK_BUDGET = 50`) with a TODO — "until it is exposed as a query parameter" — so `heap_factor` had no effect on a disk field.

This wires `heap_factor` (already on the query) to `k_prime` in `NativeIndexScorer`, so one knob drives both paths. The map is a deliberately simple, monotone linear rule (no per-corpus calibration, no lookup table):
```
k_prime = round(20 + 100 * (heap_factor - 1.0)), floored at 1
```
`heap_factor` = 1.0 → 20 blocks (the new per_block default); ±0.01 → ±1 block. No ceiling is needed — the native `block_budget_query` clamps `k_prime` to the per-query candidate pool. The native `k_prime` API is unchanged, so callers using nsparse directly are unaffected. Removed the now-unused `DEFAULT_BLOCK_BUDGET` constant.

**Behavior change**: a per_block field's default budget goes from 50 to 20 (`heap_factor` default 1.0).

#### Testing

- New `DiskSeismicKPrimeTests` (unit steps, floor clamp, overflow saturation, monotonicity).
- `NativeIndexScorerTests` green against the built native library.
- Real check on base_small (100k docs, exact-truth oracle): monotone dial — heap_factor 0.9/1.0/1.2 → recall@10 0.72/0.87/0.95.

### Related Issues
Relates to #1802 
Follows #1974 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
