### PR TITLE
Fail the shard, not the node, when the native sparse library cannot load

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/jni/NativeLibrary.java
+++ b/src/main/java/org/opensearch/neuralsearch/jni/NativeLibrary.java
@@ -17,11 +17,23 @@ import java.util.Map;
 @Log4j2
 public class NativeLibrary {
 
+    /**
+     * Why the load failed, or null once a variant has been loaded.
+     * <p>
+     * The message and not the {@link UnsatisfiedLinkError} itself, deliberately.
+     * ExceptionsHelper.maybeDieOnAnotherThread unwraps causes and suppressed exceptions looking
+     * for an {@code Error} and rethrows any it finds on a fresh thread, so keeping the link error
+     * reachable from what {@link #ensureLoaded()} throws would halt the node just as surely as
+     * throwing it directly. The message carries the whole diagnosis, and the static initializer
+     * below logs the error with its stack once, at load time.
+     */
+    private static final String LOAD_FAILURE;
+
     static {
-        String loaded = AccessController.doPrivileged((PrivilegedAction<String>) () -> {
+        LOAD_FAILURE = AccessController.doPrivileged((PrivilegedAction<String>) () -> {
             // Report every attempt. Only one variant is ever present, so failures for the
             // other candidates are expected and say nothing; the interesting case is a
-            // library that IS on disk but will not link (a missing libomp, say). Rethrowing
+            // library that IS on disk but will not link (a missing libomp, say). Reporting
             // only the last error reports "not found" for the unsuffixed name and buries the
             // real cause, which makes a broken native install very hard to diagnose.
             List<String> candidates = NativeLibraryCandidates.candidates();
@@ -29,11 +41,17 @@ public class NativeLibrary {
             for (String candidate : candidates) {
                 try {
                     System.loadLibrary(candidate);
-                    return candidate;
+                    log.info("Loaded library: {}", candidate);
+                    return null;
                 } catch (UnsatisfiedLinkError e) {
                     failures.add(candidate + ": " + e.getMessage());
                 }
             }
+            // plugins/opensearch-neural-search/lib is on java.library.path only because whoever
+            // starts the node put it there -- opensearch-build's tar and zip startup scripts do,
+            // and the deb/rpm service environment and the release Docker images have to as well,
+            // the same way they already do for opensearch-knn/lib. Nothing here can substitute for
+            // that, so say plainly where the library was looked for.
             UnsatisfiedLinkError error = new UnsatisfiedLinkError(
                 "Could not load the native sparse library. Tried "
                     + candidates
@@ -42,10 +60,26 @@ public class NativeLibrary {
                     + ". Attempts: "
                     + String.join("; ", failures)
             );
-            log.error(error.getMessage());
-            throw error;
+            // The only place the link error itself is reported: everything after this point sees
+            // the message alone, so nothing can rethrow an Error onto a node thread.
+            log.error(error.getMessage(), error);
+            return error.getMessage();
         });
-        log.info("Loaded library: {}", loaded);
+    }
+
+    /**
+     * Fails the caller when the native library is not loaded, so that the native methods below are
+     * never reached unlinked.
+     * <p>
+     * The static initializer records the failure instead of throwing it: an {@code Error} out of
+     * either the initializer or an unlinked native method halts the whole node (see
+     * {@link NativeLibraryUnavailableException}). Every entry point into the native engine calls
+     * this first, which turns the same broken install into a failed shard or query.
+     */
+    public static void ensureLoaded() {
+        if (LOAD_FAILURE != null) {
+            throw new NativeLibraryUnavailableException(LOAD_FAILURE);
+        }
     }
 
     public static native long initIndex(long numDocs, int dim, Map<String, Object> parameters);

--- a/src/main/java/org/opensearch/neuralsearch/jni/NativeLibraryUnavailableException.java
+++ b/src/main/java/org/opensearch/neuralsearch/jni/NativeLibraryUnavailableException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.jni;
+
+import org.opensearch.OpenSearchException;
+
+/**
+ * Thrown when the native sparse library could not be loaded, so a request that needs the native
+ * engine cannot be served.
+ * <p>
+ * An exception rather than the {@link UnsatisfiedLinkError} behind it, and one that does not carry
+ * that error as a cause. OpenSearchUncaughtExceptionHandler halts the JVM for every {@code Error}
+ * that reaches a thread pool, and ExceptionsHelper.maybeDieOnAnotherThread digs through causes and
+ * suppressed exceptions to find one and rethrow it, so a wrapped link error kills the node just as
+ * surely as an unwrapped one. Refresh runs the sparse codec, so that halt landed on the first
+ * refresh after an ingest, before any response could be sent. Carrying only the message fails the
+ * shard or the query instead and leaves the node up; {@link NativeLibrary} logs the error with its
+ * stack when the load fails.
+ */
+public class NativeLibraryUnavailableException extends OpenSearchException {
+
+    public NativeLibraryUnavailableException(String loadFailure) {
+        super("the native sparse engine is unavailable: " + loadFailure);
+    }
+}

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/CsrFileNativeIndexWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/CsrFileNativeIndexWriter.java
@@ -79,6 +79,8 @@ public class CsrFileNativeIndexWriter {
      * @throws IOException if the engine file cannot be written
      */
     public void writeIndex(BinaryDocValues binaryDocValues) throws IOException {
+        // Before any work: a missing native library must fail this flush, not the node.
+        NativeLibrary.ensureLoaded();
         int threadCount = SparseSettings.state().getSettingValue(SparseSettings.SPARSE_ALGO_PARAM_INDEX_THREAD_QTY);
         final String engineFileName = CodecUtils.buildIndexFileName(
             state.segmentInfo.name,

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/DefaultNativeIndexWriter.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/DefaultNativeIndexWriter.java
@@ -65,6 +65,8 @@ public class DefaultNativeIndexWriter {
      * @throws IOException if the engine file cannot be written
      */
     public void writeIndex(BinaryDocValues binaryDocValues) throws IOException {
+        // Before any work: a missing native library must fail this flush, not the node.
+        NativeLibrary.ensureLoaded();
         int threadCount = SparseSettings.state().getSettingValue(SparseSettings.SPARSE_ALGO_PARAM_INDEX_THREAD_QTY);
         final String engineFileName = CodecUtils.buildIndexFileName(
             state.segmentInfo.name,

--- a/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/SegmentNativeIndex.java
+++ b/src/main/java/org/opensearch/neuralsearch/sparse/codec/nativeindex/SegmentNativeIndex.java
@@ -63,6 +63,9 @@ public final class SegmentNativeIndex implements Closeable {
      * @param fieldName the sparse field to load
      */
     public static SegmentNativeIndex open(LeafReader reader, SegmentInfo segmentInfo, String fieldName) throws IOException {
+        // Every native address a query can reach comes from here, so this is where a missing
+        // native library has to fail the query rather than take the node down.
+        NativeLibrary.ensureLoaded();
         final IndexReader.CacheHelper coreCache = reader.getCoreCacheHelper();
         if (coreCache == null) {
             // A reader wrapper that exposes no core lifecycle leaves nothing to hang the handle

--- a/src/test/java/org/opensearch/neuralsearch/jni/NativeLibraryUnavailableExceptionTests.java
+++ b/src/test/java/org/opensearch/neuralsearch/jni/NativeLibraryUnavailableExceptionTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.neuralsearch.jni;
+
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * What keeps a broken native install from killing the node: the failure has to reach OpenSearch as
+ * an exception with no {@code Error} anywhere in it. OpenSearchUncaughtExceptionHandler halts the
+ * JVM for every Error that escapes onto a thread pool, and
+ * {@link ExceptionsHelper#maybeDieOnAnotherThread} rethrows one found nested inside an exception —
+ * and the sparse codec runs on the refresh thread, so an UnsatisfiedLinkError there took the node
+ * down before any response could be written.
+ */
+public class NativeLibraryUnavailableExceptionTests extends OpenSearchTestCase {
+
+    public void testIsNotAnError() {
+        Throwable thrown = new NativeLibraryUnavailableException("no opensearch_neuralsearch_nsparse in java.library.path");
+
+        assertFalse("an Error here halts the node instead of failing the request", thrown instanceof Error);
+        assertTrue(thrown instanceof RuntimeException);
+    }
+
+    /**
+     * The check OpenSearch itself makes before deciding to die. It walks causes and suppressed
+     * exceptions, so attaching the UnsatisfiedLinkError as a cause would be enough to lose the node.
+     */
+    public void testHidesNoErrorFromMaybeDieOnAnotherThread() {
+        Throwable thrown = new NativeLibraryUnavailableException("no opensearch_neuralsearch_nsparse in java.library.path");
+
+        assertTrue("nothing in this exception may be an Error", ExceptionsHelper.maybeError(thrown).isEmpty());
+    }
+
+    /** The load attempt lists every name and path it tried, which is the whole diagnosis. */
+    public void testKeepsTheLoadFailureDetail() {
+        String loadFailure = "tried [a, b] against java.library.path=/usr/lib";
+
+        NativeLibraryUnavailableException thrown = new NativeLibraryUnavailableException(loadFailure);
+
+        assertTrue(thrown.getMessage(), thrown.getMessage().contains(loadFailure));
+    }
+}


### PR DESCRIPTION
### Description

Loading the native sparse library could kill the node: `NativeLibrary`'s static initializer threw `UnsatisfiedLinkError`, and OpenSearch halts the JVM for any `Error` reaching a thread pool. The sparse codec runs on the refresh thread, so the first refresh after an ingest took the node down — hence the 3.9 [deb/rpm integ-test](https://ci.opensearch.org/ci/dbc/integ-test/3.9.0/12190/linux/x64/rpm/test-results/11598/integ-test/neural-search/without-security/stdout.txt) failures, where every suite after the first sparse one gets `Connection refused`. Those distributions omit `plugins/opensearch-neural-search/lib` from `java.library.path`; opensearch-build fixes that separately.

The failure is now recorded, not thrown, and `ensureLoaded()` throws `NativeLibraryUnavailableException` from the three native entry points (both index writers, `SegmentNativeIndex.open`). It carries only the message: `ExceptionsHelper.maybeError` unwraps causes and suppressed exceptions too, so a wrapped `Error` still halts the node.

Verified on the 3.9.0 distribution: library missing, shard fails, node stays up.

### Check List
- [x] Testing included.
- [x] Commits signed per the DCO.
