### PR TITLE
[Fusion] Limit rescore pool to documents ranked by fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * In-query fusion in hybrid search. Let a response processor read the hybrid a fused query replaced, so batch semantic highlighting and a `rerank` processor's `query_context.query_text_path` work in fused mode ([#1989](https://github.com/opensearch-project/neural-search/pull/1989))
 * In-query fusion in hybrid search. Gate fused mode behind an opt-in cluster setting ([#1993](https://github.com/opensearch-project/neural-search/pull/1993))
 * In-query fusion in hybrid search. Refuse a non-object fusion `parameters`, and name rrf's rank constant in explain ([#1995](https://github.com/opensearch-project/neural-search/pull/1995))
+* In-query fusion in hybrid search. Keep a rescore from returning documents the fusion did not rank ([#1999](https://github.com/opensearch-project/neural-search/pull/1999))
 
 ### Bug Fixes
 * [SemanticHighlighter] Fix SemanticHighlighterExtBuilder.toXContent ([#1906](https://github.com/opensearch-project/neural-search/issues/1906)) (query-insights [#651](https://github.com/opensearch-project/query-insights/issues/651))

--- a/src/main/java/org/opensearch/neuralsearch/common/MinClusterVersionUtil.java
+++ b/src/main/java/org/opensearch/neuralsearch/common/MinClusterVersionUtil.java
@@ -32,6 +32,10 @@ public final class MinClusterVersionUtil {
     public static final Version MINIMAL_SUPPORTED_VERSION_METRICS_STATS = Version.V_3_3_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_NEURAL_KNN_QUERY_BUILDER = Version.V_3_0_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_AGENTIC_EMBEDDING_MODEL_ID = Version.V_3_6_0;
+    // Placeholder until the feature branch merges: 3.8.0 is released and contains no fused-mode code, so this has to name
+    // the release that actually ships the feature before either the hybrid_fusion query or the fused rescore guard can
+    // reach a mixed-version cluster. Tracked by https://github.com/opensearch-project/neural-search/issues/2002 and held
+    // to by HybridQueryFusedFanOutTests#testFusedModeMinimumVersion_isNotBehindTheVersionUnderDevelopment.
     public static final Version MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY = Version.V_3_8_0;
 
     // Constant for neural_knn_query version check

--- a/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
+++ b/src/main/java/org/opensearch/neuralsearch/plugin/NeuralSearch.java
@@ -36,6 +36,7 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.HybridFusionQueryBuilder;
+import org.opensearch.neuralsearch.query.FusedWindowGuardRescorerBuilder;
 import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralKNNQueryBuilder;
 import org.opensearch.neuralsearch.query.AgenticSearchQueryBuilder;
@@ -159,6 +160,7 @@ import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.fetch.subphase.highlight.Highlighter;
 import org.opensearch.search.pipeline.SearchPhaseResultsProcessor;
+import org.opensearch.search.rescore.RescorerBuilder;
 import org.opensearch.search.pipeline.SearchRequestProcessor;
 import org.opensearch.search.pipeline.SearchResponseProcessor;
 import org.opensearch.search.pipeline.SystemGeneratedProcessor;
@@ -259,6 +261,29 @@ public class NeuralSearch extends Plugin
             new QuerySpec<>(NeuralKNNQueryBuilder.NAME, NeuralKNNQueryBuilder::new, NeuralKNNQueryBuilder::fromXContent),
             new QuerySpec<>(AgenticSearchQueryBuilder.NAME, AgenticSearchQueryBuilder::new, AgenticSearchQueryBuilder::fromXContent),
             new QuerySpec<>(HybridFusionQueryBuilder.NAME, HybridFusionQueryBuilder::new, HybridFusionQueryBuilder::fromXContent)
+        );
+    }
+
+    /**
+     * The fused-mode rescore guard's wire form, and deliberately ONLY its wire form.
+     *
+     * <p>{@link FusedWindowGuardRescorerBuilder} wraps the request's own rescorer chain so that a rescore cannot change
+     * which documents a fused hybrid is allowed to return. The coordinator installs it during the fused rewrite, so the
+     * shard has to be able to deserialize it — but no user should be able to write it. Registering it here, as a named
+     * writeable under the {@link RescorerBuilder} category, gives the shard exactly that and nothing more.
+     *
+     * <p>The alternative, {@code SearchPlugin#getRescorers()}, would also add a {@code NamedXContentRegistry} entry in
+     * the same call, and that entry is what makes a rescorer name parseable from a request body — turning an internal
+     * wrapper into public request syntax the plugin would then have to support.
+     */
+    @Override
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return List.of(
+            new NamedWriteableRegistry.Entry(
+                RescorerBuilder.class,
+                FusedWindowGuardRescorerBuilder.NAME,
+                FusedWindowGuardRescorerBuilder::new
+            )
         );
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/query/FusedRescoreScope.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusedRescoreScope.java
@@ -53,8 +53,9 @@ import org.opensearch.search.rescore.RescorerBuilder;
  * for any weights.
  *
  * <p>The guard demotes rather than removes, and that is not a preference: core's {@code RescoreProcessor} reads
- * {@code scoreDocs[0].score} on the rescorer's <i>output</i> with no length check, so a rescorer that returned a shorter
- * array would raise an {@code ArrayIndexOutOfBoundsException} as a shard failure. Demotion also costs the paradigm
+ * {@code scoreDocs[0].score} on the rescorer's <i>output</i> with no length check, so a rescorer that returned an
+ * <b>empty</b> array would raise an {@code ArrayIndexOutOfBoundsException} as a shard failure. Empty is the whole hazard —
+ * index 0 is the only one read, so a shorter but non-empty return trips nothing. Demotion also costs the paradigm
  * nothing on its own terms — nothing leaves the pool, so {@code total_hits} and aggregations, computed over the full leg
  * union, cannot be affected at all.
  *

--- a/src/main/java/org/opensearch/neuralsearch/query/FusedRescoreScope.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusedRescoreScope.java
@@ -25,8 +25,38 @@ import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.rescore.RescorerBuilder;
 
 /**
- * Confines every {@code rescore} in a fused-mode request to the fused window, so a rescore can reorder the hybrid's hits
- * but never add to them.
+ * Confines every {@code rescore} in a fused-mode request to the fused window, so a rescore query cannot match a document
+ * the fusion never ranked and therefore cannot lift one above the documents it did rank.
+ *
+ * <p><b>What this does not do, stated first because the distinction is easy to lose.</b> It bounds what the rescore
+ * query can <b>match</b>. It does not bound the arithmetic core applies to the scores afterwards, and ranked documents
+ * are separated from the non-scoring Tail by nothing but {@link HybridFusionOrchestrator#MIN_RANKED_SCORE}. Core's
+ * {@code QueryRescorer} multiplies the first-pass score of every document in the rescore window by
+ * {@code query_weight} whether the rescore query matched it or not, does the same beyond that window, and then
+ * re-sorts with a comparator whose score ties break by <b>ascending Lucene doc id</b>. So a request whose own weights
+ * land a ranked document on exactly {@code 0.0f} makes it indistinguishable from a Tail-only document, and the page
+ * can contain documents fusion did not rank — MEASURED at 20 shards with no window named anywhere in the request:
+ * {@code query_weight: 0} returned two documents from outside a default 100-document window on a six-hit page, and
+ * {@code query_weight: -1} returned a page of which none were ranked. The same request on one shard was unaffected,
+ * because the exposure is the per-shard shortfall: core sizes the rescore window from the shard's own reader while the
+ * fused window is coordinator-global.
+ *
+ * <p><b>Where that is closed.</b> Not here, and not by refusing the weights — they are legal core parameters and core
+ * applies the identical arithmetic to an ordinary non-hybrid query (measured: a plain {@code function_score} at 20
+ * shards returns mid-ranked documents for {@code query_weight: 0} and low-ranked ones for {@code -1}). It is closed one
+ * layer down, on the shard, by {@link FusedWindowGuardRescorer}: it reads which documents fusion ranked from the pristine
+ * pool, lets the request's own rescorers run over that pool untouched, and then <b>demotes</b> the unranked ones into a
+ * score band strictly below every ranked document — so no arithmetic the request chose can order one above the window.
+ * {@code FusedRescoreScoreNormalizer} maps that band's sentinel back to {@code 0.0} on the coordinator, the score those
+ * documents already carry without a rescore, so the band never reaches the response. This class therefore bounds what the
+ * rescore query can <b>match</b> and the guard bounds what it can <b>promote</b>; together they make the guarantee hold
+ * for any weights.
+ *
+ * <p>The guard demotes rather than removes, and that is not a preference: core's {@code RescoreProcessor} reads
+ * {@code scoreDocs[0].score} on the rescorer's <i>output</i> with no length check, so a rescorer that returned a shorter
+ * array would raise an {@code ArrayIndexOutOfBoundsException} as a shard failure. Demotion also costs the paradigm
+ * nothing on its own terms — nothing leaves the pool, so {@code total_hits} and aggregations, computed over the full leg
+ * union, cannot be affected at all.
  *
  * <p><b>Why this is needed at all.</b> {@code rescore} is {@link CandidateScope.Disposition#NOT_PROPAGATED} — it is never
  * pushed down to a leg, because a leg is a plain search whose scores are about to be normalized away. So it runs where
@@ -112,9 +142,13 @@ final class FusedRescoreScope {
             confined.add(scope.confined(requireQueryRescorer(declared)));
         }
         // Written back only once the whole chain has been accepted, so a refusal leaves the request's own rescore list as
-        // the user wrote it rather than half-replaced with placeholders that can never resolve.
-        for (int i = 0; i < confined.size(); i++) {
-            rescores.set(i, confined.get(i));
+        // the user wrote it rather than half-replaced with placeholders that can never resolve. The whole chain collapses
+        // to ONE element — the guard — which applies the confined delegates in order and then restores the
+        // ranked/unranked separation their arithmetic can destroy; see FusedWindowGuardRescorer for why the guard has to
+        // read membership once, ahead of the chain, rather than once per element.
+        rescores.set(0, new FusedWindowGuardRescorerBuilder(confined));
+        while (rescores.size() > 1) {
+            rescores.remove(rescores.size() - 1);
         }
         return scope;
     }

--- a/src/main/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorer.java
@@ -61,8 +61,10 @@ import org.opensearch.search.rescore.Rescorer;
  * already saturated, and it is the same two constants on every shard, so the coordinator's merge — which compares raw
  * floats and breaks ties by (shard, doc id) — sees one consistent band boundary rather than a per-shard one.
  *
- * <p>The sentinel is an internal encoding, not a score the user asked for; {@code FusedRescoreScope} normalises it back
- * to {@code 0.0f} on the coordinator so the response is what the same request without a rescore would return.
+ * <p>Both band values are an internal encoding, not scores the user asked for; {@code FusedRescoreScoreNormalizer}
+ * decodes them on the coordinator — the unranked sentinel to {@code 0.0f} and the ranked floor to
+ * {@link FusedWindowGuardRescorerBuilder#RANKED_FLOOR_NORMALIZED} — so the response reports what the same request
+ * without a rescore would return.
  */
 class FusedWindowGuardRescorer implements Rescorer {
 
@@ -90,6 +92,12 @@ class FusedWindowGuardRescorer implements Rescorer {
         // to MIN_RANKED_SCORE, and a Tail-only document carries exactly 0.0f. The test is exact rather than heuristic —
         // the hybrid query refuses any boost other than 1.0 and indices_boost is rejected for fused mode, so nothing
         // attenuates the floor before this point.
+        //
+        // One site hands over a pool round 2 did not score: a `global` aggregation's top_hits, which core collects in a
+        // separate match_all pass, so every document arrives at 1.0f. The inference is vacuous there rather than wrong —
+        // nothing reads as unranked, the separation below is skipped, and the bucket gets exactly what it would without
+        // the guard, which is what `global` means (it is defined to ignore the query, so its documents are not the
+        // hybrid's hits and there is no fused ranking to preserve).
         Set<Integer> unranked = new HashSet<>();
         for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
             if (scoreDoc.score <= 0.0f) {
@@ -102,11 +110,27 @@ class FusedWindowGuardRescorer implements Rescorer {
             rescored = delegate.rescorer().rescore(rescored, searcher, delegate);
         }
 
-        if (unranked.isEmpty()) {
+        if (unranked.isEmpty() && needsTheRankedFloor(rescored) == false) {
             // Nothing to separate: every document in the pool was ranked, so the user's rescore stands as it is.
             return rescored;
         }
         return separate(rescored, unranked);
+    }
+
+    /**
+     * Whether any score still has to be clamped even though there is no band to separate. A pool of nothing but ranked
+     * documents still reaches the coordinator through this method, and a delegate can have driven one of those scores to
+     * NaN or past {@link #UNRANKED} — NaN would render as a null {@code _score} and sort to the top of the page, and a
+     * saturated score would tie the sentinel a later shard is about to report. Checking is a scan of an array the
+     * delegates just rewrote; the alternative is rebuilding and re-sorting it for nothing on the common path.
+     */
+    private static boolean needsTheRankedFloor(final TopDocs rescored) {
+        for (ScoreDoc scoreDoc : rescored.scoreDocs) {
+            if (Float.isNaN(scoreDoc.score) || scoreDoc.score <= UNRANKED) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorer.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorer.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.opensearch.search.rescore.RescoreContext;
+import org.opensearch.search.rescore.Rescorer;
+
+/**
+ * Runs the request's own rescorers and then restores the one distinction their arithmetic can destroy: a document the
+ * fusion ranked always outranks a document it did not.
+ *
+ * <p><b>What it is defending.</b> Fused mode's round 2 is a self-erased
+ * {@code bool{should: constant_score(window ids)^fusedScore, filter: <the legs>}} with a null
+ * {@code minimum_should_match}, so the non-scoring Tail filter decides matching and the Top only adds score: every
+ * document any leg matched matches round 2, at exactly {@code 0.0f}, while only the window was ranked. Ranked documents
+ * are held above them by {@link HybridFusionOrchestrator#MIN_RANKED_SCORE} alone. Core's {@code QueryRescorer} then
+ * multiplies the first-pass score of every document in the rescore window by {@code query_weight} whether the rescore
+ * query matched it or not, does the same beyond that window, and re-sorts with score ties broken by ascending Lucene
+ * doc id — so {@code query_weight <= 0}, or {@code score_mode} {@code multiply}/{@code min} with a zero weighted rescore
+ * term, collapses ranked and unranked onto the same number and lets doc id decide the page.
+ *
+ * <p><b>Why demote and not remove.</b> Removing the unranked documents here is not expressible: a shard holding Tail
+ * matches but none of the coordinator-global window — routine once the shard count exceeds
+ * {@code fusion.window_size / rescore window} — would have to return an empty array, and core's
+ * {@code RescoreProcessor} length-guards only its INPUT before reading {@code scoreDocs[0].score} on the loop's output,
+ * so an empty return is an {@code ArrayIndexOutOfBoundsException} escaping a {@code catch (IOException)} — a shard
+ * failure. Demoting preserves the array length, so that path is never taken, and it also never shortens the page.
+ *
+ * <p><b>The guarantee this delivers.</b> A rescore may reorder the hybrid's hits; it may not change which documents are
+ * eligible to be returned. That is exactly the ordering the same request has with no rescore at all — ranked documents
+ * at or above the floor, Tail-only documents at {@code 0.0f} — which is also the contract
+ * {@link HybridFusionQueryBuilder#buildSelfErasedQuery} states for {@code size <= window_size}.
+ *
+ * <p><b>Why one guard wraps the whole chain rather than one guard per rescorer.</b> Membership has to be read from the
+ * PRISTINE pool, before any of the user's rescorers has touched a score. Wrapping each element separately would read it
+ * again between elements, and by then a {@code query_weight: 0} element has set every genuinely-ranked document back to
+ * exactly {@code 0.0f} — so the second wrapper would classify the ranked documents as unranked and demote them below
+ * the real Tail, inverting the page. Recording membership once, ahead of the whole chain, makes that unreachable
+ * without needing to carry the window itself to the shard.
+ *
+ * <p><b>The two-band clamp, and why a single fixed sentinel is not enough on its own.</b> Both rescore weights are
+ * unvalidated floats, so a ranked document's post-rescore score is not bounded below: a large negative
+ * {@code rescore_query_weight} can saturate it to {@code -Infinity}, and nothing sorts strictly below that. So the
+ * demotion is a BAND, not a value: unranked documents are set to exactly {@code -Float.MAX_VALUE}, and ranked documents
+ * are clamped UP to {@code Math.nextUp(-Float.MAX_VALUE)} if they landed at or below it (or became NaN). Nothing is
+ * representable between those two floats, so the bands cannot meet; the clamp only touches ranked documents that had
+ * already saturated, and it is the same two constants on every shard, so the coordinator's merge — which compares raw
+ * floats and breaks ties by (shard, doc id) — sees one consistent band boundary rather than a per-shard one.
+ *
+ * <p>The sentinel is an internal encoding, not a score the user asked for; {@code FusedRescoreScope} normalises it back
+ * to {@code 0.0f} on the coordinator so the response is what the same request without a rescore would return.
+ */
+class FusedWindowGuardRescorer implements Rescorer {
+
+    /** @see FusedWindowGuardRescorerBuilder#UNRANKED_SCORE */
+    static final float UNRANKED = FusedWindowGuardRescorerBuilder.UNRANKED_SCORE;
+    /** @see FusedWindowGuardRescorerBuilder#RANKED_FLOOR */
+    static final float RANKED_FLOOR = FusedWindowGuardRescorerBuilder.RANKED_FLOOR;
+
+    /**
+     * Descending by score, ties by ascending doc id — the same order core's own {@code RescoreProcessor} asserts and
+     * the coordinator's merge assumes.
+     */
+    private static final Comparator<ScoreDoc> BY_SCORE_THEN_DOC = Comparator.<ScoreDoc>comparingDouble(d -> -d.score)
+        .thenComparingInt(d -> d.doc);
+
+    private final List<RescoreContext> delegates;
+
+    FusedWindowGuardRescorer(final List<RescoreContext> delegates) {
+        this.delegates = delegates;
+    }
+
+    @Override
+    public TopDocs rescore(final TopDocs topDocs, final IndexSearcher searcher, final RescoreContext rescoreContext) throws IOException {
+        // Read membership from the pool as the collector produced it: a ranked document carries its fused score, floored
+        // to MIN_RANKED_SCORE, and a Tail-only document carries exactly 0.0f. The test is exact rather than heuristic —
+        // the hybrid query refuses any boost other than 1.0 and indices_boost is rejected for fused mode, so nothing
+        // attenuates the floor before this point.
+        Set<Integer> unranked = new HashSet<>();
+        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+            if (scoreDoc.score <= 0.0f) {
+                unranked.add(scoreDoc.doc);
+            }
+        }
+
+        TopDocs rescored = topDocs;
+        for (RescoreContext delegate : delegates) {
+            rescored = delegate.rescorer().rescore(rescored, searcher, delegate);
+        }
+
+        if (unranked.isEmpty()) {
+            // Nothing to separate: every document in the pool was ranked, so the user's rescore stands as it is.
+            return rescored;
+        }
+        return separate(rescored, unranked);
+    }
+
+    /**
+     * Push every unranked document into the bottom band and lift any ranked document that saturated into it, then
+     * re-sort. The array is rebuilt rather than sorted in place because the delegates may have returned the caller's own
+     * array, and a caller that kept a reference to it should not see it reordered underneath them.
+     */
+    private TopDocs separate(final TopDocs rescored, final Set<Integer> unranked) {
+        ScoreDoc[] separated = new ScoreDoc[rescored.scoreDocs.length];
+        for (int i = 0; i < rescored.scoreDocs.length; i++) {
+            ScoreDoc scoreDoc = rescored.scoreDocs[i];
+            float score = unranked.contains(scoreDoc.doc) ? UNRANKED : rankedScore(scoreDoc.score);
+            separated[i] = new ScoreDoc(scoreDoc.doc, score, scoreDoc.shardIndex);
+        }
+        Arrays.sort(separated, BY_SCORE_THEN_DOC);
+        return new TopDocs(rescored.totalHits, separated);
+    }
+
+    /**
+     * A ranked document's score, clamped up into the ranked band. NaN is treated as saturated rather than propagated:
+     * NaN is the largest value under {@code Float.compare}, so letting it through would float the document to the top of
+     * the page and would also trip core's own sortedness assertion.
+     */
+    private static float rankedScore(final float score) {
+        if (Float.isNaN(score) || score <= UNRANKED) {
+            return RANKED_FLOOR;
+        }
+        return score;
+    }
+
+    /**
+     * Chain the delegates' explanations in the order core would have applied them, so {@code explain: true} describes
+     * the rescore the user asked for rather than this wrapper.
+     *
+     * <p>The value it reports is the delegates' own combined value, which for a demoted document is its score BEFORE
+     * the band was applied. That is deliberate: the explanation explains the user's rescore, and the band is an internal
+     * encoding the coordinator removes again. {@code FusedExplanationMerger} replaces the tree for every ranked hit
+     * anyway.
+     */
+    @Override
+    public Explanation explain(
+        final int topLevelDocId,
+        final IndexSearcher searcher,
+        final RescoreContext rescoreContext,
+        final Explanation sourceExplanation
+    ) throws IOException {
+        Explanation explanation = sourceExplanation;
+        for (RescoreContext delegate : delegates) {
+            explanation = delegate.rescorer().explain(topLevelDocId, searcher, delegate, explanation);
+        }
+        return explanation;
+    }
+
+    /** The delegate contexts, so the builder can expose the chain it wrapped for testing. */
+    List<RescoreContext> delegates() {
+        return new ArrayList<>(delegates);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerBuilder.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.QueryRewriteContext;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.search.rescore.QueryRescorerBuilder;
+import org.opensearch.search.rescore.RescoreContext;
+import org.opensearch.search.rescore.RescorerBuilder;
+
+/**
+ * Carries the request's own rescorer chain to the shard wrapped in {@link FusedWindowGuardRescorer}, so that the
+ * guarantee "a rescore may reorder the hybrid's hits but may not change which documents are eligible" survives any
+ * weights the request used. See {@link FusedWindowGuardRescorer} for why the guard is needed and why it demotes rather
+ * than removes.
+ *
+ * <p><b>Not user-typeable, deliberately.</b> This is registered as a named WRITEABLE only — via
+ * {@code NeuralSearch#getNamedWriteables()} under the {@link RescorerBuilder} category — and NOT through
+ * {@code SearchPlugin#getRescorers()}. That matters: {@code SearchModule#registerRescorer} adds a
+ * {@code NamedXContentRegistry} entry in the same call as the writeable one, and the XContent entry is what makes a
+ * rescorer name parseable from a request body. Registering the writeable alone gives the shard what it needs to
+ * deserialize this builder while adding no new request syntax for a user to discover, mistype, or come to depend on.
+ * {@code fromXContent} therefore does not exist; {@link #doXContent} is render-only, for the slow log and
+ * {@code _tasks?detailed}.
+ *
+ * <p><b>One guard wraps the whole chain.</b> The delegates are held in the order the user declared them and are applied
+ * in that order, so per-element {@code window_size} semantics are preserved: each delegate keeps its own
+ * {@link RescoreContext} built from its own builder. This builder's own {@code window_size} is the maximum over the
+ * chain, because core sizes the shard's first-pass pool from the largest window across all rescore contexts and this
+ * builder is the only context core can see.
+ *
+ * <p><b>Why this needs no version gate of its own.</b> It is a new {@code NamedWriteable} on the shard wire, so the
+ * obvious question is what a node that cannot resolve the name does — it fails while deserializing the shard request,
+ * and with {@code allow_partial_search_results} at its default the client still gets a 200 with those shards' documents
+ * silently missing. That is already the exact hazard {@code HybridQueryBuilder#requireClusterSupportsFusedMode} exists
+ * for: it refuses fused mode cluster-wide, at rewrite and before any fan-out, unless every node can resolve
+ * {@code hybrid_fusion}. This builder is only ever installed on a request that has passed that gate, and it ships in the
+ * same release as fused mode itself — which has never shipped, so there is no released build that has fused mode and
+ * lacks this. The gate therefore covers both names with one check.
+ *
+ * <p><b>The dependency that makes that true, and it is not yet satisfied:</b>
+ * {@code MinClusterVersionUtil.MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY} must name the release that actually
+ * contains fused mode. It currently reads {@code V_3_8_0}, which is already released and contains none of it — so the
+ * constant has to be corrected before either name reaches a mixed-version cluster. That correction is tracked
+ * separately; do not add a second gate here to work around it, because a per-name gate would answer a fused rescore
+ * UNGUARDED on a cluster that failed it, which is worse than refusing.
+ *
+ * <p><b>Installed at coordinator rewrite round 1</b> by {@code FusedRescoreScope#install}, which replaces the request's
+ * rescore list with a single element holding the already-window-confined delegates. A replacement made at round 1
+ * reaches the shards: {@code SearchSourceBuilder#rewrite} rewrites the query before it reads the rescorer list, so the
+ * list core snapshots is the one this builder is in.
+ */
+public class FusedWindowGuardRescorerBuilder extends RescorerBuilder<FusedWindowGuardRescorerBuilder> {
+
+    public static final String NAME = "hybrid_fused_window_guard";
+
+    /**
+     * The score unranked documents are demoted to. Finite on purpose: a non-finite score is quoted as a JSON string by
+     * the response serializer, so {@code -Infinity} would turn {@code _score} into a string for every client.
+     *
+     * <p>Public because the coordinator has to recognise it again — {@code FusedRescoreScoreNormalizer} maps it back to
+     * {@code 0.0} before the response leaves, so the sentinel is never user-visible.
+     */
+    public static final float UNRANKED_SCORE = -Float.MAX_VALUE;
+
+    /**
+     * The lowest score a ranked document may report, one float above {@link #UNRANKED_SCORE}. Nothing is representable
+     * between the two, so the ranked and unranked bands cannot meet however extreme the request's weights are.
+     */
+    public static final float RANKED_FLOOR = Math.nextUp(-Float.MAX_VALUE);
+
+    private final List<QueryRescorerBuilder> delegates;
+
+    FusedWindowGuardRescorerBuilder(final List<QueryRescorerBuilder> delegates) {
+        if (Objects.isNull(delegates) || delegates.isEmpty()) {
+            throw new IllegalArgumentException("[" + NAME + "] requires at least one rescorer to guard");
+        }
+        this.delegates = List.copyOf(delegates);
+        // Core sizes the first-pass pool from the largest window across the request's rescore contexts, and after the
+        // wrap this builder is the only context it sees — so it has to stand in for the whole chain's depth.
+        Integer widest = null;
+        for (QueryRescorerBuilder delegate : delegates) {
+            if (Objects.nonNull(delegate.windowSize()) && (Objects.isNull(widest) || delegate.windowSize() > widest)) {
+                widest = delegate.windowSize();
+            }
+        }
+        if (Objects.nonNull(widest)) {
+            windowSize(widest);
+        }
+    }
+
+    public FusedWindowGuardRescorerBuilder(final StreamInput in) throws IOException {
+        super(in);
+        this.delegates = List.copyOf(in.readList(QueryRescorerBuilder::new));
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected void doWriteTo(final StreamOutput out) throws IOException {
+        out.writeList(delegates);
+    }
+
+    @Override
+    protected void doXContent(final XContentBuilder builder, final Params params) throws IOException {
+        // Render-only: this builder is never parsed back from a request. Named so that an operator who finds it in a slow
+        // log or a task description can tell it is the plugin's own wrapper rather than something they wrote.
+        builder.startObject(NAME);
+        builder.startArray("rescorers");
+        for (QueryRescorerBuilder delegate : delegates) {
+            delegate.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.endObject();
+    }
+
+    @Override
+    protected RescoreContext innerBuildContext(final int windowSize, final QueryShardContext context) throws IOException {
+        List<RescoreContext> delegateContexts = new ArrayList<>(delegates.size());
+        for (QueryRescorerBuilder delegate : delegates) {
+            // buildContext is final on RescorerBuilder and applies each delegate's own window size, so the chain keeps
+            // the depth semantics the user declared per element.
+            delegateContexts.add(delegate.buildContext(context));
+        }
+        return new RescoreContext(windowSize, new FusedWindowGuardRescorer(delegateContexts));
+    }
+
+    @Override
+    public RescorerBuilder<FusedWindowGuardRescorerBuilder> rewrite(final QueryRewriteContext ctx) throws IOException {
+        List<QueryRescorerBuilder> rewritten = new ArrayList<>(delegates.size());
+        boolean changed = false;
+        for (QueryRescorerBuilder delegate : delegates) {
+            RescorerBuilder<QueryRescorerBuilder> next = delegate.rewrite(ctx);
+            changed |= next != delegate;
+            rewritten.add((QueryRescorerBuilder) next);
+        }
+        if (changed == false) {
+            return this;
+        }
+        FusedWindowGuardRescorerBuilder replacement = new FusedWindowGuardRescorerBuilder(rewritten);
+        if (Objects.nonNull(windowSize())) {
+            replacement.windowSize(windowSize());
+        }
+        return replacement;
+    }
+
+    /** The chain this guard wraps, in the order the user declared it. */
+    List<QueryRescorerBuilder> delegates() {
+        return delegates;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (Objects.isNull(other) || getClass() != other.getClass()) {
+            return false;
+        }
+        FusedWindowGuardRescorerBuilder that = (FusedWindowGuardRescorerBuilder) other;
+        return Objects.equals(windowSize(), that.windowSize()) && Objects.equals(delegates, that.delegates);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(windowSize(), delegates);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerBuilder.java
@@ -9,9 +9,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.lucene.search.Query;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.ParsedQuery;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
@@ -40,20 +42,28 @@ import org.opensearch.search.rescore.RescorerBuilder;
  * builder is the only context core can see.
  *
  * <p><b>Why this needs no version gate of its own.</b> It is a new {@code NamedWriteable} on the shard wire, so the
- * obvious question is what a node that cannot resolve the name does — it fails while deserializing the shard request,
- * and with {@code allow_partial_search_results} at its default the client still gets a 200 with those shards' documents
- * silently missing. That is already the exact hazard {@code HybridQueryBuilder#requireClusterSupportsFusedMode} exists
- * for: it refuses fused mode cluster-wide, at rewrite and before any fan-out, unless every node can resolve
- * {@code hybrid_fusion}. This builder is only ever installed on a request that has passed that gate, and it ships in the
- * same release as fused mode itself — which has never shipped, so there is no released build that has fused mode and
- * lacks this. The gate therefore covers both names with one check.
+ * obvious question is what a node that cannot resolve the name does — {@code NamedWriteableRegistry} throws while the
+ * node deserializes the shard request, which comes back as a failure for that shard alone, so with
+ * {@code allow_partial_search_results} at its default the client gets a 200 carrying {@code _shards.failed} and an
+ * {@code Unknown NamedWriteable} reason (and a copy of the shard on an upgraded node clears it on retry). A reported
+ * wrong answer rather than a silent one, but a wrong answer. That is already the exact hazard
+ * {@code HybridQueryBuilder#requireClusterSupportsFusedMode} exists for: it refuses fused mode cluster-wide, at rewrite
+ * and before any fan-out, unless every node can resolve {@code hybrid_fusion}. This builder is only ever installed on a
+ * request that has passed that gate, and it ships in the same release as fused mode itself — which has never shipped, so
+ * there is no released build that has fused mode and lacks this. The gate therefore covers both names with one check.
  *
  * <p><b>The dependency that makes that true, and it is not yet satisfied:</b>
  * {@code MinClusterVersionUtil.MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY} must name the release that actually
- * contains fused mode. It currently reads {@code V_3_8_0}, which is already released and contains none of it — so the
- * constant has to be corrected before either name reaches a mixed-version cluster. That correction is tracked
- * separately; do not add a second gate here to work around it, because a per-name gate would answer a fused rescore
- * UNGUARDED on a cluster that failed it, which is worse than refusing.
+ * contains fused mode. It currently reads {@code V_3_8_0}, which is released and contains none of it — so the constant
+ * has to be corrected before either name reaches a mixed-version cluster. The exposure is not confined to fused mode:
+ * {@code HybridQueryBuilder#doWriteTo} writes the {@code fusion} presence flag to every peer at stream version
+ * {@code V_3_8_0} or later whether the query uses fused mode or not, and no cluster setting gates the serializer, so a
+ * plain classic {@code hybrid} desynchronises the stream against a released 3.8.0 node as well. Tracked by
+ * <a href="https://github.com/opensearch-project/neural-search/issues/2002">issue 2002</a>, where the value is decided at
+ * the point the feature branch merges, and held to meanwhile by
+ * {@code HybridQueryFusedFanOutTests#testFusedModeMinimumVersion_isNotBehindTheVersionUnderDevelopment}, which fails as
+ * soon as the branch's core version moves past the constant. Do not add a second gate here to work around it, because a
+ * per-name gate would answer a fused rescore UNGUARDED on a cluster that failed it, which is worse than refusing.
  *
  * <p><b>Installed at coordinator rewrite round 1</b> by {@code FusedRescoreScope#install}, which replaces the request's
  * rescore list with a single element holding the already-window-confined delegates. A replacement made at round 1
@@ -69,7 +79,7 @@ public class FusedWindowGuardRescorerBuilder extends RescorerBuilder<FusedWindow
      * the response serializer, so {@code -Infinity} would turn {@code _score} into a string for every client.
      *
      * <p>Public because the coordinator has to recognise it again — {@code FusedRescoreScoreNormalizer} maps it back to
-     * {@code 0.0} before the response leaves, so the sentinel is never user-visible.
+     * {@code 0.0} on every response and every {@code top_hits} bucket before the response leaves.
      */
     public static final float UNRANKED_SCORE = -Float.MAX_VALUE;
 
@@ -78,6 +88,20 @@ public class FusedWindowGuardRescorerBuilder extends RescorerBuilder<FusedWindow
      * between the two, so the ranked and unranked bands cannot meet however extreme the request's weights are.
      */
     public static final float RANKED_FLOOR = Math.nextUp(-Float.MAX_VALUE);
+
+    /**
+     * What a document sitting on {@link #RANKED_FLOOR} is reported as. Both band values are decoded by the same rule —
+     * the score this document would have carried with no rescore in the request at all: an unranked document scores
+     * exactly {@code 0.0f} because it matches only the non-scoring Tail, and a ranked document scores at least
+     * {@code HybridFusionOrchestrator#MIN_RANKED_SCORE}, which every fused score is already floored to. Reporting
+     * {@code RANKED_FLOOR} itself would hand a user a sentinel-adjacent float, and would print a ranked hit BELOW the
+     * {@code 0.0f} of the unranked hits it outranks.
+     *
+     * <p>Deliberately the same number as that floor rather than a distinguishable marker: a document that saturated and
+     * a document whose fused score was already at the floor are both "ranked, lowest band", and nothing downstream
+     * branches on the value. {@code FusedWindowGuardRescorerBuilderTests} pins the two constants equal.
+     */
+    public static final float RANKED_FLOOR_NORMALIZED = 1e-30f;
 
     private final List<QueryRescorerBuilder> delegates;
 
@@ -88,13 +112,27 @@ public class FusedWindowGuardRescorerBuilder extends RescorerBuilder<FusedWindow
         this.delegates = List.copyOf(delegates);
         // Core sizes the first-pass pool from the largest window across the request's rescore contexts, and after the
         // wrap this builder is the only context it sees — so it has to stand in for the whole chain's depth.
+        //
+        // Over EFFECTIVE windows, not declared ones: a delegate that names no window_size is not windowless, it is
+        // DEFAULT_WINDOW_SIZE, which RescorerBuilder#buildContext substitutes for it. Skipping such a delegate would let
+        // a chain of [window_size: 5, unset] report 5, and since this builder is the only context core can see, the pool
+        // would be collected 5 deep where the unwrapped chain would have collected 10 — the defaulting delegate silently
+        // stops reaching documents it is supposed to rescore. When NO delegate declares one the window stays unset, which
+        // is not the same as setting it to the default: core applies the same default to this builder, and leaving it
+        // unset keeps that out of the rendered request.
         Integer widest = null;
         for (QueryRescorerBuilder delegate : delegates) {
-            if (Objects.nonNull(delegate.windowSize()) && (Objects.isNull(widest) || delegate.windowSize() > widest)) {
-                widest = delegate.windowSize();
+            if (Objects.nonNull(delegate.windowSize())) {
+                widest = Objects.isNull(widest) ? delegate.windowSize() : Math.max(widest, delegate.windowSize());
             }
         }
         if (Objects.nonNull(widest)) {
+            for (QueryRescorerBuilder delegate : delegates) {
+                if (Objects.isNull(delegate.windowSize())) {
+                    widest = Math.max(widest, DEFAULT_WINDOW_SIZE);
+                    break;
+                }
+            }
             windowSize(widest);
         }
     }
@@ -135,7 +173,47 @@ public class FusedWindowGuardRescorerBuilder extends RescorerBuilder<FusedWindow
             // the depth semantics the user declared per element.
             delegateContexts.add(delegate.buildContext(context));
         }
-        return new RescoreContext(windowSize, new FusedWindowGuardRescorer(delegateContexts));
+        return new ChainRescoreContext(windowSize, delegateContexts);
+    }
+
+    /**
+     * The guard's own {@link RescoreContext}, which reports the chain's queries as if the chain were still registered
+     * directly.
+     *
+     * <p>Necessary because two core phases read the request's rescore contexts for their <b>queries</b> rather than for
+     * their rescorers, and after the wrap this context is the only one they can see. {@code MatchedQueriesPhase} collects
+     * {@code getParsedQueries().namedFilters()}, so a {@code _name} on a rescore query would vanish from
+     * {@code matched_queries}; {@code DfsPhase} collects term statistics from the same list, so under
+     * {@code dfs_query_then_fetch} the rescore query would score on local rather than global IDF and reorder the ranked
+     * hits. A bare {@code RescoreContext} answers both with an empty list, which is why the queries have to be forwarded
+     * explicitly — the wrap is meant to change which documents a rescore may return, and nothing else about it.
+     */
+    private static final class ChainRescoreContext extends RescoreContext {
+
+        private final List<RescoreContext> delegates;
+
+        ChainRescoreContext(final int windowSize, final List<RescoreContext> delegates) {
+            super(windowSize, new FusedWindowGuardRescorer(delegates));
+            this.delegates = delegates;
+        }
+
+        @Override
+        public List<Query> getQueries() {
+            List<Query> queries = new ArrayList<>();
+            for (RescoreContext delegate : delegates) {
+                queries.addAll(delegate.getQueries());
+            }
+            return queries;
+        }
+
+        @Override
+        public List<ParsedQuery> getParsedQueries() {
+            List<ParsedQuery> parsedQueries = new ArrayList<>();
+            for (RescoreContext delegate : delegates) {
+                parsedQueries.addAll(delegate.getParsedQueries());
+            }
+            return parsedQueries;
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionOrchestrator.java
@@ -105,11 +105,22 @@ final class HybridFusionOrchestrator {
      * less extreme). So this is a bound, not a promise, and it is deliberately not enforced: the attenuating values are
      * legal core parameters, and refusing them to protect an internal floor would cost more than it buys.
      *
-     * <p>What the residual exposure actually is, stated narrowly: only a document fusion scored <i>at or below</i> this
-     * floor can be annihilated, because everything else is orders of magnitude larger and attenuates to a value that is
-     * still positive. Reaching the floor at all takes a {@code weights} entry of {@code 0.0} or {@code l2} over a
-     * zero-norm leg (see {@link #scoreAboveTail}), so the exposure is the original Tail tie, confined to documents fusion
-     * ranked at effectively no score, and only under attenuation this extreme. Pinned by
+     * <p>What the residual exposure actually is. Under <i>attenuation</i> — the compounding multiplication described
+     * above — it is narrow: only a document fusion scored at or below this floor is annihilated, because everything else
+     * is orders of magnitude larger and attenuates to a value that is still positive, and reaching the floor at all takes
+     * a {@code weights} entry of {@code 0.0} or {@code l2} over a zero-norm leg (see {@link #scoreAboveTail}).
+     *
+     * <p><b>It is not narrow for every route, and an earlier version of this note wrongly said it was.</b> A weighting
+     * that multiplies by exactly zero annihilates <i>any</i> score, floor or not: {@code query_weight: 0} collapses every
+     * document in the rescore window, and {@code score_mode} {@code multiply}/{@code min} with a zero weighted rescore
+     * term collapses every document the rescore query matched — MEASURED evicting a document fusion ranked at an ordinary
+     * score of {@code 0.5}. A negative {@code query_weight} goes further and inverts the page outright, since Tail-only
+     * documents sit at {@code -0.0f} and {@code Float.compare} orders that above every negative. So the floor's value is
+     * load-bearing only against attenuation; against a zero or negative multiplier no floor can help, which is why the
+     * ranked/unranked distinction is not left to the score alone for a rescore: {@link FusedWindowGuardRescorer} records
+     * membership from the pool <i>before</i> the request's rescorers run, and afterwards re-separates the two groups into
+     * disjoint score bands, so no arithmetic can promote an unranked document however it scored it. The floor still
+     * matters for every other consumer of round 2's scores. Pinned by
      * {@code HybridFusionOrchestratorTests#testMinRankedScore_attenuationBoundIsPerFactorAndDoesNotCompose}.
      */
     static final float MIN_RANKED_SCORE = 1e-30f;

--- a/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/query/HybridFusionQueryBuilder.java
@@ -407,7 +407,12 @@ public class HybridFusionQueryBuilder extends AbstractQueryBuilder<HybridFusionQ
         // Tail: all leg matches as a non-scoring filter -> total hits and aggregations cover the full match set, and
         // highlighting has the sub-queries' terms available. A doc outside the window matches no Top clause — including
         // a doc in another index that shares a window doc's _id, which is why the Top is _index-qualified — so it scores
-        // 0 and sorts below the window, and a request with size <= window_size returns exactly the fused window.
+        // 0 and sorts below the window, so a request with size <= window_size returns exactly the fused window. A doc
+        // matching only the Tail is therefore in the MATCH set but not the RANKED set, which makes fused mode the one
+        // query here whose match set is wider than what it ranks — the Tail is load-bearing for total_hits,
+        // aggregations and highlighting, so it cannot be narrowed. For a rescore that asymmetry is closed downstream
+        // by FusedWindowGuardRescorer, which demotes the Tail-only documents below every ranked one after the request's
+        // own rescorers have run, rather than by removing them from the pool.
         if (tailQueries.isEmpty() == false) {
             BoolQueryBuilder tail = new BoolQueryBuilder();
             for (QueryBuilder q : tailQueries) {

--- a/src/main/java/org/opensearch/neuralsearch/search/FusedRescoreScoreNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/FusedRescoreScoreNormalizer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search;
+
+import java.util.Objects;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+
+/**
+ * Turns the fused rescore guard's internal sentinel back into the score a user should see.
+ *
+ * <p>{@code FusedWindowGuardRescorer} separates the documents fusion ranked from the documents it did not by putting the
+ * latter in a band below every ranked score — it has to be a score, because the score is the only channel a shard has to
+ * the coordinator's merge, and {@code sort} is refused alongside {@code rescore} so there is no sort-value channel. The
+ * band's floor is {@code -Float.MAX_VALUE}, which is correct for ordering and meaningless to a user: a document that
+ * simply was not in the fused window would be reported at {@code -3.4028235E38}.
+ *
+ * <p>Without a rescore those same documents come back at exactly {@code 0.0} — they match only the non-scoring Tail — so
+ * that is what the sentinel is mapped to here. The result is that a fused request with a rescore reports the same scores
+ * for unranked documents as the same request without one, and the sentinel never leaves the coordinator.
+ *
+ * <p>Hit scores are mutated in place, the way {@code FusedExplanationMerger} mutates explanations: {@code SearchHit} has
+ * a public score setter and the response passes its {@code SearchHits} through by reference. {@code SearchHits.maxScore}
+ * is {@code final}, so the one case that needs a rebuild is a page whose top hit was demoted — which is exactly a shard,
+ * or a request, that ranked nothing.
+ */
+final class FusedRescoreScoreNormalizer {
+
+    private FusedRescoreScoreNormalizer() {}
+
+    /**
+     * @param response the response as the search phases built it
+     * @param sentinel the score the guard demoted unranked documents to
+     * @return the response with every sentinel score replaced by {@code 0.0}, or {@code response} itself when it carried
+     *         none — a fused request whose rescore never had to demote anything is the common case and pays nothing
+     */
+    static SearchResponse normalize(final SearchResponse response, final float sentinel) {
+        if (Objects.isNull(response) || Objects.isNull(response.getInternalResponse())) {
+            return response;
+        }
+        SearchHits hits = response.getInternalResponse().hits();
+        if (Objects.isNull(hits) || Objects.isNull(hits.getHits())) {
+            return response;
+        }
+        for (SearchHit hit : hits.getHits()) {
+            if (Float.compare(hit.getScore(), sentinel) == 0) {
+                hit.score(0.0f);
+            }
+        }
+        // The top hit was demoted, so the reported max score is the sentinel as well. That is the only field here that
+        // cannot be corrected in place.
+        if (Float.compare(hits.getMaxScore(), sentinel) == 0) {
+            SearchHits corrected = new SearchHits(
+                hits.getHits(),
+                hits.getTotalHits(),
+                0.0f,
+                hits.getSortFields(),
+                hits.getCollapseField(),
+                hits.getCollapseValues()
+            );
+            return FusedResponseRebuilder.rebuild(response, null, response.isTimedOut(), corrected);
+        }
+        return response;
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/search/FusedRescoreScoreNormalizer.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/FusedRescoreScoreNormalizer.java
@@ -7,26 +7,46 @@ package org.opensearch.neuralsearch.search;
 import java.util.Objects;
 
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.neuralsearch.query.FusedWindowGuardRescorerBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregation;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.HasAggregations;
+import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.opensearch.search.aggregations.metrics.TopHits;
 
 /**
- * Turns the fused rescore guard's internal sentinel back into the score a user should see.
+ * Turns the fused rescore guard's internal band values back into the scores a user should see.
  *
  * <p>{@code FusedWindowGuardRescorer} separates the documents fusion ranked from the documents it did not by putting the
  * latter in a band below every ranked score — it has to be a score, because the score is the only channel a shard has to
  * the coordinator's merge, and {@code sort} is refused alongside {@code rescore} so there is no sort-value channel. The
- * band's floor is {@code -Float.MAX_VALUE}, which is correct for ordering and meaningless to a user: a document that
- * simply was not in the fused window would be reported at {@code -3.4028235E38}.
+ * band is two floats wide and both of them are meaningless to a user: an unranked document reports
+ * {@code -3.4028235E38} ({@code UNRANKED_SCORE}) and a ranked document whose own arithmetic saturated reports the float
+ * immediately above it ({@code RANKED_FLOOR}).
  *
- * <p>Without a rescore those same documents come back at exactly {@code 0.0} — they match only the non-scoring Tail — so
- * that is what the sentinel is mapped to here. The result is that a fused request with a rescore reports the same scores
- * for unranked documents as the same request without one, and the sentinel never leaves the coordinator.
+ * <p><b>One decoding rule covers both:</b> report what the document would have scored with no rescore in the request at
+ * all. That is exactly {@code 0.0} for an unranked document, which matches only the non-scoring Tail, and
+ * {@code RANKED_FLOOR_NORMALIZED} for a saturated ranked one, which is the floor every fused score already sits at or
+ * above. Decoding only the unranked half would leave a ranked hit printing {@code -3.4028233E38} while the unranked hits
+ * it outranks print {@code 0.0} — right order, and a page whose scores descend into nonsense.
  *
- * <p>Hit scores are mutated in place, the way {@code FusedExplanationMerger} mutates explanations: {@code SearchHit} has
- * a public score setter and the response passes its {@code SearchHits} through by reference. {@code SearchHits.maxScore}
- * is {@code final}, so the one case that needs a rebuild is a page whose top hit was demoted — which is exactly a shard,
- * or a request, that ranked nothing.
+ * <p>Scores are mutated in place, the way {@code FusedExplanationMerger} mutates explanations: {@code SearchHit} has a
+ * public score setter and both the response and {@code InternalTopHits} pass their {@code SearchHits} through by
+ * reference. {@code SearchHits.maxScore} is {@code final}, so a page whose top hit was demoted needs the hits rebuilt.
+ *
+ * <p><b>{@code top_hits} buckets are decoded too, and are not a corner case.</b> Core applies the request's own rescore
+ * contexts to every bucket's {@code TopDocs} and writes the resulting score straight onto the bucket's hit, so the guard
+ * demotes inside a bucket exactly as it does on the page — and an aggregation is precisely the shape that forces the
+ * Tail open, so a bucket asking for more hits than fusion ranked shows unranked documents with no unusual weights
+ * anywhere in the request.
+ *
+ * <p><b>The one residual, and it cannot be fixed from a plugin:</b> a bucket's own {@code max_score}. Core keeps it in
+ * the {@code final} {@code SearchHits.maxScore} of an {@code InternalTopHits} whose {@code TopDocsAndMaxScore} accessor
+ * is package-private, so the aggregation cannot be faithfully rebuilt from outside {@code org.opensearch.search}. It
+ * surfaces only for a bucket that contains no ranked document at all — the bucket's top hit is otherwise a ranked one —
+ * and the bucket's hits themselves are correct.
  */
 final class FusedRescoreScoreNormalizer {
 
@@ -35,35 +55,87 @@ final class FusedRescoreScoreNormalizer {
     /**
      * @param response the response as the search phases built it
      * @param sentinel the score the guard demoted unranked documents to
-     * @return the response with every sentinel score replaced by {@code 0.0}, or {@code response} itself when it carried
-     *         none — a fused request whose rescore never had to demote anything is the common case and pays nothing
+     * @return the response with every band value decoded, or {@code response} itself when its {@code maxScore} did not
+     *         have to change — a fused request whose rescore never had to demote anything pays only the walk
      */
     static SearchResponse normalize(final SearchResponse response, final float sentinel) {
         if (Objects.isNull(response) || Objects.isNull(response.getInternalResponse())) {
             return response;
         }
+        decodeAggregations(response.getInternalResponse().aggregations(), sentinel);
         SearchHits hits = response.getInternalResponse().hits();
         if (Objects.isNull(hits) || Objects.isNull(hits.getHits())) {
             return response;
         }
-        for (SearchHit hit : hits.getHits()) {
-            if (Float.compare(hit.getScore(), sentinel) == 0) {
-                hit.score(0.0f);
+        decodeHitScores(hits.getHits(), sentinel);
+        // Decoded through the same rule as the hits rather than assumed to be the unranked sentinel: the top hit of a
+        // page can be a ranked document that saturated, and reporting 0.0 for it would put the page's maximum below its
+        // own ranked hits. This is the only field here that cannot be corrected in place.
+        float maxScore = decode(hits.getMaxScore(), sentinel);
+        if (Float.compare(maxScore, hits.getMaxScore()) == 0) {
+            return response;
+        }
+        SearchHits corrected = new SearchHits(
+            hits.getHits(),
+            hits.getTotalHits(),
+            maxScore,
+            hits.getSortFields(),
+            hits.getCollapseField(),
+            hits.getCollapseValues()
+        );
+        return FusedResponseRebuilder.rebuild(response, null, response.isTimedOut(), corrected);
+    }
+
+    /**
+     * The band value a document is sitting on, mapped to the score it would have had with no rescore. Anything outside
+     * the band is the user's own rescore arithmetic and is returned untouched, however negative it is.
+     */
+    private static float decode(final float score, final float sentinel) {
+        if (Float.compare(score, sentinel) == 0) {
+            return 0.0f;
+        }
+        if (Float.compare(score, FusedWindowGuardRescorerBuilder.RANKED_FLOOR) == 0) {
+            return FusedWindowGuardRescorerBuilder.RANKED_FLOOR_NORMALIZED;
+        }
+        return score;
+    }
+
+    private static void decodeHitScores(final SearchHit[] hits, final float sentinel) {
+        for (SearchHit hit : hits) {
+            float decoded = decode(hit.getScore(), sentinel);
+            if (Float.compare(decoded, hit.getScore()) != 0) {
+                hit.score(decoded);
             }
         }
-        // The top hit was demoted, so the reported max score is the sentinel as well. That is the only field here that
-        // cannot be corrected in place.
-        if (Float.compare(hits.getMaxScore(), sentinel) == 0) {
-            SearchHits corrected = new SearchHits(
-                hits.getHits(),
-                hits.getTotalHits(),
-                0.0f,
-                hits.getSortFields(),
-                hits.getCollapseField(),
-                hits.getCollapseValues()
-            );
-            return FusedResponseRebuilder.rebuild(response, null, response.isTimedOut(), corrected);
+    }
+
+    /**
+     * Walk the aggregation tree for {@code top_hits}, the second place core applies the request's rescorers. Read-only
+     * on the tree itself — only the {@code SearchHit} scores are written — so nothing here depends on an aggregation
+     * being rebuildable.
+     *
+     * <p>Package-private rather than private so the nesting branches can be driven directly: the single-bucket and
+     * multi-bucket aggregations that reach them have package-private constructors in core, and the shapes that do
+     * exercise them end to end live in an integration test, which earns no coverage in {@code check}.
+     */
+    static void decodeAggregations(final Aggregations aggregations, final float sentinel) {
+        if (Objects.isNull(aggregations)) {
+            return;
         }
-        return response;
+        for (Aggregation aggregation : aggregations.asList()) {
+            if (aggregation instanceof TopHits topHits) {
+                SearchHits bucketHits = topHits.getHits();
+                if (Objects.nonNull(bucketHits) && Objects.nonNull(bucketHits.getHits())) {
+                    decodeHitScores(bucketHits.getHits(), sentinel);
+                }
+            } else if (aggregation instanceof MultiBucketsAggregation multiBucket) {
+                for (MultiBucketsAggregation.Bucket bucket : multiBucket.getBuckets()) {
+                    decodeAggregations(bucket.getAggregations(), sentinel);
+                }
+            } else if (aggregation instanceof HasAggregations hasAggregations) {
+                // Every single-bucket aggregation — filter, nested, global, reverse_nested — reaches its children here.
+                decodeAggregations(hasAggregations.getAggregations(), sentinel);
+            }
+        }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/search/FusedResponseRebuilder.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/FusedResponseRebuilder.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.profile.ProfileShardResult;
@@ -40,24 +41,24 @@ import lombok.NoArgsConstructor;
 public final class FusedResponseRebuilder {
 
     /**
-     * {@code response} with the given overrides applied, or {@code response} itself when neither changes anything.
+     * As {@link #rebuild(SearchResponse, SearchProfileShardResults, boolean)}, additionally substituting the response's
+     * {@link SearchHits}. Needed because {@code SearchHits.maxScore} is {@code final}: everything else about a hit can be
+     * corrected in place, but a page whose reported max score has to change can only be replaced.
      *
-     * @param response       the response as the search phases built it
-     * @param profileResults the profile section to substitute, or {@code null} to keep the response's own
-     * @param timedOut       the value {@code timed_out} should carry — callers pass the OR of the response's own flag and
-     *                       whatever they are contributing, never a bare {@code false} that would clear it
+     * @param hits the hits to substitute, or {@code null} to keep the response's own
      */
     public static SearchResponse rebuild(
         final SearchResponse response,
         final SearchProfileShardResults profileResults,
-        final boolean timedOut
+        final boolean timedOut,
+        final SearchHits hits
     ) {
         SearchResponseSections sections = response.getInternalResponse();
-        if (Objects.isNull(profileResults) && timedOut == sections.timedOut()) {
+        if (Objects.isNull(profileResults) && Objects.isNull(hits) && timedOut == sections.timedOut()) {
             return response;
         }
         InternalSearchResponse rebuilt = new InternalSearchResponse(
-            sections.hits(),
+            Objects.nonNull(hits) ? hits : sections.hits(),
             (InternalAggregations) sections.aggregations(),
             sections.suggest(),
             Objects.nonNull(profileResults) ? profileResults : ownProfileResults(sections),
@@ -79,6 +80,25 @@ public final class FusedResponseRebuilder {
             response.getClusters(),
             response.pointInTimeId()
         );
+    }
+
+    /**
+     * {@code response} with the given overrides applied, or {@code response} itself when neither changes anything.
+     *
+     * <p>Delegates to the four-argument form with no hits override, so that the argument list this class exists to keep
+     * correct is written down exactly once.
+     *
+     * @param response       the response as the search phases built it
+     * @param profileResults the profile section to substitute, or {@code null} to keep the response's own
+     * @param timedOut       the value {@code timed_out} should carry — callers pass the OR of the response's own flag and
+     *                       whatever they are contributing, never a bare {@code false} that would clear it
+     */
+    public static SearchResponse rebuild(
+        final SearchResponse response,
+        final SearchProfileShardResults profileResults,
+        final boolean timedOut
+    ) {
+        return rebuild(response, profileResults, timedOut, null);
     }
 
     /**

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
@@ -25,6 +25,7 @@ import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.neuralsearch.query.FusedWindowGuardRescorerBuilder;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.search.explain.FusedExplanationMerger;
 import org.opensearch.neuralsearch.search.profile.FusedLegProfileMerger;
@@ -167,7 +168,10 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
         boolean mayTimeOut = mayHitASoftTimeout(source);
         // explain() is a nullable Boolean on the source — unset means "not explained", so it cannot be unboxed.
         boolean explained = Boolean.TRUE.equals(source.explain());
-        if (profiled == false && mayTimeOut == false && explained == false) {
+        // A fused request carrying a rescore reaches the coordinator with unranked documents demoted to the guard's
+        // sentinel score; that has to be mapped back before the response is handed on. See FusedRescoreScoreNormalizer.
+        boolean rescored = Objects.nonNull(source.rescores()) && source.rescores().isEmpty() == false;
+        if (profiled == false && mayTimeOut == false && explained == false && rescored == false) {
             return listener;
         }
         FusedHybridFinder finder = new FusedHybridFinder();
@@ -208,7 +212,14 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
         // Passing the gate above is not the same as having something to report: an explained request whose fused hybrid is
         // nested reaches here with no merger attached at all, since explain deliberately declines a hybrid that is not the
         // request's own query. Hand the caller's listener back untouched rather than wrapping it to do nothing.
-        if (Objects.isNull(legProfileMerger) && Objects.isNull(timeoutMerger) && Objects.isNull(explanationMerger)) {
+        // The guard is installed only for a fused hybrid that IS the request's own query — the position guard in
+        // HybridQueryBuilder refuses a rescore alongside any other shape — so that identity test is also the exact
+        // condition under which a sentinel can appear in the hits.
+        final boolean normalizeSentinel = rescored && finder.found.get(0) == source.query();
+        if (Objects.isNull(legProfileMerger)
+            && Objects.isNull(timeoutMerger)
+            && Objects.isNull(explanationMerger)
+            && normalizeSentinel == false) {
             return listener;
         }
         final FusedLegProfileMerger profiles = legProfileMerger;
@@ -234,6 +245,11 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
             // actually returned. It passes the SearchHits through by reference, so this reaches the same hit instances.
             if (Objects.nonNull(explanations)) {
                 merged = explanations.getMergedResponse(merged);
+            }
+            // Last, and on the response that is actually returned: the steps above can replace the response around the
+            // hits, and the sentinel has to be gone from the one the caller sees.
+            if (normalizeSentinel) {
+                merged = FusedRescoreScoreNormalizer.normalize(merged, FusedWindowGuardRescorerBuilder.UNRANKED_SCORE);
             }
             listener.onResponse((Response) merged);
         }, listener::onFailure);

--- a/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
+++ b/src/main/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilter.java
@@ -213,8 +213,17 @@ public class HybridQuerySearchRequestFilter implements ActionFilter {
         // nested reaches here with no merger attached at all, since explain deliberately declines a hybrid that is not the
         // request's own query. Hand the caller's listener back untouched rather than wrapping it to do nothing.
         // The guard is installed only for a fused hybrid that IS the request's own query — the position guard in
-        // HybridQueryBuilder refuses a rescore alongside any other shape — so that identity test is also the exact
-        // condition under which a sentinel can appear in the hits.
+        // HybridQueryBuilder refuses a rescore alongside any other shape — so that identity test is the condition under
+        // which a sentinel can appear in the hits.
+        //
+        // It is exact only given something core does not guarantee. This filter reads the source as SUBMITTED, while the
+        // guard is installed during the rewrite, and search request processors run in between: TransportSearchAction calls
+        // transformRequest first and rewrites only inside its callback. A processor that ADDED a rescore to a request
+        // carrying none would install a guard this gate had already declined to normalize for, and the band would reach
+        // the response undecoded. No shipped processor does — the only one that adds a rescorer is
+        // neural_sparse_two_phase_processor, whose collection walks bool and neural clauses and never enters a hybrid, so
+        // it cannot fire on a request whose query is a fused hybrid. A processor that REPLACES the source disarms the
+        // install too, which fails safe. Re-check this whenever a request processor learns to touch source.rescores().
         final boolean normalizeSentinel = rescored && finder.found.get(0) == source.query();
         if (Objects.isNull(legProfileMerger)
             && Objects.isNull(timeoutMerger)

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -50,6 +50,9 @@ import org.opensearch.neuralsearch.processor.factory.NormalizationProcessorFacto
 import org.opensearch.neuralsearch.processor.factory.RRFProcessorFactory;
 import org.opensearch.neuralsearch.processor.factory.SemanticFieldProcessorFactory;
 import org.opensearch.neuralsearch.processor.rerank.RerankProcessor;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.neuralsearch.query.FusedWindowGuardRescorerBuilder;
+import org.opensearch.search.rescore.RescorerBuilder;
 import org.opensearch.neuralsearch.query.HybridQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralQueryBuilder;
 import org.opensearch.neuralsearch.query.NeuralSparseQueryBuilder;
@@ -147,6 +150,29 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
         );
 
         assertEquals(4, components.size());
+    }
+
+    /**
+     * The fused rescore guard is registered as a named WRITEABLE and deliberately NOT as a rescorer spec: a
+     * {@code getRescorers()} registration would also add an XContent entry, which is what makes a rescorer name
+     * parseable from a request body — turning an internal wrapper into public request syntax. The shard needs the
+     * writeable to deserialize the builder the coordinator installs; nothing needs the parser.
+     */
+    public void testNamedWriteables_registerTheFusedRescoreGuardWithoutMakingItRequestSyntax() {
+        List<NamedWriteableRegistry.Entry> entries = plugin.getNamedWriteables();
+
+        assertNotNull(entries);
+        assertTrue(
+            "the guard's wire form must be registered under the RescorerBuilder category",
+            entries.stream()
+                .anyMatch(
+                    entry -> RescorerBuilder.class.equals(entry.categoryClass) && FusedWindowGuardRescorerBuilder.NAME.equals(entry.name)
+                )
+        );
+        assertTrue(
+            "the guard must not be registered as a rescorer spec, which would make its name user-typeable",
+            plugin.getRescorers().stream().noneMatch(spec -> FusedWindowGuardRescorerBuilder.NAME.equals(spec.getName().getPreferredName()))
+        );
     }
 
     public void testQuerySpecs() {

--- a/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/plugin/NeuralSearchTests.java
@@ -173,6 +173,16 @@ public class NeuralSearchTests extends OpenSearchQueryTestCase {
             "the guard must not be registered as a rescorer spec, which would make its name user-typeable",
             plugin.getRescorers().stream().noneMatch(spec -> FusedWindowGuardRescorerBuilder.NAME.equals(spec.getName().getPreferredName()))
         );
+        // Route-agnostic, because the assertion above can only ever pass: the plugin does not override getRescorers(), so
+        // it walks an empty list. What actually has to hold is that NO registration route contributes an XContent entry for
+        // the name — getRescorers() is one route, Plugin#getNamedXContent() is another into the very same registry that
+        // parses search bodies.
+        assertTrue(
+            "no registration route may make the guard's name parseable from a request body",
+            plugin.getNamedXContent()
+                .stream()
+                .noneMatch(entry -> FusedWindowGuardRescorerBuilder.NAME.equals(entry.name.getPreferredName()))
+        );
     }
 
     public void testQuerySpecs() {

--- a/src/test/java/org/opensearch/neuralsearch/query/FusedRescoreScopeTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/FusedRescoreScopeTests.java
@@ -143,9 +143,12 @@ public class FusedRescoreScopeTests extends OpenSearchTestCase {
         scope.resolve(fusedOver("1"));
 
         SearchSourceBuilder dispatched = coreRewriteToFixedPoint(source);
-        assertEquals(2, dispatched.rescores().size());
+        assertEquals("the chain is carried inside one guard element", 1, dispatched.rescores().size());
+        assertEquals(2, ((FusedWindowGuardRescorerBuilder) dispatched.rescores().get(0)).delegates().size());
+        // Both of the user's rescorers, not both list elements: after the wrap there is one element and the chain lives
+        // inside it, so the loop walks the guard's delegates.
         for (int i = 0; i < 2; i++) {
-            BoolQueryBuilder confined = (BoolQueryBuilder) ((QueryRescorerBuilder) dispatched.rescores().get(i)).getRescoreQuery();
+            BoolQueryBuilder confined = (BoolQueryBuilder) rescorerOf(dispatched, i).getRescoreQuery();
             assertAddressedTo(confined.filter().get(0), INDEX, "1");
         }
     }
@@ -266,7 +269,7 @@ public class FusedRescoreScopeTests extends OpenSearchTestCase {
 
         FusedRescoreScope scope = FusedRescoreScope.install(source);
         // Only the first rescorer is offered to core, which is what a partially-copied source would look like.
-        ((QueryRescorerBuilder) source.rescores().get(0)).getRescoreQuery().rewrite(rewriteContext());
+        rescorerOf(source, 0).getRescoreQuery().rewrite(rewriteContext());
         scope.resolve(fusedOver("1"));
 
         expectThrows(IllegalStateException.class, scope::requireReachedTheExecutedRequest);
@@ -393,7 +396,19 @@ public class FusedRescoreScopeTests extends OpenSearchTestCase {
     }
 
     private QueryRescorerBuilder rescorerOf(SearchSourceBuilder source) {
-        return (QueryRescorerBuilder) source.rescores().get(0);
+        return rescorerOf(source, 0);
+    }
+
+    /**
+     * The {@code index}-th of the user's rescorers as it was installed. After {@code install} the request carries ONE
+     * element — the {@link FusedWindowGuardRescorerBuilder} — holding the window-confined chain in the user's order, so a
+     * test that wants the user's rescorer has to go through the guard. See {@code FusedWindowGuardRescorer} for why the
+     * chain collapses to one element rather than being wrapped element by element.
+     */
+    private QueryRescorerBuilder rescorerOf(SearchSourceBuilder source, int index) {
+        assertEquals("install leaves exactly one rescorer, the guard", 1, source.rescores().size());
+        FusedWindowGuardRescorerBuilder guard = (FusedWindowGuardRescorerBuilder) source.rescores().get(0);
+        return guard.delegates().get(index);
     }
 
     private BoolQueryBuilder confinedQueryOf(SearchSourceBuilder source) {

--- a/src/test/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerBuilderTests.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.io.IOException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.List;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryRewriteContext;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.ParsedQuery;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.SearchModule;
+import org.opensearch.search.rescore.QueryRescoreMode;
+import org.opensearch.search.rescore.QueryRescorerBuilder;
+import org.opensearch.search.rescore.RescoreContext;
+import org.opensearch.search.rescore.RescorerBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * {@link FusedWindowGuardRescorerBuilder} — the wire form that carries the request's rescorer chain to the shard wrapped
+ * in the guard.
+ *
+ * <p>Two things matter most here and both are asserted below. The chain must survive a wire round trip intact, because
+ * the shard rebuilds the user's rescorers from it and a dropped field would silently change their scoring. And the
+ * builder's own {@code window_size} must be the maximum over the chain, because after the wrap this is the only rescore
+ * context core can see and core sizes the shard's first-pass pool from the largest window across contexts — get that
+ * wrong and a deep rescorer silently stops reaching the documents it was asked to.
+ */
+public class FusedWindowGuardRescorerBuilderTests extends OpenSearchTestCase {
+
+    /** The round trip the shard depends on: name, window size, and every delegate field. */
+    public void testWireRoundTrip_preservesTheWholeChain() throws IOException {
+        QueryRescorerBuilder first = new QueryRescorerBuilder(new MatchAllQueryBuilder()).setQueryWeight(0.5f)
+            .setRescoreQueryWeight(3.0f)
+            .setScoreMode(QueryRescoreMode.Multiply);
+        first.windowSize(17);
+        QueryRescorerBuilder second = new QueryRescorerBuilder(new TermQueryBuilder("f", "v"));
+        second.windowSize(40);
+
+        FusedWindowGuardRescorerBuilder roundTripped = roundTrip(new FusedWindowGuardRescorerBuilder(List.of(first, second)));
+
+        assertEquals(FusedWindowGuardRescorerBuilder.NAME, roundTripped.getWriteableName());
+        assertEquals("window size stands in for the whole chain's depth", Integer.valueOf(40), roundTripped.windowSize());
+        assertEquals(2, roundTripped.delegates().size());
+        QueryRescorerBuilder delegate = roundTripped.delegates().get(0);
+        assertEquals(new MatchAllQueryBuilder(), delegate.getRescoreQuery());
+        assertEquals(0.5f, delegate.getQueryWeight(), 0.0f);
+        assertEquals(3.0f, delegate.getRescoreQueryWeight(), 0.0f);
+        assertEquals(QueryRescoreMode.Multiply, delegate.getScoreMode());
+        assertEquals(Integer.valueOf(17), delegate.windowSize());
+        assertEquals("a delegate that set no window keeps none", Integer.valueOf(40), roundTripped.delegates().get(1).windowSize());
+    }
+
+    /**
+     * Core sizes the pool from the widest window across rescore contexts. After the wrap there is one context, so the
+     * guard has to report the chain's widest — not the first, and not its own default.
+     */
+    public void testWindowSize_isTheMaximumOverTheChain() {
+        QueryRescorerBuilder narrow = new QueryRescorerBuilder(new MatchAllQueryBuilder());
+        narrow.windowSize(5);
+        QueryRescorerBuilder wide = new QueryRescorerBuilder(new MatchAllQueryBuilder());
+        wide.windowSize(500);
+
+        assertEquals(Integer.valueOf(500), new FusedWindowGuardRescorerBuilder(List.of(narrow, wide)).windowSize());
+        assertEquals(Integer.valueOf(500), new FusedWindowGuardRescorerBuilder(List.of(wide, narrow)).windowSize());
+    }
+
+    /** A chain that names no window leaves the guard's unset too, so core applies its own default rather than a guess. */
+    public void testWindowSize_whenNoDelegateSetsOne_thenItStaysUnset() {
+        FusedWindowGuardRescorerBuilder guard = new FusedWindowGuardRescorerBuilder(
+            List.of(new QueryRescorerBuilder(new MatchAllQueryBuilder()))
+        );
+
+        assertNull(guard.windowSize());
+    }
+
+    /** Nothing to guard is a programming error in the install path, not a request a user can send. */
+    public void testConstructor_rejectsAnEmptyChain() {
+        expectThrows(IllegalArgumentException.class, () -> new FusedWindowGuardRescorerBuilder(List.of()));
+        expectThrows(IllegalArgumentException.class, () -> new FusedWindowGuardRescorerBuilder((List<QueryRescorerBuilder>) null));
+    }
+
+    /** Rendered, never parsed: the name is there so an operator seeing it in a slow log knows whose it is. */
+    public void testXContent_rendersTheGuardAndItsDelegates() throws IOException {
+        FusedWindowGuardRescorerBuilder guard = new FusedWindowGuardRescorerBuilder(
+            List.of(new QueryRescorerBuilder(new TermQueryBuilder("colour", "hot")))
+        );
+
+        // An array, not an object: RescorerBuilder#toXContent opens its OWN anonymous object, which is only legal inside
+        // an array — and an array is exactly how core renders the request's `rescore` list. Wrapping it in an object
+        // instead throws "Cannot start an object, expecting a property name".
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startArray();
+        guard.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endArray();
+        String rendered = builder.toString();
+
+        assertTrue(rendered, rendered.contains(FusedWindowGuardRescorerBuilder.NAME));
+        assertTrue("the user's own rescore query is still visible in the rendering", rendered.contains("colour"));
+    }
+
+    /** equals/hashCode have to see the chain, or a round-trip equality test would pass on a dropped delegate. */
+    public void testEqualsAndHashCode_dependOnTheChainAndTheWindow() {
+        QueryBuilder query = new TermQueryBuilder("f", "v");
+        FusedWindowGuardRescorerBuilder one = new FusedWindowGuardRescorerBuilder(List.of(new QueryRescorerBuilder(query)));
+        FusedWindowGuardRescorerBuilder same = new FusedWindowGuardRescorerBuilder(List.of(new QueryRescorerBuilder(query)));
+        FusedWindowGuardRescorerBuilder different = new FusedWindowGuardRescorerBuilder(
+            List.of(new QueryRescorerBuilder(new MatchAllQueryBuilder()))
+        );
+
+        assertEquals(one, same);
+        assertEquals(one.hashCode(), same.hashCode());
+        assertNotEquals(one, different);
+        assertNotEquals(one, null);
+        assertNotEquals(one, "not a rescorer");
+    }
+
+    /**
+     * {@code buildContext} is what the shard actually calls, and it is where the chain becomes a guard wrapping one
+     * {@link org.opensearch.search.rescore.RescoreContext} per delegate. The only thing core's
+     * {@code QueryRescorerBuilder#innerBuildContext} needs from the shard context is {@code toQuery}, so a mock is enough
+     * to reach it.
+     */
+    public void testBuildContext_wrapsOneContextPerDelegateAndCarriesTheWindowSize() throws IOException {
+        QueryShardContext shardContext = mock(QueryShardContext.class);
+        when(shardContext.toQuery(org.mockito.ArgumentMatchers.any(QueryBuilder.class))).thenReturn(
+            new ParsedQuery(new MatchAllDocsQuery())
+        );
+        QueryRescorerBuilder first = new QueryRescorerBuilder(new MatchAllQueryBuilder());
+        first.windowSize(31);
+        FusedWindowGuardRescorerBuilder guard = new FusedWindowGuardRescorerBuilder(
+            List.of(first, new QueryRescorerBuilder(new TermQueryBuilder("f", "v")))
+        );
+
+        RescoreContext context = guard.buildContext(shardContext);
+
+        assertEquals("the guard's own window stands in for the chain's depth", 31, context.getWindowSize());
+        assertTrue(context.rescorer() instanceof FusedWindowGuardRescorer);
+        assertEquals(2, ((FusedWindowGuardRescorer) context.rescorer()).delegates().size());
+    }
+
+    /**
+     * The path that matters for a rescore query which rewrites — a {@code wrapper}, a {@code neural} query, a
+     * {@code terms} lookup. A rewritten delegate has to produce a NEW guard carrying it, or the rewrite would be lost and
+     * the shard would run the un-rewritten query.
+     */
+    public void testRewrite_whenADelegateRewrites_thenANewGuardCarriesTheRewrittenChain() throws IOException {
+        FusedWindowGuardRescorerBuilder guard = new FusedWindowGuardRescorerBuilder(
+            List.of(new QueryRescorerBuilder(new RewritesOnceQueryBuilder()))
+        );
+        guard.windowSize(12);
+
+        RescorerBuilder<FusedWindowGuardRescorerBuilder> rewritten = guard.rewrite(mock(QueryRewriteContext.class));
+
+        assertNotSame("a rewritten delegate must produce a new guard", guard, rewritten);
+        assertEquals("the window size is carried across the rewrite", Integer.valueOf(12), rewritten.windowSize());
+        QueryBuilder rescoreQuery = ((FusedWindowGuardRescorerBuilder) rewritten).delegates().get(0).getRescoreQuery();
+        assertTrue("the delegate now holds the rewritten query", rescoreQuery instanceof MatchAllQueryBuilder);
+    }
+
+    /** Rewrites to a {@code match_all} on its first rewrite, so a chain containing it is guaranteed to change. */
+    private static final class RewritesOnceQueryBuilder extends AbstractQueryBuilder<RewritesOnceQueryBuilder> {
+        @Override
+        protected QueryBuilder doRewrite(org.opensearch.index.query.QueryRewriteContext context) {
+            return new MatchAllQueryBuilder();
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "rewrites_once";
+        }
+
+        @Override
+        protected void doWriteTo(org.opensearch.core.common.io.stream.StreamOutput out) {}
+
+        @Override
+        protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject(getWriteableName()).endObject();
+        }
+
+        @Override
+        protected org.apache.lucene.search.Query doToQuery(QueryShardContext context) {
+            throw new UnsupportedOperationException("never executed");
+        }
+
+        @Override
+        protected boolean doEquals(RewritesOnceQueryBuilder other) {
+            return true;
+        }
+
+        @Override
+        protected int doHashCode() {
+            return 0;
+        }
+    }
+
+    private FusedWindowGuardRescorerBuilder roundTrip(final FusedWindowGuardRescorerBuilder guard) throws IOException {
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(
+            java.util.stream.Stream.concat(
+                new SearchModule(org.opensearch.common.settings.Settings.EMPTY, List.of()).getNamedWriteables().stream(),
+                java.util.stream.Stream.of(
+                    new NamedWriteableRegistry.Entry(
+                        RescorerBuilder.class,
+                        FusedWindowGuardRescorerBuilder.NAME,
+                        FusedWindowGuardRescorerBuilder::new
+                    )
+                )
+            ).toList()
+        );
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            guard.writeTo(out);
+            try (StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), registry)) {
+                return new FusedWindowGuardRescorerBuilder(in);
+            }
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerBuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerBuilderTests.java
@@ -89,6 +89,87 @@ public class FusedWindowGuardRescorerBuilderTests extends OpenSearchTestCase {
         assertNull(guard.windowSize());
     }
 
+    /**
+     * A delegate that names no {@code window_size} is not windowless — core substitutes
+     * {@code RescorerBuilder.DEFAULT_WINDOW_SIZE} for it. Since the guard is the only context core can see, counting only
+     * the DECLARED windows would report 5 for this chain and have the shard collect a 5-document pool where the same chain
+     * unwrapped collects 10, so the defaulting delegate would silently stop reaching documents it is supposed to rescore.
+     */
+    public void testWindowSize_whenADelegateLeavesItUnset_thenTheDefaultStillCounts() {
+        QueryRescorerBuilder declared = new QueryRescorerBuilder(new MatchAllQueryBuilder());
+        declared.windowSize(5);
+
+        FusedWindowGuardRescorerBuilder guard = new FusedWindowGuardRescorerBuilder(
+            List.of(declared, new QueryRescorerBuilder(new TermQueryBuilder("f", "v")))
+        );
+
+        assertEquals(
+            "an unset delegate window is DEFAULT_WINDOW_SIZE, not zero",
+            Integer.valueOf(RescorerBuilder.DEFAULT_WINDOW_SIZE),
+            guard.windowSize()
+        );
+    }
+
+    /** A declared window above the default still wins — the rule is the maximum, not the default. */
+    public void testWindowSize_whenADeclaredWindowExceedsTheDefault_thenItWins() {
+        QueryRescorerBuilder declared = new QueryRescorerBuilder(new MatchAllQueryBuilder());
+        declared.windowSize(64);
+
+        FusedWindowGuardRescorerBuilder guard = new FusedWindowGuardRescorerBuilder(
+            List.of(declared, new QueryRescorerBuilder(new TermQueryBuilder("f", "v")))
+        );
+
+        assertEquals(Integer.valueOf(64), guard.windowSize());
+    }
+
+    /**
+     * Two core fetch/search phases read the request's rescore contexts for their QUERIES, not their rescorers:
+     * {@code MatchedQueriesPhase} collects {@code getParsedQueries().namedFilters()} for {@code matched_queries}, and
+     * {@code DfsPhase} collects term statistics from the same list. After the wrap this context is the only one they can
+     * see, and a bare {@code RescoreContext} answers both with an empty list — so a {@code _name} on a rescore query would
+     * disappear, and under {@code dfs_query_then_fetch} the rescore query would score on local instead of global IDF.
+     */
+    public void testBuildContext_reportsEveryDelegatesQueryToTheCorePhasesThatReadThem() throws IOException {
+        QueryShardContext shardContext = mock(QueryShardContext.class);
+        when(shardContext.toQuery(org.mockito.ArgumentMatchers.any(QueryBuilder.class))).thenReturn(
+            new ParsedQuery(new MatchAllDocsQuery())
+        );
+        FusedWindowGuardRescorerBuilder guard = new FusedWindowGuardRescorerBuilder(
+            List.of(new QueryRescorerBuilder(new MatchAllQueryBuilder()), new QueryRescorerBuilder(new TermQueryBuilder("f", "v")))
+        );
+
+        RescoreContext context = guard.buildContext(shardContext);
+
+        assertEquals("one parsed query per delegate, or matched_queries loses the name", 2, context.getParsedQueries().size());
+        assertEquals("and the same for the DFS term-statistics walk", 2, context.getQueries().size());
+    }
+
+    /**
+     * The three band constants, pinned against each other rather than against literals. Nothing may be representable
+     * between the unranked sentinel and the ranked floor, or an extreme weight could land a ranked document inside the
+     * unranked band; and the value the coordinator reports a floored ranked document as has to be both strictly above
+     * the {@code 0.0} it reports an unranked one as, and the same floor a fused score already carries with no rescore in
+     * the request — otherwise the guard would invent a score rather than preserve one.
+     */
+    public void testBandConstants_cannotMeetAndDecodeToTheNoRescoreScores() {
+        assertEquals(
+            "nothing may sit between the two bands",
+            FusedWindowGuardRescorerBuilder.RANKED_FLOOR,
+            Math.nextUp(FusedWindowGuardRescorerBuilder.UNRANKED_SCORE),
+            0.0f
+        );
+        assertTrue(
+            "a decoded ranked document must outrank a decoded unranked one",
+            FusedWindowGuardRescorerBuilder.RANKED_FLOOR_NORMALIZED > 0.0f
+        );
+        assertEquals(
+            "the decoded ranked floor is the floor a fused score already has without a rescore",
+            HybridFusionOrchestrator.MIN_RANKED_SCORE,
+            FusedWindowGuardRescorerBuilder.RANKED_FLOOR_NORMALIZED,
+            0.0f
+        );
+    }
+
     /** Nothing to guard is a programming error in the install path, not a request a user can send. */
     public void testConstructor_rejectsAnEmptyChain() {
         expectThrows(IllegalArgumentException.class, () -> new FusedWindowGuardRescorerBuilder(List.of()));

--- a/src/test/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerTests.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.query;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.search.rescore.RescoreContext;
+import org.opensearch.search.rescore.Rescorer;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * {@link FusedWindowGuardRescorer} — the guard that keeps a rescore from changing which documents a fused hybrid may
+ * return.
+ *
+ * <p>The invariant every test here is about: after the guard runs, every document that arrived at exactly {@code 0.0f}
+ * (Tail-only, i.e. matched by a leg but not ranked by the fusion) sorts below every document that arrived above it,
+ * whatever the delegates did to the scores in between. The array length and the {@code TotalHits} must come back
+ * unchanged, because core's {@code RescoreProcessor} reads {@code scoreDocs[0].score} after the loop without a length
+ * check and the coordinator sums {@code totalHits} by value.
+ */
+public class FusedWindowGuardRescorerTests extends OpenSearchTestCase {
+
+    private static final float UNRANKED = FusedWindowGuardRescorerBuilder.UNRANKED_SCORE;
+    private static final float RANKED_FLOOR = FusedWindowGuardRescorerBuilder.RANKED_FLOOR;
+    private static final TotalHits TOTAL = new TotalHits(500, TotalHits.Relation.EQUAL_TO);
+
+    /** The defect, in one test: a delegate that flattens every score must not let a Tail-only document take a slot. */
+    public void testRescore_whenADelegateFlattensEveryScore_thenUnrankedDocumentsSortLast() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(9, 0.7f), new ScoreDoc(1, 0.0f), new ScoreDoc(4, 0.2f), new ScoreDoc(2, 0.0f));
+
+        TopDocs result = guard(flattenTo(0.0f)).rescore(pool, null, context());
+
+        // Ranked 9 and 4 keep the band; Tail-only 1 and 2 are pushed under it, and within a band it is doc id order.
+        assertEquals(List.of(4, 9, 1, 2), docsOf(result));
+        // The delegate put the ranked documents at 0.0, which is already above the sentinel, so the clamp leaves them
+        // alone — it only lifts a ranked score that landed AT or BELOW the sentinel. The band separates them regardless.
+        assertEquals(0.0f, result.scoreDocs[0].score, 0.0f);
+        assertEquals(UNRANKED, result.scoreDocs[2].score, 0.0f);
+        assertTrue("every ranked document outranks every unranked one", result.scoreDocs[1].score > result.scoreDocs[2].score);
+        assertEquals("the pool length is the contract with RescoreProcessor", 4, result.scoreDocs.length);
+        assertSame("total_hits must be carried through untouched", TOTAL, result.totalHits);
+    }
+
+    /**
+     * A negative {@code query_weight} is legal and drives ranked documents below zero. The band still has to hold, which
+     * is why the guard clamps rather than trusting a fixed sentinel to be lower than everything.
+     */
+    public void testRescore_whenADelegateDrivesRankedScoresNegative_thenTheBandStillHolds() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(7, 1.0f), new ScoreDoc(3, 0.0f), new ScoreDoc(8, 0.5f));
+
+        TopDocs result = guard(multiplyBy(-1.0f)).rescore(pool, null, context());
+
+        assertEquals("both ranked documents stay above the Tail-only one", List.of(8, 7, 3), docsOf(result));
+        assertTrue("a ranked document is never at or below the sentinel", result.scoreDocs[0].score > UNRANKED);
+        assertTrue(result.scoreDocs[1].score > UNRANKED);
+        assertEquals(UNRANKED, result.scoreDocs[2].score, 0.0f);
+    }
+
+    /**
+     * The saturation case the clamp exists for: a large negative {@code rescore_query_weight} can take a ranked document
+     * to {@code -Infinity}, and nothing is representable strictly below that — so the guard lifts it into the ranked band
+     * instead of trying to demote the Tail below it.
+     */
+    public void testRescore_whenARankedScoreSaturates_thenItIsClampedIntoTheRankedBand() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(5, 0.9f), new ScoreDoc(6, 0.0f));
+
+        TopDocs result = guard(flattenTo(Float.NEGATIVE_INFINITY)).rescore(pool, null, context());
+
+        assertEquals(List.of(5, 6), docsOf(result));
+        assertEquals("a saturated ranked score is clamped up, not left at -Infinity", RANKED_FLOOR, result.scoreDocs[0].score, 0.0f);
+        assertEquals(UNRANKED, result.scoreDocs[1].score, 0.0f);
+    }
+
+    /**
+     * NaN is treated as saturation rather than propagated. It is the LARGEST value under {@code Float.compare}, so
+     * letting it through would float the document to the top of the page and would also trip core's own sortedness
+     * assertion.
+     */
+    public void testRescore_whenADelegateProducesNaN_thenItIsClampedRatherThanPropagated() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(2, 0.4f), new ScoreDoc(3, 0.0f));
+
+        TopDocs result = guard(flattenTo(Float.NaN)).rescore(pool, null, context());
+
+        assertFalse("NaN must not reach the page", Float.isNaN(result.scoreDocs[0].score));
+        assertEquals(RANKED_FLOOR, result.scoreDocs[0].score, 0.0f);
+        assertEquals(List.of(2, 3), docsOf(result));
+    }
+
+    /**
+     * The chain-inversion case, and the reason ONE guard wraps the whole chain rather than one guard per rescorer.
+     * Membership is read once from the pristine pool; after the first delegate has flattened everything to {@code 0.0f} a
+     * second reading would classify the genuinely-ranked documents as Tail and demote them below the real Tail.
+     */
+    public void testRescore_whenTheChainFlattensThenReorders_thenMembershipIsStillTheOriginalOne() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(1, 0.8f), new ScoreDoc(5, 0.0f), new ScoreDoc(2, 0.3f));
+
+        TopDocs result = guard(flattenTo(0.0f), addTo(2.0f)).rescore(pool, null, context());
+
+        assertEquals("document 5 was never ranked and cannot come first however the chain scored it", 5, docsOf(result).get(2).intValue());
+        assertEquals(List.of(1, 2, 5), docsOf(result));
+    }
+
+    /** Delegates are applied in the order the user declared them. */
+    public void testRescore_appliesDelegatesInOrder() throws IOException {
+        List<String> calls = new ArrayList<>();
+        TopDocs pool = poolOf(new ScoreDoc(1, 1.0f));
+
+        guard(recording(calls, "first"), recording(calls, "second")).rescore(pool, null, context());
+
+        assertEquals(List.of("first", "second"), calls);
+    }
+
+    /** With nothing unranked in the pool there is nothing to separate, so the delegates' own result is returned as is. */
+    public void testRescore_whenEveryDocumentWasRanked_thenTheDelegateResultIsUntouched() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.4f));
+
+        TopDocs result = guard(flattenTo(0.25f)).rescore(pool, null, context());
+
+        assertEquals(0.25f, result.scoreDocs[0].score, 0.0f);
+        assertEquals("no document is demoted when none was unranked", 0.25f, result.scoreDocs[1].score, 0.0f);
+    }
+
+    /** A pool that is entirely Tail-only still comes back at full length — the case that made pruning impossible. */
+    public void testRescore_whenNothingWasRanked_thenTheLengthIsStillPreserved() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(4, 0.0f), new ScoreDoc(1, 0.0f));
+
+        TopDocs result = guard(flattenTo(3.0f)).rescore(pool, null, context());
+
+        assertEquals("an empty return would be an AIOOBE in RescoreProcessor", 2, result.scoreDocs.length);
+        assertEquals(UNRANKED, result.scoreDocs[0].score, 0.0f);
+        assertEquals(List.of(1, 4), docsOf(result));
+        assertSame(TOTAL, result.totalHits);
+    }
+
+    /** The explanation describes the user's rescore, chained in the order core would have applied it. */
+    public void testExplain_chainsTheDelegatesInOrder() throws IOException {
+        FusedWindowGuardRescorer rescorer = guard(recording(new ArrayList<>(), "a"), recording(new ArrayList<>(), "b"));
+
+        Explanation explanation = rescorer.explain(1, null, context(), Explanation.match(1.0f, "first pass"));
+
+        assertEquals("b", explanation.getDescription());
+        assertEquals("a", explanation.getDetails()[0].getDescription());
+    }
+
+    // ---- helpers ----
+
+    private FusedWindowGuardRescorer guard(final Rescorer... delegates) {
+        List<RescoreContext> contexts = new ArrayList<>();
+        for (Rescorer delegate : delegates) {
+            contexts.add(new RescoreContext(10, delegate));
+        }
+        return new FusedWindowGuardRescorer(contexts);
+    }
+
+    private RescoreContext context() {
+        return new RescoreContext(10, flattenTo(0.0f));
+    }
+
+    private TopDocs poolOf(final ScoreDoc... docs) {
+        return new TopDocs(TOTAL, docs);
+    }
+
+    private List<Integer> docsOf(final TopDocs topDocs) {
+        List<Integer> docs = new ArrayList<>();
+        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+            docs.add(scoreDoc.doc);
+        }
+        return docs;
+    }
+
+    /** Mutates in place and returns the same instance, exactly as core's own QueryRescorer does. */
+    private Rescorer flattenTo(final float score) {
+        return new TestRescorer(topDocs -> {
+            for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                scoreDoc.score = score;
+            }
+            return topDocs;
+        }, null);
+    }
+
+    private Rescorer multiplyBy(final float factor) {
+        return new TestRescorer(topDocs -> {
+            for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                scoreDoc.score *= factor;
+            }
+            return topDocs;
+        }, null);
+    }
+
+    private Rescorer addTo(final float delta) {
+        return new TestRescorer(topDocs -> {
+            for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                scoreDoc.score += delta;
+            }
+            return topDocs;
+        }, null);
+    }
+
+    private Rescorer recording(final List<String> calls, final String name) {
+        return new TestRescorer(topDocs -> {
+            calls.add(name);
+            return topDocs;
+        }, name);
+    }
+
+    private interface Rescore {
+        TopDocs apply(TopDocs topDocs);
+    }
+
+    private static class TestRescorer implements Rescorer {
+        private final Rescore rescore;
+        private final String name;
+
+        TestRescorer(final Rescore rescore, final String name) {
+            this.rescore = rescore;
+            this.name = name;
+        }
+
+        @Override
+        public TopDocs rescore(final TopDocs topDocs, final IndexSearcher searcher, final RescoreContext rescoreContext) {
+            return rescore.apply(topDocs);
+        }
+
+        @Override
+        public Explanation explain(
+            final int topLevelDocId,
+            final IndexSearcher searcher,
+            final RescoreContext rescoreContext,
+            final Explanation sourceExplanation
+        ) {
+            return Explanation.match(sourceExplanation.getValue(), name, sourceExplanation);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/FusedWindowGuardRescorerTests.java
@@ -129,6 +129,32 @@ public class FusedWindowGuardRescorerTests extends OpenSearchTestCase {
         assertEquals("no document is demoted when none was unranked", 0.25f, result.scoreDocs[1].score, 0.0f);
     }
 
+    /**
+     * The all-ranked pool still has to be clamped. There is no band to separate, but the delegates can have driven a
+     * ranked score past {@code -Float.MAX_VALUE} or to NaN, and returning that verbatim reaches the coordinator raw: NaN
+     * is the largest value under {@code Float.compare} so it would float to rank 1 and render as a null {@code _score},
+     * and a saturated score would tie the sentinel a shard holding Tail matches is about to report for a document this
+     * one outranks.
+     */
+    public void testRescore_whenEverythingWasRankedButAScoreSaturated_thenItIsStillClamped() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.4f));
+
+        TopDocs result = guard(flattenTo(Float.NEGATIVE_INFINITY)).rescore(pool, null, context());
+
+        assertEquals(RANKED_FLOOR, result.scoreDocs[0].score, 0.0f);
+        assertEquals(RANKED_FLOOR, result.scoreDocs[1].score, 0.0f);
+    }
+
+    /** Same path for NaN, which is the value that would otherwise be sorted to the top of the page. */
+    public void testRescore_whenEverythingWasRankedButAScoreWentNaN_thenItIsStillClamped() throws IOException {
+        TopDocs pool = poolOf(new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.4f));
+
+        TopDocs result = guard(flattenTo(Float.NaN)).rescore(pool, null, context());
+
+        assertFalse("NaN must not reach the coordinator", Float.isNaN(result.scoreDocs[0].score));
+        assertEquals(RANKED_FLOOR, result.scoreDocs[0].score, 0.0f);
+    }
+
     /** A pool that is entirely Tail-only still comes back at full length — the case that made pruning impossible. */
     public void testRescore_whenNothingWasRanked_thenTheLengthIsStillPreserved() throws IOException {
         TopDocs pool = poolOf(new ScoreDoc(4, 0.0f), new ScoreDoc(1, 0.0f));

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedFanOutTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedFanOutTests.java
@@ -863,6 +863,33 @@ public class HybridQueryFusedFanOutTests extends OpenSearchQueryTestCase {
     }
 
     /**
+     * The constant itself, not the gate built on it. Every mixed-cluster protection fused mode has — the coordinator's
+     * refusal, and the {@code fusion} presence flag {@code HybridQueryBuilder#doWriteTo} writes on the shard wire — is
+     * only as good as {@code MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY} naming a release that actually
+     * contains fused mode. While it does not ship, the only version that can be true of is the one under development, so
+     * the constant must not fall behind {@code Version.CURRENT}: a released version below it is a version whose nodes
+     * pass the gate, cannot resolve {@code hybrid_fusion} or {@code hybrid_fused_window_guard}, and — because the
+     * presence flag is written whether or not the query uses fused mode — cannot read a plain classic {@code hybrid}
+     * off the wire either.
+     *
+     * <p>Deliberately fails when the branch's core version moves past the constant, which is the moment the constant
+     * has to be raised with it — the decision itself is tracked by
+     * <a href="https://github.com/opensearch-project/neural-search/issues/2002">issue 2002</a> and taken when the feature
+     * branch merges. Delete this test in the release that actually ships fused mode: from then on the constant names a
+     * real released version and {@code Version.CURRENT} is legitimately ahead of it.
+     */
+    public void testFusedModeMinimumVersion_isNotBehindTheVersionUnderDevelopment() {
+        assertTrue(
+            "["
+                + MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY
+                + "] is behind the version under development ["
+                + Version.CURRENT
+                + "], so it names a release that cannot contain fused mode",
+            MINIMAL_SUPPORTED_VERSION_FUSED_MODE_IN_HYBRID_QUERY.onOrAfter(Version.CURRENT)
+        );
+    }
+
+    /**
      * The refusal sits above the {@code SearchRequest} cast on purpose. {@code _explain} and {@code _validate/query} rewrite
      * on the coordinator with an {@code ExplainRequest}/{@code ValidateQueryRequest} and are then dispatched <i>still
      * fused</i> to the node holding the document — where the {@code fusion} field is gated off the wire, so an old node

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeRescoreIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeRescoreIT.java
@@ -515,33 +515,123 @@ public class HybridQueryFusedModeRescoreIT extends BaseNeuralSearchIT {
     }
 
     /**
-     * {@code query_weight: 0} — the one request shape the confinement cannot fully repair, pinned here so that what it does
-     * and does not guarantee is a tested statement rather than a claim in a design note.
+     * {@code query_weight: 0} and a negative {@code query_weight} — the two shapes that multiply the ranked/Tail
+     * separation away — now return only documents fusion ranked, because the rescore pool is limited to them before the
+     * rescore runs.
      *
-     * <p>A weight of zero multiplies away <i>all</i> first-pass information, so every document the rescore query did not match
-     * arrives at {@code 0.0} regardless of whether fusion ranked it, and Lucene orders that block by ascending doc id. No
-     * floor can survive being multiplied by zero, and nothing about the rescore query changes what happens to documents it
-     * does not match — this is core's arithmetic, and the request asked for it.
+     * <p>History, because this test has asserted three different things and the reason matters. Limiting the rescore
+     * <i>query</i> makes a Tail-only document unmatchable, which was originally taken to mean a rescore could not return
+     * one. It does not: core's {@code QueryRescorer} multiplies the first-pass score of every document in the rescore
+     * window by {@code query_weight} whether the rescore query matched it or not, then breaks score ties by ascending
+     * Lucene doc id — so any weighting that lands a ranked document on exactly {@code 0.0f} makes it indistinguishable
+     * from a Tail-only one. MEASURED, on a 300-document index at 20 shards with no window named anywhere in the request:
+     * {@code query_weight: 0} returned two documents from outside a default 100-document window, and
+     * {@code query_weight: -1} returned a page of which none were ranked.
      *
-     * <p>What the confinement still guarantees, and what this asserts: the <b>top</b> of the page is exactly right. Only a
-     * document inside the fused window can match the rescore query, so only a document fusion ranked can be lifted above the
-     * collapsed block. Document 5 is in the window and comes first; document 6 matches the user's {@code ids} query just as
-     * well, is not in the window, and stays out of the page. Below the lifted document the order is doc id, not fused rank —
-     * which on this dataset coincides with the fused order, so the second assertion reads it off the scores instead: hit 2
-     * comes back at exactly {@code 0.0}, the collapse itself.
+     * <p>Fixed by demoting, not by refusing: {@link org.opensearch.neuralsearch.query.FusedWindowGuardRescorer} records
+     * which documents fusion ranked from the pool as it arrives — {@code score <= 0.0f} means Tail-only — then applies the
+     * request's own rescorers and afterwards separates the two groups into disjoint score bands, so an unranked document
+     * cannot be ordered above a ranked one however the request's arithmetic scored it. The weights stay legal — they are
+     * core's own parameters and they wreck a plain {@code function_score} identically — and {@code total_hits} and
+     * aggregations are untouched because nothing ever leaves the pool, which the totals assertion below pins.
+     *
+     * <p>It demotes rather than prunes because core's {@code RescoreProcessor} reads {@code scoreDocs[0].score} on the
+     * rescorer's output with no length check, so returning a shorter array is an {@code ArrayIndexOutOfBoundsException}
+     * shard failure. The demoted band's sentinel is mapped back to {@code 0.0} on the coordinator by
+     * {@code FusedRescoreScoreNormalizer} — the score those documents carry without a rescore — so the scores asserted
+     * below are the ones a user sees, not the internal band.
+     *
+     * <p><b>Both weight parameters are covered, and neither is validated by core.</b> {@code query_weight} and
+     * {@code rescore_query_weight} are each parsed with a bare {@code declareFloat} and set by bare assignment — the only
+     * validations anywhere in core's rescore package are a null {@code rescore_query}, an unknown field, and an illegal
+     * {@code score_mode} — so zero and negative values for both are legal input that has to be answered, not rejected.
+     * They reach the ranked documents differently, which is why the rows differ: {@code query_weight} multiplies the
+     * first-pass score of every document in the rescore window whether the rescore query matched it or not, while a zero
+     * or negative {@code rescore_query_weight} only reaches the documents it did match. MEASURED across all five score
+     * modes on a 300-document, 20-shard index: with the guard in place none of the 20 combinations returned a document
+     * outside the fused window.
+     *
+     * <p>The fixture matters. {@code fusedHybrid}'s window is documents 1-5, the five lowest doc ids in the index, so it
+     * wins every {@code 0.0} tie and cannot show the effect at any shard count — which is also why
+     * {@link #testDefaultRescoreWindowAtHighShardCount_admitsNothingUnranked} passed while the defect was live.
+     * {@code fusedWithAZeroWeightedLeg}'s window is {@code [1, 2, 3, 4, 5, 26]}: document 26 is ranked with a HIGH doc
+     * id and documents 6-25 are Tail-only with lower ones, so any assertion about membership has to use that one.
      */
     @SneakyThrows
-    public void testQueryWeightZero_collapsesTheScaleButStillCannotLiftAnUnrankedDocument() {
+    public void testFlatteningWeightsCannotAdmitAnUnrankedDocument() {
         ensureDatasets();
 
-        Map<String, Object> response = searchForHits(
+        // The top of the page is still exactly right: only a ranked document can be lifted.
+        Map<String, Object> lifted = searchForHits(
             INDEX_ONE_SHARD,
             rescoredSearch("{\"ids\":{\"values\":[\"5\",\"6\"]}}", 20, 10.0f).replace("\"query_weight\":1.0", "\"query_weight\":0.0")
         );
+        assertEquals("document 6 cannot be lifted", List.of("5", "1", "2", "3", "4"), hitIds(lifted));
+        assertEquals("the only document both in the window and matched by the rescore query", 10.0, hitScores(lifted).get(0), 0.01);
 
-        assertEquals("document 6 is unliftable; the rest of the page is doc id order", List.of("5", "1", "2", "3", "4"), hitIds(response));
-        assertEquals("the only document both in the window and matched by the rescore query", 10.0, hitScores(response).get(0), 0.01);
-        assertEquals("query_weight 0 collapses every unmatched document, ranked or not, onto 0.0", 0.0, hitScores(response).get(1), 0.0);
+        // Membership now holds over a window whose ranked documents are NOT doc-id-minimal. Each row below is chosen so
+        // that it individually flattens or inverts document 26 — the one ranked document with a HIGH doc id — because a
+        // row that only flattens document 1 is not discriminating: document 1 holds the lowest doc id in the index and
+        // wins every 0.0 tie whether the guard demoted anything or not. Both the `query_weight` and the `rescore_query_weight`
+        // sides are covered; the expected page for every row is the window and nothing else.
+        List<String> window = List.of("1", "2", "3", "4", "5", "26");
+        Map<String, String> flattening = new LinkedHashMap<>();
+        // query_weight side: zero and negative multiply away the first-pass score of EVERY document in the window,
+        // matched or not, so they need no particular rescore target.
+        flattening.put(
+            "query_weight=0",
+            "{\"ids\":{\"values\":[\"1\"]}}|\"query_weight\":0.0,\"rescore_query_weight\":10.0,\"score_mode\":\"total\""
+        );
+        flattening.put(
+            "query_weight=-1",
+            "{\"ids\":{\"values\":[\"999\"]}}|\"query_weight\":-1.0,\"rescore_query_weight\":10.0,\"score_mode\":\"total\""
+        );
+        // rescore_query_weight side: a zero or negative secondary only reaches the documents the rescore query MATCHED,
+        // so each of these has to point at document 26 to be discriminating.
+        flattening.put(
+            "multiply, rescore_query_weight=0",
+            "{\"ids\":{\"values\":[\"26\"]}}|\"query_weight\":1.0,\"rescore_query_weight\":0.0,\"score_mode\":\"multiply\""
+        );
+        flattening.put(
+            "min, rescore_query_weight=0",
+            "{\"ids\":{\"values\":[\"26\"]}}|\"query_weight\":1.0,\"rescore_query_weight\":0.0,\"score_mode\":\"min\""
+        );
+        flattening.put(
+            "total, both weights negative",
+            "{\"ids\":{\"values\":[\"26\"]}}|\"query_weight\":-1.0,\"rescore_query_weight\":-5.0,\"score_mode\":\"total\""
+        );
+        flattening.put(
+            "multiply, both weights negative",
+            "{\"ids\":{\"values\":[\"26\"]}}|\"query_weight\":-1.0,\"rescore_query_weight\":-5.0,\"score_mode\":\"multiply\""
+        );
+
+        List<String> mismatches = new ArrayList<>();
+        for (Map.Entry<String, String> shape : flattening.entrySet()) {
+            String[] parts = shape.getValue().split("\\|", 2);
+            Map<String, Object> response = searchForHits(
+                INDEX_ONE_SHARD,
+                "{\"size\":6,\"query\":"
+                    + fusedWithAZeroWeightedLeg(6)
+                    + ",\"rescore\":{\"window_size\":20,\"query\":{\"rescore_query\":"
+                    + parts[0]
+                    + ","
+                    + parts[1]
+                    + "}}}"
+            );
+            List<String> ids = hitIds(response);
+            for (String id : ids) {
+                if (window.contains(id) == false) {
+                    mismatches.add(shape.getKey() + ": returned unranked document " + id + " (page " + ids + ")");
+                }
+            }
+            if (ids.contains("26") == false) {
+                mismatches.add(shape.getKey() + ": ranked document 26 lost its slot (page " + ids + ")");
+            }
+            if (totalHits(response) != TOTAL_DOCS) {
+                mismatches.add(shape.getKey() + ": total_hits must still count the whole leg union, was " + totalHits(response));
+            }
+        }
+        assertEquals("no weighting may admit a document fusion did not rank", List.of(), mismatches);
     }
 
     // ------------------------------------------------ bodies ------------------------------------------------

--- a/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeRescoreIT.java
+++ b/src/test/java/org/opensearch/neuralsearch/query/HybridQueryFusedModeRescoreIT.java
@@ -309,6 +309,49 @@ public class HybridQueryFusedModeRescoreIT extends BaseNeuralSearchIT {
     }
 
     /**
+     * The bucket case the test above cannot see, because it asks a bucket for exactly as many hits as the fusion ranked.
+     * Ask for more and the bucket must show unranked documents — that is what an aggregation is for — and every one of
+     * them goes through the guard's demotion inside the bucket, at the request's own ordinary weights. So this is where
+     * the guard's internal band would reach a user if the coordinator decoded only the top-level page: the bucket would
+     * report {@code _score: -3.4028235E38} for documents 6-10.
+     *
+     * <p>What it must report instead is {@code 0.0}, the score those documents have in the same request with no rescore
+     * at all — the same contract as the page, one level down.
+     */
+    @SneakyThrows
+    public void testTopHitsBucketsWiderThanTheFusedWindow_reportTheUnrankedScoreAndNotTheBand() {
+        ensureDatasets();
+
+        int bucketSize = WINDOW_SIZE * 2;
+        String body = "{\"size\":0,\"aggs\":{\"all\":{\"filter\":{\"match_all\":{}},\"aggs\":{\"top\":{\"top_hits\":{\"size\":"
+            + bucketSize
+            + "}}}}},\"query\":"
+            + fusedHybrid(WINDOW_SIZE)
+            + ",\"rescore\":{\"window_size\":20,\"query\":{\"rescore_query\":{\"range\":{\""
+            + SCORE_FIELD
+            + "\":{\"lte\":"
+            + (SCORE_BASE - WINDOW_SIZE)
+            + "}}},\"query_weight\":1.0,\"rescore_query_weight\":10.0,\"score_mode\":\"total\"}}}";
+        List<Map<String, Object>> bucketHits = bucketTopHits(searchForHits(INDEX_ONE_SHARD, body), "all", "top");
+
+        assertEquals(bucketSize, bucketHits.size());
+        List<Double> scores = scoresOf(bucketHits);
+        for (int i = 0; i < scores.size(); i++) {
+            assertTrue(
+                "no bucket hit may report the guard's band: " + idsOf(bucketHits).get(i) + " at " + scores.get(i),
+                scores.get(i) >= 0.0
+            );
+        }
+        // The five ranked documents keep the page's own arithmetic; the five the fusion never ranked report the score they
+        // would have had with no rescore in the request.
+        assertEquals(List.of("5", "1", "2", "3", "4"), idsOf(bucketHits).subList(0, WINDOW_SIZE));
+        assertTrue("a ranked bucket hit still outranks an unranked one", scores.get(WINDOW_SIZE - 1) > 0.0);
+        for (int i = WINDOW_SIZE; i < bucketSize; i++) {
+            assertEquals("an unranked bucket hit reports 0.0", 0.0, scores.get(i), 0.0);
+        }
+    }
+
+    /**
      * A ranked document whose fused score is exactly {@code 0.0}, with no rescore anywhere in the request. The Top scores
      * and the Tail does not, which is the entire mechanism separating the fused window from everything else — and a ranked
      * document at {@code 0.0} ties every Tail-only document instead of outranking it. Lucene breaks that tie by ascending

--- a/src/test/java/org/opensearch/neuralsearch/search/FusedRescoreScoreNormalizerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/FusedRescoreScoreNormalizerTests.java
@@ -4,27 +4,46 @@
  */
 package org.opensearch.neuralsearch.search;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
 import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.neuralsearch.query.FusedWindowGuardRescorerBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.opensearch.search.aggregations.bucket.SingleBucketAggregation;
+import org.opensearch.search.aggregations.metrics.InternalTopHits;
+import org.opensearch.search.aggregations.metrics.TopHits;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.test.OpenSearchTestCase;
 
 /**
- * {@link FusedRescoreScoreNormalizer} — turns the fused rescore guard's internal sentinel back into the score a user
+ * {@link FusedRescoreScoreNormalizer} — turns the fused rescore guard's internal band values back into the scores a user
  * should see.
  *
  * <p>The guard has to encode "this document was not ranked by the fusion" as a score, because the score is the only
- * channel a shard has to the coordinator's merge. That encoding must not reach the user: without a rescore those
- * documents come back at exactly {@code 0.0}, so that is what the sentinel maps to, and the response for a fused request
- * with a rescore reports the same unranked scores as the same request without one.
+ * channel a shard has to the coordinator's merge, and it needs a second value one float above it for a ranked document
+ * whose own arithmetic saturated. Neither may reach the user: both are decoded to what the document would have scored
+ * with no rescore in the request at all — {@code 0.0} for an unranked document, which matches only the non-scoring Tail,
+ * and {@link FusedWindowGuardRescorerBuilder#RANKED_FLOOR_NORMALIZED} for a saturated ranked one.
  */
 public class FusedRescoreScoreNormalizerTests extends OpenSearchTestCase {
 
     private static final float SENTINEL = -Float.MAX_VALUE;
+    private static final float RANKED_FLOOR = FusedWindowGuardRescorerBuilder.RANKED_FLOOR;
+    private static final float RANKED_FLOOR_NORMALIZED = FusedWindowGuardRescorerBuilder.RANKED_FLOOR_NORMALIZED;
 
     public void testNormalize_replacesEverySentinelScoreWithZero() {
         SearchResponse response = responseOf(2.5f, hit(1, 2.5f), hit(2, SENTINEL), hit(3, SENTINEL));
@@ -61,14 +80,63 @@ public class FusedRescoreScoreNormalizerTests extends OpenSearchTestCase {
         assertEquals(9.0f, normalized.getInternalResponse().hits().getHits()[0].getScore(), 0.0f);
     }
 
-    /** A score that merely looks small is not the sentinel: the test is exact equality, not a threshold. */
-    public void testNormalize_leavesAVeryNegativeButNonSentinelScoreAlone() {
-        float almost = Math.nextUp(-Float.MAX_VALUE);
-        SearchResponse response = responseOf(almost, hit(1, almost));
+    /**
+     * The band's OTHER value. {@code RANKED_FLOOR} is where the guard parks a ranked document whose post-rescore score
+     * saturated or went NaN, and it is not the sentinel — so decoding only the sentinel would report it verbatim, at
+     * {@code -3.4028233E38}, one float away from an internal marker.
+     */
+    public void testNormalize_mapsTheRankedFloorToTheLowestReportableRankedScore() {
+        SearchResponse response = responseOf(RANKED_FLOOR, hit(1, RANKED_FLOOR));
 
         SearchResponse normalized = FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
 
-        assertEquals(almost, normalized.getInternalResponse().hits().getHits()[0].getScore(), 0.0f);
+        assertEquals(RANKED_FLOOR_NORMALIZED, normalized.getInternalResponse().hits().getHits()[0].getScore(), 0.0f);
+        assertTrue("a ranked document must still outrank the normalized unranked band", RANKED_FLOOR_NORMALIZED > 0.0f);
+    }
+
+    /**
+     * The maxScore half of the same question: the page's top hit can be a ranked document that saturated, and the
+     * correction is then NOT {@code 0.0} — reporting that would put the page's maximum below its own ranked hits.
+     */
+    public void testNormalize_whenTheTopHitIsASaturatedRankedDocument_thenMaxScoreIsTheRankedFloor() {
+        SearchResponse response = responseOf(RANKED_FLOOR, hit(1, RANKED_FLOOR), hit(2, SENTINEL));
+
+        SearchResponse normalized = FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
+
+        assertEquals(RANKED_FLOOR_NORMALIZED, normalized.getInternalResponse().hits().getMaxScore(), 0.0f);
+    }
+
+    /**
+     * Both band values on one page, which is the shape that makes decoding only one of them visibly wrong: the ranked
+     * document outranks the unranked ones and must also print above them.
+     */
+    public void testNormalize_whenBothBandsAreOnThePage_thenTheReportedScoresStillDescend() {
+        SearchResponse response = responseOf(RANKED_FLOOR, hit(1, RANKED_FLOOR), hit(2, SENTINEL), hit(3, SENTINEL));
+
+        SearchResponse normalized = FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
+
+        SearchHits hits = normalized.getInternalResponse().hits();
+        float previous = hits.getMaxScore();
+        for (SearchHit hit : hits.getHits()) {
+            assertTrue("max_score must not be below any hit score", hit.getScore() <= hits.getMaxScore());
+            assertTrue("reported scores must not ascend down the page", hit.getScore() <= previous);
+            previous = hit.getScore();
+        }
+        assertTrue("the ranked hit must print above the unranked ones", hits.getHits()[0].getScore() > hits.getHits()[1].getScore());
+    }
+
+    /**
+     * A score outside the band is the user's own rescore arithmetic and stays exactly as core computed it, however
+     * negative. The test is exact equality against two constants, not a threshold.
+     */
+    public void testNormalize_leavesAScoreOutsideTheBandAlone() {
+        SearchResponse response = responseOf(-5.0f, hit(1, -5.0f), hit(2, Math.nextUp(RANKED_FLOOR)));
+
+        SearchResponse normalized = FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
+
+        assertSame("nothing in the band, so no rebuild", response, normalized);
+        assertEquals(-5.0f, normalized.getInternalResponse().hits().getHits()[0].getScore(), 0.0f);
+        assertEquals(Math.nextUp(RANKED_FLOOR), normalized.getInternalResponse().hits().getHits()[1].getScore(), 0.0f);
     }
 
     /** Fails open rather than throwing on the way to the caller's listener. */
@@ -79,6 +147,90 @@ public class FusedRescoreScoreNormalizerTests extends OpenSearchTestCase {
         assertSame(empty, FusedRescoreScoreNormalizer.normalize(empty, SENTINEL));
     }
 
+    /**
+     * {@code top_hits} is the second place core applies the request's rescorers, so the guard demotes inside a bucket
+     * too — and unlike the page, a bucket asking for more hits than fusion ranked reaches that state with no unusual
+     * weights anywhere in the request, because an aggregation is what forces the Tail open.
+     */
+    public void testNormalize_decodesTopHitsBucketsAsWellAsThePage() {
+        SearchHits bucketHits = new SearchHits(
+            new SearchHit[] { hit(1, 3.0f), hit(2, RANKED_FLOOR), hit(3, SENTINEL) },
+            new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+            3.0f
+        );
+        SearchResponse response = responseWithAggregations(topHitsAggregation(bucketHits), 3.0f, hit(1, 3.0f));
+
+        FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
+
+        assertEquals("a ranked bucket hit is untouched", 3.0f, bucketHits.getHits()[0].getScore(), 0.0f);
+        assertEquals(RANKED_FLOOR_NORMALIZED, bucketHits.getHits()[1].getScore(), 0.0f);
+        assertEquals(0.0f, bucketHits.getHits()[2].getScore(), 0.0f);
+    }
+
+    /** A {@code top_hits} under a single-bucket aggregation — {@code filter}, {@code nested}, {@code global}. */
+    public void testDecodeAggregations_descendsIntoSingleBucketAggregations() {
+        SearchHits bucketHits = hitsOf(hit(1, SENTINEL));
+        // Built before the outer stubbing starts: stubbing one mock inside another's thenReturn argument is an
+        // UnfinishedStubbingException.
+        Aggregations children = new Aggregations(List.of(topHits(bucketHits)));
+        SingleBucketAggregation singleBucket = mock(SingleBucketAggregation.class);
+        when(singleBucket.getAggregations()).thenReturn(children);
+
+        FusedRescoreScoreNormalizer.decodeAggregations(new Aggregations(List.of(singleBucket)), SENTINEL);
+
+        assertEquals(0.0f, bucketHits.getHits()[0].getScore(), 0.0f);
+    }
+
+    /** And under every bucket of a multi-bucket aggregation — {@code terms}, {@code date_histogram}, {@code range}. */
+    public void testDecodeAggregations_descendsIntoEveryBucketOfAMultiBucketAggregation() {
+        SearchHits first = hitsOf(hit(1, SENTINEL));
+        SearchHits second = hitsOf(hit(2, RANKED_FLOOR));
+        MultiBucketsAggregation multiBucket = mock(MultiBucketsAggregation.class);
+        // doReturn rather than when(...).thenReturn: getBuckets() is declared List<? extends Bucket>, which no concrete
+        // list literal can be inferred against.
+        doReturn(List.of(bucketOf(first), bucketOf(second))).when(multiBucket).getBuckets();
+
+        FusedRescoreScoreNormalizer.decodeAggregations(new Aggregations(List.of(multiBucket)), SENTINEL);
+
+        assertEquals(0.0f, first.getHits()[0].getScore(), 0.0f);
+        assertEquals(RANKED_FLOOR_NORMALIZED, second.getHits()[0].getScore(), 0.0f);
+    }
+
+    /** No aggregations at all is the overwhelming majority of requests and must not throw. */
+    public void testDecodeAggregations_whenThereAreNone_thenNothingHappens() {
+        FusedRescoreScoreNormalizer.decodeAggregations(null, SENTINEL);
+        FusedRescoreScoreNormalizer.decodeAggregations(new Aggregations(List.of()), SENTINEL);
+    }
+
+    private MultiBucketsAggregation.Bucket bucketOf(final SearchHits bucketHits) {
+        Aggregations children = new Aggregations(List.of(topHits(bucketHits)));
+        MultiBucketsAggregation.Bucket bucket = mock(MultiBucketsAggregation.Bucket.class);
+        when(bucket.getAggregations()).thenReturn(children);
+        return bucket;
+    }
+
+    private TopHits topHits(final SearchHits bucketHits) {
+        TopHits topHits = mock(TopHits.class);
+        when(topHits.getHits()).thenReturn(bucketHits);
+        return topHits;
+    }
+
+    private InternalTopHits topHitsAggregation(final SearchHits bucketHits) {
+        TopDocs topDocs = new TopDocs(bucketHits.getTotalHits(), new ScoreDoc[0]);
+        return new InternalTopHits(
+            "top",
+            0,
+            bucketHits.getHits().length,
+            new TopDocsAndMaxScore(topDocs, bucketHits.getMaxScore()),
+            bucketHits,
+            null
+        );
+    }
+
+    private SearchHits hitsOf(final SearchHit... hits) {
+        return new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), hits[0].getScore());
+    }
+
     private SearchHit hit(final int docId, final float score) {
         SearchHit hit = new SearchHit(docId, String.valueOf(docId), null, null);
         hit.score(score);
@@ -87,8 +239,13 @@ public class FusedRescoreScoreNormalizerTests extends OpenSearchTestCase {
     }
 
     private SearchResponse responseOf(final float maxScore, final SearchHit... hits) {
+        return responseWithAggregations(null, maxScore, hits);
+    }
+
+    private SearchResponse responseWithAggregations(final InternalTopHits aggregation, final float maxScore, final SearchHit... hits) {
         SearchHits searchHits = new SearchHits(hits, new TotalHits(42, TotalHits.Relation.EQUAL_TO), maxScore);
-        SearchResponseSections sections = new InternalSearchResponse(searchHits, null, null, null, false, null, 1);
+        InternalAggregations aggregations = aggregation == null ? null : InternalAggregations.from(List.of(aggregation));
+        SearchResponseSections sections = new InternalSearchResponse(searchHits, aggregations, null, null, false, null, 1);
         return new SearchResponse(sections, null, 1, 1, 0, 1L, new org.opensearch.action.search.ShardSearchFailure[0], null, null);
     }
 }

--- a/src/test/java/org/opensearch/neuralsearch/search/FusedRescoreScoreNormalizerTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/FusedRescoreScoreNormalizerTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.search;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * {@link FusedRescoreScoreNormalizer} — turns the fused rescore guard's internal sentinel back into the score a user
+ * should see.
+ *
+ * <p>The guard has to encode "this document was not ranked by the fusion" as a score, because the score is the only
+ * channel a shard has to the coordinator's merge. That encoding must not reach the user: without a rescore those
+ * documents come back at exactly {@code 0.0}, so that is what the sentinel maps to, and the response for a fused request
+ * with a rescore reports the same unranked scores as the same request without one.
+ */
+public class FusedRescoreScoreNormalizerTests extends OpenSearchTestCase {
+
+    private static final float SENTINEL = -Float.MAX_VALUE;
+
+    public void testNormalize_replacesEverySentinelScoreWithZero() {
+        SearchResponse response = responseOf(2.5f, hit(1, 2.5f), hit(2, SENTINEL), hit(3, SENTINEL));
+
+        SearchResponse normalized = FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
+
+        SearchHit[] hits = normalized.getInternalResponse().hits().getHits();
+        assertEquals("a ranked score is untouched", 2.5f, hits[0].getScore(), 0.0f);
+        assertEquals(0.0f, hits[1].getScore(), 0.0f);
+        assertEquals(0.0f, hits[2].getScore(), 0.0f);
+    }
+
+    /**
+     * The one field that cannot be corrected in place: {@code SearchHits.maxScore} is {@code final}, so a page whose TOP
+     * hit was demoted — a request that ranked nothing — needs the hits rebuilt.
+     */
+    public void testNormalize_whenTheTopHitWasDemoted_thenMaxScoreIsCorrectedToo() {
+        SearchResponse response = responseOf(SENTINEL, hit(1, SENTINEL), hit(2, SENTINEL));
+
+        SearchResponse normalized = FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
+
+        assertEquals("max_score must not report the sentinel", 0.0f, normalized.getInternalResponse().hits().getMaxScore(), 0.0f);
+        assertEquals(0.0f, normalized.getInternalResponse().hits().getHits()[0].getScore(), 0.0f);
+        assertEquals("the rebuild must not lose the totals", 42, normalized.getInternalResponse().hits().getTotalHits().value());
+    }
+
+    /** A response with nothing demoted is handed back untouched — the common case pays nothing. */
+    public void testNormalize_whenNothingWasDemoted_thenTheResponseIsTheSameInstance() {
+        SearchResponse response = responseOf(9.0f, hit(1, 9.0f), hit(2, 0.25f));
+
+        SearchResponse normalized = FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
+
+        assertSame(response, normalized);
+        assertEquals(9.0f, normalized.getInternalResponse().hits().getHits()[0].getScore(), 0.0f);
+    }
+
+    /** A score that merely looks small is not the sentinel: the test is exact equality, not a threshold. */
+    public void testNormalize_leavesAVeryNegativeButNonSentinelScoreAlone() {
+        float almost = Math.nextUp(-Float.MAX_VALUE);
+        SearchResponse response = responseOf(almost, hit(1, almost));
+
+        SearchResponse normalized = FusedRescoreScoreNormalizer.normalize(response, SENTINEL);
+
+        assertEquals(almost, normalized.getInternalResponse().hits().getHits()[0].getScore(), 0.0f);
+    }
+
+    /** Fails open rather than throwing on the way to the caller's listener. */
+    public void testNormalize_whenThereAreNoHits_thenNothingHappens() {
+        assertNull(FusedRescoreScoreNormalizer.normalize(null, SENTINEL));
+
+        SearchResponse empty = responseOf(Float.NaN);
+        assertSame(empty, FusedRescoreScoreNormalizer.normalize(empty, SENTINEL));
+    }
+
+    private SearchHit hit(final int docId, final float score) {
+        SearchHit hit = new SearchHit(docId, String.valueOf(docId), null, null);
+        hit.score(score);
+        hit.sourceRef(new BytesArray("{}"));
+        return hit;
+    }
+
+    private SearchResponse responseOf(final float maxScore, final SearchHit... hits) {
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(42, TotalHits.Relation.EQUAL_TO), maxScore);
+        SearchResponseSections sections = new InternalSearchResponse(searchHits, null, null, null, false, null, 1);
+        return new SearchResponse(sections, null, 1, 1, 0, 1L, new org.opensearch.action.search.ShardSearchFailure[0], null, null);
+    }
+}

--- a/src/test/java/org/opensearch/neuralsearch/search/FusedResponseRebuilderTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/FusedResponseRebuilderTests.java
@@ -49,6 +49,39 @@ public class FusedResponseRebuilderTests extends OpenSearchTestCase {
     private static final String SHARD_KEY = "[node][index][0]";
 
     /** The cheap path: a request that collected nothing and did not time out gets its own response straight back. */
+    /**
+     * The 4-arg overload exists for the one field that cannot be corrected in place — {@code SearchHits.maxScore} is
+     * {@code final} — so a {@code null} hits override has to behave exactly like the 3-arg form, including its
+     * nothing-changed short circuit.
+     */
+    public void testRebuild_withHitsOverride_whenNothingChanges_thenTheSameResponseIsReturned() {
+        SearchResponse completed = responseWithProfile(Map.of(SHARD_KEY, shardResult(1)));
+
+        assertSame(
+            "a null hits override plus an unchanged timeout flag is a no-op",
+            completed,
+            FusedResponseRebuilder.rebuild(completed, null, false, null)
+        );
+    }
+
+    /** And when hits ARE supplied they replace the response's own, with every other section carried across. */
+    public void testRebuild_withHitsOverride_thenTheHitsAreSubstitutedAndTheRestPreserved() {
+        SearchResponse response = responseWithProfile(Map.of(SHARD_KEY, shardResult(1)));
+        SearchHits replacement = new SearchHits(
+            new SearchHit[0],
+            new org.apache.lucene.search.TotalHits(7, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO),
+            0.0f
+        );
+
+        SearchResponse rebuilt = FusedResponseRebuilder.rebuild(response, null, response.isTimedOut(), replacement);
+
+        assertNotSame(response, rebuilt);
+        assertSame("the supplied hits are the ones carried", replacement, rebuilt.getInternalResponse().hits());
+        assertEquals(7, rebuilt.getInternalResponse().hits().getTotalHits().value());
+        assertEquals("the point in time id survives the substitution", response.pointInTimeId(), rebuilt.pointInTimeId());
+        assertEquals(response.getTotalShards(), rebuilt.getTotalShards());
+    }
+
     public void testRebuild_whenNeitherOverrideChangesAnything_thenTheSameResponseIsReturned() {
         SearchResponse timedOut = responseWithEverything("scroll-id", null);
         assertSame(

--- a/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/search/HybridQuerySearchRequestFilterTests.java
@@ -52,6 +52,8 @@ import org.opensearch.search.profile.SearchProfileShardResults;
 import org.opensearch.search.profile.aggregation.AggregationProfileShardResult;
 import org.opensearch.search.profile.fetch.FetchProfileShardResult;
 import org.opensearch.tasks.Task;
+import org.opensearch.search.rescore.QueryRescorerBuilder;
+import org.opensearch.neuralsearch.query.FusedWindowGuardRescorerBuilder;
 
 public class HybridQuerySearchRequestFilterTests extends OpenSearchQueryTestCase {
 
@@ -94,6 +96,81 @@ public class HybridQuerySearchRequestFilterTests extends OpenSearchQueryTestCase
         assertThat(
             exceptionCaptor.getValue().getMessage(),
             containsString("hybrid query does not support search_type [dfs_query_then_fetch]")
+        );
+    }
+
+    /**
+     * The wiring that makes the fused rescore guard invisible to a user: a fused hybrid carrying a {@code rescore} comes
+     * back from the shards with unranked documents demoted to {@code FusedWindowGuardRescorerBuilder.UNRANKED_SCORE}, and
+     * this filter's response wrap maps that back to {@code 0.0} — the score those documents carry when the same request
+     * has no rescore. Driven through the real listener the filter hands the chain, because the normalisation happens on
+     * the response path.
+     */
+    @SuppressWarnings("unchecked")
+    public void testApply_whenFusedHybridWithARescore_thenTheGuardSentinelIsNormalisedOutOfTheResponse() {
+        HybridQueryBuilder fused = new HybridQueryBuilder();
+        fused.add(new MatchQueryBuilder("field", "value"));
+        fused.add(new MatchAllQueryBuilder());
+        fused.fusion(new java.util.HashMap<>(java.util.Map.of("normalization", java.util.Map.of("technique", "min_max"))));
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        searchRequest.source(new SearchSourceBuilder().query(fused).addRescorer(new QueryRescorerBuilder(new MatchAllQueryBuilder())));
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        ArgumentCaptor<ActionListener<ActionResponse>> wrapped = ArgumentCaptor.forClass(ActionListener.class);
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), wrapped.capture());
+        assertNotSame("a fused request with a rescore must get a wrapped listener", listener, wrapped.getValue());
+
+        wrapped.getValue().onResponse(responseWithScores(FusedWindowGuardRescorerBuilder.UNRANKED_SCORE, 3.0f));
+
+        ArgumentCaptor<ActionResponse> delivered = ArgumentCaptor.forClass(ActionResponse.class);
+        verify(listener).onResponse(delivered.capture());
+        SearchHit[] hits = ((SearchResponse) delivered.getValue()).getInternalResponse().hits().getHits();
+        assertEquals("the sentinel must never reach a response", 0.0f, hits[0].getScore(), 0.0f);
+        assertEquals("a ranked score is untouched", 3.0f, hits[1].getScore(), 0.0f);
+    }
+
+    /** A fused hybrid with no rescore has no sentinel to normalise, so the caller's listener is handed straight through. */
+    @SuppressWarnings("unchecked")
+    public void testApply_whenFusedHybridWithoutARescore_thenTheListenerIsNotWrappedForNormalisation() {
+        HybridQueryBuilder fused = new HybridQueryBuilder();
+        fused.add(new MatchAllQueryBuilder());
+        fused.fusion(new java.util.HashMap<>(java.util.Map.of("normalization", java.util.Map.of("technique", "min_max"))));
+
+        SearchRequest searchRequest = new SearchRequest("test_index");
+        searchRequest.source(new SearchSourceBuilder().query(fused));
+
+        Task task = mock(Task.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+
+        filter.apply(task, SearchAction.NAME, searchRequest, listener, chain);
+
+        verify(chain).proceed(eq(task), eq(SearchAction.NAME), eq(searchRequest), eq(listener));
+    }
+
+    private SearchResponse responseWithScores(final float... scores) {
+        SearchHit[] hits = new SearchHit[scores.length];
+        for (int i = 0; i < scores.length; i++) {
+            hits[i] = new SearchHit(i, String.valueOf(i), null, null);
+            hits[i].score(scores[i]);
+        }
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(scores.length, TotalHits.Relation.EQUAL_TO), scores[0]);
+        return new SearchResponse(
+            new InternalSearchResponse(searchHits, null, null, null, false, null, 1),
+            null,
+            1,
+            1,
+            0,
+            1L,
+            new ShardSearchFailure[0],
+            null,
+            null
         );
     }
 


### PR DESCRIPTION
### Description
Fixed scenario when `rescore` on a fused  hybrid could return documents the hybrid never ranked, and drop documents it did.

By design fused mode's round 2 is a self-erased query:

```
bool {
  should: [ constant_score(ids(window doc i))^fusedScore_i, ... ]   // "Top", the ranked window
  filter: bool{ should: [ ...the original legs... ] }               // "Tail" non-scoring part
}
```

`minimum_should_match` is left null, and core's `Queries.applyMinimumShouldMatch` is a no-op for null, so with a
`FILTER` clause present Lucene compiles this to `ReqOptSumScorer(req = Tail, opt = Top)`: Tail alone decides
matching and Top only adds score. Every document any leg matched therefore matches round 2, at score exactly
`0.0f`, while only the window was ranked (score should be >=`HybridFusionOrchestrator.MIN_RANKED_SCORE`).

Any weighting that lands a ranked document on exactly `0.0f` makes it indistinguishable from a Tail-only doc. And worse, the Tail-only document with a lower doc id pushed higher in the final list of hits.

Proposed fix is to attach custom rescorer that filters out the unwanted hits/docs. Coordinator installs the request's own rescorer chain inside a plugin-owned rescorer. At shard time it records which documents arrived unranked, applies the user's rescorers in order, and then puts the unranked ones in a score band below every ranked one.

```
FusedRescoreScope.install (coordinator, rewrite round 1)
    source.rescores()  =  [ FusedWindowGuardRescorerBuilder{ the user's window-confined chain, in order } ]

FusedWindowGuardRescorer.rescore (shard)
    1. unranked := { doc : score <= 0.0f }        // read from the PRISTINE pool, before any delegate runs
    2. for each delegate: topDocs = delegate.rescore(topDocs, ...)
    3. unranked -> UNRANKED_SCORE ; ranked -> max(score, RANKED_FLOOR)
    4. re-sort (score desc, doc id asc)
```

Rescore may reorder the hybrid's hits, but it may not change which documents are eligible to be returned. That is exactly the ordering the same request has with no rescore — ranked documents at or above the floor, Tail-only documents at `0.0f`. 

Alternative approach I considered is with use of query phase searcher as injection point, but I want to avoid usage of query phase classes of hybrid query for new functionality.

##### Example A — `query_weight: 0` at default windows. 

Index: **300 documents**, one integer field `s` with `s = _id`, **20 shards**. Two identical legs scoring by `s`, so the default `fusion.window_size` of 100 makes the ranked window documents 201–300, highest doc ids, while never-ranked documents 1–200 are lowest.

```json
POST /idx/_search
{
  "size": 6,
  "query": {
    "hybrid": {
      "fusion": {
        "normalization": { "technique": "min_max" },
        "combination": { "technique": "arithmetic_mean", "parameters": { "weights": [0.5, 0.5] } }
      },
      "queries": [
        { "function_score": { "query": { "match_all": {} },
                              "field_value_factor": { "field": "s", "modifier": "none", "missing": 1 } } },
        { "function_score": { "query": { "match_all": {} },
                              "field_value_factor": { "field": "s", "modifier": "none", "missing": 1 } } }
      ]
    }
  },
  "rescore": {
    "query": {
      "rescore_query": { "ids": { "values": ["300"] } },
      "query_weight": 0.0,
      "rescore_query_weight": 10.0,
      "score_mode": "total"
    }
  }
}
```
Before this change

```
ids    = [300,  5,   11,  202, 206, 227]
scores = [10.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```

Documents `5` and `11` are outside the fused window: two of six hits are documents the fusion never ranked, and two
it did rank were pushed off the page to make room.

With/after this PR

```
ids    = [300,  202, 206, 227, 231, 240]
scores = [10.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```

Every hit is inside the window. The scores are unchanged, only the *membership* is fixed.

##### Example B — `query_weight: -1.0`, whole page was unranked.

Same index and query as A, with `"query_weight": -1.0` and a `rescore_query` matching nothing
(`{"ids":{"values":["9999"]}}`). Core applies no sign check.

Before this change

```
ids    = [5,    11,   35,   73,   93,   110 ]
scores = [-0.0, -0.0, -0.0, -0.0, -0.0, -0.0]
```

Every hit is a document the fusion never ranked. 

With/after this PR

```
ids    = [201,    202,       203,       204,        205,       206      ]
scores = [-0.001, -0.010101, -0.020202, -0.0303030, -0.040404, -0.050505]
```

All ranked. The ordering is inverted, which is literally what a negative `query_weight` asks for, but nothing unranked
appears.

##### Example C — `score_mode: multiply` with `rescore_query_weight: 0`, on a normally-scored ranked document

This one shows the defect is not an artefact of the ranked floor. Index: 30 documents, 1 shard. Three legs at weights
`[0.5, 0.5, 0.0]` — a range leg matching documents 1–4, an `ids` leg matching 26 and 27, and a `match_all` leg at weight
zero so the Tail covers everything. `fusion.window_size: 6`.

Baseline, no rescore, document 26 is ranked at an ordinary fused score of `0.5`, with a high doc id:

```
ids    = [1,   26,  2,          3,          4,      27    ]
scores = [0.5, 0.5, 0.33333334, 0.16666667, 5.0E-4, 5.0E-4]
```

Add:

```json
"rescore": { "window_size": 20,
  "query": { "rescore_query": { "ids": { "values": ["26"] } },
             "query_weight": 1.0, "rescore_query_weight": 0.0, "score_mode": "multiply" } }
```

Before this change `[1, 2, 3, 4, 27, 5]` — ranked document 26 is gone, never-ranked document 5 took its slot. `score_mode: min` returned exactly the same page.

After this change `[1, 2, 3, 4, 27, 26]` — document 26 keeps its slot, document 5 is absent.

##### Example D, full `rescore_query_weight` × `score_mode` matrix, fused vs plain

`rescore_query_weight ∈ {1.0, 0.0, −5.0}` plus a both-negative row, × `score_mode ∈ {total, avg, max, min, multiply}`, on the 300-document / 20-shard index. With this fix, none of the 20 fused combinations returned a document outside the window. Plain-query arm is included to show the behaviour is consistent with the rest of the engine:

| weighting | fused (after) | plain `function_score` | reading |
|---|---|---|---|
| `rqw=-5.0, qw=1.0` | `[300,299,…]` | `[300,299,…]` | identical |
| `rqw=0.0, qw=1.0` | `[300,299,…]` | `[300,299,…]` | identical — under `multiply` the matched document collapses and drops off the page; nothing unranked appears |
| `rqw=-5.0, qw=-1.0` | `[201…206]` — all ranked, inverted | `[25,52,58,63,67,68]` | both invert; fused's inversion is confined to the ranked set |
| `multiply, rqw=-5.0, qw=-1.0` | `[250,201,202,…]` | `[250,25,52,…]` | same shape — a double negative makes the matched document win |

I've added some of these scenario to test suite.

### Related Issues
#1930 

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
