### PR TITLE
[Sparse ANN] [Native] Add support for neural-sparse-cpp's wider 64-bit nnz-offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Hybrid Query] Read the current document and its sub-query matches from the positioned disjunction iterator, fixing an ArrayIndexOutOfBoundsException and silently misattributed scores when a sub-query has a two-phase iterator ([#1946](https://github.com/opensearch-project/neural-search/issues/1946))
 * [RRF] Reject a combination technique other than rrf when creating a score-ranker-processor, instead of accepting the pipeline and throwing NullPointerException on every query ([#1949](https://github.com/opensearch-project/neural-search/pull/1949))
 * [Sparse ANN] Skip cache cleanup for a closed index's shards, which have no MapperService, so reopening a sparse index no longer leaks the shard lock and leaves the shard unassigned ([#1982](https://github.com/opensearch-project/neural-search/issues/1982))
+* [Sparse ANN] Widen the CSR indptr offset to 64-bit across the JNI/Java boundary (matching neural-sparse-cpp `offset_t=int64`) so a single segment can hold more than 2.15B cumulative non-zeros without int32 overflow ([#2001](https://github.com/opensearch-project/neural-search/pull/2001))
 
 ### Infrastructure
 * [Sparse ANN] Add scripts/build.sh so the distribution build ships the native sparse engine: every SIMD variant the target architecture may need is built into the plugin zip, and the variant to load is picked from the host's CPU flags at runtime ([#1978](https://github.com/opensearch-project/neural-search/pull/1978))

--- a/jni/src/common.h
+++ b/jni/src/common.h
@@ -15,7 +15,7 @@ namespace neural_search_jni {
  * Transfer sparse vector data from Java on-heap arrays into off-heap std::vectors.
  *
  * memoryAddresses is a 3-element array of pointers to std::vectors:
- *   [0] -> std::vector<int32_t>*  (indices / CSR indptr)
+ *   [0] -> std::vector<int64_t>*  (indices / CSR indptr — 64-bit cumulative nnz offset)
  *   [1] -> std::vector<int32_t>*  (tokens)
  *   [2] -> std::vector<float>*    (weights)
  *
@@ -36,12 +36,15 @@ inline void transferVectors(
     // an existing vector we must (a) skip the redundant leading 0 and
     // (b) offset every value by the current cumulative nnz so the indptr
     // remains a valid, monotonically-increasing CSR array.
-    std::vector<int32_t>* indicesVec;
+    // CSR indptr is the cumulative-nnz offset (nsparse offset_t = int64_t). Each Java flush sends a
+    // RELATIVE int32 indptr starting at 0 (one flush's nnz stays < INT32_MAX), but the accumulated
+    // offset across flushes can exceed INT32_MAX, so it is stored 64-bit here to match offset_t.
+    std::vector<int64_t>* indicesVec;
     if (memoryAddresses[0] == 0) {
-        indicesVec = new std::vector<int32_t>();
+        indicesVec = new std::vector<int64_t>();
         memoryAddresses[0] = reinterpret_cast<int64_t>(indicesVec);
     } else {
-        indicesVec = reinterpret_cast<std::vector<int32_t>*>(memoryAddresses[0]);
+        indicesVec = reinterpret_cast<std::vector<int64_t>*>(memoryAddresses[0]);
     }
     // Emptiness, not a null address, decides which branch applies: a first call
     // carrying no indptr at all leaves an allocated-but-empty vector behind, and
@@ -50,10 +53,11 @@ inline void transferVectors(
     if (indicesVec->empty()) {
         indicesVec->insert(indicesVec->end(), indices, indices + indicesLen);
     } else {
-        const int32_t offset = indicesVec->back();
-        // Skip indices[0] (always 0) and offset the rest
+        const int64_t offset = indicesVec->back();
+        // Skip indices[0] (always 0) and offset the rest; widen each int32 relative
+        // value to int64 before adding the (possibly >INT32_MAX) cumulative offset.
         for (int i = 1; i < indicesLen; ++i) {
-            indicesVec->push_back(indices[i] + offset);
+            indicesVec->push_back(static_cast<int64_t>(indices[i]) + offset);
         }
     }
 
@@ -87,7 +91,7 @@ inline void transferVectors(
  * a second call a no-op -- closing a buffer twice must not double free.
  */
 inline void freeVectors(int64_t* memoryAddresses) {
-    delete reinterpret_cast<std::vector<int32_t>*>(memoryAddresses[0]);
+    delete reinterpret_cast<std::vector<int64_t>*>(memoryAddresses[0]);
     memoryAddresses[0] = 0;
     delete reinterpret_cast<std::vector<int32_t>*>(memoryAddresses[1]);
     memoryAddresses[1] = 0;

--- a/jni/src/nsparse_wrapper.cpp
+++ b/jni/src/nsparse_wrapper.cpp
@@ -291,8 +291,10 @@ void insertToIndex(int64_t indexAddress, const int32_t* ids, int numIds,
     // the range check below and add_with_ids/build() can all throw, and every one
     // of those paths must still free them. Java has already dropped its only
     // handle (the raw addresses), so anything not freed here is unreachable.
-    std::unique_ptr<std::vector<int32_t>> indptr(
-        reinterpret_cast<std::vector<int32_t>*>(indicesAddress));
+    // indptr is the CSR nnz-offset vector, stored 64-bit (nsparse offset_t = int64_t) by
+    // transferVectors so the cumulative offset can exceed INT32_MAX.
+    std::unique_ptr<std::vector<int64_t>> indptr(
+        reinterpret_cast<std::vector<int64_t>*>(indicesAddress));
     std::unique_ptr<std::vector<int32_t>> tokens(
         reinterpret_cast<std::vector<int32_t>*>(tokensAddress));
     std::unique_ptr<std::vector<float>> values(
@@ -315,7 +317,7 @@ void insertToIndex(int64_t indexAddress, const int32_t* ids, int numIds,
 
     omp_set_num_threads(threadCount);
     index->add_with_ids(static_cast<nsparse::idx_t>(numIds),
-                        reinterpret_cast<const nsparse::idx_t*>(indptr->data()),
+                        reinterpret_cast<const nsparse::offset_t*>(indptr->data()),
                         termTokens.data(), values->data(),
                         reinterpret_cast<const nsparse::idx_t*>(ids));
 
@@ -384,8 +386,8 @@ void queryIndex(int64_t indexAddress, const int32_t* tokens,
     }
 
     // Build single-query CSR indptr: [0, numTokens]
-    nsparse::idx_t indptr[2] = {0,
-                                static_cast<nsparse::idx_t>(termTokens.size())};
+    nsparse::offset_t indptr[2] = {0,
+                                static_cast<nsparse::offset_t>(termTokens.size())};
 
     std::unique_ptr<nsparse::SearchParameters> params =
         methodParameters.empty() ? nullptr
@@ -412,8 +414,8 @@ void queryIndexWithFilter(
     }
 
     // Build single-query CSR indptr: [0, numTokens]
-    nsparse::idx_t indptr[2] = {0,
-                                static_cast<nsparse::idx_t>(termTokens.size())};
+    nsparse::offset_t indptr[2] = {0,
+                                static_cast<nsparse::offset_t>(termTokens.size())};
 
     // Convert int64_t filter IDs to idx_t (int32_t)
     std::vector<nsparse::idx_t> idxFilterIds(filterIds,

--- a/jni/tests/commons_test.cpp
+++ b/jni/tests/commons_test.cpp
@@ -29,8 +29,10 @@ namespace {
 struct OffHeap {
     int64_t addr[3] = {0, 0, 0};
 
-    std::vector<int32_t>* indices() {
-        return reinterpret_cast<std::vector<int32_t>*>(addr[0]);
+    // slot [0] is the CSR indptr accumulator, widened to int64 (nsparse offset_t)
+    // so the cumulative nnz offset can exceed INT32_MAX.
+    std::vector<int64_t>* indices() {
+        return reinterpret_cast<std::vector<int64_t>*>(addr[0]);
     }
     std::vector<int32_t>* tokens() {
         return reinterpret_cast<std::vector<int32_t>*>(addr[1]);
@@ -61,7 +63,7 @@ TEST(TransferVectorsTest, FirstCallAllocatesAndCopies) {
     ASSERT_NE(off.addr[1], 0);
     ASSERT_NE(off.addr[2], 0);
 
-    EXPECT_EQ(*off.indices(), (std::vector<int32_t>{0, 2, 3}));
+    EXPECT_EQ(*off.indices(), (std::vector<int64_t>{0, 2, 3}));
     EXPECT_EQ(*off.tokens(), (std::vector<int32_t>{5, 9, 7}));
     EXPECT_EQ(*off.values(), (std::vector<float>{1.0f, 2.0f, 3.0f}));
 }
@@ -84,7 +86,7 @@ TEST(TransferVectorsTest, SecondCallAppendsAndOffsetsIndptr) {
                     tok2.size(), w2.data(), w2.size());
 
     // Expected merged CSR: [0,2,3] then 4(=1+3), 6(=3+3).
-    EXPECT_EQ(*off.indices(), (std::vector<int32_t>{0, 2, 3, 4, 6}));
+    EXPECT_EQ(*off.indices(), (std::vector<int64_t>{0, 2, 3, 4, 6}));
     EXPECT_EQ(*off.tokens(), (std::vector<int32_t>{5, 9, 7, 2, 4, 6}));
     EXPECT_EQ(*off.values(),
               (std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}));
@@ -134,7 +136,7 @@ TEST(TransferVectorsTest, EmptyAppendDoesNotCorruptIndptr) {
     transferVectors(off.addr, indptrEmpty.data(), indptrEmpty.size(), nullptr, 0,
                     nullptr, 0);
 
-    EXPECT_EQ(*off.indices(), (std::vector<int32_t>{0, 3}));
+    EXPECT_EQ(*off.indices(), (std::vector<int64_t>{0, 3}));
     EXPECT_EQ(off.tokens()->size(), 3u);
 }
 
@@ -154,7 +156,7 @@ TEST(TransferVectorsTest, ZeroLengthFirstCallLeavesBuffersUsable) {
     transferVectors(off.addr, indptr.data(), indptr.size(), tok.data(),
                     tok.size(), w.data(), w.size());
 
-    EXPECT_EQ(*off.indices(), (std::vector<int32_t>{0, 3, 7}));
+    EXPECT_EQ(*off.indices(), (std::vector<int64_t>{0, 3, 7}));
     EXPECT_EQ(off.tokens()->size(), 7u);
 }
 
@@ -165,7 +167,7 @@ TEST(TransferVectorsTest, LeadingZeroOnlyFirstCallDoesNotDoubleCount) {
     std::vector<int32_t> indptrZero = {0};
     transferVectors(off.addr, indptrZero.data(), indptrZero.size(), nullptr, 0,
                     nullptr, 0);
-    EXPECT_EQ(*off.indices(), (std::vector<int32_t>{0}));
+    EXPECT_EQ(*off.indices(), (std::vector<int64_t>{0}));
 
     std::vector<int32_t> indptr = {0, 3, 7};
     std::vector<int32_t> tok = {1, 2, 3, 4, 5, 6, 7};
@@ -173,7 +175,7 @@ TEST(TransferVectorsTest, LeadingZeroOnlyFirstCallDoesNotDoubleCount) {
     transferVectors(off.addr, indptr.data(), indptr.size(), tok.data(),
                     tok.size(), w.data(), w.size());
 
-    EXPECT_EQ(*off.indices(), (std::vector<int32_t>{0, 3, 7}));
+    EXPECT_EQ(*off.indices(), (std::vector<int64_t>{0, 3, 7}));
 }
 
 TEST(FreeVectorsTest, FreesAndZeroesEveryAddress) {

--- a/jni/tests/nsparse_wrapper_test.cpp
+++ b/jni/tests/nsparse_wrapper_test.cpp
@@ -479,7 +479,7 @@ TEST_F(NsparseWrapperTest, WriteIndexProducesDeserializableBytes) {
     int k = 2;
     std::vector<float> distances(k, 0.0f);
     std::vector<nsparse::idx_t> labels(k, -1);
-    nsparse::idx_t qIndptr[2] = {0, 1};
+    nsparse::offset_t qIndptr[2] = {0, 1};
     std::vector<nsparse::term_t> qTokens = {2};
     std::vector<float> qWeights = {1.0f};
     loaded->search(1, qIndptr, qTokens.data(), qWeights.data(), k,
@@ -502,7 +502,7 @@ TEST_F(NsparseWrapperTest, LoadIndexAndQuerySingleLevel) {
     // Build a single-level inverted index directly (add(), not add_with_ids)
     // and persist it via nsparse's file writer.
     nsparse::Index* idx = nsparse::index_factory(16, "inverted");
-    nsparse::idx_t indptr[3] = {0, 2, 4};
+    nsparse::offset_t indptr[3] = {0, 2, 4};
     std::vector<nsparse::term_t> tok = {1, 2, 2, 3};
     std::vector<float> w = {1.0f, 1.0f, 1.0f, 1.0f};
     idx->add(2, indptr, tok.data(), w.data());

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/CsrSparseVectorsFile.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/CsrSparseVectorsFile.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * <pre>
  *   int64  header[3]        rows, cols, nnz
- *   int32  indptr[rows + 1] idx_t
+ *   int64  indptr[rows + 1] offset_t
  *   uint16 indices[nnz]     term_t
  *          &lt;padding to 4&gt;   present iff nnz is odd
  *   value  values[nnz]      uint8 codes, or float32
@@ -59,8 +59,9 @@ import java.util.List;
  * A CSR file cannot be written in one forward pass: {@code nnz} and {@code cols} are only known after
  * the last document, and the indices and the values are separate sections while the doc values hand
  * them over interleaved. So the two nnz-sized arrays go to their own scratch files as they stream,
- * {@code indptr} stays on the heap (4 bytes per row), and {@link #finish} assembles them. Peak heap
- * is one vector plus indptr; the cost is writing the nnz arrays twice.
+ * {@code indptr} stays on the heap (8 bytes per row: it is {@code offset_t}, int64), and
+ * {@link #finish} assembles them. Peak heap is one vector plus indptr; the cost is writing the nnz
+ * arrays twice.
  */
 class CsrSparseVectorsFile implements Closeable {
 
@@ -89,8 +90,10 @@ class CsrSparseVectorsFile implements Closeable {
     private IndexOutput indicesScratch;
     private IndexOutput valuesScratch;
 
-    /** Prefix sums of the per-row nnz, so {@code indptr[0] == 0} and {@code indptr[rows] == nnz}. */
-    private int[] indptr = new int[1024];
+    /** Prefix sums of the per-row nnz, so {@code indptr[0] == 0} and {@code indptr[rows] == nnz}.
+     *  64-bit: the cumulative nnz can exceed INT_MAX (native offset_t is int64), and the on-disk
+     *  .csr indptr is read as int64 by nsparse read_csr. */
+    private long[] indptr = new long[1024];
     private int rows;
     private long nnz;
 
@@ -184,15 +187,10 @@ class CsrSparseVectorsFile implements Closeable {
             }
         }
         nnz += tokens.size();
-        // idx_t is int32, so the running offset has to fit one. Checked per row rather than only in
-        // finish() so the failure names a bound the caller can act on before the file is assembled.
-        if (nnz > Integer.MAX_VALUE) {
-            throw new IllegalStateException(
-                "sparse segment has " + nnz + " non-zeros, more than the native engine's 32-bit CSR offsets hold"
-            );
-        }
+        // The native offset type is int64 (offset_t), so the cumulative nnz only needs to fit a long
+        // (Lucene bounds a segment's total terms well under that anyway). No INT_MAX cap.
         indptr = ArrayUtil.grow(indptr, rows + 2);
-        indptr[++rows] = (int) nnz;
+        indptr[++rows] = nnz;
     }
 
     /**
@@ -235,7 +233,7 @@ class CsrSparseVectorsFile implements Closeable {
             csrOutput.writeLong(dimension);
             csrOutput.writeLong(nnz);
             for (int row = 0; row <= rows; row++) {
-                csrOutput.writeInt(indptr[row]);
+                csrOutput.writeLong(indptr[row]);
             }
             copyScratch(csrOutput, indicesName);
             // The mapped reader reinterprets the values in place, so they have to start on a 4-byte

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/OffHeapSparseVectorsBuffer.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/OffHeapSparseVectorsBuffer.java
@@ -50,6 +50,7 @@ public class OffHeapSparseVectorsBuffer implements Closeable {
     }
 
     public void addVector(int[] vectorTokens, float[] vectorValues) {
+        requirePerFlushNnzFitsInt(nnzSize, vectorTokens.length);
         ensureNnzCapacity(nnzSize + vectorTokens.length);
         System.arraycopy(vectorTokens, 0, tokens, nnzSize, vectorTokens.length);
         System.arraycopy(vectorValues, 0, values, nnzSize, vectorValues.length);
@@ -99,6 +100,23 @@ public class OffHeapSparseVectorsBuffer implements Closeable {
         if (minCapacity > indices.length) {
             int newCapacity = Math.max(indices.length * 2, minCapacity);
             indices = Arrays.copyOf(indices, newCapacity);
+        }
+    }
+
+    /**
+     * The indptr here is a per-flush RELATIVE offset: it resets to 0 on every {@link #flush()}, and
+     * the cumulative (whole-segment) offset is accumulated 64-bit on the native side
+     * ({@link NativeLibrary#transferVectors} stores it as {@code offset_t = int64}). So this running
+     * {@code nnzSize} only has to hold one flush's non-zeros, which {@code byteSizeLimit} (1% of the
+     * heap) bounds well below {@code INT_MAX} at any real heap. Fail fast rather than let the int add
+     * wrap negative and silently corrupt the indptr handed to nsparse.
+     */
+    static void requirePerFlushNnzFitsInt(int currentNnz, int addedNnz) {
+        if ((long) currentNnz + addedNnz > Integer.MAX_VALUE) {
+            throw new IllegalStateException(
+                "a single streaming flush exceeded Integer.MAX_VALUE non-zeros; flush more often (the "
+                    + "cumulative offset is 64-bit, but one flush's relative indptr must fit an int)"
+            );
         }
     }
 

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/CsrSparseVectorsFileTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/CsrSparseVectorsFileTests.java
@@ -65,9 +65,10 @@ public class CsrSparseVectorsFileTests extends AbstractSparseTestBase {
         assertEquals("cols", 65536L, buffer.getLong());
         assertEquals("nnz", 3L, buffer.getLong());
 
-        assertEquals("indptr[0]", 0, buffer.getInt());
-        assertEquals("indptr[1]", 2, buffer.getInt());
-        assertEquals("indptr[2]", 3, buffer.getInt());
+        // indptr is offset_t (int64): the cumulative nnz offset nsparse maps in place is 8 bytes/entry.
+        assertEquals("indptr[0]", 0L, buffer.getLong());
+        assertEquals("indptr[1]", 2L, buffer.getLong());
+        assertEquals("indptr[2]", 3L, buffer.getLong());
 
         // Tokens keep the order the doc values stored them in, and 65535 has to survive as uint16
         // rather than wrapping to -1.
@@ -101,10 +102,10 @@ public class CsrSparseVectorsFileTests extends AbstractSparseTestBase {
         assertEquals("padding before the values", 0, CsrSparseVectorsFile.paddingBytes(2));
         assertEquals(
             "native_file_size(indptr_size = 2, nnz = 2, element_size = 1)",
-            CsrSparseVectorsFile.HEADER_BYTES + 2 * Integer.BYTES + 2 * Short.BYTES + 2 * CsrSparseVectorsFile.QUANTIZED_VALUE_BYTES,
+            CsrSparseVectorsFile.HEADER_BYTES + 2 * Long.BYTES + 2 * Short.BYTES + 2 * CsrSparseVectorsFile.QUANTIZED_VALUE_BYTES,
             contents.length
         );
-        int valuesOffset = CsrSparseVectorsFile.HEADER_BYTES + 2 * Integer.BYTES + 2 * Short.BYTES;
+        int valuesOffset = CsrSparseVectorsFile.HEADER_BYTES + 2 * Long.BYTES + 2 * Short.BYTES;
         assertEquals(255, contents[valuesOffset] & 0xFF);
         assertEquals(128, contents[valuesOffset + 1] & 0xFF);
     }
@@ -130,7 +131,7 @@ public class CsrSparseVectorsFileTests extends AbstractSparseTestBase {
             contents = readFile(csrFile.resolveCsrPath());
         }
 
-        int valuesOffset = CsrSparseVectorsFile.HEADER_BYTES + 2 * Integer.BYTES + 3 * Short.BYTES + CsrSparseVectorsFile.paddingBytes(3);
+        int valuesOffset = CsrSparseVectorsFile.HEADER_BYTES + 2 * Long.BYTES + 3 * Short.BYTES + CsrSparseVectorsFile.paddingBytes(3);
         assertEquals("a weight above the ceiling clamps to 255", 255, contents[valuesOffset] & 0xFF);
         assertEquals("a negative weight clamps to 0", 0, contents[valuesOffset + 1] & 0xFF);
         assertEquals("0.5 of the ceiling rounds to 128", 128, contents[valuesOffset + 2] & 0xFF);

--- a/src/test/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/OffHeapVectorOwnershipTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/OffHeapVectorOwnershipTests.java
@@ -172,6 +172,24 @@ public class OffHeapVectorOwnershipTests extends AbstractSparseTestBase {
         );
     }
 
+    /**
+     * A single flush's relative indptr is a plain int, so its running non-zero count must fit one.
+     * The cumulative offset is widened to 64-bit on the native side, but overflowing an int here would
+     * wrap the indptr negative and silently corrupt what nsparse maps -- so the buffer refuses it.
+     * Checked directly rather than by adding INT_MAX non-zeros, which no test heap could stage.
+     */
+    public void testPerFlushNnzOverflowIsRejected() {
+        // Well within an int: the common case, where the guard does nothing.
+        OffHeapSparseVectorsBuffer.requirePerFlushNnzFitsInt(1_000_000, 200);
+
+        // The boundary: a running count that a further batch pushes past Integer.MAX_VALUE.
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> OffHeapSparseVectorsBuffer.requirePerFlushNnzFitsInt(Integer.MAX_VALUE - 1, 2)
+        );
+        assertTrue(e.getMessage(), e.getMessage().contains("Integer.MAX_VALUE non-zeros"));
+    }
+
     /** {@link #ATTEMPTS_PER_BATCH} writes that stream every document off-heap and then fail. */
     private void runFailingWrites(int firstSegment) {
         for (int attempt = 0; attempt < ATTEMPTS_PER_BATCH; attempt++) {


### PR DESCRIPTION
### Description
neural-sparse-cpp [#54](https://github.com/opensearch-project/neural-sparse-cpp/pull/54) widened the CSR forward-index offset from 32-bit to a new `offset_t = int64_t` so a single segment can hold more than ~2.1B non-zeros. The 32-bit cap was hit by large corpora — e.g. MS MARCO V2 (138M docs, ~28.7B nnz) overflows a signed-int32 `indptr` and cannot be built as a single force-merged segment on the native engine.

This PR bumps the submodule to the merged nsparse commit and adapts the plugin's JNI + Java side so the wider offset flows through end to end. Doc-ids, labels, term-ids, and the per-block on-disk structures deliberately **stay 32-bit** (nsparse `idx_t`) — only the CSR nnz-offset widens.

#### Changes
- **Submodule bump** — `jni/external/neural-sparse-cpp` `354c756` → `da0d43c` ("Widen the CSR offset to 64 bit", opensearch-project/neural-sparse-cpp#54, now merged to nsparse `main`).
- **Streaming path** (`jni/src/common.h`) — the off-heap CSR `indptr` accumulator widens from `std::vector<int32_t>` to `std::vector<int64_t>`, so a segment's cumulative nnz can exceed `INT32_MAX`. Each per-flush indptr is still a **relative** int32 array (reset to 0 per flush, bounded by the streaming flush limit) and is widened before the cumulative offset is added — so the `transferVectors`/`insertToIndex` JNI signatures are unchanged.
- **Insert / query** (`jni/src/nsparse_wrapper.cpp`) — hands `add_with_ids` and `search` the `indptr` as `nsparse::offset_t` (was `idx_t`) on both the insert and the single-query paths.
- **Disk `.csr` writer** (`CsrSparseVectorsFile.java`) — emits int64 `indptr` entries (8 bytes/row, matching nsparse `read_csr`); the id file's `external_ids` stay int32 (`idx_t`). Removes the now-obsolete `INT_MAX` nnz cap. `CsrSparseVectorsFileTests` updated for the 8-byte indptr (reads + byte-offset math); all 11 tests pass.

#### Cost (measured on MS MARCO V1, 8.8M docs, native `seismic_sq`, 1 segment)                                              
Widening the offset is effectively free — only the `indptr` array grows 4→8 bytes/row:                                                                                                                         
  | metric | int32 | int64 | Δ |                                                                                             
  |---|---|---|---|                                            
  | disk size (1 segment) | 41.361 GB | 41.406 GB | **+0.11%** (~45 MB) |                          
  | peak JVM RSS | 105,617 MB | 105,616 MB | ~0 |
  | build time | 2227 s | 2223 s | ~0 |                        

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
