### PR TITLE
[Sparse ANN] Add integration tests for the native engine's untested paths

### DIFF
--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseForwardIndexIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseForwardIndexIT.java
@@ -6,13 +6,18 @@ package org.opensearch.neuralsearch.sparse;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.junit.Before;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
 import org.opensearch.neuralsearch.sparse.algorithm.SparseEngine;
 import org.opensearch.neuralsearch.sparse.algorithm.SparseForwardIndex;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Integration tests for the {@code forward_index} mapping parameter, which picks the layout the
@@ -24,6 +29,8 @@ public class SparseForwardIndexIT extends SparseBaseIT {
     private static final String TEST_INDEX_NAME = "test-forward-index";
     private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
     private static final String TEST_TEXT_FIELD_NAME = "text";
+    /** Documents the exact-match filter keeps, which stays below every {@code k} used below. */
+    private static final int FILTERED_DOC_COUNT = 3;
 
     @ParametersFactory(argumentFormatting = "engine=%s")
     public static Collection<Object[]> parameters() {
@@ -77,5 +84,103 @@ public class SparseForwardIndexIT extends SparseBaseIT {
         // n_postings = 4 prunes each posting list to its 4 highest-weight documents.
         assertEquals(4, getHitCount(searchResults));
         assertEquals(List.of("8", "7", "6", "5"), getDocIDs(searchResults));
+    }
+
+    /**
+     * A filter no larger than {@code k} has to leave the block-budget path and match exactly, the way
+     * the shared layout and the Lucene engine already do. per_block reaches that decision inside
+     * nsparse rather than through {@code SparseQueryWeight#selectScorer}, so it is the one layout
+     * where a filtered query can silently come back empty.
+     *
+     * <p>The corpus has to be large enough that the budget is the binding constraint: with a few
+     * blocks in total, k' covers them all and even a broken build finds the filtered documents by
+     * accident. 500 documents at cluster_ratio 0.1 give ~50 blocks per posting against a budget of
+     * 20, and the 3 documents this filter keeps are then very unlikely to sit in the top blocks.
+     */
+    public void testSearchDocuments_withPerBlockForwardIndexAndFilterSmallerThanK() throws Exception {
+        int docCount = 500;
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, SparseForwardIndex.PER_BLOCK, docCount, 0.4f, 0.1f, docCount);
+
+        List<String> texts = new ArrayList<>();
+        for (int i = 0; i < docCount; ++i) {
+            texts.add(i < FILTERED_DOC_COUNT ? "apple" : "tree");
+        }
+        ingestDocumentsAndForceMergeForSingleShard(
+            TEST_INDEX_NAME,
+            TEST_TEXT_FIELD_NAME,
+            TEST_SPARSE_FIELD_NAME,
+            prepareIngestDocuments(docCount),
+            texts
+        );
+
+        // 3 documents pass, well under k = 10.
+        BoolQueryBuilder filter = new BoolQueryBuilder().must(new MatchQueryBuilder(TEST_TEXT_FIELD_NAME, "apple"));
+        Map<String, Float> queryTokens = Map.of("1000", 1.0f);
+        Map<String, Object> searchResults = search(
+            TEST_INDEX_NAME,
+            getNeuralSparseQueryBuilder(TEST_SPARSE_FIELD_NAME, 1, 1.0f, 10, queryTokens, filter),
+            10
+        );
+        assertNotNull(searchResults);
+        assertEquals("every filtered document has to be scored on the exact-match path", FILTERED_DOC_COUNT, getHitCount(searchResults));
+        // Weights are random, so the order among the three is not fixed, but the set is.
+        assertEquals(Set.of("1", "2", "3"), new HashSet<>(getDocIDs(searchResults)));
+
+        // The exact-match path neither prunes nor reads block summaries, so heap_factor cannot move
+        // it. A result that changes with heap_factor means the query stayed on the budget path.
+        Map<String, Object> highHeapFactorResults = search(
+            TEST_INDEX_NAME,
+            getNeuralSparseQueryBuilder(TEST_SPARSE_FIELD_NAME, 1, 20.0f, 10, queryTokens, filter),
+            10
+        );
+        assertEquals(getDocIDs(searchResults), getDocIDs(highHeapFactorResults));
+        assertEquals(getNormalizationScoreList(searchResults), getNormalizationScoreList(highHeapFactorResults));
+    }
+
+    /**
+     * per_block does not prune with a relative threshold: it scores the globally best k' block
+     * summaries and reads exactly those, so {@code NativeIndexScorer} converts heap_factor into k'
+     * through {@code DiskSeismicKPrime} (20 blocks at 1.0, 120 at 2.0). k' bounds how many documents
+     * can be scored at all, so raising heap_factor has to widen the result set on a corpus with more
+     * blocks than the budget. A flat hit count across the sweep means the conversion never reached
+     * nsparse - the regression #1997 fixed, which unit tests on the arithmetic alone cannot see.
+     */
+    public void testHeapFactorWidensTheBlockBudget() throws Exception {
+        int docCount = 500;
+        // cluster_ratio 0.1 over a posting list holding all 500 documents gives ~50 blocks per
+        // posting, more than the 20 the default heap_factor budgets for.
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, SparseForwardIndex.PER_BLOCK, docCount, 0.4f, 0.1f, docCount);
+        ingestDocumentsAndForceMergeForSingleShard(
+            TEST_INDEX_NAME,
+            TEST_TEXT_FIELD_NAME,
+            TEST_SPARSE_FIELD_NAME,
+            prepareIngestDocuments(docCount)
+        );
+
+        // A single query token keeps the candidate blocks to one posting list, so the budget stays
+        // the binding constraint. k is the whole corpus so the hit count reports documents scored.
+        Map<String, Float> queryTokens = Map.of("1000", 1.0f);
+        List<Float> heapFactors = List.of(1.0f, 1.3f, 2.0f);
+        List<Integer> hitCounts = new ArrayList<>();
+        for (float heapFactor : heapFactors) {
+            Map<String, Object> results = search(
+                TEST_INDEX_NAME,
+                getNeuralSparseQueryBuilder(TEST_SPARSE_FIELD_NAME, 1, heapFactor, docCount, queryTokens),
+                docCount
+            );
+            assertNotNull(results);
+            hitCounts.add(getHitCount(results));
+        }
+
+        for (int i = 1; i < hitCounts.size(); ++i) {
+            assertTrue(
+                "raising heap_factor shrank the result set: " + heapFactors + " -> " + hitCounts,
+                hitCounts.get(i) >= hitCounts.get(i - 1)
+            );
+        }
+        assertTrue(
+            "heap_factor never reached k': the same documents came back at 1.0 and 2.0, " + heapFactors + " -> " + hitCounts,
+            hitCounts.get(hitCounts.size() - 1) > hitCounts.get(0)
+        );
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseNativeParityIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseNativeParityIT.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.junit.Before;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.neuralsearch.SparseTestCommon;
+import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
+import org.opensearch.neuralsearch.sparse.algorithm.SparseEngine;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cross-arm parity tests for the native engine.
+ *
+ * <p>Every other sparse suite is parameterized over {@link SparseEngine} and asserts each engine
+ * against its own expectations, so a systematic scoring error on the native side - a dropped token,
+ * a rescaled weight, an off-by-one document - passes them all. These tests build a second index on
+ * a reference implementation and require the two to agree, which is the only assertion in the suite
+ * that can tell "native is correct" apart from "native is self-consistently wrong".
+ *
+ * <p>Only the paths where agreement is exact are compared here. The approximate seismic path prunes
+ * with clustering that seeds from {@code std::random_device} on the native side, so its result set
+ * is not reproducible run to run and belongs in the manual recall sanity tests instead.
+ */
+public class SparseNativeParityIT extends SparseBaseIT {
+
+    private static final String NATIVE_INDEX = "test-native-parity";
+    private static final String LUCENE_INDEX = "test-lucene-parity";
+    private static final String RANK_FEATURES_INDEX = "test-rank-features-parity";
+    private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
+    private static final String TEST_TEXT_FIELD_NAME = "text";
+
+    /**
+     * Doc weights are multiples of 1/8. {@code FeatureField} stores a weight as
+     * {@code floatToIntBits(w) >>> 15}, keeping 8 mantissa bits, so a weight needing more than that
+     * comes back from the rank_features arm truncated by up to 0.4% - a disagreement with the
+     * unquantized native arm that is not a bug. These values round-trip exactly, which keeps the
+     * comparison below a strict one.
+     */
+    private static final List<Map<String, Float>> DOCS = List.of(
+        Map.of("1000", 0.125f, "2000", 0.25f, "3000", 0.5f),
+        Map.of("1000", 0.25f, "2000", 0.5f, "3000", 0.125f),
+        Map.of("1000", 0.375f, "2000", 0.75f, "3000", 0.25f),
+        Map.of("1000", 0.5f, "2000", 1.0f, "3000", 0.375f),
+        Map.of("1000", 0.625f, "2000", 1.25f, "3000", 0.5f),
+        Map.of("1000", 0.75f, "2000", 1.5f, "3000", 0.625f),
+        Map.of("1000", 0.875f, "2000", 1.75f, "3000", 0.75f),
+        Map.of("1000", 1.0f, "2000", 2.0f, "3000", 0.875f)
+    );
+
+    /** Half the corpus matches "apple", which gives a filter of cardinality 4. */
+    private static final List<String> TEXTS = List.of("apple", "tree", "apple", "tree", "apple", "tree", "apple", "tree");
+
+    private static final Map<String, Float> QUERY_TOKENS = Map.of("1000", 2.0f, "2000", 1.5f, "3000", 0.5f);
+
+    /** Above the 8-doc corpus, so no segment is clustered and both engines run the exact path. */
+    private static final int THRESHOLD_ABOVE_CORPUS = 1000;
+
+    /** At or below the 8-doc corpus, so the whole field is clustered. */
+    private static final int THRESHOLD_AT_CORPUS = 8;
+
+    private static final int K = 10;
+
+    /** Both arms compute a float dot product; only summation order can differ. */
+    private static final double EXACT_SCORE_DELTA = 1e-5;
+
+    /**
+     * The forward index a seismic segment scores from holds 8-bit codes, and the native and Lucene
+     * quantizers do not derive their scale the same way (see {@link #QUANTIZATION_IS_LUCENE_ONLY}),
+     * so scores on that path are only compared to the unquantized dot product loosely. Tight enough
+     * to catch a wrong document, a dropped token or a rescaled weight.
+     */
+    private static final double QUANTIZED_SCORE_TOLERANCE = 0.05;
+
+    @ParametersFactory(argumentFormatting = "engine=%s")
+    public static Collection<Object[]> parameters() {
+        return nativeEngineOnly();
+    }
+
+    public SparseNativeParityIT(SparseEngine engine) {
+        super(engine);
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    /**
+     * The inverted path is unquantized on both arms - nsparse holds raw float32 postings and
+     * rank_features holds a losslessly encoded weight for the values used here - so the native
+     * scores have to equal the rank_features scores, and both have to equal the dot product this
+     * test computes itself. Any divergence here is a real bug.
+     */
+    public void testInvertedIndexPathMatchesRankFeaturesBaseline() throws Exception {
+        createSparseIndex(NATIVE_INDEX, TEST_SPARSE_FIELD_NAME, 100, 0.4f, 0.1f, THRESHOLD_ABOVE_CORPUS);
+        ingestDocumentsAndForceMergeForSingleShard(NATIVE_INDEX, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, DOCS, TEXTS);
+
+        prepareSparseEncodingIndex(RANK_FEATURES_INDEX, List.of(TEST_SPARSE_FIELD_NAME), 1);
+        ingestDocuments(RANK_FEATURES_INDEX, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, DOCS, TEXTS, 1);
+
+        Map<String, Object> nativeResults = search(
+            NATIVE_INDEX,
+            getNeuralSparseQueryBuilder(TEST_SPARSE_FIELD_NAME, QUERY_TOKENS.size(), 1.0f, K, QUERY_TOKENS),
+            K
+        );
+        // The rank_features field has no method_parameters to accept, so the baseline is queried
+        // with the plain neural_sparse body.
+        Map<String, Object> baselineResults = search(RANK_FEATURES_INDEX, rankFeaturesQuery(), K);
+
+        List<String> expectedIds = expectedIdsByScore(null);
+        assertEquals(expectedIds, getDocIDs(nativeResults));
+        assertEquals("the rank_features baseline itself disagrees with the dot product", expectedIds, getDocIDs(baselineResults));
+
+        List<Double> nativeScores = getNormalizationScoreList(nativeResults);
+        List<Double> baselineScores = getNormalizationScoreList(baselineResults);
+        assertEquals(expectedIds.size(), nativeScores.size());
+        for (int i = 0; i < expectedIds.size(); ++i) {
+            double expected = expectedScore(expectedIds.get(i));
+            assertEquals(
+                "score mismatch on the rank_features baseline for _id " + expectedIds.get(i),
+                expected,
+                baselineScores.get(i),
+                EXACT_SCORE_DELTA
+            );
+            assertEquals(
+                "native score diverges from the baseline for _id " + expectedIds.get(i),
+                expected,
+                nativeScores.get(i),
+                EXACT_SCORE_DELTA
+            );
+        }
+    }
+
+    /**
+     * A filter no larger than {@code k} sends both engines down the exact-match path, which does not
+     * prune, so the two arms have to return the same documents in the same order. Scores are read
+     * from a quantized forward index on this path, so they are checked against the dot product
+     * within {@link #QUANTIZED_SCORE_TOLERANCE} rather than against each other.
+     */
+    public void testExactMatchFilterPathMatchesLuceneEngine() throws Exception {
+        createSparseIndex(NATIVE_INDEX, TEST_SPARSE_FIELD_NAME, 8, 0.4f, 0.5f, THRESHOLD_AT_CORPUS);
+        ingestDocumentsAndForceMergeForSingleShard(NATIVE_INDEX, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, DOCS, TEXTS);
+
+        // Built through SparseTestCommon rather than the inherited helper: this suite runs on the
+        // native engine, and the point of the test is to compare it against the other one.
+        SparseTestCommon.createSparseIndex(
+            client(),
+            SparseEngine.LUCENE,
+            LUCENE_INDEX,
+            TEST_SPARSE_FIELD_NAME,
+            8,
+            0.4f,
+            0.5f,
+            THRESHOLD_AT_CORPUS
+        );
+        SparseTestCommon.ingestDocumentsAndForceMergeForSingleShard(
+            client(),
+            LUCENE_INDEX,
+            TEST_TEXT_FIELD_NAME,
+            TEST_SPARSE_FIELD_NAME,
+            DOCS,
+            TEXTS
+        );
+
+        List<String> expectedIds = expectedIdsByScore("apple");
+        assertEquals("filter has to stay at or below k to reach the exact-match path", 4, expectedIds.size());
+
+        for (String index : List.of(NATIVE_INDEX, LUCENE_INDEX)) {
+            Map<String, Object> results = search(
+                index,
+                getNeuralSparseQueryBuilder(
+                    TEST_SPARSE_FIELD_NAME,
+                    QUERY_TOKENS.size(),
+                    1.0f,
+                    K,
+                    QUERY_TOKENS,
+                    new BoolQueryBuilder().must(new MatchQueryBuilder(TEST_TEXT_FIELD_NAME, "apple"))
+                ),
+                K
+            );
+            assertEquals("the exact-match path dropped a filtered document on " + index, expectedIds.size(), getHitCount(results));
+            assertEquals("exact-match ordering differs on " + index, expectedIds, getDocIDs(results));
+
+            List<Double> scores = getNormalizationScoreList(results);
+            for (int i = 0; i < expectedIds.size(); ++i) {
+                double expected = expectedScore(expectedIds.get(i));
+                assertEquals(
+                    "score on "
+                        + index
+                        + " for _id "
+                        + expectedIds.get(i)
+                        + " is not within "
+                        + QUANTIZED_SCORE_TOLERANCE
+                        + " of the dot product",
+                    expected,
+                    scores.get(i),
+                    expected * QUANTIZED_SCORE_TOLERANCE
+                );
+            }
+        }
+    }
+
+    /** Plain neural_sparse body for the rank_features baseline. */
+    private NeuralSparseQueryBuilder rankFeaturesQuery() {
+        return new NeuralSparseQueryBuilder().fieldName(TEST_SPARSE_FIELD_NAME).queryTokensMapSupplier(() -> QUERY_TOKENS);
+    }
+
+    /**
+     * Dot product of the query against the document ingested under {@code docId}. Weights are read
+     * back through the {@code FeatureField} encoding so the same expectation holds for both arms;
+     * for the values in {@link #DOCS} that encoding is a no-op.
+     */
+    private double expectedScore(String docId) {
+        return computeExpectedScore(DOCS.get(Integer.parseInt(docId) - 1), QUERY_TOKENS);
+    }
+
+    /**
+     * Document ids ordered by descending score, restricted to the documents whose text is
+     * {@code matchingText} when one is given. Ids are assigned by the ingest helper starting at 1.
+     */
+    private List<String> expectedIdsByScore(String matchingText) {
+        List<String> ids = new ArrayList<>();
+        for (int i = 0; i < DOCS.size(); ++i) {
+            if (matchingText == null || matchingText.equals(TEXTS.get(i))) {
+                ids.add(String.valueOf(i + 1));
+            }
+        }
+        ids.sort(Comparator.comparingDouble(this::expectedScore).reversed());
+        return ids;
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/sparse/SparseReplicaIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/SparseReplicaIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.sparse;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.junit.Before;
+import org.opensearch.neuralsearch.SparseTestCommon;
+import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
+import org.opensearch.neuralsearch.sparse.algorithm.SparseEngine;
+import org.opensearch.neuralsearch.sparse.algorithm.SparseForwardIndex;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration tests for a replicated sparse index.
+ *
+ * <p>The native engine writes its index to a {@code .nsparse} file that has to be part of the
+ * segment's file set, with the Lucene footer {@code DefaultNativeIndexWriter} appends, for peer
+ * recovery to carry it to the replica. When that breaks, the replica ends up with a segment whose
+ * engine file is missing and answers with a shard failure or with nothing - never with visibly wrong
+ * scores - so only a query that is routed at the replica on purpose can catch it.
+ *
+ * <p>Requires two or more data nodes: with one node the replica stays unassigned and every
+ * assertion below is vacuous. CI covers this through the {@code integMultiNodeTest} job
+ * ({@code -PnumNodes=3}); a local single-node {@code ./gradlew integTest} run skips it.
+ */
+public class SparseReplicaIT extends SparseBaseIT {
+
+    private static final String TEST_INDEX_NAME = "test-sparse-replica";
+    private static final String TEST_SPARSE_FIELD_NAME = "sparse_field";
+    private static final String TEST_TEXT_FIELD_NAME = "text";
+    private static final int SHARDS = 1;
+    private static final int REPLICAS = 1;
+    private static final int DOC_COUNT = 8;
+
+    private static final List<Map<String, Float>> DOCS = List.of(
+        Map.of("1000", 0.1f, "2000", 0.1f),
+        Map.of("1000", 0.2f, "2000", 0.2f),
+        Map.of("1000", 0.3f, "2000", 0.3f),
+        Map.of("1000", 0.4f, "2000", 0.4f),
+        Map.of("1000", 0.5f, "2000", 0.5f),
+        Map.of("1000", 0.6f, "2000", 0.6f),
+        Map.of("1000", 0.7f, "2000", 0.7f),
+        Map.of("1000", 0.8f, "2000", 0.8f)
+    );
+
+    private static final Map<String, Float> QUERY_TOKENS = Map.of("1000", 0.1f, "2000", 0.2f);
+
+    @ParametersFactory(argumentFormatting = "engine=%s")
+    public static Collection<Object[]> parameters() {
+        return allEngines();
+    }
+
+    public SparseReplicaIT(SparseEngine engine) {
+        super(engine);
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        assumeTrue(
+            "a replica needs a second data node; run with -PnumNodes=2 or more",
+            SparseTestCommon.getDataNodeCount(client()) >= REPLICAS + 1
+        );
+    }
+
+    /** The default forward index layout, which is the only one the Lucene engine has. */
+    public void testPrimaryAndReplicaBothServeTheSparseIndex() throws Exception {
+        createSparseIndex(TEST_INDEX_NAME, TEST_SPARSE_FIELD_NAME, 8, 0.4f, 0.5f, DOC_COUNT, SHARDS, REPLICAS);
+        assertPrimaryAndReplicaAgree();
+    }
+
+    /**
+     * per_block is where an unshipped engine file is most likely to go unnoticed: a disk-resident
+     * index reads only the blocks a query selects, so a truncated or absent file can still answer
+     * some queries.
+     */
+    public void testPrimaryAndReplicaBothServeAPerBlockSparseIndex() throws Exception {
+        assumeTrue("forward_index is a native-only mapping parameter", SparseEngine.NATIVE == engine);
+        SparseTestCommon.createSparseIndex(
+            client(),
+            engine,
+            SparseForwardIndex.PER_BLOCK,
+            TEST_INDEX_NAME,
+            TEST_SPARSE_FIELD_NAME,
+            8,
+            0.4f,
+            0.5f,
+            DOC_COUNT,
+            SHARDS,
+            REPLICAS
+        );
+        assertPrimaryAndReplicaAgree();
+    }
+
+    private void assertPrimaryAndReplicaAgree() throws Exception {
+        ingestDocuments(TEST_INDEX_NAME, TEST_TEXT_FIELD_NAME, TEST_SPARSE_FIELD_NAME, DOCS, null, 1);
+        forceMerge(TEST_INDEX_NAME);
+        waitForSegmentMerge(TEST_INDEX_NAME, SHARDS, REPLICAS);
+        // Every copy has to be STARTED before a preference can pick one, and a replica that failed to
+        // recover its engine file never gets there.
+        waitForClusterHealthGreen(String.valueOf(REPLICAS + 1));
+        assertEquals(SHARDS * (REPLICAS + 1), getSegmentCount(TEST_INDEX_NAME));
+
+        Map<String, Object> primaryResults = searchWithPreference("_primary");
+        Map<String, Object> replicaResults = searchWithPreference("_replica");
+
+        assertShardsSucceeded(primaryResults, "_primary");
+        assertShardsSucceeded(replicaResults, "_replica");
+        assertEquals("the replica returned a different number of hits", getHitCount(primaryResults), getHitCount(replicaResults));
+        assertTrue("the replica returned no hits at all", getHitCount(replicaResults) > 0);
+        // Under document replication each copy builds and clusters its own segments, and native
+        // clustering seeds from std::random_device, so the two copies may order the approximate top-k
+        // differently. The documents they retrieve still have to be the same.
+        assertEquals(
+            "the replica retrieved a different set of documents",
+            new HashSet<>(getDocIDs(primaryResults)),
+            new HashSet<>(getDocIDs(replicaResults))
+        );
+    }
+
+    private Map<String, Object> searchWithPreference(String preference) {
+        NeuralSparseQueryBuilder queryBuilder = getNeuralSparseQueryBuilder(TEST_SPARSE_FIELD_NAME, 2, 1.0f, DOC_COUNT, QUERY_TOKENS);
+        return search(TEST_INDEX_NAME, queryBuilder, null, DOC_COUNT, Map.of("preference", preference), null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertShardsSucceeded(Map<String, Object> searchResults, String preference) {
+        Map<String, Object> shards = (Map<String, Object>) searchResults.get("_shards");
+        assertNotNull(shards);
+        assertEquals("shard failure with preference " + preference + ": " + shards, 0, ((Number) shards.get("failed")).intValue());
+        assertEquals(
+            "no shard answered with preference " + preference + ": " + shards,
+            SHARDS,
+            ((Number) shards.get("successful")).intValue()
+        );
+    }
+}

--- a/src/testFixtures/java/org/opensearch/neuralsearch/SparseTestCommon.java
+++ b/src/testFixtures/java/org/opensearch/neuralsearch/SparseTestCommon.java
@@ -81,7 +81,23 @@ public class SparseTestCommon {
         float clusterRatio,
         int approximateThreshold
     ) throws IOException {
-        String indexSettings = prepareIndexSettings(1, 0);
+        createSparseIndex(client, engine, forwardIndex, indexName, fieldName, nPostings, alpha, clusterRatio, approximateThreshold, 1, 0);
+    }
+
+    public static void createSparseIndex(
+        RestClient client,
+        SparseEngine engine,
+        SparseForwardIndex forwardIndex,
+        String indexName,
+        String fieldName,
+        int nPostings,
+        float alpha,
+        float clusterRatio,
+        int approximateThreshold,
+        int shards,
+        int replicas
+    ) throws IOException {
+        String indexSettings = prepareIndexSettings(shards, replicas);
         String indexMappings = prepareIndexMapping(
             engine,
             forwardIndex,


### PR DESCRIPTION
### Description

Every sparse IT is parameterized over `SparseEngine` and asserts each engine against its own expectations, so a systematic native scoring error passes all of them. Four gaps:

- **`SparseNativeParityIT`** (new) compares native against a reference: the inverted path vs `rank_features` (unquantized both sides, so exact ids and scores), and the exact-match filter path vs a Lucene seismic index. The approximate path is not compared — native clustering seeds from `std::random_device`.
- **`SparseForwardIndexIT`**: a `per_block` filter no larger than `k` must match exactly (needs submodule bump `d9d0df1` → `354c756`, neural-sparse-cpp#52); `heap_factor` must reach `k'` in nsparse.
- **`SparseReplicaIT`** (new): the engine file must reach the replica through peer recovery. Runs in `integMultiNodeTest`.

Sparse suite: 121 tests, 0 failures. The `per_block` test fails against the old submodule.

Part of #1802

### Check List
- [x] Functionality includes testing.
- [x] Commits are signed off.